### PR TITLE
Add support for multiple response status codes

### DIFF
--- a/core/src/main/scala/tapir/StatusCodes.scala
+++ b/core/src/main/scala/tapir/StatusCodes.scala
@@ -1,0 +1,77 @@
+package tapir
+
+// https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+trait StatusCodes {
+  val Continue = 100
+  val SwitchingProtocols = 101
+  val Processing = 102
+  val EarlyHints = 103
+
+  val Ok = 200
+  val Created = 201
+  val Accepted = 202
+  val NonAuthoritativeInformation = 203
+  val NoContent = 204
+  val ResetContent = 205
+  val PartialContent = 206
+  val MultiStatus = 207
+  val AlreadyReported = 208
+  val ImUsed = 226
+
+  val MultipleChoices = 300
+  val MovedPermanently = 301
+  val Found = 302
+  val SeeOther = 303
+  val NotModified = 304
+  val UseProxy = 305
+  val TemporaryRedirect = 307
+  val PermanentRedirect = 308
+
+  val BadRequest = 400
+  val Unauthorized = 401
+  val PaymentRequired = 402
+  val Forbidden = 403
+  val NotFound = 404
+  val MethodNotAllowed = 405
+  val NotAcceptable = 406
+  val ProxyAuthenticationRequired = 407
+  val RequestTimeout = 408
+  val Conflict = 409
+  val Gone = 410
+  val LengthRequired = 411
+  val PreconditionFailed = 412
+  val PayloadTooLarge = 413
+  val UriTooLong = 414
+  val UnsupportedMediaType = 415
+  val RangeNotSatisfiable = 416
+  val ExpectationFailed = 417
+  val MisdirectedRequest = 421
+  val UnprocessableEntity = 422
+  val Locked = 423
+  val FailedDependency = 424
+  val UpgradeRequired = 426
+  val PreconditionRequired = 428
+  val TooManyRequests = 429
+  val RequestHeaderFieldsTooLarge = 431
+  val UnavailableForLegalReasons = 451
+
+  val InternalServerError = 500
+  val NotImplemented = 501
+  val BadGateway = 502
+  val ServiceUnavailable = 503
+  val GatewayTimeout = 504
+  val HttpVersionNotSupported = 505
+  val VariantAlsoNegotiates = 506
+  val InsufficientStorage = 507
+  val LoopDetected = 508
+  val NotExtended = 510
+  val NetworkAuthenticationRequired = 511
+}
+
+object StatusCodes extends StatusCodes {
+  def isInformational(status: StatusCode): Boolean = status / 100 == 1
+  def isSuccess(status: StatusCode): Boolean = status / 100 == 2
+  def isRedirect(status: StatusCode): Boolean = status / 100 == 3
+  def isClientError(status: StatusCode): Boolean = status / 100 == 4
+  def isServerError(status: StatusCode): Boolean = status / 100 == 5
+}

--- a/core/src/main/scala/tapir/Tapir.scala
+++ b/core/src/main/scala/tapir/Tapir.scala
@@ -1,6 +1,7 @@
 package tapir
 
-import tapir.GeneralCodec.{PlainCodec, GeneralPlainCodec}
+import tapir.GeneralCodec.{GeneralPlainCodec, PlainCodec}
+import tapir.internal.DefaultStatusMappers
 
 trait Tapir {
   def path[T: PlainCodec]: EndpointInput[T] =
@@ -34,6 +35,8 @@ trait Tapir {
       EndpointInput.Multiple(Vector.empty),
       EndpointIO.Multiple(Vector.empty),
       EndpointIO.Multiple(Vector.empty),
-      EndpointInfo(None, None, None, Vector.empty)
+      EndpointInfo(None, None, None, Vector.empty),
+      DefaultStatusMappers.out,
+      DefaultStatusMappers.error
     )
 }

--- a/core/src/main/scala/tapir/internal/DefaultStatusMappers.scala
+++ b/core/src/main/scala/tapir/internal/DefaultStatusMappers.scala
@@ -1,0 +1,15 @@
+package tapir.internal
+import tapir.{StatusCode, StatusCodes}
+
+object DefaultStatusMappers {
+  def out[O]: O => StatusCode = {
+    { _: O =>
+      StatusCodes.Ok
+    }
+  }
+  def error[E]: E => StatusCode = {
+    { _: E =>
+      StatusCodes.BadRequest
+    }
+  }
+}

--- a/core/src/main/scala/tapir/package.scala
+++ b/core/src/main/scala/tapir/package.scala
@@ -1,1 +1,3 @@
-package object tapir extends Tapir
+package object tapir extends Tapir {
+  type StatusCode = Int
+}

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenAPIDocs.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenAPIDocs.scala
@@ -8,7 +8,7 @@ import tapir.openapi.{MediaType => OMediaType, Schema => OSchema, _}
 
 object EndpointToOpenAPIDocs {
   def toOpenAPI(title: String, version: String, es: Iterable[Endpoint[_, _, _]]): OpenAPI = {
-    val es2 = es.map(nameAllPathCapturesInEndpoint)
+    val es2 = es.map(e => nameAllPathCapturesInEndpoint(e))
     val withSchemaKeys = new WithSchemaKeys(ObjectSchemasForEndpoints(es2))
 
     OpenAPI(
@@ -257,7 +257,7 @@ object EndpointToOpenAPIDocs {
     }
   }
 
-  private def nameAllPathCapturesInEndpoint(e: Endpoint[_, _, _]): Endpoint[_, _, _] = {
+  private def nameAllPathCapturesInEndpoint[E, O](e: Endpoint[_, E, O]): Endpoint[_, E, O] = {
     val (input2, _) = new EndpointInputMapper[Int](
       {
         case (EndpointInput.PathCapture(codec, None, description, example), i) =>

--- a/server/akka-http-server/src/main/scala/tapir/server/akkahttp/AkkaHttpInputMatcher.scala
+++ b/server/akka-http-server/src/main/scala/tapir/server/akkahttp/AkkaHttpInputMatcher.scala
@@ -1,0 +1,84 @@
+package tapir.server.akkahttp
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.server.RequestContext
+import tapir.internal.SeqToParams
+import tapir.{DecodeResult, EndpointIO, EndpointInput}
+
+private[akkahttp] object AkkaHttpInputMatcher {
+
+  case class MatchResult(values: List[Any], ctx: RequestContext, canRemoveSlash: Boolean) {
+    def prependValue(v: Any): MatchResult = copy(values = v :: values)
+  }
+
+  def doMatch(inputs: Vector[EndpointInput.Single[_]], ctx: RequestContext, body: Any): Option[MatchResult] = {
+    doMatch(inputs, ctx, canRemoveSlash = true, body)
+  }
+
+  private def doMatch(inputs: Vector[EndpointInput.Single[_]],
+                      ctx: RequestContext,
+                      canRemoveSlash: Boolean,
+                      body: Any): Option[MatchResult] = {
+
+    def handleMapped[II, T](wrapped: EndpointInput[II], f: II => T, inputsTail: Vector[EndpointInput.Single[_]]): Option[MatchResult] = {
+      doMatch(wrapped.asVectorOfSingle, ctx, canRemoveSlash, body).flatMap { result =>
+        doMatch(inputsTail, result.ctx, result.canRemoveSlash, body).map {
+          _.prependValue(f.asInstanceOf[Any => Any].apply(SeqToParams(result.values)))
+        }
+      }
+    }
+
+    inputs match {
+      case Vector() => Some(MatchResult(Nil, ctx, canRemoveSlash))
+      case EndpointInput.PathSegment(ss) +: inputsTail =>
+        ctx.unmatchedPath match {
+          case Uri.Path.Slash(pathTail) if canRemoveSlash =>
+            doMatch(inputs, ctx.withUnmatchedPath(pathTail), canRemoveSlash = false, body)
+          case Uri.Path.Segment(`ss`, pathTail) =>
+            doMatch(inputsTail, ctx.withUnmatchedPath(pathTail), canRemoveSlash = true, body)
+          case _ => None
+        }
+      case EndpointInput.PathCapture(codec, _, _, _) +: inputsTail =>
+        ctx.unmatchedPath match {
+          case Uri.Path.Slash(pathTail) if canRemoveSlash =>
+            doMatch(inputs, ctx.withUnmatchedPath(pathTail), canRemoveSlash = false, body)
+          case Uri.Path.Segment(s, pathTail) =>
+            codec.decode(s) match {
+              case DecodeResult.Value(v) =>
+                doMatch(inputsTail, ctx.withUnmatchedPath(pathTail), canRemoveSlash = true, body).map {
+                  _.prependValue(v)
+                }
+              case _ => None
+            }
+          case _ => None
+        }
+      case EndpointInput.Query(name, codec, _, _) +: inputsTail =>
+        codec.decodeOptional(ctx.request.uri.query().get(name)) match {
+          case DecodeResult.Value(v) =>
+            doMatch(inputsTail, ctx, canRemoveSlash = true, body).map {
+              _.prependValue(v)
+            }
+          case _ => None
+        }
+      case EndpointIO.Header(name, codec, _, _) +: inputsTail =>
+        codec.decodeOptional(ctx.request.headers.find(_.is(name.toLowerCase)).map(_.value())) match {
+          case DecodeResult.Value(v) =>
+            doMatch(inputsTail, ctx, canRemoveSlash = true, body).map {
+              _.prependValue(v)
+            }
+          case _ => None
+        }
+      case EndpointIO.Body(codec, _, _) +: inputsTail =>
+        codec.decodeOptional(Some(body)) match {
+          case DecodeResult.Value(v) =>
+            doMatch(inputsTail, ctx, canRemoveSlash = true, body).map {
+              _.prependValue(v)
+            }
+          case _ => None
+        }
+      case EndpointInput.Mapped(wrapped, f, _, _) +: inputsTail =>
+        handleMapped(wrapped, f, inputsTail)
+      case EndpointIO.Mapped(wrapped, f, _, _) +: inputsTail =>
+        handleMapped(wrapped, f, inputsTail)
+    }
+  }
+}

--- a/server/akka-http-server/src/main/scala/tapir/server/akkahttp/EndpointToAkkaServer.scala
+++ b/server/akka-http-server/src/main/scala/tapir/server/akkahttp/EndpointToAkkaServer.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.model.HttpHeader.ParsingResult
 import akka.http.scaladsl.model.{MediaType => _, _}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.util.{Tuple => AkkaTuple}
-import akka.http.scaladsl.server.{Directive, Directive1, Route}
+import akka.http.scaladsl.server.{Directive, Directive1, RequestContext, Route}
 import tapir._
 import tapir.internal.{ParamsToSeq, SeqToParams}
 import tapir.typelevel.{ParamsAsArgs, ParamsToTuple}
@@ -74,89 +74,10 @@ object EndpointToAkkaServer {
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server._
 
-    val methodDirective = e.method match {
-      case Method.GET     => get
-      case Method.HEAD    => head
-      case Method.POST    => post
-      case Method.PUT     => put
-      case Method.DELETE  => delete
-      case Method.OPTIONS => options
-      case Method.PATCH   => patch
-      case m              => method(HttpMethod.custom(m.m))
-    }
+    val methodDirective = methodDirectiveType(e)
 
     // TODO: when parsing a query parameter/header/body/path fragment fails, provide an option to return a nice
     // error to the user (instead of a 404).
-
-    case class MatchResult(values: List[Any], ctx: RequestContext, canRemoveSlash: Boolean) {
-      def prependValue(v: Any): MatchResult = copy(values = v :: values)
-    }
-
-    def doMatch(inputs: Vector[EndpointInput.Single[_]], ctx: RequestContext, canRemoveSlash: Boolean, body: Any): Option[MatchResult] = {
-
-      def handleMapped[II, T](wrapped: EndpointInput[II], f: II => T, inputsTail: Vector[EndpointInput.Single[_]]): Option[MatchResult] = {
-        doMatch(wrapped.asVectorOfSingle, ctx, canRemoveSlash, body).flatMap { result =>
-          doMatch(inputsTail, result.ctx, result.canRemoveSlash, body).map {
-            _.prependValue(f.asInstanceOf[Any => Any].apply(SeqToParams(result.values)))
-          }
-        }
-      }
-
-      inputs match {
-        case Vector() => Some(MatchResult(Nil, ctx, canRemoveSlash))
-        case EndpointInput.PathSegment(ss) +: inputsTail =>
-          ctx.unmatchedPath match {
-            case Uri.Path.Slash(pathTail) if canRemoveSlash =>
-              doMatch(inputs, ctx.withUnmatchedPath(pathTail), canRemoveSlash = false, body)
-            case Uri.Path.Segment(`ss`, pathTail) =>
-              doMatch(inputsTail, ctx.withUnmatchedPath(pathTail), canRemoveSlash = true, body)
-            case _ => None
-          }
-        case EndpointInput.PathCapture(codec, _, _, _) +: inputsTail =>
-          ctx.unmatchedPath match {
-            case Uri.Path.Slash(pathTail) if canRemoveSlash =>
-              doMatch(inputs, ctx.withUnmatchedPath(pathTail), canRemoveSlash = false, body)
-            case Uri.Path.Segment(s, pathTail) =>
-              codec.decode(s) match {
-                case DecodeResult.Value(v) =>
-                  doMatch(inputsTail, ctx.withUnmatchedPath(pathTail), canRemoveSlash = true, body).map {
-                    _.prependValue(v)
-                  }
-                case _ => None
-              }
-            case _ => None
-          }
-        case EndpointInput.Query(name, codec, _, _) +: inputsTail =>
-          codec.decodeOptional(ctx.request.uri.query().get(name)) match {
-            case DecodeResult.Value(v) =>
-              doMatch(inputsTail, ctx, canRemoveSlash = true, body).map {
-                _.prependValue(v)
-              }
-            case _ => None
-          }
-        case EndpointIO.Header(name, codec, _, _) +: inputsTail =>
-          codec.decodeOptional(ctx.request.headers.find(_.is(name.toLowerCase)).map(_.value())) match {
-            case DecodeResult.Value(v) =>
-              doMatch(inputsTail, ctx, canRemoveSlash = true, body).map {
-                _.prependValue(v)
-              }
-            case _ => None
-          }
-        case EndpointIO.Body(codec, _, _) +: inputsTail =>
-          codec.decodeOptional(Some(body)) match {
-            case DecodeResult.Value(v) =>
-              doMatch(inputsTail, ctx, canRemoveSlash = true, body).map {
-                _.prependValue(v)
-              }
-            case _ => None
-          }
-        case EndpointInput.Mapped(wrapped, f, _, _) +: inputsTail =>
-          handleMapped(wrapped, f, inputsTail)
-        case EndpointIO.Mapped(wrapped, f, _, _) +: inputsTail =>
-          handleMapped(wrapped, f, inputsTail)
-      }
-
-    }
 
     val inputDirectives: Directive1[I] = {
       val bodyDirective: Directive1[Any] = bodyType(e.input) match {
@@ -166,7 +87,7 @@ object EndpointToAkkaServer {
       }
       bodyDirective.flatMap { body =>
         extractRequestContext.flatMap { ctx =>
-          doMatch(e.input.asVectorOfSingle, ctx, canRemoveSlash = true, body) match {
+          AkkaHttpInputMatcher.doMatch(e.input.asVectorOfSingle, ctx, body) match {
             case Some(result) =>
               provide(SeqToParams(result.values).asInstanceOf[I]) & mapRequestContext(_ => result.ctx)
             case None => reject
@@ -176,6 +97,19 @@ object EndpointToAkkaServer {
     }
 
     methodDirective & inputDirectives
+  }
+
+  private def methodDirectiveType[O, E, I](e: Endpoint[I, E, O]) = {
+    e.method match {
+      case Method.GET     => get
+      case Method.HEAD    => head
+      case Method.POST    => post
+      case Method.PUT     => put
+      case Method.DELETE  => delete
+      case Method.OPTIONS => options
+      case Method.PATCH   => patch
+      case m              => method(HttpMethod.custom(m.m))
+    }
   }
 
   private def bodyType[I](in: EndpointInput[I]): Option[RawValueType[_]] = {

--- a/server/http4s-server/src/main/scala/tapir/server/http4s/EndpointToHttp4sServer.scala
+++ b/server/http4s-server/src/main/scala/tapir/server/http4s/EndpointToHttp4sServer.scala
@@ -88,7 +88,7 @@ object EndpointToHttp4sServer {
             unmatchedPath = req.uri.renderString
           )
 
-      val response: ContextState[F] = new Http4sInputMatcher().matchInputs[F](inputs)
+      val response: ContextState[F] = Http4sInputMatcher.matchInputs[F](inputs)
 
       val value: F[Either[Error, (Context[F], MatchResult[F])]] = context.map(response.run)
 
@@ -113,7 +113,6 @@ object EndpointToHttp4sServer {
     }
 
     service
-
   }
 
   private def statusCodeToStatus(code: tapir.StatusCode): Status = {

--- a/server/http4s-server/src/main/scala/tapir/server/http4s/EndpointToHttp4sServer.scala
+++ b/server/http4s-server/src/main/scala/tapir/server/http4s/EndpointToHttp4sServer.scala
@@ -2,7 +2,6 @@ package tapir.server.http4s
 
 import java.nio.charset.{Charset => NioCharset}
 
-import cats.Applicative
 import cats.data._
 import cats.effect.Sync
 import cats.implicits._
@@ -12,16 +11,10 @@ import org.http4s.util.CaseInsensitiveString
 import org.http4s.{Charset, EntityBody, Header, Headers, HttpRoutes, Request, Response, Status}
 import tapir.internal.{ParamsToSeq, SeqToParams}
 import tapir.typelevel.ParamsAsArgs
-import tapir.{DecodeResult, Endpoint, EndpointIO, EndpointInput, GeneralCodec, MediaType}
+import tapir.{Endpoint, EndpointIO, EndpointInput, GeneralCodec, MediaType}
 
 object EndpointToHttp4sServer {
   private val logger = org.log4s.getLogger
-
-  private case class MatchResult[F[_]](values: List[Any], ctx: Context[F]) {
-    def prependValue(v: Any): MatchResult[F] = copy(values = v :: values)
-  }
-
-  private type Error = String
 
   private def mediaTypeToContentType(mediaType: MediaType): `Content-Type` =
     mediaType match {
@@ -95,7 +88,7 @@ object EndpointToHttp4sServer {
             unmatchedPath = req.uri.renderString
           )
 
-      val response: ContextState[F] = matchInputs[F](inputs)
+      val response: ContextState[F] = new Http4sInputMatcher().matchInputs[F](inputs)
 
       val value: F[Either[Error, (Context[F], MatchResult[F])]] = context.map(response.run)
 
@@ -147,113 +140,5 @@ object EndpointToHttp4sServer {
         Response(status = statusCode, headers = Headers(responseHeaders))
     }
 
-  }
-
-  private def nextSegment(unmatchedPath: String): Either[Error, (String, String)] =
-    if (unmatchedPath.startsWith("/")) {
-      val noSlash = unmatchedPath.drop(1)
-      val lastIndex =
-        if (noSlash.contains("/")) noSlash.indexOf("/")
-        else if (noSlash.contains("?")) noSlash.indexOf("?")
-        else
-          noSlash.length
-      val (segment, remaining) = noSlash.splitAt(lastIndex)
-      Either.right((segment, remaining))
-    } else {
-      Either.left("path doesn't start with \"/\"")
-    }
-
-  private case class Context[F[_]](queryParams: Map[String, String], headers: Headers, body: Option[Any], unmatchedPath: String) {
-    def getHeader(key: String): Option[String] = headers.get(CaseInsensitiveString.apply(key)).map(_.value)
-    def getQueryParam(name: String): Option[String] = queryParams.get(name)
-    def dropPath(n: Int): Context[F] = copy(unmatchedPath = unmatchedPath.drop(n))
-  }
-
-  private def handleMapped[II, T, F[_]: Sync](wrapped: EndpointInput[II],
-                                              f: II => T,
-                                              inputsTail: Vector[EndpointInput.Single[_]]): ContextState[F] =
-    for {
-      r1 <- matchInputs[F](wrapped.asVectorOfSingle)
-      r2 <- matchInputs[F](inputsTail)
-        .map(_.prependValue(f.asInstanceOf[Any => Any].apply(SeqToParams(r1.values))))
-    } yield r2
-
-  private def continueMatch[F[_]: Sync](decodeResult: DecodeResult[Any], inputsTail: Vector[EndpointInput.Single[_]]): ContextState[F] =
-    decodeResult match {
-      case DecodeResult.Value(v) =>
-        logger.debug(s"Continuing match: $v")
-        matchInputs[F](inputsTail).map(_.prependValue(v))
-      case err =>
-        StateT.inspectF((ctx: Context[F]) => Either.left(s"${err.toString}, ${ctx.unmatchedPath}"))
-    }
-
-  private type ContextState[F[_]] = StateT[Either[Error, ?], Context[F], MatchResult[F]]
-  private def getState[F[_]]: StateT[Either[Error, ?], Context[F], Context[F]] = StateT.get
-  private def modifyState[F[_]: Applicative](f: Context[F] => Context[F]): StateT[Either[Error, ?], Context[F], Unit] =
-    StateT.modify[Either[Error, ?], Context[F]](f)
-
-  private def matchInputs[F[_]: Sync](inputs: Vector[EndpointInput.Single[_]]): ContextState[F] = inputs match {
-    case Vector() =>
-      StateT(context => Either.right((context, MatchResult[F](Nil, context))))
-    case EndpointInput.PathSegment(ss: String) +: inputsTail =>
-      for {
-        ctx <- getState[F]
-        _ <- modifyState[F](_.dropPath(ss.length + 1))
-        doesMatch = ctx.unmatchedPath.drop(1).startsWith(ss)
-        _ = logger.debug(s"$doesMatch, ${ctx.unmatchedPath}, $ss")
-        r <- if (ctx.unmatchedPath.drop(1).startsWith(ss)) {
-          val value: ContextState[F] = matchInputs[F](inputsTail)
-          value
-        } else {
-          val value: ContextState[F] = StateT.liftF(Either.left(s"Unmatched path segment: $ss, $ctx"))
-          value
-        }
-      } yield r
-    case EndpointInput.PathCapture(m, name, _, _) +: inputsTail =>
-      val decodeResult: StateT[Either[Error, ?], Context[F], DecodeResult[Any]] = StateT(
-        (ctx: Context[F]) =>
-          nextSegment(ctx.unmatchedPath)
-            .map {
-              case (segment, remaining) =>
-                logger.debug(s"Capturing path: $segment, remaining: $remaining, $name")
-                (ctx.copy(unmatchedPath = remaining), m.decode(segment))
-          })
-
-      decodeResult.flatMap {
-        case DecodeResult.Value(v) =>
-          logger.debug(s"Decoded path: $v")
-          matchInputs[F](inputsTail).map(_.prependValue(v))
-        case decodingFailure => StateT.liftF(Either.left(s"Decoding path failed: $decodingFailure"))
-      }
-    case EndpointInput.Query(name, m, _, _) +: inputsTail =>
-      for {
-        ctx <- getState[F]
-        query = m.decodeOptional(ctx.getQueryParam(name))
-        _ = logger.debug(s"Found query: $query, $name, ${ctx.headers}")
-        res <- continueMatch(query, inputsTail)
-      } yield res
-    case EndpointIO.Header(name, m, _, _) +: inputsTail =>
-      for {
-        ctx <- getState[F]
-        header = m.decodeOptional(ctx.getHeader(name))
-        _ = logger.debug(s"Found header: $header")
-        res <- continueMatch(header, inputsTail)
-      } yield res
-    case EndpointIO.Body(codec, _, _) +: inputsTail =>
-      for {
-        ctx <- getState[F]
-        decoded: DecodeResult[Any] = codec.decodeOptional(ctx.body)
-        res <- decoded match {
-          case DecodeResult.Value(_) =>
-            val r: ContextState[F] = continueMatch(decoded, inputsTail)
-            r
-          case _ =>
-            matchInputs(inputsTail)
-        }
-      } yield res
-    case EndpointInput.Mapped(wrapped, f, _, _) +: inputsTail =>
-      handleMapped(wrapped, f, inputsTail)
-    case EndpointIO.Mapped(wrapped, f, _, _) +: inputsTail =>
-      handleMapped(wrapped, f, inputsTail)
   }
 }

--- a/server/http4s-server/src/main/scala/tapir/server/http4s/Http4sInputMatcher.scala
+++ b/server/http4s-server/src/main/scala/tapir/server/http4s/Http4sInputMatcher.scala
@@ -1,0 +1,112 @@
+package tapir.server.http4s
+import cats.Applicative
+import cats.data.StateT
+import cats.effect.Sync
+import cats.implicits._
+import tapir.internal.SeqToParams
+import tapir.{DecodeResult, EndpointIO, EndpointInput}
+
+private[http4s] class Http4sInputMatcher {
+  private val logger = org.log4s.getLogger
+
+  def matchInputs[F[_]: Sync](inputs: Vector[EndpointInput.Single[_]]): ContextState[F] = inputs match {
+    case Vector() =>
+      StateT(context => Either.right((context, MatchResult[F](Nil, context))))
+    case EndpointInput.PathSegment(ss: String) +: inputsTail =>
+      for {
+        ctx <- getState[F]
+        _ <- modifyState[F](_.dropPath(ss.length + 1))
+        doesMatch = ctx.unmatchedPath.drop(1).startsWith(ss)
+        _ = logger.debug(s"$doesMatch, ${ctx.unmatchedPath}, $ss")
+        r <- if (ctx.unmatchedPath.drop(1).startsWith(ss)) {
+          val value: ContextState[F] = matchInputs[F](inputsTail)
+          value
+        } else {
+          val value: ContextState[F] = StateT.liftF(Either.left(s"Unmatched path segment: $ss, $ctx"))
+          value
+        }
+      } yield r
+    case EndpointInput.PathCapture(m, name, _, _) +: inputsTail =>
+      val decodeResult: StateT[Either[Error, ?], Context[F], DecodeResult[Any]] = StateT(
+        (ctx: Context[F]) =>
+          nextSegment(ctx.unmatchedPath)
+            .map {
+              case (segment, remaining) =>
+                logger.debug(s"Capturing path: $segment, remaining: $remaining, $name")
+                (ctx.copy(unmatchedPath = remaining), m.decode(segment))
+          })
+
+      decodeResult.flatMap {
+        case DecodeResult.Value(v) =>
+          logger.debug(s"Decoded path: $v")
+          matchInputs[F](inputsTail).map(_.prependValue(v))
+        case decodingFailure => StateT.liftF(Either.left(s"Decoding path failed: $decodingFailure"))
+      }
+    case EndpointInput.Query(name, m, _, _) +: inputsTail =>
+      for {
+        ctx <- getState[F]
+        query = m.decodeOptional(ctx.getQueryParam(name))
+        _ = logger.debug(s"Found query: $query, $name, ${ctx.headers}")
+        res <- continueMatch(query, inputsTail)
+      } yield res
+    case EndpointIO.Header(name, m, _, _) +: inputsTail =>
+      for {
+        ctx <- getState[F]
+        header = m.decodeOptional(ctx.getHeader(name))
+        _ = logger.debug(s"Found header: $header")
+        res <- continueMatch(header, inputsTail)
+      } yield res
+    case EndpointIO.Body(codec, _, _) +: inputsTail =>
+      for {
+        ctx <- getState[F]
+        decoded: DecodeResult[Any] = codec.decodeOptional(ctx.body)
+        res <- decoded match {
+          case DecodeResult.Value(_) =>
+            val r: ContextState[F] = continueMatch(decoded, inputsTail)
+            r
+          case _ =>
+            matchInputs(inputsTail)
+        }
+      } yield res
+    case EndpointInput.Mapped(wrapped, f, _, _) +: inputsTail =>
+      handleMapped(wrapped, f, inputsTail)
+    case EndpointIO.Mapped(wrapped, f, _, _) +: inputsTail =>
+      handleMapped(wrapped, f, inputsTail)
+  }
+
+  private def continueMatch[F[_]: Sync](decodeResult: DecodeResult[Any], inputsTail: Vector[EndpointInput.Single[_]]): ContextState[F] =
+    decodeResult match {
+      case DecodeResult.Value(v) =>
+        logger.debug(s"Continuing match: $v")
+        matchInputs[F](inputsTail).map(_.prependValue(v))
+      case err =>
+        StateT.inspectF((ctx: Context[F]) => Either.left(s"${err.toString}, ${ctx.unmatchedPath}"))
+    }
+
+  private def handleMapped[II, T, F[_]: Sync](wrapped: EndpointInput[II],
+                                              f: II => T,
+                                              inputsTail: Vector[EndpointInput.Single[_]]): ContextState[F] =
+    for {
+      r1 <- matchInputs[F](wrapped.asVectorOfSingle)
+      r2 <- matchInputs[F](inputsTail)
+        .map(_.prependValue(f.asInstanceOf[Any => Any].apply(SeqToParams(r1.values))))
+    } yield r2
+
+  private def nextSegment(unmatchedPath: String): Either[Error, (String, String)] =
+    if (unmatchedPath.startsWith("/")) {
+      val noSlash = unmatchedPath.drop(1)
+      val lastIndex =
+        if (noSlash.contains("/")) noSlash.indexOf("/")
+        else if (noSlash.contains("?")) noSlash.indexOf("?")
+        else
+          noSlash.length
+      val (segment, remaining) = noSlash.splitAt(lastIndex)
+      Either.right((segment, remaining))
+    } else {
+      Either.left("path doesn't start with \"/\"")
+    }
+
+  private def getState[F[_]]: StateT[Either[Error, ?], Context[F], Context[F]] = StateT.get
+  private def modifyState[F[_]: Applicative](f: Context[F] => Context[F]): StateT[Either[Error, ?], Context[F], Unit] =
+    StateT.modify[Either[Error, ?], Context[F]](f)
+}

--- a/server/http4s-server/src/main/scala/tapir/server/http4s/Http4sInputMatcher.scala
+++ b/server/http4s-server/src/main/scala/tapir/server/http4s/Http4sInputMatcher.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import tapir.internal.SeqToParams
 import tapir.{DecodeResult, EndpointIO, EndpointInput}
 
-private[http4s] class Http4sInputMatcher {
+private[http4s] object Http4sInputMatcher {
   private val logger = org.log4s.getLogger
 
   def matchInputs[F[_]: Sync](inputs: Vector[EndpointInput.Single[_]]): ContextState[F] = inputs match {

--- a/server/http4s-server/src/main/scala/tapir/server/http4s/Http4sServer.scala
+++ b/server/http4s-server/src/main/scala/tapir/server/http4s/Http4sServer.scala
@@ -1,17 +1,9 @@
 package tapir.server.http4s
 
-import cats.Applicative
-import cats.data._
 import cats.effect.Sync
-import cats.implicits._
-import org.http4s
-import org.http4s.headers.`Content-Type`
-import org.http4s.util.CaseInsensitiveString
-import org.http4s.{Charset, EntityBody, Header, Headers, HttpRoutes, Request, Response, Status}
-import tapir.internal.{ParamsToSeq, SeqToParams}
+import org.http4s.HttpRoutes
+import tapir.Endpoint
 import tapir.typelevel.ParamsAsArgs
-import tapir.{DecodeResult, Endpoint, EndpointIO, EndpointInput, GeneralCodec, MediaType}
-import java.nio.charset.{Charset => NioCharset}
 
 trait Http4sServer {
   implicit class RichHttp4sHttpEndpoint[I, E, O](e: Endpoint[I, E, O]) {

--- a/server/http4s-server/src/main/scala/tapir/server/http4s/package.scala
+++ b/server/http4s-server/src/main/scala/tapir/server/http4s/package.scala
@@ -1,3 +1,20 @@
 package tapir.server
+import cats.data.StateT
+import org.http4s.Headers
+import org.http4s.util.CaseInsensitiveString
 
-package object http4s extends Http4sServer
+package object http4s extends Http4sServer {
+  private[http4s] case class MatchResult[F[_]](values: List[Any], ctx: Context[F]) {
+    def prependValue(v: Any): MatchResult[F] = copy(values = v :: values)
+  }
+
+  private[http4s] type Error = String
+
+  private[http4s] type ContextState[F[_]] = StateT[Either[Error, ?], Context[F], MatchResult[F]]
+
+  private[http4s] case class Context[F[_]](queryParams: Map[String, String], headers: Headers, body: Option[Any], unmatchedPath: String) {
+    def getHeader(key: String): Option[String] = headers.get(CaseInsensitiveString.apply(key)).map(_.value)
+    def getQueryParam(name: String): Option[String] = queryParams.get(name)
+    def dropPath(n: Int): Context[F] = copy(unmatchedPath = unmatchedPath.drop(n))
+  }
+}

--- a/tests/src/main/scala/tapir/tests/package.scala
+++ b/tests/src/main/scala/tapir/tests/package.scala
@@ -50,6 +50,32 @@ package object tests {
   val in_string_out_byte_list: Endpoint[String, Unit, List[Byte]] =
     endpoint.post.in("api" / "echo").in(stringBody).out(byteArrayBody.map(_.toList)(_.toArray))
 
+  val endpoint_with_path: Endpoint[Unit, Unit, String] =
+    endpoint.in("fruit" / "amount").out(stringBody)
+
+  val endpoint_with_status_mapping_no_body: Endpoint[Unit, Unit, Unit] =
+    endpoint
+      .in("api")
+      .mapStatusTo { _: Unit =>
+        StatusCodes.AlreadyReported
+      }
+
+  val endpoint_with_status_mapping: Endpoint[Unit, Unit, String] =
+    endpoint
+      .in("api")
+      .out(stringBody)
+      .mapStatusTo { _: String =>
+        StatusCodes.AlreadyReported
+      }
+
+  val endpoint_with_error_status_mapping: Endpoint[Unit, String, Unit] =
+    endpoint
+      .in("api")
+      .errorOut(stringBody)
+      .mapErrorStatusTo { _: String =>
+        StatusCodes.TooManyRequests
+      }
+
   val allTestEndpoints = List(
     in_query_out_string,
     in_query_query_out_string,


### PR DESCRIPTION
This closes #4 

1. It would be great if all http libraries could use same http codes implementation. Can we extract it from here and from sttp to independent project?
2. I also extracted something which I called xInputMatcher from both servers code implementations which I believe will help us refactor them further.
3. Having two generic fields, within a single case class, which share generic type leads to interesting problems. Like you cannot simply make a copy and change one of them. 