### PR TITLE
Add `codecMap` to `Codec[...]`, `flatMap` to `DecodeResult[+T]`

### DIFF
--- a/core/src/main/scala/tapir/Codec.scala
+++ b/core/src/main/scala/tapir/Codec.scala
@@ -5,6 +5,8 @@ import java.nio.ByteBuffer
 import java.nio.charset.{Charset, StandardCharsets}
 
 import tapir.DecodeResult._
+import tapir.GeneralCodec.PlainCodec
+import tapir.MediaType.TextPlain
 
 /**
   * A codec which can encode/decode both optional and non-optional values of type `T` to raw values of type `R`.
@@ -52,15 +54,16 @@ trait Codec[T, M <: MediaType, R] extends GeneralCodec[T, M, R] { outer =>
 
   def isOptional: Boolean = false
 
-  override def map[TT](f: T => TT)(g: TT => T): Codec[TT, M, R] = new Codec[TT, M, R] {
-    override val rawValueType: RawValueType[R] = outer.rawValueType
+  def codecMap[TT](f: T => DecodeResult[TT])(g: TT => T): Codec[TT, M, R] =
+    new Codec[TT, M, R] {
+      override def encode(t: TT): R = outer.encode(g(t))
+      override def decode(s: R): DecodeResult[TT] = outer.decode(s).flatMap(f)
+      override val rawValueType: RawValueType[R] = outer.rawValueType
+      override def schema: Schema = outer.schema
+      override def mediaType: M = outer.mediaType
+    }
 
-    override def encode(t: TT): R = outer.encode(g(t))
-    override def decode(s: R): DecodeResult[TT] = outer.decode(s).map(f)
-    override def isOptional: Boolean = outer.isOptional
-    override def schema: Schema = outer.schema
-    override def mediaType: M = outer.mediaType
-  }
+  override def map[TT](f: T => TT)(g: TT => T): Codec[TT, M, R] = codecMap[TT](f.andThen(Value.apply))(g)
 }
 
 object GeneralCodec {

--- a/core/src/main/scala/tapir/DecodeResult.scala
+++ b/core/src/main/scala/tapir/DecodeResult.scala
@@ -3,19 +3,23 @@ package tapir
 sealed trait DecodeResult[+T] {
   def getOrThrow(e: (DecodeResult[Nothing], Option[Throwable]) => Throwable): T
   def map[TT](f: T => TT): DecodeResult[TT]
+  def flatMap[U](f: T => DecodeResult[U]): DecodeResult[U]
 }
 object DecodeResult {
   case class Value[T](v: T) extends DecodeResult[T] {
     def getOrThrow(e: (DecodeResult[Nothing], Option[Throwable]) => Throwable): T = v
     override def map[TT](f: T => TT): DecodeResult[TT] = Value(f(v))
+    override def flatMap[U](f: T => DecodeResult[U]): DecodeResult[U] = f(v)
   }
   case object Missing extends DecodeResult[Nothing] {
     def getOrThrow(e: (DecodeResult[Nothing], Option[Throwable]) => Throwable): Nothing = throw e(this, None)
     override def map[TT](f: Nothing => TT): DecodeResult[TT] = this
+    override def flatMap[U](f: Nothing => DecodeResult[U]): DecodeResult[U] = this
   }
   case class Error(original: String, error: Throwable, message: String) extends DecodeResult[Nothing] {
     def getOrThrow(e: (DecodeResult[Nothing], Option[Throwable]) => Throwable): Nothing = throw e(this, Some(error))
     override def map[TT](f: Nothing => TT): DecodeResult[TT] = this
+    override def flatMap[U](f: Nothing => DecodeResult[U]): DecodeResult[U] = this
   }
 
   // TODO: to reduce allocations, maybe replace with exceptions (which would all be handled by formats / codecs?)


### PR DESCRIPTION
This allows users to write concise codecs:

```scala
  implicit private val uuidCodec: PlainCodec[UUID] =
    GeneralCodec.stringPlainCodecUtf8
      .codecMap(
        s => Either.catchNonFatal(UUID.fromString(s)).fold(_ => Missing, Value(_))
      )(_.toString)
```