### PR TITLE
Upgrade http4s version to 0.20.0-M6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
 
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
 
-val http4sVersion = "0.20.0-M5"
+val http4sVersion = "0.20.0-M6"
 val circeVersion = "0.11.1"
 val sttpVersion = "1.5.11"
 


### PR DESCRIPTION
Upgrade http4s to the newest version. Unfortunately there are breaking changes between M5 and M6 so it's crucial to release this version.

I've ran `sbt compile test` and everything passed successfully, so it seems like `tapir` wasn't using any of breaking changes itself.