### PR TITLE
Add servers parameter to toOpenAPI

### DIFF
--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenAPIDocs.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenAPIDocs.scala
@@ -7,14 +7,14 @@ import tapir.{EndpointInput, _}
 import scala.collection.immutable.ListMap
 
 object EndpointToOpenAPIDocs {
-  def toOpenAPI(api: Info, es: Iterable[Endpoint[_, _, _, _]], options: OpenAPIDocsOptions): OpenAPI = {
+  def toOpenAPI(api: Info, es: Iterable[Endpoint[_, _, _, _]], options: OpenAPIDocsOptions, servers: List[Server] = List.empty): OpenAPI = {
     val es2 = es.map(nameAllPathCapturesInEndpoint)
     val objectSchemas = ObjectSchemasForEndpoints(es2)
     val securitySchemes = SecuritySchemesForEndpoints(es2)
     val pathCreator = new EndpointToOpenApiPaths(objectSchemas, securitySchemes, options)
     val componentsCreator = new EndpointToOpenApiComponents(objectSchemas, securitySchemes)
 
-    val base = apiToOpenApi(api, componentsCreator)
+    val base = apiToOpenApi(api, componentsCreator, servers)
 
     es2.map(pathCreator.pathItem).foldLeft(base) {
       case (current, (path, pathItem)) =>
@@ -22,10 +22,10 @@ object EndpointToOpenAPIDocs {
     }
   }
 
-  private def apiToOpenApi(info: Info, componentsCreator: EndpointToOpenApiComponents): OpenAPI = {
+  private def apiToOpenApi(info: Info, componentsCreator: EndpointToOpenApiComponents, servers: List[Server]): OpenAPI = {
     OpenAPI(
       info = info,
-      servers = List.empty,
+      servers = servers,
       paths = ListMap.empty,
       components = componentsCreator.components,
       security = List.empty


### PR DESCRIPTION
Add servers parameter to toOpenAPI to avoid `.toOpenAPI(...).copy(servers = List(Server(...)))`

Addresses https://github.com/softwaremill/tapir/issues/61