### PR TITLE
Add servers parameter openapi

### DIFF
--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenAPIDocs.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenAPIDocs.scala
@@ -7,14 +7,14 @@ import tapir.{EndpointInput, _}
 import scala.collection.immutable.ListMap
 
 object EndpointToOpenAPIDocs {
-  def toOpenAPI(api: Info, es: Iterable[Endpoint[_, _, _, _]], options: OpenAPIDocsOptions, servers: List[Server] = List.empty): OpenAPI = {
+  def toOpenAPI(api: Info, es: Iterable[Endpoint[_, _, _, _]], options: OpenAPIDocsOptions): OpenAPI = {
     val es2 = es.map(nameAllPathCapturesInEndpoint)
     val objectSchemas = ObjectSchemasForEndpoints(es2)
     val securitySchemes = SecuritySchemesForEndpoints(es2)
     val pathCreator = new EndpointToOpenApiPaths(objectSchemas, securitySchemes, options)
     val componentsCreator = new EndpointToOpenApiComponents(objectSchemas, securitySchemes)
 
-    val base = apiToOpenApi(api, componentsCreator, servers)
+    val base = apiToOpenApi(api, componentsCreator)
 
     es2.map(pathCreator.pathItem).foldLeft(base) {
       case (current, (path, pathItem)) =>
@@ -22,10 +22,10 @@ object EndpointToOpenAPIDocs {
     }
   }
 
-  private def apiToOpenApi(info: Info, componentsCreator: EndpointToOpenApiComponents, servers: List[Server]): OpenAPI = {
+  private def apiToOpenApi(info: Info, componentsCreator: EndpointToOpenApiComponents): OpenAPI = {
     OpenAPI(
       info = info,
-      servers = servers,
+      servers = List.empty,
       paths = ListMap.empty,
       components = componentsCreator.components,
       security = List.empty

--- a/openapi/openapi-model/src/main/scala/tapir/openapi/OpenAPI.scala
+++ b/openapi/openapi-model/src/main/scala/tapir/openapi/OpenAPI.scala
@@ -20,6 +20,8 @@ case class OpenAPI(openapi: String = "3.0.1",
 
     copy(paths = paths + (path -> pathItem2))
   }
+
+  def servers(s: List[Server]): OpenAPI = copy(servers = s)
 }
 
 object OpenAPI {


### PR DESCRIPTION
Avoid using a default parameter and instead add a `servers` method to `OpenAPI` which prevents error like this:
```
[error] /Users/adamw/projects/tapir/docs/openapi-docs/src/main/scala/tapir/docs/openapi/TapirOpenAPIDocs.scala:7:18: in class RichOpenAPIEndpoint, multiple overloaded alternatives of method toOpenAPI define default arguments.
[error]   implicit class RichOpenAPIEndpoint[I, E, O, S](e: Endpoint[I, E, O, S]) {
```