### PR TITLE
Add support for coproducts

### DIFF
--- a/core/src/main/scala/tapir/Schema.scala
+++ b/core/src/main/scala/tapir/Schema.scala
@@ -45,11 +45,11 @@ object Schema {
 
   case class SObjectInfo(shortName: String, fullName: String)
 
-  case class Discriminator[T](propertyName: String, mapping: Map[String, SchemaFor[_ <: T]])
+  case class Discriminator[T](propertyName: String, mapping: Map[String, Schema])
 
   def discriminator[T, R](name: MethodName)(mapping: Map[R, SchemaFor[_ <: T]]): Discriminator[T] = {
-    val map: Map[String, SchemaFor[_ <: T]] = mapping.map {
-      case (k, v) => k.toString -> v
+    val map: Map[String, Schema] = mapping.map {
+      case (k, v) => k.toString -> v.schema
     }.toMap
     Discriminator[T](name.name, map)
   }

--- a/core/src/main/scala/tapir/Schema.scala
+++ b/core/src/main/scala/tapir/Schema.scala
@@ -1,7 +1,5 @@
 package tapir
 
-import tapir.generic.MethodName
-
 sealed trait Schema {
   def show: String
 }
@@ -39,18 +37,11 @@ object Schema {
     def show: String = s"ref($fullName)"
   }
 
-  case class SCoproduct(schemas: List[Schema], discriminator: Option[Discriminator[_]]) extends Schema {
+  case class SCoproduct(schemas: List[Schema], discriminator: Option[Discriminator]) extends Schema {
     override def show: String = "oneOf:" + schemas.mkString(",")
   }
 
   case class SObjectInfo(shortName: String, fullName: String)
 
-  case class Discriminator[T](propertyName: String, mapping: Map[String, Schema])
-
-  def discriminator[T, R](name: MethodName)(mapping: Map[R, SchemaFor[_ <: T]]): Discriminator[T] = {
-    val map: Map[String, Schema] = mapping.map {
-      case (k, v) => k.toString -> v.schema
-    }.toMap
-    Discriminator[T](name.name, map)
-  }
+  case class Discriminator(propertyName: String, mapping: Map[String, SRef])
 }

--- a/core/src/main/scala/tapir/Schema.scala
+++ b/core/src/main/scala/tapir/Schema.scala
@@ -1,5 +1,7 @@
 package tapir
 
+import tapir.generic.MethodName
+
 sealed trait Schema {
   def show: String
 }
@@ -37,9 +39,18 @@ object Schema {
     def show: String = s"ref($fullName)"
   }
 
-  case class SCoproduct(schemas: List[Schema]) extends Schema {
+  case class SCoproduct(schemas: List[Schema], discriminator: Option[Discriminator[_]]) extends Schema {
     override def show: String = "allOf:" + schemas.mkString(",")
   }
 
   case class SObjectInfo(shortName: String, fullName: String)
+
+  case class Discriminator[T](propertyName: String, mapping: Map[String, SchemaFor[_ <: T]])
+
+  def discriminator[T, R](name: MethodName)(mapping: Map[R, SchemaFor[_ <: T]]): Discriminator[T] = {
+    val map: Map[String, SchemaFor[_ <: T]] = mapping.map {
+      case (k, v) => k.toString -> v
+    }.toMap
+    Discriminator[T](name.name, map)
+  }
 }

--- a/core/src/main/scala/tapir/Schema.scala
+++ b/core/src/main/scala/tapir/Schema.scala
@@ -37,5 +37,9 @@ object Schema {
     def show: String = s"ref($fullName)"
   }
 
+  case class SCoproduct(schemas: List[Schema]) extends Schema {
+    override def show: String = "allOf:" + schemas.mkString(",")
+  }
+
   case class SObjectInfo(shortName: String, fullName: String)
 }

--- a/core/src/main/scala/tapir/Schema.scala
+++ b/core/src/main/scala/tapir/Schema.scala
@@ -37,7 +37,7 @@ object Schema {
     def show: String = s"ref($fullName)"
   }
 
-  case class SCoproduct(schemas: List[Schema], discriminator: Option[Discriminator]) extends Schema {
+  case class SCoproduct(schemas: Set[Schema], discriminator: Option[Discriminator]) extends Schema {
     override def show: String = "oneOf:" + schemas.mkString(",")
   }
 

--- a/core/src/main/scala/tapir/Schema.scala
+++ b/core/src/main/scala/tapir/Schema.scala
@@ -40,7 +40,7 @@ object Schema {
   }
 
   case class SCoproduct(schemas: List[Schema], discriminator: Option[Discriminator[_]]) extends Schema {
-    override def show: String = "allOf:" + schemas.mkString(",")
+    override def show: String = "oneOf:" + schemas.mkString(",")
   }
 
   case class SObjectInfo(shortName: String, fullName: String)

--- a/core/src/main/scala/tapir/Schema.scala
+++ b/core/src/main/scala/tapir/Schema.scala
@@ -43,5 +43,5 @@ object Schema {
 
   case class SObjectInfo(shortName: String, fullName: String)
 
-  case class Discriminator(propertyName: String, mapping: Map[String, SRef])
+  case class Discriminator(propertyName: String, mappingOverride: Map[String, SRef])
 }

--- a/core/src/main/scala/tapir/SchemaFor.scala
+++ b/core/src/main/scala/tapir/SchemaFor.scala
@@ -7,7 +7,7 @@ import java.time._
 import java.util.Date
 
 import tapir.Schema._
-import tapir.generic.DiscriminatorDerivationMacro.oneOfMacro
+import tapir.generic.OneOfMacro.oneOfMacro
 import tapir.generic.SchemaForMagnoliaDerivation
 import tapir.model.Part
 
@@ -55,5 +55,5 @@ object SchemaFor extends SchemaForMagnoliaDerivation {
     override def schema: Schema = implicitly[SchemaFor[T]].schema
   }
 
-  def oneOf[E, V](extractor: E => V, stringer: E => String)(mapping: (V, SchemaFor[_])*): Discriminator = macro oneOfMacro[E, V]
+  def oneOf[E, V](extractor: E => V, asString: V => String)(mapping: (V, SchemaFor[_])*): Discriminator = macro oneOfMacro[E, V]
 }

--- a/core/src/main/scala/tapir/SchemaFor.scala
+++ b/core/src/main/scala/tapir/SchemaFor.scala
@@ -7,6 +7,7 @@ import java.time._
 import java.util.Date
 
 import tapir.Schema._
+import tapir.generic.DiscriminatorDerivationMacro.oneOfMacro
 import tapir.generic.SchemaForMagnoliaDerivation
 import tapir.model.Part
 
@@ -53,4 +54,6 @@ object SchemaFor extends SchemaForMagnoliaDerivation {
   implicit def schemaForPart[T: SchemaFor]: SchemaFor[Part[T]] = new SchemaFor[Part[T]] {
     override def schema: Schema = implicitly[SchemaFor[T]].schema
   }
+
+  implicit def oneOf[E, V](extractor: E => V, stringer: E => String)(mapping: (V, SchemaFor[_])*): Discriminator = macro oneOfMacro[E, V]
 }

--- a/core/src/main/scala/tapir/SchemaFor.scala
+++ b/core/src/main/scala/tapir/SchemaFor.scala
@@ -55,5 +55,5 @@ object SchemaFor extends SchemaForMagnoliaDerivation {
     override def schema: Schema = implicitly[SchemaFor[T]].schema
   }
 
-  implicit def oneOf[E, V](extractor: E => V, stringer: E => String)(mapping: (V, SchemaFor[_])*): Discriminator = macro oneOfMacro[E, V]
+  def oneOf[E, V](extractor: E => V, stringer: E => String)(mapping: (V, SchemaFor[_])*): Discriminator = macro oneOfMacro[E, V]
 }

--- a/core/src/main/scala/tapir/SchemaFor.scala
+++ b/core/src/main/scala/tapir/SchemaFor.scala
@@ -55,5 +55,5 @@ object SchemaFor extends SchemaForMagnoliaDerivation {
     override def schema: Schema = implicitly[SchemaFor[T]].schema
   }
 
-  def oneOf[E, V](extractor: E => V, asString: V => String)(mapping: (V, SchemaFor[_])*): Discriminator = macro oneOfMacro[E, V]
+  def oneOf[E, V](extractor: E => V, asString: V => String)(mapping: (V, SchemaFor[_])*): SchemaFor[E] = macro oneOfMacro[E, V]
 }

--- a/core/src/main/scala/tapir/generic/DiscriminatorDerivationMacro.scala
+++ b/core/src/main/scala/tapir/generic/DiscriminatorDerivationMacro.scala
@@ -1,27 +1,31 @@
 package tapir.generic
 
+import tapir.Schema.Discriminator
+import tapir.SchemaFor
+
 import scala.annotation.tailrec
 import scala.reflect.macros.blackbox
 
-object MethodNameMacro {
+object DiscriminatorDerivationMacro {
   // http://onoffswitch.net/extracting-scala-method-names-objects-macros/
-  implicit def methodName[A](extractor: A => Any): MethodName = macro methodNamesMacro[A]
 
-  def methodNamesMacro[A: c.WeakTypeTag](c: blackbox.Context)(extractor: c.Expr[A => Any]): c.Expr[MethodName] = {
+  def oneOfMacro[E: c.WeakTypeTag, V: c.WeakTypeTag](
+      c: blackbox.Context
+  )(extractor: c.Expr[E => V], stringer: c.Expr[E => String])(mapping: c.Expr[(V, SchemaFor[_])]*): c.Expr[Discriminator] = {
     import c.universe._
 
     @tailrec
     def resolveFunctionName(f: Function): String = {
       f.body match {
         // the function name
-        case t: Select => t.name.decoded
+        case t: Select => t.name.decodedName.toString
 
         case t: Function =>
           resolveFunctionName(t)
 
         // an application of a function and extracting the name
         case t: Apply if t.fun.isInstanceOf[Select] =>
-          t.fun.asInstanceOf[Select].name.decoded
+          t.fun.asInstanceOf[Select].name.decodedName.toString
 
         // curried lambda
         case t: Block if t.expr.isInstanceOf[Function] =>
@@ -29,20 +33,16 @@ object MethodNameMacro {
 
           resolveFunctionName(func)
 
-        case _ => {
+        case _ =>
           throw new RuntimeException("Unable to resolve function name for expression: " + f.body)
-        }
       }
     }
 
     val name = resolveFunctionName(extractor.tree.asInstanceOf[Function])
-
-    val literal = c.Expr[String](Literal(Constant(name)))
-
-    reify {
-      MethodName(literal.splice)
-    }
+    //TODO ${c.typecheck(stringer.tree)}.apply(k)
+    val aaa =
+      q"""val rawMapping = Map(..$mapping)
+         tapir.Schema.Discriminator($name,rawMapping.collect{case (k, sf)=> k.toString -> tapir.Schema.SRef(sf.schema.asInstanceOf[tapir.Schema.SObject].info.fullName)})"""
+    c.Expr[Discriminator](aaa)
   }
 }
-
-case class MethodName(name: String)

--- a/core/src/main/scala/tapir/generic/MethodNameMacro.scala
+++ b/core/src/main/scala/tapir/generic/MethodNameMacro.scala
@@ -4,6 +4,7 @@ import scala.annotation.tailrec
 import scala.reflect.macros.blackbox
 
 object MethodNameMacro {
+  // http://onoffswitch.net/extracting-scala-method-names-objects-macros/
   implicit def methodName[A](extractor: A => Any): MethodName = macro methodNamesMacro[A]
 
   def methodNamesMacro[A: c.WeakTypeTag](c: blackbox.Context)(extractor: c.Expr[A => Any]): c.Expr[MethodName] = {

--- a/core/src/main/scala/tapir/generic/MethodNameMacro.scala
+++ b/core/src/main/scala/tapir/generic/MethodNameMacro.scala
@@ -1,0 +1,47 @@
+package tapir.generic
+
+import scala.annotation.tailrec
+import scala.reflect.macros.blackbox
+
+object MethodNameMacro {
+  implicit def methodName[A](extractor: A => Any): MethodName = macro methodNamesMacro[A]
+
+  def methodNamesMacro[A: c.WeakTypeTag](c: blackbox.Context)(extractor: c.Expr[A => Any]): c.Expr[MethodName] = {
+    import c.universe._
+
+    @tailrec
+    def resolveFunctionName(f: Function): String = {
+      f.body match {
+        // the function name
+        case t: Select => t.name.decoded
+
+        case t: Function =>
+          resolveFunctionName(t)
+
+        // an application of a function and extracting the name
+        case t: Apply if t.fun.isInstanceOf[Select] =>
+          t.fun.asInstanceOf[Select].name.decoded
+
+        // curried lambda
+        case t: Block if t.expr.isInstanceOf[Function] =>
+          val func = t.expr.asInstanceOf[Function]
+
+          resolveFunctionName(func)
+
+        case _ => {
+          throw new RuntimeException("Unable to resolve function name for expression: " + f.body)
+        }
+      }
+    }
+
+    val name = resolveFunctionName(extractor.tree.asInstanceOf[Function])
+
+    val literal = c.Expr[String](Literal(Constant(name)))
+
+    reify {
+      MethodName(literal.splice)
+    }
+  }
+}
+
+case class MethodName(name: String)

--- a/core/src/main/scala/tapir/generic/OneOfMacro.scala
+++ b/core/src/main/scala/tapir/generic/OneOfMacro.scala
@@ -41,7 +41,7 @@ object OneOfMacro {
     val name = resolveFunctionName(extractor.tree.asInstanceOf[Function])
     val discriminator =
       q"""val rawMapping = Map(..$mapping)
-         tapir.Schema.Discriminator($name,rawMapping.collect{case (k, sf)=> ${reify(asString.splice)}.apply(k) -> tapir.Schema.SRef(sf.schema.asInstanceOf[tapir.Schema.SObject].info.fullName)})"""
+         tapir.Schema.Discriminator($name,rawMapping.collect{case (k, sf)=> $asString.apply(k) -> tapir.Schema.SRef(sf.schema.asInstanceOf[tapir.Schema.SObject].info.fullName)})"""
     c.Expr[Discriminator](discriminator)
   }
 }

--- a/core/src/main/scala/tapir/generic/SchemaForMagnoliaDerivation.scala
+++ b/core/src/main/scala/tapir/generic/SchemaForMagnoliaDerivation.scala
@@ -1,13 +1,12 @@
 package tapir.generic
 
 import magnolia._
-import tapir.{Schema, SchemaFor}
 import tapir.Schema._
+import tapir.generic.SchemaForMagnoliaDerivation.deriveInProgress
+import tapir.{Schema, SchemaFor}
 
 import scala.collection.mutable
 import scala.language.experimental.macros
-
-import SchemaForMagnoliaDerivation.deriveInProgress
 
 trait SchemaForMagnoliaDerivation {
   type Typeclass[T] = SchemaFor[T]
@@ -53,7 +52,7 @@ trait SchemaForMagnoliaDerivation {
   }
 
   def dispatch[T](ctx: SealedTrait[SchemaFor, T]): SchemaFor[T] = {
-    throw new RuntimeException(s"Sealed trait hierarchies are not yet supported for: ${ctx.typeName}")
+    SchemaFor(SCoproduct(ctx.subtypes.map(_.typeclass.schema).toList))
   }
 
   implicit def schemaForCaseClass[T]: SchemaFor[T] = macro Magnolia.gen[T]

--- a/core/src/main/scala/tapir/generic/SchemaForMagnoliaDerivation.scala
+++ b/core/src/main/scala/tapir/generic/SchemaForMagnoliaDerivation.scala
@@ -52,7 +52,7 @@ trait SchemaForMagnoliaDerivation {
   }
 
   def dispatch[T](ctx: SealedTrait[SchemaFor, T]): SchemaFor[T] = {
-    SchemaFor(SCoproduct(ctx.subtypes.map(_.typeclass.schema).toList, None))
+    SchemaFor(SCoproduct(ctx.subtypes.map(_.typeclass.schema).toSet, None))
   }
 
   implicit def schemaForCaseClass[T]: SchemaFor[T] = macro Magnolia.gen[T]

--- a/core/src/main/scala/tapir/generic/SchemaForMagnoliaDerivation.scala
+++ b/core/src/main/scala/tapir/generic/SchemaForMagnoliaDerivation.scala
@@ -52,7 +52,7 @@ trait SchemaForMagnoliaDerivation {
   }
 
   def dispatch[T](ctx: SealedTrait[SchemaFor, T]): SchemaFor[T] = {
-    SchemaFor(SCoproduct(ctx.subtypes.map(_.typeclass.schema).toList))
+    SchemaFor(SCoproduct(ctx.subtypes.map(_.typeclass.schema).toList, None))
   }
 
   implicit def schemaForCaseClass[T]: SchemaFor[T] = macro Magnolia.gen[T]

--- a/doc/endpoint/codecs.md
+++ b/doc/endpoint/codecs.md
@@ -66,10 +66,8 @@ The discriminator may look like:
 ```scala
 val sPerson = implicitly[SchemaFor[Person]]
 val sOrganization = implicitly[SchemaFor[Organization]]
-val discriminator = 
-    SchemaFor.oneOf[Entity, String](_.kind, _.toString)("person" -> sPerson, "org" -> sOrganization)
 implicit val sEntity: SchemaFor[Entity] = 
-    SchemaFor(SCoproduct(List(sPerson.schema, sOrganization.schema), Some(discriminator)))
+    SchemaFor.oneOf[Entity, String](_.kind, _.toString)("person" -> sPerson, "org" -> sOrganization)
 ```
  
 ## Media types

--- a/doc/endpoint/codecs.md
+++ b/doc/endpoint/codecs.md
@@ -47,6 +47,31 @@ The schema is left unchanged when mapping over a codec, as the underlying repres
 When codecs are derived for complex types, e.g. for json mapping, schemas are looked up through implicit
 `SchemaFor[T]` values. See [json support](json.html) for more details.
 
+Tapir supports schema generation for coproduct types of the box. In order to extend openApi schema
+representation a discriminator object can be specified. 
+
+For example, given following coproduct:
+```scala
+sealed trait Entity{
+  def kind: String
+} 
+case class Person(firstName:String, lastName:String) extends Entity {
+  def kind: String = "person"
+}
+case class Organization(name: String) extends Entity {
+  def kind: String = "org"  
+}
+```
+The discriminator may look like:
+```scala
+val sPerson = implicitly[SchemaFor[Person]]
+val sOrganization = implicitly[SchemaFor[Organization]]
+val discriminator = 
+    SchemaFor.oneOf[Entity, String](_.kind, _.toString)("person" -> sPerson, "org" -> sOrganization)
+implicit val sEntity: SchemaFor[Entity] = 
+    SchemaFor(SCoproduct(List(sPerson.schema, sOrganization.schema), Some(discriminator)))
+```
+ 
 ## Media types
 
 Codecs carry an additional type parameter, which specifies the media type. Some built-in media types include 

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenAPIDocs.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenAPIDocs.scala
@@ -9,10 +9,10 @@ import scala.collection.immutable.ListMap
 object EndpointToOpenAPIDocs {
   def toOpenAPI(api: Info, es: Iterable[Endpoint[_, _, _, _]], options: OpenAPIDocsOptions): OpenAPI = {
     val es2 = es.map(nameAllPathCapturesInEndpoint)
-    val objectSchemas = ObjectSchemasForEndpoints(es2)
+    val (keyToSchema, objectSchemas) = ObjectSchemasForEndpoints(es2)
     val securitySchemes = SecuritySchemesForEndpoints(es2)
     val pathCreator = new EndpointToOpenApiPaths(objectSchemas, securitySchemes, options)
-    val componentsCreator = new EndpointToOpenApiComponents(objectSchemas, securitySchemes)
+    val componentsCreator = new EndpointToOpenApiComponents(keyToSchema, securitySchemes)
 
     val base = apiToOpenApi(api, componentsCreator)
 

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenApiComponents.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenApiComponents.scala
@@ -1,11 +1,14 @@
 package tapir.docs.openapi
 
-import tapir.docs.openapi.schema.ObjectSchemas
-import tapir.openapi._
+import tapir.docs.openapi.schema.SchemaKey
+import tapir.openapi.OpenAPI.ReferenceOr
+import tapir.openapi.{Schema => OSchema, _}
 
-private[openapi] class EndpointToOpenApiComponents(objectSchemas: ObjectSchemas, securitySchemes: SecuritySchemes) {
+import scala.collection.immutable.ListMap
+
+private[openapi] class EndpointToOpenApiComponents(keyToSchema: ListMap[SchemaKey, ReferenceOr[OSchema]],
+                                                   securitySchemes: SecuritySchemes) {
   def components: Option[Components] = {
-    val keyToSchema = objectSchemas.keyToOSchema
     if (keyToSchema.nonEmpty || securitySchemes.nonEmpty)
       Some(Components(keyToSchema, securitySchemes.values.toMap.mapValues(Right(_)).toListMap))
     else None

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenApiComponents.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenApiComponents.scala
@@ -6,8 +6,10 @@ import tapir.openapi.{Schema => OSchema, _}
 
 import scala.collection.immutable.ListMap
 
-private[openapi] class EndpointToOpenApiComponents(keyToSchema: ListMap[SchemaKey, ReferenceOr[OSchema]],
-                                                   securitySchemes: SecuritySchemes) {
+private[openapi] class EndpointToOpenApiComponents(
+    keyToSchema: ListMap[SchemaKey, ReferenceOr[OSchema]],
+    securitySchemes: SecuritySchemes
+) {
   def components: Option[Components] = {
     if (keyToSchema.nonEmpty || securitySchemes.nonEmpty)
       Some(Components(keyToSchema, securitySchemes.values.toMap.mapValues(Right(_)).toListMap))

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/DiscriminatorToOpenApi.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/DiscriminatorToOpenApi.scala
@@ -1,13 +1,13 @@
 package tapir.docs.openapi.schema
 
-import tapir.Schema.SObject
 import tapir.openapi.{Discriminator, _}
 import tapir.{Schema => TSchema}
 
 class DiscriminatorToOpenApi(schemaReferenceMapper: SchemaReferenceMapper) {
-  def apply(discriminator: TSchema.Discriminator[_]): Discriminator = {
+  def apply(discriminator: TSchema.Discriminator): Discriminator = {
     val schemas = Some(
-      discriminator.mapping.map { case (k, SObject(i, _, _)) => k -> schemaReferenceMapper.map(i.fullName).$ref }.toListMap)
+      discriminator.mapping.map { case (k, TSchema.SRef(fullName)) => k -> schemaReferenceMapper.map(fullName).$ref }.toListMap
+    )
     Discriminator(discriminator.propertyName, schemas)
   }
 }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/DiscriminatorToOpenApi.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/DiscriminatorToOpenApi.scala
@@ -6,7 +6,7 @@ import tapir.{Schema => TSchema}
 class DiscriminatorToOpenApi(schemaReferenceMapper: SchemaReferenceMapper) {
   def apply(discriminator: TSchema.Discriminator): Discriminator = {
     val schemas = Some(
-      discriminator.mapping.map { case (k, TSchema.SRef(fullName)) => k -> schemaReferenceMapper.map(fullName).$ref }.toListMap
+      discriminator.mappingOverride.map { case (k, TSchema.SRef(fullName)) => k -> schemaReferenceMapper.map(fullName).$ref }.toListMap
     )
     Discriminator(discriminator.propertyName, schemas)
   }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/DiscriminatorToOpenApi.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/DiscriminatorToOpenApi.scala
@@ -1,0 +1,13 @@
+package tapir.docs.openapi.schema
+
+import tapir.Schema.SObject
+import tapir.openapi.{Discriminator, _}
+import tapir.{Schema => TSchema}
+
+class DiscriminatorToOpenApi(schemaReferenceMapper: SchemaReferenceMapper) {
+  def apply(discriminator: TSchema.Discriminator[_]): Discriminator = {
+    val schemas = Some(
+      discriminator.mapping.map { case (k, SObject(i, _, _)) => k -> schemaReferenceMapper.map(i.fullName).$ref }.toListMap)
+    Discriminator(discriminator.propertyName, schemas)
+  }
+}

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemas.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemas.scala
@@ -4,9 +4,11 @@ import tapir.openapi.OpenAPI.ReferenceOr
 import tapir.openapi.{Schema => OSchema}
 import tapir.{Schema => TSchema}
 
-class ObjectSchemas(tschemaToOSchema: TSchemaToOSchema,
-                    schemaReferenceMapper: SchemaReferenceMapper,
-                    discriminatorToOpenApi: DiscriminatorToOpenApi) {
+class ObjectSchemas(
+    tschemaToOSchema: TSchemaToOSchema,
+    schemaReferenceMapper: SchemaReferenceMapper,
+    discriminatorToOpenApi: DiscriminatorToOpenApi
+) {
   def apply(schema: TSchema): ReferenceOr[OSchema] = {
     schema match {
       case TSchema.SObject(info, _, _) => Left(schemaReferenceMapper.map(info.fullName))

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemas.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemas.scala
@@ -1,24 +1,18 @@
 package tapir.docs.openapi.schema
 
-import tapir.Schema.{SCoproduct, SObject, SObjectInfo, SRef}
 import tapir.openapi.OpenAPI.ReferenceOr
-import tapir.openapi.{Discriminator, Schema => OSchema, _}
+import tapir.openapi.{Schema => OSchema}
 import tapir.{Schema => TSchema}
 
-import scala.collection.immutable.ListMap
-
-class ObjectSchemas(tschemaToOSchema: TSchemaToOSchema, schemaKeys: Map[SObjectInfo, (SchemaKey, ReferenceOr[OSchema])]) {
+class ObjectSchemas(tschemaToOSchema: TSchemaToOSchema,
+                    schemaReferenceMapper: SchemaReferenceMapper,
+                    discriminatorToOpenApi: DiscriminatorToOpenApi) {
   def apply(schema: TSchema): ReferenceOr[OSchema] = {
     schema match {
-      // by construction, references to all object schemas should be present in tschemaToOSchema
-      case SObject(info, _, _) => tschemaToOSchema(SRef(info.fullName))
-      case SCoproduct(schemas, d) =>
-        Right(
-          OSchema.apply(schemas.map(apply),
-                        d.map(x => Discriminator(x.propertyName, Some(x.mapping.mapValues(v => apply(v.schema).left.get.$ref).toListMap)))))
+      case TSchema.SObject(info, _, _) => Left(schemaReferenceMapper.map(info.fullName))
+      case TSchema.SCoproduct(schemas, d) =>
+        Right(OSchema.apply(schemas.map(apply), d.map(discriminatorToOpenApi.apply)))
       case _ => tschemaToOSchema(schema)
     }
   }
-
-  def keyToOSchema: ListMap[SchemaKey, ReferenceOr[OSchema]] = schemaKeys.values.toListMap
 }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemas.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemas.scala
@@ -1,6 +1,6 @@
 package tapir.docs.openapi.schema
 
-import tapir.Schema.{SObject, SObjectInfo, SRef}
+import tapir.Schema.{SCoproduct, SObject, SObjectInfo, SRef}
 import tapir.openapi.OpenAPI.ReferenceOr
 import tapir.openapi.{Schema => OSchema}
 import tapir.{Schema => TSchema}
@@ -12,6 +12,7 @@ class ObjectSchemas(tschemaToOSchema: TSchemaToOSchema, schemaKeys: Map[SObjectI
     schema match {
       // by construction, references to all object schemas should be present in tschemaToOSchema
       case SObject(info, _, _) => tschemaToOSchema(SRef(info.fullName))
+      case SCoproduct(schemas)      => Right(OSchema.apply(schemas.map(apply)))
       case _                   => tschemaToOSchema(schema)
     }
   }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemas.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemas.scala
@@ -13,7 +13,7 @@ class ObjectSchemas(
     schema match {
       case TSchema.SObject(info, _, _) => Left(schemaReferenceMapper.map(info.fullName))
       case TSchema.SCoproduct(schemas, d) =>
-        Right(OSchema.apply(schemas.map(apply), d.map(discriminatorToOpenApi.apply)))
+        Right(OSchema.apply(schemas.map(apply).toList, d.map(discriminatorToOpenApi.apply)))
       case _ => tschemaToOSchema(schema)
     }
   }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
@@ -1,8 +1,8 @@
 package tapir.docs.openapi.schema
 
 import tapir.Schema.SObjectInfo
-import tapir.{Schema => TSchema, _}
 import tapir.docs.openapi.uniqueName
+import tapir.{Schema => TSchema, _}
 
 object ObjectSchemasForEndpoints {
 
@@ -35,6 +35,8 @@ object ObjectSchemasForEndpoints {
     schema match {
       case s: TSchema.SObject =>
         List(s)
+      case s: TSchema.SCoproduct =>
+        s.schemas.collect { case so: TSchema.SObject => so }
       case _ => List.empty
     }
   }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
@@ -29,7 +29,7 @@ object ObjectSchemasForEndpoints {
           .map(_._2)
           .flatMap(collectFieldObjects)
           .toList
-      case c: TSchema.SCoproduct => c.schemas.flatMap(collectFieldObjects)
+      case c: TSchema.SCoproduct => c.schemas.flatMap(collectFieldObjects).toList
       case _                     => List()
     }
   }
@@ -61,7 +61,7 @@ object ObjectSchemasForEndpoints {
       case s: TSchema.SObject =>
         List(s)
       case s: TSchema.SCoproduct =>
-        s.schemas.collect { case so: TSchema.SObject => so }
+        s.schemas.collect { case so: TSchema.SObject => so }.toList
       case _ => List.empty
     }
   }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/SchemaReferenceMapper.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/SchemaReferenceMapper.scala
@@ -1,0 +1,10 @@
+package tapir.docs.openapi.schema
+
+import tapir.openapi.Reference
+
+class SchemaReferenceMapper(fullNameToKey: Map[String, SchemaKey]) {
+
+  def map(fullName: String): Reference = {
+    Reference("#/components/schemas/" + fullNameToKey(fullName))
+  }
+}

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
@@ -41,8 +41,6 @@ private[schema] class TSchemaToOSchema(fullNameToKey: Map[String, SchemaKey]) {
         Right(OSchema(SchemaType.String).copy(format = Some(SchemaFormat.DateTime)))
       case SRef(fullName) =>
         Left(Reference("#/components/schemas/" + fullNameToKey(fullName)))
-      case TSchema.SCoproduct(schemas) =>
-        Right(OSchema(schemas.map(apply)))
     }
   }
 }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
@@ -41,6 +41,8 @@ private[schema] class TSchemaToOSchema(fullNameToKey: Map[String, SchemaKey]) {
         Right(OSchema(SchemaType.String).copy(format = Some(SchemaFormat.DateTime)))
       case SRef(fullName) =>
         Left(Reference("#/components/schemas/" + fullNameToKey(fullName)))
+      case TSchema.SCoproduct(schemas) =>
+        Right(OSchema(schemas.map(apply)))
     }
   }
 }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
@@ -45,8 +45,11 @@ private[schema] class TSchemaToOSchema(schemaReferenceMapper: SchemaReferenceMap
         Left(schemaReferenceMapper.map(fullName))
       case SCoproduct(schemas, d) =>
         Right(
-          OSchema.apply(schemas.collect { case s: TSchema.SObject => Left(schemaReferenceMapper.map(s.info.fullName)) },
-                        d.map(discriminatorToOpenApi.apply)))
+          OSchema.apply(
+            schemas.collect { case s: TSchema.SObject => Left(schemaReferenceMapper.map(s.info.fullName)) },
+            d.map(discriminatorToOpenApi.apply)
+          )
+        )
     }
   }
 }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
@@ -1,6 +1,6 @@
 package tapir.docs.openapi.schema
 
-import tapir.Schema.SRef
+import tapir.Schema.SCoproduct
 import tapir.openapi.OpenAPI.ReferenceOr
 import tapir.openapi.{Schema => OSchema, _}
 import tapir.{Schema => TSchema}
@@ -8,7 +8,7 @@ import tapir.{Schema => TSchema}
 /**
   * Converts a tapir schema to an OpenAPI schema, using the given map to resolve references.
   */
-private[schema] class TSchemaToOSchema(fullNameToKey: Map[String, SchemaKey]) {
+private[schema] class TSchemaToOSchema(schemaReferenceMapper: SchemaReferenceMapper, discriminatorToOpenApi: DiscriminatorToOpenApi) {
   def apply(schema: TSchema): ReferenceOr[OSchema] = {
     schema match {
       case TSchema.SInteger =>
@@ -39,8 +39,12 @@ private[schema] class TSchemaToOSchema(fullNameToKey: Map[String, SchemaKey]) {
         Right(OSchema(SchemaType.String).copy(format = Some(SchemaFormat.Date)))
       case TSchema.SDateTime =>
         Right(OSchema(SchemaType.String).copy(format = Some(SchemaFormat.DateTime)))
-      case SRef(fullName) =>
-        Left(Reference("#/components/schemas/" + fullNameToKey(fullName)))
+      case TSchema.SRef(fullName) =>
+        Left(schemaReferenceMapper.map(fullName))
+      case SCoproduct(schemas, d) =>
+        Right(
+          OSchema.apply(schemas.collect { case s: TSchema.SObject => Left(schemaReferenceMapper.map(s.info.fullName)) },
+                        d.map(discriminatorToOpenApi.apply)))
     }
   }
 }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
@@ -46,7 +46,7 @@ private[schema] class TSchemaToOSchema(schemaReferenceMapper: SchemaReferenceMap
       case SCoproduct(schemas, d) =>
         Right(
           OSchema.apply(
-            schemas.collect { case s: TSchema.SObject => Left(schemaReferenceMapper.map(s.info.fullName)) },
+            schemas.collect { case s: TSchema.SObject => Left(schemaReferenceMapper.map(s.info.fullName)) }.toList,
             d.map(discriminatorToOpenApi.apply)
           )
         )

--- a/docs/openapi-docs/src/test/resources/expected_coproduct.yml
+++ b/docs/openapi-docs/src/test/resources/expected_coproduct.yml
@@ -1,0 +1,36 @@
+openapi: 3.0.1
+info:
+  title: Fruits
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Person'
+                  - $ref: '#/components/schemas/Organization'
+components:
+  schemas:
+    Person:
+      required:
+        - name
+        - age
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+    Organization:
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          type: string

--- a/docs/openapi-docs/src/test/resources/expected_coproduct_discriminator.yml
+++ b/docs/openapi-docs/src/test/resources/expected_coproduct_discriminator.yml
@@ -1,0 +1,41 @@
+openapi: 3.0.1
+info:
+  title: Fruits
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/Person'
+                  - $ref: '#/components/schemas/Organization'
+                discriminator:
+                  propertyName: name
+                  mapping:
+                    john: '#/components/schemas/Person'
+                    sml: '#/components/schemas/Organization'
+components:
+  schemas:
+    Person:
+      required:
+        - name
+        - age
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+    Organization:
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          type: string

--- a/docs/openapi-docs/src/test/resources/expected_coproduct_discriminator_nested.yml
+++ b/docs/openapi-docs/src/test/resources/expected_coproduct_discriminator_nested.yml
@@ -1,0 +1,48 @@
+openapi: 3.0.1
+info:
+  title: Fruits
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NestedEntity'
+components:
+  schemas:
+    NestedEntity:
+      required:
+        - entity
+      type: object
+      properties:
+        entity:
+          oneOf:
+            - $ref: '#/components/schemas/Person'
+            - $ref: '#/components/schemas/Organization'
+          discriminator:
+            propertyName: name
+            mapping:
+              john: '#/components/schemas/Person'
+              sml: '#/components/schemas/Organization'
+    Person:
+      required:
+        - name
+        - age
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+    Organization:
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          type: string

--- a/docs/openapi-docs/src/test/resources/expected_coproduct_nested.yml
+++ b/docs/openapi-docs/src/test/resources/expected_coproduct_nested.yml
@@ -1,0 +1,43 @@
+openapi: 3.0.1
+info:
+  title: Fruits
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NestedEntity'
+components:
+  schemas:
+    NestedEntity:
+      required:
+        - entity
+      type: object
+      properties:
+        entity:
+          oneOf:
+            - $ref: '#/components/schemas/Person'
+            - $ref: '#/components/schemas/Organization'
+    Person:
+      required:
+        - name
+        - age
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+    Organization:
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          type: string

--- a/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
@@ -184,8 +184,8 @@ class VerifyYamlTest extends FunSuite with Matchers {
   test("should match the expected yaml when using coproduct types with discriminator") {
     val sPerson = implicitly[SchemaFor[Person]]
     val sOrganization = implicitly[SchemaFor[Organization]]
-    val discr = SchemaFor.oneOf[Entity, String](_.name, _.toString)("john" -> sPerson, "sml" -> sOrganization)
-    implicit val sEntity: SchemaFor[Entity] = SchemaFor(SCoproduct(List(sPerson.schema, sOrganization.schema), Some(discr)))
+    val discriminator = SchemaFor.oneOf[Entity, String](_.name, _.toString)("john" -> sPerson, "sml" -> sOrganization)
+    implicit val sEntity: SchemaFor[Entity] = SchemaFor(SCoproduct(List(sPerson.schema, sOrganization.schema), Some(discriminator)))
 
     val expectedYaml = loadYaml("expected_coproduct_discriminator.yml")
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, Entity, Nothing] = endpoint

--- a/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
@@ -218,7 +218,7 @@ class VerifyYamlTest extends FunSuite with Matchers {
       .out(jsonBody[NestedEntity])
     val actualYaml = endpoint_wit_sealed_trait.toOpenAPI(Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
-    println(actualYaml)
+
     actualYamlNoIndent shouldBe expectedYaml
   }
 

--- a/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
@@ -2,175 +2,194 @@ package tapir.docs.openapi
 
 import io.circe.generic.auto._
 import org.scalatest.{FunSuite, Matchers}
+import tapir.Schema.{Discriminator, SCoproduct}
 import tapir._
+import tapir.generic.{MethodName, MethodNameMacro}
 import tapir.json.circe._
-import tapir.model.{Method, StatusCodes}
+import tapir.openapi.Info
 import tapir.openapi.circe.yaml._
-import tapir.openapi.{Contact, Info, License}
-import tapir.tests._
 
 import scala.io.Source
 
 class VerifyYamlTest extends FunSuite with Matchers {
 
-  val all_the_way: Endpoint[(FruitAmount, String), Unit, (FruitAmount, Int), Nothing] = endpoint
-    .in(("fruit" / path[String] / "amount" / path[Int]).mapTo(FruitAmount))
-    .in(query[String]("color"))
-    .out(jsonBody[FruitAmount])
-    .out(header[Int]("X-Role"))
+//  val all_the_way: Endpoint[(FruitAmount, String), Unit, (FruitAmount, Int), Nothing] = endpoint
+//    .in(("fruit" / path[String] / "amount" / path[Int]).mapTo(FruitAmount))
+//    .in(query[String]("color"))
+//    .out(jsonBody[FruitAmount])
+//    .out(header[Int]("X-Role"))
+//
+//  test("should match the expected yaml") {
+//    val expectedYaml = loadYaml("expected.yml")
+//
+//    val actualYaml = List(in_query_query_out_string, all_the_way).toOpenAPI(Info("Fruits", "1.0")).toYaml
+//    val actualYamlNoIndent = noIndentation(actualYaml)
+//
+//    actualYamlNoIndent shouldBe expectedYaml
+//  }
+//
+//  val endpoint_wit_recursive_structure: Endpoint[Unit, Unit, F1, Nothing] = endpoint
+//    .out(jsonBody[F1])
+//
+//  test("should match the expected yaml when schema is recursive") {
+//    val expectedYaml = loadYaml("expected_recursive.yml")
+//
+//    val actualYaml = endpoint_wit_recursive_structure.toOpenAPI(Info("Fruits", "1.0")).toYaml
+//    val actualYamlNoIndent = noIndentation(actualYaml)
+//
+//    actualYamlNoIndent shouldBe expectedYaml
+//  }
+//
+//  test("should use custom operationId generator") {
+//    def customOperationIdGenerator(pc: Vector[String], m: Method) = pc.map(_.toUpperCase).mkString("", "+", "-") + m.m.toUpperCase
+//    val options = OpenAPIDocsOptions.default.copy(customOperationIdGenerator)
+//    val expectedYaml = loadYaml("expected_custom_operation_id.yml")
+//
+//    val actualYaml = in_query_query_out_string
+//      .in("add")
+//      .in("path")
+//      .toOpenAPI(Info("Fruits", "1.0"))(options)
+//      .toYaml
+//    noIndentation(actualYaml) shouldBe expectedYaml
+//  }
+//
+//  val streaming_endpoint: Endpoint[Vector[Byte], Unit, Vector[Byte], Vector[Byte]] = endpoint
+//    .in(streamBody[Vector[Byte]](schemaFor[String], MediaType.TextPlain()))
+//    .out(streamBody[Vector[Byte]](Schema.SBinary, MediaType.OctetStream()))
+//
+//  test("should match the expected yaml for streaming endpoints") {
+//    val expectedYaml = loadYaml("expected_streaming.yml")
+//
+//    val actualYaml = streaming_endpoint.toOpenAPI(Info("Fruits", "1.0")).toYaml
+//    val actualYamlNoIndent = noIndentation(actualYaml)
+//
+//    actualYamlNoIndent shouldBe expectedYaml
+//  }
+//
+//  test("should support tags") {
+//    val userTaggedEndpointShow = endpoint.tag("user").in("user" / "show").get.out(plainBody[String])
+//    val userTaggedEdnpointSearch = endpoint.tags(List("user", "admin")).in("user" / "search").get.out(plainBody[String])
+//    val adminTaggedEndpointAdd = endpoint.tag("admin").in("admin" / "add").get.out(plainBody[String])
+//
+//    val expectedYaml = loadYaml("expected_tags.yml")
+//
+//    val actualYaml = List(userTaggedEndpointShow, userTaggedEdnpointSearch, adminTaggedEndpointAdd).toOpenAPI(Info("Fruits", "1.0")).toYaml
+//    val actualYamlNoIndent = noIndentation(actualYaml)
+//
+//    actualYamlNoIndent shouldBe expectedYaml
+//  }
+//
+//  test("should match the expected yaml for general info") {
+//    val expectedYaml = loadYaml("expected_general_info.yml")
+//
+//    val api = Info(
+//      "Fruits",
+//      "1.0",
+//      description = Some("Fruits are awesome"),
+//      termsOfService = Some("our.terms.of.service"),
+//      contact = Some(Contact(Some("Author"), Some("tapir@softwaremill.com"), Some("tapir.io"))),
+//      license = Some(License("MIT", Some("mit.license")))
+//    )
+//
+//    val actualYaml = in_query_query_out_string.toOpenAPI(api).toYaml
+//    val actualYamlNoIndent = noIndentation(actualYaml)
+//
+//    actualYamlNoIndent shouldBe expectedYaml
+//  }
+//
+//  test("should support multipart") {
+//    val expectedYaml = loadYaml("expected_multipart.yml")
+//
+//    val actualYaml = List(in_file_multipart_out_multipart).toOpenAPI("Fruits", "1.0").toYaml
+//    val actualYamlNoIndent = noIndentation(actualYaml)
+//
+//    actualYamlNoIndent shouldBe expectedYaml
+//  }
+//
+//  test("should support authentication") {
+//    val expectedYaml = loadYaml("expected_auth.yml")
+//
+//    val e1 = endpoint.in(auth.bearer).in("api1" / path[String]).out(stringBody)
+//    val e2 = endpoint.in(auth.bearer).in("api2" / path[String]).out(stringBody)
+//    val e3 = endpoint.in(auth.apiKey(header[String]("apikey"))).in("api3" / path[String]).out(stringBody)
+//
+//    val actualYaml = List(e1, e2, e3).toOpenAPI(Info("Fruits", "1.0")).toYaml
+//    val actualYamlNoIndent = noIndentation(actualYaml)
+//
+//    actualYamlNoIndent shouldBe expectedYaml
+//  }
+//
+//  test("should support empty bodies") {
+//    val expectedYaml = loadYaml("expected_empty.yml")
+//
+//    val actualYaml = List(endpoint).toOpenAPI(Info("Fruits", "1.0")).toYaml
+//    val actualYamlNoIndent = noIndentation(actualYaml)
+//
+//    actualYamlNoIndent shouldBe expectedYaml
+//  }
+//
+//  test("should support multiple status codes") {
+//    // given
+//    val expectedYaml = loadYaml("expected_status_codes.yml")
+//
+//    // work-around for #10: unsupported sealed trait families
+//    implicit val schemaForErrorInfo: SchemaFor[ErrorInfo] = new SchemaFor[ErrorInfo] {
+//      override def schema: Schema = Schema.SObject(Schema.SObjectInfo("ErrorInfo", "ErrorInfo"), Nil, Nil)
+//    }
+//
+//    val e = endpoint.errorOut(
+//      statusFrom(
+//        jsonBody[ErrorInfo],
+//        StatusCodes.BadRequest,
+//        whenClass[ErrorInfo.NotFound] -> StatusCodes.NotFound,
+//        whenClass[ErrorInfo.Unauthorized] -> StatusCodes.Unauthorized
+//      ).defaultSchema(schemaFor[ErrorInfo.Unknown]))
+//
+//    // when
+//    val actualYaml = List(e).toOpenAPI(Info("Fruits", "1.0")).toYaml
+//    val actualYamlNoIndent = noIndentation(actualYaml)
+//
+//    // then
+//    actualYamlNoIndent shouldBe expectedYaml
+//  }
+//
+//  test("should keep the order of multiple endpoints") {
+//    val expectedYaml = loadYaml("expected_multiple.yml")
+//
+//    val actualYaml = List(endpoint.in("p1"), endpoint.in("p3"), endpoint.in("p2"), endpoint.in("p5"), endpoint.in("p4"))
+//      .toOpenAPI(Info("Fruits", "1.0"))
+//      .toYaml
+//    println(actualYaml)
+//    val actualYamlNoIndent = noIndentation(actualYaml)
+//
+//    actualYamlNoIndent shouldBe expectedYaml
+//  }
+//
 
-  test("should match the expected yaml") {
-    val expectedYaml = loadYaml("expected.yml")
-
-    val actualYaml = List(in_query_query_out_string, all_the_way).toOpenAPI(Info("Fruits", "1.0")).toYaml
-    val actualYamlNoIndent = noIndentation(actualYaml)
-
-    actualYamlNoIndent shouldBe expectedYaml
-  }
-
-  val endpoint_wit_recursive_structure: Endpoint[Unit, Unit, F1, Nothing] = endpoint
-    .out(jsonBody[F1])
-
-  test("should match the expected yaml when schema is recursive") {
-    val expectedYaml = loadYaml("expected_recursive.yml")
-
-    val actualYaml = endpoint_wit_recursive_structure.toOpenAPI(Info("Fruits", "1.0")).toYaml
-    val actualYamlNoIndent = noIndentation(actualYaml)
-
-    actualYamlNoIndent shouldBe expectedYaml
-  }
-
-  test("should use custom operationId generator") {
-    def customOperationIdGenerator(pc: Vector[String], m: Method) = pc.map(_.toUpperCase).mkString("", "+", "-") + m.m.toUpperCase
-    val options = OpenAPIDocsOptions.default.copy(customOperationIdGenerator)
-    val expectedYaml = loadYaml("expected_custom_operation_id.yml")
-
-    val actualYaml = in_query_query_out_string
-      .in("add")
-      .in("path")
-      .toOpenAPI(Info("Fruits", "1.0"))(options)
-      .toYaml
-    noIndentation(actualYaml) shouldBe expectedYaml
-  }
-
-  val streaming_endpoint: Endpoint[Vector[Byte], Unit, Vector[Byte], Vector[Byte]] = endpoint
-    .in(streamBody[Vector[Byte]](schemaFor[String], MediaType.TextPlain()))
-    .out(streamBody[Vector[Byte]](Schema.SBinary, MediaType.OctetStream()))
-
-  test("should match the expected yaml for streaming endpoints") {
-    val expectedYaml = loadYaml("expected_streaming.yml")
-
-    val actualYaml = streaming_endpoint.toOpenAPI(Info("Fruits", "1.0")).toYaml
-    val actualYamlNoIndent = noIndentation(actualYaml)
-
-    actualYamlNoIndent shouldBe expectedYaml
-  }
-
-  test("should support tags") {
-    val userTaggedEndpointShow = endpoint.tag("user").in("user" / "show").get.out(plainBody[String])
-    val userTaggedEdnpointSearch = endpoint.tags(List("user", "admin")).in("user" / "search").get.out(plainBody[String])
-    val adminTaggedEndpointAdd = endpoint.tag("admin").in("admin" / "add").get.out(plainBody[String])
-
-    val expectedYaml = loadYaml("expected_tags.yml")
-
-    val actualYaml = List(userTaggedEndpointShow, userTaggedEdnpointSearch, adminTaggedEndpointAdd).toOpenAPI(Info("Fruits", "1.0")).toYaml
-    val actualYamlNoIndent = noIndentation(actualYaml)
-
-    actualYamlNoIndent shouldBe expectedYaml
-  }
-
-  test("should match the expected yaml for general info") {
-    val expectedYaml = loadYaml("expected_general_info.yml")
-
-    val api = Info(
-      "Fruits",
-      "1.0",
-      description = Some("Fruits are awesome"),
-      termsOfService = Some("our.terms.of.service"),
-      contact = Some(Contact(Some("Author"), Some("tapir@softwaremill.com"), Some("tapir.io"))),
-      license = Some(License("MIT", Some("mit.license")))
-    )
-
-    val actualYaml = in_query_query_out_string.toOpenAPI(api).toYaml
-    val actualYamlNoIndent = noIndentation(actualYaml)
-
-    actualYamlNoIndent shouldBe expectedYaml
-  }
-
-  test("should support multipart") {
-    val expectedYaml = loadYaml("expected_multipart.yml")
-
-    val actualYaml = List(in_file_multipart_out_multipart).toOpenAPI("Fruits", "1.0").toYaml
-    val actualYamlNoIndent = noIndentation(actualYaml)
-
-    actualYamlNoIndent shouldBe expectedYaml
-  }
-
-  test("should support authentication") {
-    val expectedYaml = loadYaml("expected_auth.yml")
-
-    val e1 = endpoint.in(auth.bearer).in("api1" / path[String]).out(stringBody)
-    val e2 = endpoint.in(auth.bearer).in("api2" / path[String]).out(stringBody)
-    val e3 = endpoint.in(auth.apiKey(header[String]("apikey"))).in("api3" / path[String]).out(stringBody)
-
-    val actualYaml = List(e1, e2, e3).toOpenAPI(Info("Fruits", "1.0")).toYaml
-    val actualYamlNoIndent = noIndentation(actualYaml)
-
-    actualYamlNoIndent shouldBe expectedYaml
-  }
-
-  test("should support empty bodies") {
-    val expectedYaml = loadYaml("expected_empty.yml")
-
-    val actualYaml = List(endpoint).toOpenAPI(Info("Fruits", "1.0")).toYaml
-    val actualYamlNoIndent = noIndentation(actualYaml)
-
-    actualYamlNoIndent shouldBe expectedYaml
-  }
-
-  test("should support multiple status codes") {
-    // given
-    val expectedYaml = loadYaml("expected_status_codes.yml")
-
-    // work-around for #10: unsupported sealed trait families
-    implicit val schemaForErrorInfo: SchemaFor[ErrorInfo] = new SchemaFor[ErrorInfo] {
-      override def schema: Schema = Schema.SObject(Schema.SObjectInfo("ErrorInfo", "ErrorInfo"), Nil, Nil)
-    }
-
-    val e = endpoint.errorOut(
-      statusFrom(
-        jsonBody[ErrorInfo],
-        StatusCodes.BadRequest,
-        whenClass[ErrorInfo.NotFound] -> StatusCodes.NotFound,
-        whenClass[ErrorInfo.Unauthorized] -> StatusCodes.Unauthorized
-      ).defaultSchema(schemaFor[ErrorInfo.Unknown]))
-
-    // when
-    val actualYaml = List(e).toOpenAPI(Info("Fruits", "1.0")).toYaml
-    val actualYamlNoIndent = noIndentation(actualYaml)
-
-    // then
-    actualYamlNoIndent shouldBe expectedYaml
-  }
-
-  test("should keep the order of multiple endpoints") {
-    val expectedYaml = loadYaml("expected_multiple.yml")
-
-    val actualYaml = List(endpoint.in("p1"), endpoint.in("p3"), endpoint.in("p2"), endpoint.in("p5"), endpoint.in("p4"))
-      .toOpenAPI(Info("Fruits", "1.0"))
-      .toYaml
-    println(actualYaml)
-    val actualYamlNoIndent = noIndentation(actualYaml)
-
-    actualYamlNoIndent shouldBe expectedYaml
-  }
-
-  val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, Entity, Nothing] = endpoint
-    .out(jsonBody[Entity])
-
-  test("should match the expected yaml when when using coproduct types") {
+  test("should match the expected yaml when using coproduct types") {
     val expectedYaml = loadYaml("expected_coproduct.yml")
 
+    val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, Entity, Nothing] = endpoint
+      .out(jsonBody[Entity])
+
+    val actualYaml = endpoint_wit_sealed_trait.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    println(actualYaml)
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should match the expected yaml when using coproduct types with discriminator") {
+    val sPerson = implicitly[SchemaFor[Person]]
+    val sOrganization = implicitly[SchemaFor[Organization]]
+    val methodName = MethodNameMacro.methodName[Entity](_.name)
+    val discr =
+      Schema.discriminator[Entity, String](methodName)(Map("john" -> sPerson, "sml" -> sOrganization))
+    implicit val sEntity: SchemaFor[Entity] = SchemaFor(SCoproduct(List(sPerson.schema, sOrganization.schema), Some(discr)))
+
+    val expectedYaml = loadYaml("expected_coproduct_discriminator.yml")
+    val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, Entity, Nothing] = endpoint
+      .out(jsonBody[Entity])
     val actualYaml = endpoint_wit_sealed_trait.toOpenAPI(Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -187,7 +206,9 @@ class VerifyYamlTest extends FunSuite with Matchers {
 
 case class F1(data: List[F1])
 
-sealed trait Entity
+sealed trait Entity {
+  def name: String
+}
 case class Person(name: String, age: Int) extends Entity
 case class Organization(name: String) extends Entity
 

--- a/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
@@ -184,8 +184,7 @@ class VerifyYamlTest extends FunSuite with Matchers {
   test("should match the expected yaml when using coproduct types with discriminator") {
     val sPerson = implicitly[SchemaFor[Person]]
     val sOrganization = implicitly[SchemaFor[Organization]]
-    val discriminator = SchemaFor.oneOf[Entity, String](_.name, _.toString)("john" -> sPerson, "sml" -> sOrganization)
-    implicit val sEntity: SchemaFor[Entity] = SchemaFor(SCoproduct(List(sPerson.schema, sOrganization.schema), Some(discriminator)))
+    implicit val sEntity: SchemaFor[Entity] = SchemaFor.oneOf[Entity, String](_.name, _.toString)("john" -> sPerson, "sml" -> sOrganization)
 
     val expectedYaml = loadYaml("expected_coproduct_discriminator.yml")
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, Entity, Nothing] = endpoint
@@ -211,8 +210,7 @@ class VerifyYamlTest extends FunSuite with Matchers {
   test("should match the expected yaml when using nested coproduct types with discriminator") {
     val sPerson = implicitly[SchemaFor[Person]]
     val sOrganization = implicitly[SchemaFor[Organization]]
-    val discriminator = SchemaFor.oneOf[Entity, String](_.name, _.toString)("john" -> sPerson, "sml" -> sOrganization)
-    implicit val sEntity: SchemaFor[Entity] = SchemaFor(SCoproduct(List(sPerson.schema, sOrganization.schema), Some(discriminator)))
+    implicit val sEntity: SchemaFor[Entity] = SchemaFor.oneOf[Entity, String](_.name, _.toString)("john" -> sPerson, "sml" -> sOrganization)
 
     val expectedYaml = loadYaml("expected_coproduct_discriminator_nested.yml")
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, NestedEntity, Nothing] = endpoint

--- a/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
@@ -165,6 +165,19 @@ class VerifyYamlTest extends FunSuite with Matchers {
     actualYamlNoIndent shouldBe expectedYaml
   }
 
+  val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, Entity, Nothing] = endpoint
+    .out(jsonBody[Entity])
+
+  test("should match the expected yaml when when using coproduct types") {
+    val expectedYaml = loadYaml("expected_coproduct.yml")
+
+    val actualYaml = endpoint_wit_sealed_trait.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    println(actualYaml)
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
   private def loadYaml(fileName: String): String = {
     noIndentation(Source.fromResource(fileName).getLines().mkString("\n"))
   }
@@ -173,6 +186,10 @@ class VerifyYamlTest extends FunSuite with Matchers {
 }
 
 case class F1(data: List[F1])
+
+sealed trait Entity
+case class Person(name: String, age: Int) extends Entity
+case class Organization(name: String) extends Entity
 
 sealed trait ErrorInfo
 object ErrorInfo {

--- a/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
@@ -4,7 +4,6 @@ import io.circe.generic.auto._
 import org.scalatest.{FunSuite, Matchers}
 import tapir.Schema.SCoproduct
 import tapir._
-import tapir.generic.MethodNameMacro
 import tapir.docs.openapi.dtos.Book
 import tapir.docs.openapi.dtos.a.{Pet => APet}
 import tapir.docs.openapi.dtos.b.{Pet => BPet}
@@ -185,8 +184,7 @@ class VerifyYamlTest extends FunSuite with Matchers {
   test("should match the expected yaml when using coproduct types with discriminator") {
     val sPerson = implicitly[SchemaFor[Person]]
     val sOrganization = implicitly[SchemaFor[Organization]]
-    val discr =
-      Schema.discriminator[Entity, String](MethodNameMacro.methodName[Entity](_.name))(Map("john" -> sPerson, "sml" -> sOrganization))
+    val discr = SchemaFor.oneOf[Entity, String](_.name, _.toString)("john" -> sPerson, "sml" -> sOrganization)
     implicit val sEntity: SchemaFor[Entity] = SchemaFor(SCoproduct(List(sPerson.schema, sOrganization.schema), Some(discr)))
 
     val expectedYaml = loadYaml("expected_coproduct_discriminator.yml")
@@ -213,8 +211,7 @@ class VerifyYamlTest extends FunSuite with Matchers {
   test("should match the expected yaml when using nested coproduct types with discriminator") {
     val sPerson = implicitly[SchemaFor[Person]]
     val sOrganization = implicitly[SchemaFor[Organization]]
-    val discriminator =
-      Schema.discriminator[Entity, String](MethodNameMacro.methodName[Entity](_.name))(Map("john" -> sPerson, "sml" -> sOrganization))
+    val discriminator = SchemaFor.oneOf[Entity, String](_.name, _.toString)("john" -> sPerson, "sml" -> sOrganization)
     implicit val sEntity: SchemaFor[Entity] = SchemaFor(SCoproduct(List(sPerson.schema, sOrganization.schema), Some(discriminator)))
 
     val expectedYaml = loadYaml("expected_coproduct_discriminator_nested.yml")

--- a/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
@@ -2,169 +2,169 @@ package tapir.docs.openapi
 
 import io.circe.generic.auto._
 import org.scalatest.{FunSuite, Matchers}
-import tapir.Schema.{Discriminator, SCoproduct}
+import tapir.Schema.SCoproduct
 import tapir._
-import tapir.generic.{MethodName, MethodNameMacro}
+import tapir.generic.MethodNameMacro
 import tapir.json.circe._
-import tapir.openapi.Info
+import tapir.model.{Method, StatusCodes}
 import tapir.openapi.circe.yaml._
+import tapir.openapi.{Contact, Info, License}
+import tapir.tests.{FruitAmount, _}
 
 import scala.io.Source
 
 class VerifyYamlTest extends FunSuite with Matchers {
 
-//  val all_the_way: Endpoint[(FruitAmount, String), Unit, (FruitAmount, Int), Nothing] = endpoint
-//    .in(("fruit" / path[String] / "amount" / path[Int]).mapTo(FruitAmount))
-//    .in(query[String]("color"))
-//    .out(jsonBody[FruitAmount])
-//    .out(header[Int]("X-Role"))
-//
-//  test("should match the expected yaml") {
-//    val expectedYaml = loadYaml("expected.yml")
-//
-//    val actualYaml = List(in_query_query_out_string, all_the_way).toOpenAPI(Info("Fruits", "1.0")).toYaml
-//    val actualYamlNoIndent = noIndentation(actualYaml)
-//
-//    actualYamlNoIndent shouldBe expectedYaml
-//  }
-//
-//  val endpoint_wit_recursive_structure: Endpoint[Unit, Unit, F1, Nothing] = endpoint
-//    .out(jsonBody[F1])
-//
-//  test("should match the expected yaml when schema is recursive") {
-//    val expectedYaml = loadYaml("expected_recursive.yml")
-//
-//    val actualYaml = endpoint_wit_recursive_structure.toOpenAPI(Info("Fruits", "1.0")).toYaml
-//    val actualYamlNoIndent = noIndentation(actualYaml)
-//
-//    actualYamlNoIndent shouldBe expectedYaml
-//  }
-//
-//  test("should use custom operationId generator") {
-//    def customOperationIdGenerator(pc: Vector[String], m: Method) = pc.map(_.toUpperCase).mkString("", "+", "-") + m.m.toUpperCase
-//    val options = OpenAPIDocsOptions.default.copy(customOperationIdGenerator)
-//    val expectedYaml = loadYaml("expected_custom_operation_id.yml")
-//
-//    val actualYaml = in_query_query_out_string
-//      .in("add")
-//      .in("path")
-//      .toOpenAPI(Info("Fruits", "1.0"))(options)
-//      .toYaml
-//    noIndentation(actualYaml) shouldBe expectedYaml
-//  }
-//
-//  val streaming_endpoint: Endpoint[Vector[Byte], Unit, Vector[Byte], Vector[Byte]] = endpoint
-//    .in(streamBody[Vector[Byte]](schemaFor[String], MediaType.TextPlain()))
-//    .out(streamBody[Vector[Byte]](Schema.SBinary, MediaType.OctetStream()))
-//
-//  test("should match the expected yaml for streaming endpoints") {
-//    val expectedYaml = loadYaml("expected_streaming.yml")
-//
-//    val actualYaml = streaming_endpoint.toOpenAPI(Info("Fruits", "1.0")).toYaml
-//    val actualYamlNoIndent = noIndentation(actualYaml)
-//
-//    actualYamlNoIndent shouldBe expectedYaml
-//  }
-//
-//  test("should support tags") {
-//    val userTaggedEndpointShow = endpoint.tag("user").in("user" / "show").get.out(plainBody[String])
-//    val userTaggedEdnpointSearch = endpoint.tags(List("user", "admin")).in("user" / "search").get.out(plainBody[String])
-//    val adminTaggedEndpointAdd = endpoint.tag("admin").in("admin" / "add").get.out(plainBody[String])
-//
-//    val expectedYaml = loadYaml("expected_tags.yml")
-//
-//    val actualYaml = List(userTaggedEndpointShow, userTaggedEdnpointSearch, adminTaggedEndpointAdd).toOpenAPI(Info("Fruits", "1.0")).toYaml
-//    val actualYamlNoIndent = noIndentation(actualYaml)
-//
-//    actualYamlNoIndent shouldBe expectedYaml
-//  }
-//
-//  test("should match the expected yaml for general info") {
-//    val expectedYaml = loadYaml("expected_general_info.yml")
-//
-//    val api = Info(
-//      "Fruits",
-//      "1.0",
-//      description = Some("Fruits are awesome"),
-//      termsOfService = Some("our.terms.of.service"),
-//      contact = Some(Contact(Some("Author"), Some("tapir@softwaremill.com"), Some("tapir.io"))),
-//      license = Some(License("MIT", Some("mit.license")))
-//    )
-//
-//    val actualYaml = in_query_query_out_string.toOpenAPI(api).toYaml
-//    val actualYamlNoIndent = noIndentation(actualYaml)
-//
-//    actualYamlNoIndent shouldBe expectedYaml
-//  }
-//
-//  test("should support multipart") {
-//    val expectedYaml = loadYaml("expected_multipart.yml")
-//
-//    val actualYaml = List(in_file_multipart_out_multipart).toOpenAPI("Fruits", "1.0").toYaml
-//    val actualYamlNoIndent = noIndentation(actualYaml)
-//
-//    actualYamlNoIndent shouldBe expectedYaml
-//  }
-//
-//  test("should support authentication") {
-//    val expectedYaml = loadYaml("expected_auth.yml")
-//
-//    val e1 = endpoint.in(auth.bearer).in("api1" / path[String]).out(stringBody)
-//    val e2 = endpoint.in(auth.bearer).in("api2" / path[String]).out(stringBody)
-//    val e3 = endpoint.in(auth.apiKey(header[String]("apikey"))).in("api3" / path[String]).out(stringBody)
-//
-//    val actualYaml = List(e1, e2, e3).toOpenAPI(Info("Fruits", "1.0")).toYaml
-//    val actualYamlNoIndent = noIndentation(actualYaml)
-//
-//    actualYamlNoIndent shouldBe expectedYaml
-//  }
-//
-//  test("should support empty bodies") {
-//    val expectedYaml = loadYaml("expected_empty.yml")
-//
-//    val actualYaml = List(endpoint).toOpenAPI(Info("Fruits", "1.0")).toYaml
-//    val actualYamlNoIndent = noIndentation(actualYaml)
-//
-//    actualYamlNoIndent shouldBe expectedYaml
-//  }
-//
-//  test("should support multiple status codes") {
-//    // given
-//    val expectedYaml = loadYaml("expected_status_codes.yml")
-//
-//    // work-around for #10: unsupported sealed trait families
-//    implicit val schemaForErrorInfo: SchemaFor[ErrorInfo] = new SchemaFor[ErrorInfo] {
-//      override def schema: Schema = Schema.SObject(Schema.SObjectInfo("ErrorInfo", "ErrorInfo"), Nil, Nil)
-//    }
-//
-//    val e = endpoint.errorOut(
-//      statusFrom(
-//        jsonBody[ErrorInfo],
-//        StatusCodes.BadRequest,
-//        whenClass[ErrorInfo.NotFound] -> StatusCodes.NotFound,
-//        whenClass[ErrorInfo.Unauthorized] -> StatusCodes.Unauthorized
-//      ).defaultSchema(schemaFor[ErrorInfo.Unknown]))
-//
-//    // when
-//    val actualYaml = List(e).toOpenAPI(Info("Fruits", "1.0")).toYaml
-//    val actualYamlNoIndent = noIndentation(actualYaml)
-//
-//    // then
-//    actualYamlNoIndent shouldBe expectedYaml
-//  }
-//
-//  test("should keep the order of multiple endpoints") {
-//    val expectedYaml = loadYaml("expected_multiple.yml")
-//
-//    val actualYaml = List(endpoint.in("p1"), endpoint.in("p3"), endpoint.in("p2"), endpoint.in("p5"), endpoint.in("p4"))
-//      .toOpenAPI(Info("Fruits", "1.0"))
-//      .toYaml
-//    println(actualYaml)
-//    val actualYamlNoIndent = noIndentation(actualYaml)
-//
-//    actualYamlNoIndent shouldBe expectedYaml
-//  }
-//
+  val all_the_way: Endpoint[(FruitAmount, String), Unit, (FruitAmount, Int), Nothing] = endpoint
+    .in(("fruit" / path[String] / "amount" / path[Int]).mapTo(FruitAmount))
+    .in(query[String]("color"))
+    .out(jsonBody[FruitAmount])
+    .out(header[Int]("X-Role"))
+
+  test("should match the expected yaml") {
+    val expectedYaml = loadYaml("expected.yml")
+
+    val actualYaml = List(in_query_query_out_string, all_the_way).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  val endpoint_wit_recursive_structure: Endpoint[Unit, Unit, F1, Nothing] = endpoint
+    .out(jsonBody[F1])
+
+  test("should match the expected yaml when schema is recursive") {
+    val expectedYaml = loadYaml("expected_recursive.yml")
+
+    val actualYaml = endpoint_wit_recursive_structure.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should use custom operationId generator") {
+    def customOperationIdGenerator(pc: Vector[String], m: Method) = pc.map(_.toUpperCase).mkString("", "+", "-") + m.m.toUpperCase
+    val options = OpenAPIDocsOptions.default.copy(customOperationIdGenerator)
+    val expectedYaml = loadYaml("expected_custom_operation_id.yml")
+
+    val actualYaml = in_query_query_out_string
+      .in("add")
+      .in("path")
+      .toOpenAPI(Info("Fruits", "1.0"))(options)
+      .toYaml
+    noIndentation(actualYaml) shouldBe expectedYaml
+  }
+
+  val streaming_endpoint: Endpoint[Vector[Byte], Unit, Vector[Byte], Vector[Byte]] = endpoint
+    .in(streamBody[Vector[Byte]](schemaFor[String], MediaType.TextPlain()))
+    .out(streamBody[Vector[Byte]](Schema.SBinary, MediaType.OctetStream()))
+
+  test("should match the expected yaml for streaming endpoints") {
+    val expectedYaml = loadYaml("expected_streaming.yml")
+
+    val actualYaml = streaming_endpoint.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should support tags") {
+    val userTaggedEndpointShow = endpoint.tag("user").in("user" / "show").get.out(plainBody[String])
+    val userTaggedEdnpointSearch = endpoint.tags(List("user", "admin")).in("user" / "search").get.out(plainBody[String])
+    val adminTaggedEndpointAdd = endpoint.tag("admin").in("admin" / "add").get.out(plainBody[String])
+
+    val expectedYaml = loadYaml("expected_tags.yml")
+
+    val actualYaml = List(userTaggedEndpointShow, userTaggedEdnpointSearch, adminTaggedEndpointAdd).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should match the expected yaml for general info") {
+    val expectedYaml = loadYaml("expected_general_info.yml")
+
+    val api = Info(
+      "Fruits",
+      "1.0",
+      description = Some("Fruits are awesome"),
+      termsOfService = Some("our.terms.of.service"),
+      contact = Some(Contact(Some("Author"), Some("tapir@softwaremill.com"), Some("tapir.io"))),
+      license = Some(License("MIT", Some("mit.license")))
+    )
+
+    val actualYaml = in_query_query_out_string.toOpenAPI(api).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should support multipart") {
+    val expectedYaml = loadYaml("expected_multipart.yml")
+
+    val actualYaml = List(in_file_multipart_out_multipart).toOpenAPI("Fruits", "1.0").toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should support authentication") {
+    val expectedYaml = loadYaml("expected_auth.yml")
+
+    val e1 = endpoint.in(auth.bearer).in("api1" / path[String]).out(stringBody)
+    val e2 = endpoint.in(auth.bearer).in("api2" / path[String]).out(stringBody)
+    val e3 = endpoint.in(auth.apiKey(header[String]("apikey"))).in("api3" / path[String]).out(stringBody)
+
+    val actualYaml = List(e1, e2, e3).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should support empty bodies") {
+    val expectedYaml = loadYaml("expected_empty.yml")
+
+    val actualYaml = List(endpoint).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should support multiple status codes") {
+    // given
+    val expectedYaml = loadYaml("expected_status_codes.yml")
+
+    // work-around for #10: unsupported sealed trait families
+    implicit val schemaForErrorInfo: SchemaFor[ErrorInfo] = new SchemaFor[ErrorInfo] {
+      override def schema: Schema = Schema.SObject(Schema.SObjectInfo("ErrorInfo", "ErrorInfo"), Nil, Nil)
+    }
+
+    val e = endpoint.errorOut(
+      statusFrom(
+        jsonBody[ErrorInfo],
+        StatusCodes.BadRequest,
+        whenClass[ErrorInfo.NotFound] -> StatusCodes.NotFound,
+        whenClass[ErrorInfo.Unauthorized] -> StatusCodes.Unauthorized
+      ).defaultSchema(schemaFor[ErrorInfo.Unknown]))
+
+    // when
+    val actualYaml = List(e).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    // then
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should keep the order of multiple endpoints") {
+    val expectedYaml = loadYaml("expected_multiple.yml")
+
+    val actualYaml = List(endpoint.in("p1"), endpoint.in("p3"), endpoint.in("p2"), endpoint.in("p5"), endpoint.in("p4"))
+      .toOpenAPI(Info("Fruits", "1.0"))
+      .toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
 
   test("should match the expected yaml when using coproduct types") {
     val expectedYaml = loadYaml("expected_coproduct.yml")
@@ -175,16 +175,14 @@ class VerifyYamlTest extends FunSuite with Matchers {
     val actualYaml = endpoint_wit_sealed_trait.toOpenAPI(Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
-    println(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
 
   test("should match the expected yaml when using coproduct types with discriminator") {
     val sPerson = implicitly[SchemaFor[Person]]
     val sOrganization = implicitly[SchemaFor[Organization]]
-    val methodName = MethodNameMacro.methodName[Entity](_.name)
     val discr =
-      Schema.discriminator[Entity, String](methodName)(Map("john" -> sPerson, "sml" -> sOrganization))
+      Schema.discriminator[Entity, String](MethodNameMacro.methodName[Entity](_.name))(Map("john" -> sPerson, "sml" -> sOrganization))
     implicit val sEntity: SchemaFor[Entity] = SchemaFor(SCoproduct(List(sPerson.schema, sOrganization.schema), Some(discr)))
 
     val expectedYaml = loadYaml("expected_coproduct_discriminator.yml")
@@ -193,6 +191,33 @@ class VerifyYamlTest extends FunSuite with Matchers {
     val actualYaml = endpoint_wit_sealed_trait.toOpenAPI(Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should match the expected yaml when using nested coproduct types") {
+    val expectedYaml = loadYaml("expected_coproduct_nested.yml")
+
+    val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, NestedEntity, Nothing] = endpoint
+      .out(jsonBody[NestedEntity])
+
+    val actualYaml = endpoint_wit_sealed_trait.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should match the expected yaml when using nested coproduct types with discriminator") {
+    val sPerson = implicitly[SchemaFor[Person]]
+    val sOrganization = implicitly[SchemaFor[Organization]]
+    val discriminator =
+      Schema.discriminator[Entity, String](MethodNameMacro.methodName[Entity](_.name))(Map("john" -> sPerson, "sml" -> sOrganization))
+    implicit val sEntity: SchemaFor[Entity] = SchemaFor(SCoproduct(List(sPerson.schema, sOrganization.schema), Some(discriminator)))
+
+    val expectedYaml = loadYaml("expected_coproduct_discriminator_nested.yml")
+    val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, NestedEntity, Nothing] = endpoint
+      .out(jsonBody[NestedEntity])
+    val actualYaml = endpoint_wit_sealed_trait.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
     println(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -205,6 +230,8 @@ class VerifyYamlTest extends FunSuite with Matchers {
 }
 
 case class F1(data: List[F1])
+
+case class NestedEntity(entity: Entity)
 
 sealed trait Entity {
   def name: String

--- a/openapi/openapi-circe/src/main/scala/tapir/openapi/circe/package.scala
+++ b/openapi/openapi-circe/src/main/scala/tapir/openapi/circe/package.scala
@@ -54,6 +54,7 @@ trait TapirOpenAPICirceEncoders {
   implicit val encoderContact: Encoder[Contact] = deriveMagnoliaEncoder[Contact]
   implicit val encoderLicense: Encoder[License] = deriveMagnoliaEncoder[License]
   implicit val encoderOpenAPI: Encoder[OpenAPI] = deriveMagnoliaEncoder[OpenAPI]
+  implicit val encoderDiscriminator: Encoder[Discriminator] = deriveMagnoliaEncoder[Discriminator]
   implicit def encodeList[T: Encoder]: Encoder[List[T]] = {
     case Nil        => Json.Null
     case l: List[T] => Json.arr(l.map(i => implicitly[Encoder[T]].apply(i)): _*)

--- a/openapi/openapi-model/src/main/scala/tapir/openapi/OpenAPI.scala
+++ b/openapi/openapi-model/src/main/scala/tapir/openapi/OpenAPI.scala
@@ -182,7 +182,7 @@ case class Reference($ref: String)
 // todo: discriminator, xml, json-schema properties
 case class Schema(title: Option[String],
                   required: List[String],
-                  `type`: SchemaType.SchemaType,
+                  `type`: Option[SchemaType.SchemaType],
                   items: Option[ReferenceOr[Schema]],
                   properties: ListMap[String, ReferenceOr[Schema]],
                   description: Option[String],
@@ -192,11 +192,15 @@ case class Schema(title: Option[String],
                   readOnly: Option[Boolean],
                   writeOnly: Option[Boolean],
                   example: Option[ExampleValue],
-                  deprecated: Option[Boolean])
+                  deprecated: Option[Boolean],
+                  oneOf: Option[List[ReferenceOr[Schema]]])
 
 object Schema {
   def apply(`type`: SchemaType.SchemaType): Schema =
-    Schema(None, List.empty, `type`, None, ListMap.empty, None, None, None, None, None, None, None, None)
+    Schema(None, List.empty, Some(`type`), None, ListMap.empty, None, None, None, None, None, None, None, None, None)
+
+  def apply(references: List[ReferenceOr[Schema]]): Schema =
+    Schema(None, List.empty, None, None, ListMap.empty, None, None, None, None, None, None, None, None, Some(references))
 }
 
 object SchemaType extends Enumeration {

--- a/openapi/openapi-model/src/main/scala/tapir/openapi/OpenAPI.scala
+++ b/openapi/openapi-model/src/main/scala/tapir/openapi/OpenAPI.scala
@@ -193,14 +193,17 @@ case class Schema(title: Option[String],
                   writeOnly: Option[Boolean],
                   example: Option[ExampleValue],
                   deprecated: Option[Boolean],
-                  oneOf: Option[List[ReferenceOr[Schema]]])
+                  oneOf: Option[List[ReferenceOr[Schema]]],
+                  discriminator: Option[Discriminator])
+
+case class Discriminator(propertyName: String, mapping: Option[ListMap[String, String]])
 
 object Schema {
   def apply(`type`: SchemaType.SchemaType): Schema =
-    Schema(None, List.empty, Some(`type`), None, ListMap.empty, None, None, None, None, None, None, None, None, None)
+    Schema(None, List.empty, Some(`type`), None, ListMap.empty, None, None, None, None, None, None, None, None, None, None)
 
-  def apply(references: List[ReferenceOr[Schema]]): Schema =
-    Schema(None, List.empty, None, None, ListMap.empty, None, None, None, None, None, None, None, None, Some(references))
+  def apply(references: List[ReferenceOr[Schema]], discriminator: Option[Discriminator]): Schema =
+    Schema(None, List.empty, None, None, ListMap.empty, None, None, None, None, None, None, None, None, Some(references), discriminator)
 }
 
 object SchemaType extends Enumeration {

--- a/openapi/openapi-model/src/main/scala/tapir/openapi/OpenAPI.scala
+++ b/openapi/openapi-model/src/main/scala/tapir/openapi/OpenAPI.scala
@@ -184,21 +184,23 @@ case class Header(
 case class Reference($ref: String)
 
 // todo: discriminator, xml, json-schema properties
-case class Schema(title: Option[String],
-                  required: List[String],
-                  `type`: Option[SchemaType.SchemaType],
-                  items: Option[ReferenceOr[Schema]],
-                  properties: ListMap[String, ReferenceOr[Schema]],
-                  description: Option[String],
-                  format: Option[SchemaFormat.SchemaFormat],
-                  default: Option[ExampleValue],
-                  nullable: Option[Boolean],
-                  readOnly: Option[Boolean],
-                  writeOnly: Option[Boolean],
-                  example: Option[ExampleValue],
-                  deprecated: Option[Boolean],
-                  oneOf: Option[List[ReferenceOr[Schema]]],
-                  discriminator: Option[Discriminator])
+case class Schema(
+    title: Option[String],
+    required: List[String],
+    `type`: Option[SchemaType.SchemaType],
+    items: Option[ReferenceOr[Schema]],
+    properties: ListMap[String, ReferenceOr[Schema]],
+    description: Option[String],
+    format: Option[SchemaFormat.SchemaFormat],
+    default: Option[ExampleValue],
+    nullable: Option[Boolean],
+    readOnly: Option[Boolean],
+    writeOnly: Option[Boolean],
+    example: Option[ExampleValue],
+    deprecated: Option[Boolean],
+    oneOf: Option[List[ReferenceOr[Schema]]],
+    discriminator: Option[Discriminator]
+)
 
 case class Discriminator(propertyName: String, mapping: Option[ListMap[String, String]])
 

--- a/playground/src/main/scala/tapir/example/BooksExample.scala
+++ b/playground/src/main/scala/tapir/example/BooksExample.scala
@@ -29,7 +29,8 @@ object Endpoints {
     .in(
       jsonBody[Book]
         .description("The book to add")
-        .example(Book("Pride and Prejudice", Genre("Novel", ""), 1813, Author("Jane Austen", Country("United Kingdom")))))
+        .example(Book("Pride and Prejudice", Genre("Novel", ""), 1813, Author("Jane Austen", Country("United Kingdom"))))
+    )
     .in(header[String]("X-Auth-Token").description("The token is 'secret'"))
 
   // Re-usable parameter description
@@ -169,10 +170,12 @@ object Library {
 
   val Books = new AtomicReference(
     Vector(
-      Book("The Sorrows of Young Werther",
-           Genre("Novel", "Novel is genre"),
-           1774,
-           Author("Johann Wolfgang von Goethe", Country("Germany"))),
+      Book(
+        "The Sorrows of Young Werther",
+        Genre("Novel", "Novel is genre"),
+        1774,
+        Author("Johann Wolfgang von Goethe", Country("Germany"))
+      ),
       Book("Iliad", Genre("Poetry", ""), -8000, Author("Homer", Country("Greece"))),
       Book("Nad Niemnem", Genre("Novel", ""), 1888, Author("Eliza Orzeszkowa", Country("Poland"))),
       Book("The Colour of Magic", Genre("Fantasy", ""), 1983, Author("Terry Pratchett", Country("United Kingdom"))),


### PR DESCRIPTION
I am not very happy with the `disclaimer` implementation as with how it is being used although generally this solution works quite well even for more complicated sets of coproducts. 

I had to use @BBartosz code for schemas extraction in order to properly reference sealed classes within `oneOf` section.

This closes #10 