### PR TITLE
Add support for scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ jdk:
   - oraclejdk8
 scala:
   - 2.12.8
+  - 2.11.12
 before_cache:
   - du -h -d 1 $HOME/.ivy2/
   - du -h -d 2 $HOME/.sbt/

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   crossScalaVersions := Seq(scala2_11, scala2_12),
   scalacOptions ++= 
     (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) if v <= 12 =>
+      case Some((2, 11)) =>
         Seq(
           "-Xexperimental",
           "-Ypartial-unification"

--- a/build.sbt
+++ b/build.sbt
@@ -5,19 +5,19 @@ lazy val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   scalaVersion := scala2_12,
   scalafmtOnCompile := true,
   crossScalaVersions := Seq(scala2_11, scala2_12),
-  scalacOptions ++= {
-    CrossVersion.partialVersion(scalaVersion.value) match {
+  scalacOptions ++= 
+    (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, v)) if v <= 12 =>
         Seq(
           "-Xexperimental",
           "-Ywarn-nullary-unit",
           "-Ywarn-inaccessible",
-          "-Ywarn-adapted-args"
+          "-Ywarn-adapted-args",
+          "-Ypartial-unification"
         )
       case _ =>
         Nil
-    }
-  }
+    })
 )
 
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.7"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,23 @@
+val scala2_11 = "2.11.12"
+val scala2_12 = "2.12.8"
 lazy val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   organization := "com.softwaremill.tapir",
-  scalaVersion := "2.12.8",
-  scalafmtOnCompile := true
+  scalaVersion := scala2_12,
+  scalafmtOnCompile := true,
+  crossScalaVersions := Seq(scala2_11, scala2_12),
+  scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, v)) if v <= 12 =>
+        Seq(
+          "-Xexperimental",
+          "-Ywarn-nullary-unit",
+          "-Ywarn-inaccessible",
+          "-Ywarn-adapted-args"
+        )
+      case _ =>
+        Nil
+    }
+  }
 )
 
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.7"
@@ -13,7 +29,7 @@ val sttpVersion = "1.5.12"
 lazy val loggerDependencies = Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "ch.qos.logback" % "logback-core" % "1.2.3",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0"
 )
 
 lazy val rootProject = (project in file("."))
@@ -86,7 +102,7 @@ lazy val openapiCirce: Project = (project in file("openapi/openapi-circe"))
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
-      "io.circe" %% "circe-magnolia-derivation" % "0.4.0"
+      "io.circe" %% "circe-generic" % circeVersion
     ),
     name := "tapir-openapi-circe"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -10,9 +10,6 @@ lazy val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
       case Some((2, v)) if v <= 12 =>
         Seq(
           "-Xexperimental",
-          "-Ywarn-nullary-unit",
-          "-Ywarn-inaccessible",
-          "-Ywarn-adapted-args",
           "-Ypartial-unification"
         )
       case _ =>

--- a/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
@@ -2,7 +2,6 @@ package tapir.docs.openapi
 
 import io.circe.generic.auto._
 import org.scalatest.{FunSuite, Matchers}
-import tapir.Schema.SCoproduct
 import tapir._
 import tapir.docs.openapi.dtos.Book
 import tapir.docs.openapi.dtos.a.{Pet => APet}
@@ -145,9 +144,9 @@ class VerifyYamlTest extends FunSuite with Matchers {
       statusFrom(
         jsonBody[ErrorInfo],
         StatusCodes.BadRequest,
-        whenClass[ErrorInfo.NotFound] -> StatusCodes.NotFound,
-        whenClass[ErrorInfo.Unauthorized] -> StatusCodes.Unauthorized
-      ).defaultSchema(schemaFor[ErrorInfo.Unknown])
+        whenClass[NotFound] -> StatusCodes.NotFound,
+        whenClass[Unauthorized] -> StatusCodes.Unauthorized
+      ).defaultSchema(schemaFor[Unknown])
     )
 
     // when
@@ -246,7 +245,7 @@ class VerifyYamlTest extends FunSuite with Matchers {
   }
 
   private def loadYaml(fileName: String): String = {
-    noIndentation(Source.fromResource(fileName).getLines().mkString("\n"))
+    noIndentation(Source.fromInputStream(getClass.getResourceAsStream(s"/$fileName")).getLines().mkString("\n"))
   }
 
   private def noIndentation(s: String) = s.replaceAll("[ \t]", "").trim
@@ -263,8 +262,6 @@ case class Person(name: String, age: Int) extends Entity
 case class Organization(name: String) extends Entity
 
 sealed trait ErrorInfo
-object ErrorInfo {
-  case class NotFound(what: String) extends ErrorInfo
-  case class Unauthorized(realm: String) extends ErrorInfo
-  case class Unknown(code: Int, msg: String) extends ErrorInfo
-}
+case class NotFound(what: String) extends ErrorInfo
+case class Unauthorized(realm: String) extends ErrorInfo
+case class Unknown(code: Int, msg: String) extends ErrorInfo

--- a/openapi/openapi-circe/src/main/scala/tapir/openapi/circe/package.scala
+++ b/openapi/openapi-circe/src/main/scala/tapir/openapi/circe/package.scala
@@ -1,6 +1,6 @@
 package tapir.openapi
 
-import io.circe.magnolia.derivation.encoder.semiauto._
+import io.circe.generic.semiauto._
 import io.circe.parser._
 import io.circe.syntax._
 import io.circe.{Encoder, Json}
@@ -18,25 +18,25 @@ trait TapirOpenAPICirceEncoders {
     case Right(t)             => implicitly[Encoder[T]].apply(t)
   }
 
-  implicit val encoderOAuthFlow: Encoder[OAuthFlow] = deriveMagnoliaEncoder[OAuthFlow]
-  implicit val encoderOAuthFlows: Encoder[OAuthFlows] = deriveMagnoliaEncoder[OAuthFlows]
-  implicit val encoderSecurityScheme: Encoder[SecurityScheme] = deriveMagnoliaEncoder[SecurityScheme]
+  implicit val encoderOAuthFlow: Encoder[OAuthFlow] = deriveEncoder[OAuthFlow]
+  implicit val encoderOAuthFlows: Encoder[OAuthFlows] = deriveEncoder[OAuthFlows]
+  implicit val encoderSecurityScheme: Encoder[SecurityScheme] = deriveEncoder[SecurityScheme]
   implicit val encoderExampleValue: Encoder[ExampleValue] = { ev: ExampleValue =>
-    parse(ev.value).toOption.getOrElse(Json.fromString(ev.value))
+    parse(ev.value).right.getOrElse(Json.fromString(ev.value))
   }
   implicit val encoderSchemaFormat: Encoder[SchemaFormat.SchemaFormat] = Encoder.enumEncoder(SchemaFormat)
   implicit val encoderSchemaType: Encoder[SchemaType.SchemaType] = Encoder.enumEncoder(SchemaType)
-  implicit val encoderSchema: Encoder[Schema] = deriveMagnoliaEncoder[Schema]
-  implicit val encoderReference: Encoder[Reference] = deriveMagnoliaEncoder[Reference]
-  implicit val encoderHeader: Encoder[Header] = deriveMagnoliaEncoder[Header]
-  implicit val encoderExample: Encoder[Example] = deriveMagnoliaEncoder[Example]
-  implicit val encoderResponse: Encoder[Response] = deriveMagnoliaEncoder[Response]
-  implicit val encoderEncoding: Encoder[Encoding] = deriveMagnoliaEncoder[Encoding]
-  implicit val encoderMediaType: Encoder[MediaType] = deriveMagnoliaEncoder[MediaType]
-  implicit val encoderRequestBody: Encoder[RequestBody] = deriveMagnoliaEncoder[RequestBody]
+  implicit val encoderSchema: Encoder[Schema] = deriveEncoder[Schema]
+  implicit val encoderReference: Encoder[Reference] = deriveEncoder[Reference]
+  implicit val encoderHeader: Encoder[Header] = deriveEncoder[Header]
+  implicit val encoderExample: Encoder[Example] = deriveEncoder[Example]
+  implicit val encoderResponse: Encoder[Response] = deriveEncoder[Response]
+  implicit val encoderEncoding: Encoder[Encoding] = deriveEncoder[Encoding]
+  implicit val encoderMediaType: Encoder[MediaType] = deriveEncoder[MediaType]
+  implicit val encoderRequestBody: Encoder[RequestBody] = deriveEncoder[RequestBody]
   implicit val encoderParameterStyle: Encoder[ParameterStyle.ParameterStyle] = Encoder.enumEncoder(ParameterStyle)
   implicit val encoderParameterIn: Encoder[ParameterIn.ParameterIn] = Encoder.enumEncoder(ParameterIn)
-  implicit val encoderParameter: Encoder[Parameter] = deriveMagnoliaEncoder[Parameter]
+  implicit val encoderParameter: Encoder[Parameter] = deriveEncoder[Parameter]
   implicit val encoderResponseMap: Encoder[ListMap[ResponsesKey, ReferenceOr[Response]]] =
     (responses: ListMap[ResponsesKey, ReferenceOr[Response]]) => {
       val fields = responses.map {
@@ -46,15 +46,15 @@ trait TapirOpenAPICirceEncoders {
 
       Json.obj(fields.toSeq: _*)
     }
-  implicit val encoderOperation: Encoder[Operation] = deriveMagnoliaEncoder[Operation]
-  implicit val encoderPathItem: Encoder[PathItem] = deriveMagnoliaEncoder[PathItem]
-  implicit val encoderComponents: Encoder[Components] = deriveMagnoliaEncoder[Components]
-  implicit val encoderServer: Encoder[Server] = deriveMagnoliaEncoder[Server]
-  implicit val encoderInfo: Encoder[Info] = deriveMagnoliaEncoder[Info]
-  implicit val encoderContact: Encoder[Contact] = deriveMagnoliaEncoder[Contact]
-  implicit val encoderLicense: Encoder[License] = deriveMagnoliaEncoder[License]
-  implicit val encoderOpenAPI: Encoder[OpenAPI] = deriveMagnoliaEncoder[OpenAPI]
-  implicit val encoderDiscriminator: Encoder[Discriminator] = deriveMagnoliaEncoder[Discriminator]
+  implicit val encoderOperation: Encoder[Operation] = deriveEncoder[Operation]
+  implicit val encoderPathItem: Encoder[PathItem] = deriveEncoder[PathItem]
+  implicit val encoderComponents: Encoder[Components] = deriveEncoder[Components]
+  implicit val encoderServer: Encoder[Server] = deriveEncoder[Server]
+  implicit val encoderInfo: Encoder[Info] = deriveEncoder[Info]
+  implicit val encoderContact: Encoder[Contact] = deriveEncoder[Contact]
+  implicit val encoderLicense: Encoder[License] = deriveEncoder[License]
+  implicit val encoderOpenAPI: Encoder[OpenAPI] = deriveEncoder[OpenAPI]
+  implicit val encoderDiscriminator: Encoder[Discriminator] = deriveEncoder[Discriminator]
   implicit def encodeList[T: Encoder]: Encoder[List[T]] = {
     case Nil        => Json.Null
     case l: List[T] => Json.arr(l.map(i => implicitly[Encoder[T]].apply(i)): _*)

--- a/server/http4s-server/src/main/scala/tapir/server/http4s/EndpointToHttp4sServer.scala
+++ b/server/http4s-server/src/main/scala/tapir/server/http4s/EndpointToHttp4sServer.scala
@@ -77,7 +77,7 @@ class EndpointToHttp4sServer[F[_]: Sync: ContextShift](serverOptions: Http4sServ
   def toRoutes[I, E, O](serverEndpoints: List[ServerEndpoint[_, _, _, EntityBody[F], F]]): HttpRoutes[F] = {
     NonEmptyList.fromList(serverEndpoints.map(se => toRoutes(se))) match {
       case Some(routes) => routes.reduceK
-      case None => HttpRoutes.empty
+      case None         => HttpRoutes.empty
     }
   }
 

--- a/server/http4s-server/src/main/scala/tapir/server/http4s/EndpointToHttp4sServer.scala
+++ b/server/http4s-server/src/main/scala/tapir/server/http4s/EndpointToHttp4sServer.scala
@@ -77,7 +77,7 @@ class EndpointToHttp4sServer[F[_]: Sync: ContextShift](serverOptions: Http4sServ
   def toRoutes[I, E, O](serverEndpoints: List[ServerEndpoint[_, _, _, EntityBody[F], F]]): HttpRoutes[F] = {
     NonEmptyList.fromList(serverEndpoints.map(se => toRoutes(se))) match {
       case Some(routes) => routes.reduceK
-      case None         => HttpRoutes.empty
+      case None => HttpRoutes.empty
     }
   }
 

--- a/server/http4s-server/src/main/scala/tapir/server/http4s/OutputToHttp4sResponse.scala
+++ b/server/http4s-server/src/main/scala/tapir/server/http4s/OutputToHttp4sResponse.scala
@@ -3,6 +3,7 @@ package tapir.server.http4s
 import cats.data._
 import cats.implicits._
 import cats.effect.{ContextShift, Sync}
+import cats.syntax.NestedFoldableOps
 import fs2.Chunk
 import org.http4s
 import org.http4s.headers.{`Content-Disposition`, `Content-Type`}
@@ -85,8 +86,8 @@ class OutputToHttp4sResponse[F[_]: Sync: ContextShift](serverOptions: Http4sServ
       case (EndpointOutput.Mapped(wrapped, _, g, _), i) =>
         toResponse(wrapped, g(vs(i)))
     }
-
-    states.sequence_
+    val sequence: State[ResponseValues, Unit] = new NestedFoldableOps[Vector, State[ResponseValues, ?], Unit](states).sequence_
+    sequence
   }
 
   def rawValueToEntity[M <: MediaType, R](codecMeta: CodecMeta[M, R], r: R): (EntityBody[F], Header) = {

--- a/server/http4s-server/src/main/scala/tapir/server/http4s/OutputToHttp4sResponse.scala
+++ b/server/http4s-server/src/main/scala/tapir/server/http4s/OutputToHttp4sResponse.scala
@@ -3,7 +3,6 @@ package tapir.server.http4s
 import cats.data._
 import cats.implicits._
 import cats.effect.{ContextShift, Sync}
-import cats.syntax.NestedFoldableOps
 import fs2.Chunk
 import org.http4s
 import org.http4s.headers.{`Content-Disposition`, `Content-Type`}
@@ -86,8 +85,7 @@ class OutputToHttp4sResponse[F[_]: Sync: ContextShift](serverOptions: Http4sServ
       case (EndpointOutput.Mapped(wrapped, _, g, _), i) =>
         toResponse(wrapped, g(vs(i)))
     }
-    val sequence: State[ResponseValues, Unit] = new NestedFoldableOps[Vector, State[ResponseValues, ?], Unit](states).sequence_
-    sequence
+    states.sequence_
   }
 
   def rawValueToEntity[M <: MediaType, R](codecMeta: CodecMeta[M, R], r: R): (EntityBody[F], Header) = {

--- a/server/tests/src/main/scala/tapir/server/tests/ServerTests.scala
+++ b/server/tests/src/main/scala/tapir/server/tests/ServerTests.scala
@@ -441,11 +441,9 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
       port <- Resource.liftF(IO(nextPort()))
       _ <- server(rs, port)
     } yield uri"http://localhost:$port"
-    test(name)(restartOnBindException(resources).use(runTest).unsafeRunSync())
-  }
 
-  private def restartOnBindException(r: Resource[IO, Uri]): Resource[IO, Uri] =
-    r.recoverWith { case e if e.getCause.isInstanceOf[BindException] => restartOnBindException(r) }
+    test(name)(resources.recoverWith { case _: BindException => resources }.use(runTest).unsafeRunSync())
+  }
 
   //
 

--- a/server/tests/src/main/scala/tapir/server/tests/ServerTests.scala
+++ b/server/tests/src/main/scala/tapir/server/tests/ServerTests.scala
@@ -1,6 +1,7 @@
 package tapir.server.tests
 
 import java.io.{ByteArrayInputStream, File, InputStream}
+import java.net.BindException
 import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -9,13 +10,13 @@ import cats.effect.{IO, Resource}
 import cats.implicits._
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsBackend
+import io.circe.generic.auto._
 import org.scalatest.{Assertion, BeforeAndAfterAll, FunSuite, Matchers}
+import tapir._
+import tapir.json.circe._
 import tapir.model.{MultiQueryParams, Part, SetCookieValue, UsernamePassword}
 import tapir.tests.TestUtil._
 import tapir.tests._
-import tapir._
-import tapir.json.circe._
-import io.circe.generic.auto._
 
 import scala.reflect.ClassTag
 
@@ -441,7 +442,7 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
       _ <- server(rs, port)
     } yield uri"http://localhost:$port"
 
-    test(name)(resources.use(runTest).unsafeRunSync())
+    test(name)(resources.recoverWith { case _: BindException => resources }.use(runTest).unsafeRunSync())
   }
 
   //

--- a/server/tests/src/main/scala/tapir/server/tests/ServerTests.scala
+++ b/server/tests/src/main/scala/tapir/server/tests/ServerTests.scala
@@ -441,9 +441,11 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
       port <- Resource.liftF(IO(nextPort()))
       _ <- server(rs, port)
     } yield uri"http://localhost:$port"
-
-    test(name)(resources.recoverWith { case _: BindException => resources }.use(runTest).unsafeRunSync())
+    test(name)(restartOnBindException(resources).use(runTest).unsafeRunSync())
   }
+
+  private def restartOnBindException(r: Resource[IO, Uri]): Resource[IO, Uri] =
+    r.recoverWith { case e if e.getCause.isInstanceOf[BindException] => restartOnBindException(r) }
 
   //
 


### PR DESCRIPTION
This closes #59 

Solved issues:
- knownDirectSubclasses of <class> observed before subclass <class> registered - circe/circe#639
- http4s compilation errors -  enabling YpartialUnification
- other compilation errors - enabling Xexperimental
- fromResource is not a member of Source class - https://stackoverflow.com/questions/27360977/how-to-read-files-from-resources-folder-in-scala
- downgraded scala-logging due to missing artifact for scala 2.11 - https://github.com/lightbend/scala-logging/issues/160