### PR TITLE
A fix for issue #82: Scanning for object schemas doesn't go deep enough

### DIFF
--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
@@ -55,8 +55,10 @@ object ObjectSchemasForEndpoints {
           .toList
       case TSchema.SArray(o: TSchema.SObject) =>
         objectSchemas(o)
+      case TSchema.SArray(o: TSchema.SCoproduct) =>
+        objectSchemas(o)
       case s: TSchema.SCoproduct =>
-        s.schemas.collect { case so: TSchema.SObject => so }.toList
+        s.schemas.collect { case so: TSchema.SObject => objectSchemas(so) }.flatten.toList
       case _ => List.empty
     }
   }


### PR DESCRIPTION
When TSchema.SCoproduct contains a complex object - only the object itself is added - there is no recursive call to the fields
case TSchema.SArray(o: TSchema.SCoproduct) is not covered - it misses the objects that are defined with oneOf if they are in TSchema.SArray