### PR TITLE
Oauth2 authorization code

### DIFF
--- a/core/src/main/scala/tapir/EndpointIO.scala
+++ b/core/src/main/scala/tapir/EndpointIO.scala
@@ -7,6 +7,8 @@ import tapir.internal.ProductToParams
 import tapir.model.{Method, MultiQueryParams, ServerRequest}
 import tapir.typelevel.{FnComponents, ParamConcat, ParamsAsArgs}
 
+import scala.collection.immutable.ListMap
+
 sealed trait EndpointInput[I] {
   def and[J, IJ](other: EndpointInput[J])(implicit ts: ParamConcat.Aux[I, J, IJ]): EndpointInput[IJ]
   def /[J, IJ](other: EndpointInput[J])(implicit ts: ParamConcat.Aux[I, J, IJ]): EndpointInput[IJ] = and(other)
@@ -90,6 +92,15 @@ object EndpointInput {
     }
     case class Http[T](scheme: String, input: EndpointInput.Single[T]) extends Auth[T] {
       def show = s"auth($scheme http, via ${input.show})"
+    }
+    case class Oauth2(
+        authorizationUrl: String,
+        tokenUrl: String,
+        scopes: ListMap[String, String],
+        refreshUrl: Option[String] = None,
+        input: EndpointInput.Single[String]
+    ) extends Auth[String] {
+      def show = s"auth(bearer oauth2, via ${input.show})"
     }
   }
 

--- a/core/src/main/scala/tapir/TapirAuth.scala
+++ b/core/src/main/scala/tapir/TapirAuth.scala
@@ -4,6 +4,8 @@ import java.util.Base64
 import tapir.Codec.PlainCodec
 import tapir.model.UsernamePassword
 
+import scala.collection.immutable.ListMap
+
 object TapirAuth {
   private val BasicAuthType = "Basic"
   private val BearerAuthType = "Bearer"
@@ -11,6 +13,15 @@ object TapirAuth {
   def apiKey[T](input: EndpointInput.Single[T]): EndpointInput.Auth.ApiKey[T] = EndpointInput.Auth.ApiKey[T](input)
   val basic: EndpointInput.Auth.Http[UsernamePassword] = httpAuth(BasicAuthType, usernamePasswordCodec(credentialsCodec(BasicAuthType)))
   val bearer: EndpointInput.Auth.Http[String] = httpAuth(BearerAuthType, credentialsCodec(BearerAuthType))
+
+  def oauth2(authorizationUrl: String, tokenUrl: String, scopes: ListMap[String, String], refreshUrl: Option[String] = None) =
+    EndpointInput.Auth.Oauth2(
+      authorizationUrl,
+      tokenUrl,
+      scopes,
+      refreshUrl,
+      header[String]("Authorization")(CodecForMany.fromCodec(credentialsCodec(BearerAuthType)))
+    )
 
   private def httpAuth[T](authType: String, codec: PlainCodec[T]): EndpointInput.Auth.Http[T] =
     EndpointInput.Auth.Http(authType, header[T]("Authorization")(CodecForMany.fromCodec(codec)))

--- a/doc/endpoint/auth.md
+++ b/doc/endpoint/auth.md
@@ -11,6 +11,9 @@ cookie or a query parameter
 * `auth.basic: EndpointInput[UsernamePassword]`: maps to the base64-encoded username/password pair in the 
 `Authorization` header
 * `auth.bearer: EndpointInput[String]`: maps to `Bearer [token]` in the `Authorization` header
+* `auth.oauth2(authorizationUrl, tokenUrl, scopes, refreshUrl): EndpointInput[String]`: creates an Oauth2 authorization 
+using Authorization Code - sign in using an auth service. (requires defining also the oauth2-redirect.html, see 
+[Generating OpenAPI documentation](../openapi.html))
 
 Multiple authentication inputs indicate that all of the given authentication values should be provided. Specifying
 alternative authentication methods (where only one value out of many needs to be provided) is currently not supported.

--- a/doc/openapi.md
+++ b/doc/openapi.md
@@ -54,6 +54,10 @@ val SwaggerYml = "swagger.yml"
 private val redirectToIndex: Route =
   redirect(s"/swagger/index.html?url=/swagger/$SwaggerYml", StatusCodes.PermanentRedirect) 
 
+private def redirectToOath2(query: String): Route =
+    redirect(s"/swagger/oauth2-redirect.html$query", StatusCodes.PermanentRedirect)
+
+
 private val swaggerVersion = {
   val p = new Properties()
   p.load(getClass.getResourceAsStream("/META-INF/maven/org.webjars/swagger-ui/pom.properties"))
@@ -61,16 +65,14 @@ private val swaggerVersion = {
 }
 
 val routes: Route =
-  path("swagger") {
-    redirectToIndex
-  } ~
-    pathPrefix("swagger") {
-      path("") { // this is for trailing slash
-        redirectToIndex
-      } ~
-        path(SwaggerYml) {
+    path("oauth2-redirect.html") { request => 
+      redirectToOath2(request.request.uri.rawQueryString.map(s => '?' + s).getOrElse(""))(request)
+    } ~
+      pathPrefix("swagger") {
+        pathEndOrSingleSlash {
+          redirectToIndex
+        } ~ path(SwaggerYml) {
           complete(yml)
-        } ~
-        getFromResourceDirectory(s"META-INF/resources/webjars/swagger-ui/$swaggerVersion/")
-    }
+        } ~ getFromResourceDirectory(s"META-INF/resources/webjars/swagger-ui/$swaggerVersion/")
+      }
 ```

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/SecuritySchemesForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/SecuritySchemesForEndpoints.scala
@@ -1,7 +1,7 @@
 package tapir.docs.openapi
 
 import tapir.internal._
-import tapir.openapi.SecurityScheme
+import tapir.openapi.{OAuthFlow, OAuthFlows, SecurityScheme}
 import tapir.{Endpoint, EndpointIO, EndpointInput}
 
 import scala.annotation.tailrec
@@ -38,6 +38,17 @@ private[openapi] object SecuritySchemesForEndpoints {
       SecurityScheme("apiKey", None, Some(name), Some(in), None, None, None, None)
     case EndpointInput.Auth.Http(scheme, _) =>
       SecurityScheme("http", None, None, None, Some(scheme.toLowerCase()), None, None, None)
+    case EndpointInput.Auth.Oauth2(authorizationUrl, tokenUrl, scopes, refreshUrl, _) =>
+      SecurityScheme(
+        "oauth2",
+        None,
+        Some("Oauth2"),
+        Some("header"),
+        Some("bearer"),
+        None,
+        Some(OAuthFlows(authorizationCode = Some(OAuthFlow(authorizationUrl, tokenUrl, refreshUrl, scopes)))),
+        None
+      )
   }
 
   private def apiKeyInputNameAndIn(input: Vector[EndpointInput.Basic[_]]) = input match {

--- a/openapi/openapi-model/src/main/scala/tapir/openapi/OpenAPI.scala
+++ b/openapi/openapi-model/src/main/scala/tapir/openapi/OpenAPI.scala
@@ -257,10 +257,10 @@ case class SecurityScheme(
 )
 
 case class OAuthFlows(
-    `implicit`: Option[OAuthFlow],
-    password: Option[OAuthFlow],
-    clientCredentials: Option[OAuthFlow],
-    authorizationCode: Option[OAuthFlow]
+    `implicit`: Option[OAuthFlow] = None,
+    password: Option[OAuthFlow] = None,
+    clientCredentials: Option[OAuthFlow] = None,
+    authorizationCode: Option[OAuthFlow] = None
 )
 
 case class OAuthFlow(authorizationUrl: String, tokenUrl: String, refreshUrl: Option[String], scopes: ListMap[String, String])


### PR DESCRIPTION
add another auth method - oauth2 using authorizationCode.
I did not investigate the other methods, so this PR is specific for authorizationCode.

example usage:
```
 val apiEndpoint = baseEndpoint.in("api" / "v1")
        .in(auth.oauth2(
          "http://localhost:8080/auth/realms/realm/protocol/openid-connect/auth",
          "http://localhost:8080/auth/realms/realm/protocol/openid-connect/token", 
          ListMap(("profile", "")))
        ).mapInTo(Auth)
```

in order for it to work - need to add the following route: 
```
private def redirectToOath2(query: String): Route =
    redirect(s"/swagger/oauth2-redirect.html$query", StatusCodes.PermanentRedirect)


 ~ path("oauth2-redirect.html") { request =>
      redirectToOath2(request.request.uri.rawQueryString.map(s => '?' + s).getOrElse(""))(request)
    }
```
