### PR TITLE
Added method to render path of Endpoint

### DIFF
--- a/core/src/main/scala/tapir/Endpoint.scala
+++ b/core/src/main/scala/tapir/Endpoint.scala
@@ -2,6 +2,7 @@ package tapir
 
 import tapir.EndpointInput.{FixedMethod, PathCapture, Query}
 import tapir.EndpointOutput.StatusMapping
+import tapir.EndpointPathTemplate.{PathParamRendering, QueryParamRendering}
 import tapir.model.Method
 import tapir.server.ServerEndpoint
 import tapir.typelevel.{FnComponents, ParamConcat, ParamsAsArgs}
@@ -123,58 +124,66 @@ case class Endpoint[I, E, O, +S](input: EndpointInput[I], errorOutput: EndpointO
     * }}}
     * returns `/p1/{param1}?par2={par2}`
     */
-  def renderPath(
-      renderPathComponent: (Int, PathCapture[_]) => String = Endpoint.defaultPathCaptureRender,
-      renderQueryComponent: Option[(Int, Query[_]) => String] = Some(Endpoint.defaultQueryRender)
-  ): String = {
-    import tapir.internal._
-
-    def namedPathComponents(
-        inputs: Vector[EndpointInput.Basic[_]],
-        renderPath: (Int, PathCapture[_]) => String
-    ): (Vector[String], Int) =
-      inputs.foldLeft((Vector.empty[String], 1)) {
-        case ((acc, index), component) =>
-          component match {
-            case p: EndpointInput.PathCapture[_] => (acc :+ renderPath(index, p), index + 1)
-            case EndpointInput.FixedPath(s)      => (acc :+ s, index)
-            case _                               => (acc, index)
-          }
-      }
-
-    def namedQueryComponents(
-        inputs: Vector[EndpointInput.Basic[_]],
-        renderQuery: (Int, Query[_]) => String,
-        pathParamCount: Int
-    ): Vector[String] =
-      inputs
-        .foldLeft((Vector.empty[String], pathParamCount)) {
-          case ((acc, index), component) =>
-            component match {
-              case q: EndpointInput.Query[_] => (acc :+ renderQuery(index, q), index + 1)
-              case _                         => (acc, index)
-            }
-        }
-        ._1
-
-    val inputs = input.asVectorOfBasicInputs(includeAuth = false)
-    val (pathComponents, pathParamCount) = namedPathComponents(inputs, renderPathComponent)
-    val queryParams = renderQueryComponent
-      .map(namedQueryComponents(inputs, _, pathParamCount))
-      .map(_.mkString("&"))
-      .getOrElse("")
-
-    "/" + pathComponents.mkString("/") + (if (queryParams.isEmpty) "" else "?" + queryParams)
-  }
+  def renderPathTemplate(
+      pathParamRendering: PathParamRendering = EndpointPathTemplate.Defaults.path,
+      queryParamRendering: Option[QueryParamRendering] = Some(EndpointPathTemplate.Defaults.query)
+  ): String =
+    EndpointPathTemplate.renderPathTemplate(this)(pathParamRendering, queryParamRendering)
 
   def serverLogic[F[_]](f: I => F[Either[E, O]]): ServerEndpoint[I, E, O, S, F] = ServerEndpoint(this, f)
 }
 
-object Endpoint {
-  val defaultPathCaptureRender: (Int, PathCapture[_]) => String =
-    (index, pc) => pc.name.map(name => s"{$name}").getOrElse(s"{param$index}")
-  val defaultQueryRender: (Int, Query[_]) => String =
-    (_, q) => s"${q.name}={${q.name}}"
+object EndpointPathTemplate {
+  type PathParamRendering = (Int, PathCapture[_]) => String
+  type QueryParamRendering = (Int, Query[_]) => String
+
+  object Defaults {
+    val path: PathParamRendering = (index, pc) => pc.name.map(name => s"{$name}").getOrElse(s"{param$index}")
+    val query: QueryParamRendering = (_, q) => s"${q.name}={${q.name}}"
+  }
+
+  def renderPathTemplate(
+      e: Endpoint[_, _, _, _]
+  )(pathParamRendering: PathParamRendering, queryParamRendering: Option[QueryParamRendering]): String = {
+    import tapir.internal._
+
+    val inputs = e.input.asVectorOfBasicInputs(includeAuth = false)
+    val (pathComponents, pathParamCount) = renderedPathComponents(inputs, pathParamRendering)
+    val queryComponents = queryParamRendering
+      .map(renderedQueryComponents(inputs, _, pathParamCount))
+      .map(_.mkString("&"))
+      .getOrElse("")
+
+    "/" + pathComponents.mkString("/") + (if (queryComponents.isEmpty) "" else "?" + queryComponents)
+  }
+
+  private def renderedPathComponents(
+      inputs: Vector[EndpointInput.Basic[_]],
+      pathParamRendering: PathParamRendering
+  ): (Vector[String], Int) =
+    inputs.foldLeft((Vector.empty[String], 1)) {
+      case ((acc, index), component) =>
+        component match {
+          case p: EndpointInput.PathCapture[_] => (acc :+ pathParamRendering(index, p), index + 1)
+          case EndpointInput.FixedPath(s)      => (acc :+ s, index)
+          case _                               => (acc, index)
+        }
+    }
+
+  private def renderedQueryComponents(
+      inputs: Vector[EndpointInput.Basic[_]],
+      queryParamRendering: QueryParamRendering,
+      pathParamCount: Int
+  ): Vector[String] =
+    inputs
+      .foldLeft((Vector.empty[String], pathParamCount)) {
+        case ((acc, index), component) =>
+          component match {
+            case q: EndpointInput.Query[_] => (acc :+ queryParamRendering(index, q), index + 1)
+            case _                         => (acc, index)
+          }
+      }
+      ._1
 }
 
 case class EndpointInfo(name: Option[String], summary: Option[String], description: Option[String], tags: Vector[String]) {

--- a/core/src/test/scala/tapir/EndpointTest.scala
+++ b/core/src/test/scala/tapir/EndpointTest.scala
@@ -81,4 +81,30 @@ class EndpointTest extends FlatSpec with Matchers {
       testShowEndpoint.show shouldBe expectedShowResult
     }
   }
+
+  val renderTestData = List(
+    (endpoint, "/"),
+    (endpoint.in("p1"), "/p1"),
+    (endpoint.in("p1" / "p2"), "/p1/p2"),
+    (endpoint.in("p1" / path[String]), "/p1/{param1}"),
+    (endpoint.in("p1" / path[String].name("par")), "/p1/{par}"),
+    (endpoint.in("p1" / query[String]("par")), "/p1?par={par}"),
+    (endpoint.in("p1" / query[String]("par1") / query[String]("par2")), "/p1?par1={par1}&par2={par2}"),
+    (endpoint.in("p1" / path[String].name("par1") / query[String]("par2")), "/p1/{par1}?par2={par2}")
+  )
+
+  for ((testEndpoint, expectedRenderPath) <- renderTestData) {
+    s"renderPath for ${testEndpoint.showDetail}" should s"be $expectedRenderPath" in {
+      testEndpoint.renderPath() shouldBe expectedRenderPath
+    }
+  }
+
+  "renderPath" should "keep param count in render functions" in {
+    val testEndpoint = endpoint.in("p1" / path[String] / query[String]("param"))
+    testEndpoint.renderPath(
+      renderPathComponent = (index, _) => s"{param$index}",
+      renderQueryComponent = Some((index, query) => s"${query.name}={param$index}")
+    ) shouldBe "/p1/{param1}?param={param2}"
+  }
+
 }

--- a/core/src/test/scala/tapir/EndpointTest.scala
+++ b/core/src/test/scala/tapir/EndpointTest.scala
@@ -95,16 +95,16 @@ class EndpointTest extends FlatSpec with Matchers {
 
   for ((testEndpoint, expectedRenderPath) <- renderTestData) {
     s"renderPath for ${testEndpoint.showDetail}" should s"be $expectedRenderPath" in {
-      testEndpoint.renderPath() shouldBe expectedRenderPath
+      testEndpoint.renderPathTemplate() shouldBe expectedRenderPath
     }
   }
 
   "renderPath" should "keep param count in render functions" in {
     val testEndpoint = endpoint.in("p1" / path[String] / query[String]("param"))
-    testEndpoint.renderPath(
-      renderPathComponent = (index, _) => s"{param$index}",
-      renderQueryComponent = Some((index, query) => s"${query.name}={param$index}")
-    ) shouldBe "/p1/{param1}?param={param2}"
+    testEndpoint.renderPathTemplate(
+      pathParamRendering = (index, _) => s"{par$index}",
+      queryParamRendering = Some((index, query) => s"${query.name}={par$index}")
+    ) shouldBe "/p1/{par1}?param={par2}"
   }
 
 }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenApiPaths.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenApiPaths.scala
@@ -39,7 +39,7 @@ private[openapi] class EndpointToOpenApiPaths(objectSchemas: ObjectSchemas, secu
       parameters = List.empty
     )
 
-    (e.renderPath(renderQueryComponent = None), pathItem)
+    (e.renderPathTemplate(queryParamRendering = None), pathItem)
   }
 
   private def endpointToOperation(defaultId: String, e: Endpoint[_, _, _, _], inputs: Vector[EndpointInput.Basic[_]]): Operation = {


### PR DESCRIPTION
Result of discussion from gitter https://gitter.im/softwaremill/tapir?at=5d07970126477710bbc78249

Added method which can be used to return path with query params of given endpoint, e.g. for 
```scala
endpoint.in("p1" / path[String] / query[String]("par2"))
```
 returns `/p1/{param1}?par2={par2}`

It can be used in various cases when there is a need to describe the endpoint path, e.g. in transaction naming in metrics or in openapi endpoint definition. In fact most of the code is extracted from `EndpointToOpenApiPaths`.

Similar approach described in #112