### PR TITLE
Test - broken input parsing when header input is specified before path input

### DIFF
--- a/server/tests/src/main/scala/tapir/server/tests/ServerTests.scala
+++ b/server/tests/src/main/scala/tapir/server/tests/ServerTests.scala
@@ -108,6 +108,13 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
     }
   }
 
+  testServer(in_header_before_path, "Header input before path capture input"){ case (str: String, i: Int) => pureResult((i, str).asRight[Unit])} { baseUri =>
+    sttp.get(uri"$baseUri/12").header("SomeHeader", "hello").send().map { response =>
+      response.body shouldBe Right("hello")
+      response.header("IntHeader") shouldBe Some(12)
+    }
+  }
+
   testServer(in_json_out_json)((fa: FruitAmount) => pureResult(FruitAmount(fa.fruit + " banana", fa.amount * 2).asRight[Unit])) { baseUri =>
     sttp
       .post(uri"$baseUri/api/echo")

--- a/tests/src/main/scala/tapir/tests/package.scala
+++ b/tests/src/main/scala/tapir/tests/package.scala
@@ -48,6 +48,12 @@ package object tests {
     .in(query[String]("fruit"))
     .out(stringBody.and(header[Int]("X-Role")).mapTo(FruitAmount))
 
+  val in_header_before_path: Endpoint[(String, Int), Unit, (Int, String), Nothing] = endpoint
+    .in(header[String]("SomeHeader"))
+    .in(path[Int])
+    .out(header[Int]("IntHeader") and stringBody)
+
+
   val in_json_out_json: Endpoint[FruitAmount, Unit, FruitAmount, Nothing] =
     endpoint.post.in("api" / "echo").in(jsonBody[FruitAmount]).out(jsonBody[FruitAmount]).name("echo json")
 


### PR DESCRIPTION
```
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
	at tapir.server.tests.ServerTests.$anonfun$$init$$53(ServerTests.scala:112)
```