### PR TITLE
Add description for FixedStatusCode

### DIFF
--- a/client/sttp-client/src/main/scala/tapir/client/sttp/EndpointToSttpClient.scala
+++ b/client/sttp-client/src/main/scala/tapir/client/sttp/EndpointToSttpClient.scala
@@ -88,7 +88,7 @@ class EndpointToSttpClient(clientOptions: SttpClientOptions) {
         case EndpointOutput.StatusCode() =>
           Some(meta.code)
 
-        case EndpointOutput.FixedStatusCode(_) =>
+        case EndpointOutput.FixedStatusCode(_, _) =>
           None
 
         case EndpointOutput.OneOf(mappings) =>

--- a/client/tests/src/main/scala/tapir/client/tests/ClientTests.scala
+++ b/client/tests/src/main/scala/tapir/client/tests/ClientTests.scala
@@ -78,6 +78,9 @@ trait ClientTests[S] extends FunSuite with Matchers with BeforeAndAfterAll {
   testClient(in_string_out_status_from_string.name("status one of 1"), "apple", Right(Right("fruit: apple")))
   testClient(in_string_out_status_from_string.name("status one of 2"), "papaya", Right(Left(29)))
   testClient(in_string_out_status, "apple", Right(StatusCodes.Ok))
+
+  testClient(delete_endpoint, (), Right(()))
+
   testClient(in_optional_json_out_optional_json.name("defined"), Some(FruitAmount("orange", 11)), Right(Some(FruitAmount("orange", 11))))
   testClient(in_optional_json_out_optional_json.name("empty"), None, Right(None))
 
@@ -140,6 +143,9 @@ trait ClientTests[S] extends FunSuite with Matchers with BeforeAndAfterAll {
         case None    => Ok()
         case Some(h) => Ok("Role: " + h.value)
       }
+
+    case DELETE -> Root / "api" / "delete" => Ok()
+
     case r @ GET -> Root / "auth" :? apiKeyOptParam(ak) =>
       val authHeader = r.headers.get(CaseInsensitiveString("Authorization")).map(_.value)
       val xApiKey = r.headers.get(CaseInsensitiveString("X-Api-Key")).map(_.value)

--- a/core/src/main/scala/tapir/EndpointIO.scala
+++ b/core/src/main/scala/tapir/EndpointIO.scala
@@ -3,6 +3,7 @@ package tapir
 import tapir.Codec.PlainCodec
 import tapir.CodecForMany.PlainCodecForMany
 import tapir.CodecForOptional.PlainCodecForOptional
+import tapir.EndpointIO.Info
 import tapir.internal.ProductToParams
 import tapir.model.{Method, MultiQueryParams, ServerRequest}
 import tapir.typelevel.{FnComponents, ParamConcat, ParamsAsArgs}
@@ -157,7 +158,9 @@ object EndpointOutput {
     override def show: String = "{status code}"
   }
 
-  case class FixedStatusCode(statusCode: tapir.model.StatusCode) extends Basic[Unit] {
+  case class FixedStatusCode(statusCode: tapir.model.StatusCode, info: Info[Unit]) extends Basic[Unit] {
+    def description(d: String): FixedStatusCode = copy(info = info.description(d))
+
     override def show: String = s"status code ($statusCode)"
   }
 

--- a/core/src/main/scala/tapir/Tapir.scala
+++ b/core/src/main/scala/tapir/Tapir.scala
@@ -74,7 +74,7 @@ trait Tapir extends TapirDerivedInputs {
   def extractFromRequest[T](f: ServerRequest => T): EndpointInput.ExtractFromRequest[T] = EndpointInput.ExtractFromRequest(f)
 
   def statusCode: EndpointOutput.StatusCode = EndpointOutput.StatusCode()
-  def statusCode(statusCode: StatusCode): EndpointOutput.FixedStatusCode = EndpointOutput.FixedStatusCode(statusCode)
+  def statusCode(statusCode: StatusCode): EndpointOutput.FixedStatusCode = EndpointOutput.FixedStatusCode(statusCode, EndpointIO.Info.empty)
 
   /**
     * Maps status codes to outputs. All outputs must have a common supertype (`I`). Typically, the supertype is a sealed

--- a/core/src/main/scala/tapir/internal/server/EncodeOutputs.scala
+++ b/core/src/main/scala/tapir/internal/server/EncodeOutputs.scala
@@ -1,7 +1,6 @@
 package tapir.internal.server
 
 import tapir.CodecForMany.PlainCodecForMany
-import tapir.EndpointIO.Info
 import tapir.{CodecForOptional, EndpointIO, EndpointOutput, MediaType, StreamingEndpointIO}
 import tapir.internal._
 import tapir.model.StatusCode
@@ -60,7 +59,7 @@ class EncodeOutputs[B](encodeOutputBody: EncodeOutputBody[B]) {
   }
 }
 
-case class OutputValues[B](body: Option[B], headers: Vector[(String, String)], statusCode: Option[StatusCode], info: Option[Info[Unit]]) {
+case class OutputValues[B](body: Option[B], headers: Vector[(String, String)], statusCode: Option[StatusCode]) {
   def withBody(b: B): OutputValues[B] = {
     if (body.isDefined) {
       throw new IllegalArgumentException("Body is already defined")
@@ -74,7 +73,7 @@ case class OutputValues[B](body: Option[B], headers: Vector[(String, String)], s
   def withStatusCode(sc: StatusCode): OutputValues[B] = copy(statusCode = Some(sc))
 }
 object OutputValues {
-  def empty[B]: OutputValues[B] = OutputValues[B](None, Vector.empty, None, None)
+  def empty[B]: OutputValues[B] = OutputValues[B](None, Vector.empty, None)
 }
 
 trait EncodeOutputBody[B] {

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOperationResponse.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOperationResponse.scala
@@ -2,7 +2,6 @@ package tapir.docs.openapi
 
 import tapir.internal._
 import tapir.docs.openapi.schema.ObjectSchemas
-import tapir.model.StatusCode
 import tapir.openapi.OpenAPI.ReferenceOr
 import tapir.openapi._
 import tapir.{Schema => SSchema, _}
@@ -66,7 +65,7 @@ private[openapi] class EndpointToOperationResponse(objectSchemas: ObjectSchemas,
     val body = bodies.headOption
 
     val descriptions = outputs.collect {
-      case EndpointOutput.FixedStatusCode(sc, info) if info.description.isDefined => info.description.get
+      case EndpointOutput.FixedStatusCode(_, EndpointIO.Info(Some(description), _)) => description
     }
 
     val description = body.flatMap(_._1).getOrElse(descriptions.headOption.getOrElse(""))

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOperationResponse.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOperationResponse.scala
@@ -65,13 +65,18 @@ private[openapi] class EndpointToOperationResponse(objectSchemas: ObjectSchemas,
     }
     val body = bodies.headOption
 
-    val description = body.flatMap(_._1).getOrElse("")
+    val descriptions = outputs.collect {
+      case EndpointOutput.FixedStatusCode(sc, info) if info.description.isDefined => info.description.get
+    }
+
+    val description = body.flatMap(_._1).getOrElse(descriptions.headOption.getOrElse(""))
+
     val content = body.map(_._2).getOrElse(ListMap.empty)
 
     if (body.isDefined || headers.nonEmpty) {
       Some(Response(description, headers.toListMap, content))
     } else if (outputs.nonEmpty) {
-      Some(Response("", ListMap.empty, ListMap.empty))
+      Some(Response(description, ListMap.empty, ListMap.empty))
     } else {
       None
     }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
@@ -86,7 +86,7 @@ object ObjectSchemasForEndpoints {
         mappings.flatMap(mapping => forOutput(mapping.output)).toList
       case EndpointOutput.StatusCode() =>
         List.empty
-      case EndpointOutput.FixedStatusCode(_) =>
+      case EndpointOutput.FixedStatusCode(_, _) =>
         List.empty
       case EndpointOutput.Mapped(wrapped, _, _, _) =>
         forOutput(wrapped)

--- a/docs/openapi-docs/src/test/resources/expected.yml
+++ b/docs/openapi-docs/src/test/resources/expected.yml
@@ -55,6 +55,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/FruitAmount'
+  /api/delete:
+    delete:
+      operationId: deleteApiDelete
+    responses:
+      '200':
+        description: ok
 components:
   schemas:
     FruitAmount:

--- a/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
@@ -26,7 +26,7 @@ class VerifyYamlTest extends FunSuite with Matchers {
   test("should match the expected yaml") {
     val expectedYaml = loadYaml("expected.yml")
 
-    val actualYaml = List(in_query_query_out_string, all_the_way).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = List(in_query_query_out_string, all_the_way, delete_endpoint).toOpenAPI(Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml

--- a/tests/src/main/scala/tapir/tests/package.scala
+++ b/tests/src/main/scala/tapir/tests/package.scala
@@ -152,6 +152,9 @@ package object tests {
   val in_string_out_status: Endpoint[String, Unit, StatusCode, Nothing] =
     endpoint.in(query[String]("fruit")).out(statusCode)
 
+  val delete_endpoint: Endpoint[Unit, Unit, Unit, Nothing] =
+    endpoint.delete.in("api" / "delete").out(statusCode(StatusCodes.Ok).description("ok"))
+
   val in_string_out_content_type_string: Endpoint[String, Unit, (String, String), Nothing] =
     endpoint.in("api" / "echo").in(stringBody).out(stringBody).out(header[String]("Content-Type"))
 


### PR DESCRIPTION
This PR addresses issue: https://github.com/softwaremill/tapir/issues/155 and allows the assigning of a description to a response status code when using FixedStatusCode.

