### PR TITLE
Use name as operationId, if it is set

### DIFF
--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenApiPaths.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/EndpointToOpenApiPaths.scala
@@ -55,7 +55,7 @@ private[openapi] class EndpointToOpenApiPaths(objectSchemas: ObjectSchemas, secu
       e.info.tags.toList,
       e.info.summary,
       e.info.description,
-      defaultId,
+      e.info.name.getOrElse(defaultId),
       parameters.toList.map(Right(_)),
       body.headOption,
       responses,

--- a/docs/openapi-docs/src/test/resources/expected_multipart.yml
+++ b/docs/openapi-docs/src/test/resources/expected_multipart.yml
@@ -5,7 +5,7 @@ info:
 paths:
   /api/echo/multipart:
     post:
-      operationId: postApiEchoMultipart
+      operationId: echofile
       requestBody:
         content:
           multipart/form-data:


### PR DESCRIPTION
The default operationId is a concatenation of the path and operation. For example, a path

`POST /v1/user/create/:id` may become something like `client.postV1UserCreateId` in the generated python/golang/java client.

It would be great if we can use the given name, instead. That way, you can specify the name you want in the API definition. Currently, the name set to `Endpoint#info.name` does not seem to be rendered out into the OpenAPI yaml.

`endpoint.name("createUser")` would become `client.createUser`