### PR TITLE
#141 Shape-aware route matching

### DIFF
--- a/core/src/main/scala/tapir/internal/server/DecodeInputs.scala
+++ b/core/src/main/scala/tapir/internal/server/DecodeInputs.scala
@@ -55,6 +55,8 @@ trait DecodeInputsContext {
 
 object DecodeInputs {
 
+  private final case class IndexedBasicInput(input: EndpointInput.Basic[_], index: Int)
+
   /**
     * Decodes values of all inputs defined by the given `input`, and returns a map from the input to the input's value.
     *
@@ -71,119 +73,186 @@ object DecodeInputs {
 
     val basicInputs = assignInputIndexes(input.asVectorOfBasicInputs(), 0, Vector.empty)
 
-    val methodInputs = basicInputs.filter(t => isRequestMethod(t._1))
-    val pathInputs = basicInputs.filter(t => isPath(t._1))
-    val otherInputs = basicInputs.filterNot(t => isRequestMethod(t._1) || isPath(t._1)).sortBy(t => basicInputSortIndex(t._1))
+    val methodInputs = basicInputs.filter(t => isRequestMethod(t.input))
+    val pathInputs = basicInputs.filter(t => isPath(t.input))
+    val otherInputs = basicInputs.filterNot(t => isRequestMethod(t.input) || isPath(t.input)).sortBy(t => basicInputSortIndex(t.input))
 
     // we're using null as a placeholder for the future values. All except the body (which is determined by
     // interpreter-specific code), should be filled by the end of this method.
     compose(
-      apply(methodInputs, _, _),
-      apply(pathInputs, _, _),
-      (values, ctx) =>
-        verifyPathExactMatch(pathInputs, ctx) match {
-          case None          => (values, ctx)
-          case Some(failure) => (failure, ctx)
-        },
-      apply(otherInputs, _, _)
+      matchOthers(methodInputs, _, _),
+      matchPath(pathInputs, _, _),
+      matchOthers(otherInputs, _, _)
     )(DecodeInputsResult.Values(Vector.fill(basicInputs.size)(null), None), ctx)._1
   }
 
-  private def apply(
-      inputs: Vector[(EndpointInput.Basic[_], Int)],
+  private def matchPath(
+      pathInputs: Vector[IndexedBasicInput],
+      decodeValues: DecodeInputsResult.Values,
+      ctx: DecodeInputsContext
+  ): (DecodeInputsResult, DecodeInputsContext) = {
+    pathInputs match {
+      case Vector() =>
+        // Match everything if no path input is specified
+        decodeValues -> ctx
+      case in +: _ =>
+        matchPathInner(
+          pathInputs = pathInputs,
+          ctx = ctx,
+          decodeValues = decodeValues,
+          thunks = Vector.empty,
+          in
+        )
+    }
+  }
+
+  private def matchPathInner(
+      pathInputs: Vector[IndexedBasicInput],
+      ctx: DecodeInputsContext,
+      decodeValues: DecodeInputsResult.Values,
+      thunks: Vector[() => (IndexedBasicInput, DecodeResult[_])],
+      fallbackPathInput: IndexedBasicInput
+  ): (DecodeInputsResult, DecodeInputsContext) = {
+    pathInputs match {
+      case (idxInput @ IndexedBasicInput(in, idx)) +: restInputs => {
+        in match {
+          case EndpointInput.FixedPath(expectedSegment) => {
+            val (nextSegment, newCtx) = ctx.nextPathSegment
+            nextSegment match {
+              case Some(seg) =>
+                if (seg == expectedSegment) {
+                  matchPathInner(restInputs, newCtx, decodeValues, thunks, idxInput)
+                } else {
+                  val failure = DecodeInputsResult.Failure(in, DecodeResult.Mismatch(expectedSegment, seg))
+                  failure -> newCtx
+                }
+              case None =>
+                if (expectedSegment.isEmpty) {
+                  // FixedPath("") matches an empty path
+                  matchPathInner(restInputs, newCtx, decodeValues, thunks, idxInput)
+                } else {
+                  val failure = DecodeInputsResult.Failure(in, DecodeResult.Missing)
+                  failure -> newCtx
+                }
+            }
+          }
+          case i: EndpointInput.PathCapture[_] => {
+            val (nextSegment, newCtx) = ctx.nextPathSegment
+            nextSegment match {
+              case Some(seg) => {
+                val newThunks = thunks :+ { () =>
+                  (idxInput, i.codec.safeDecode(seg))
+                }
+                matchPathInner(restInputs, newCtx, decodeValues, newThunks, idxInput)
+              }
+              case None => {
+                val failure = DecodeInputsResult.Failure(in, DecodeResult.Missing)
+                failure -> newCtx
+              }
+            }
+          }
+          case _: EndpointInput.PathsCapture =>
+            val (paths, newCtx) = collectRemainingPath(Vector.empty, ctx)
+            matchPathInner(restInputs, newCtx, decodeValues.setBasicInputValue(paths, idx), thunks, idxInput)
+          case _ =>
+            throw new Error(
+              s"Unexpected EndpointInput ${in.show} encountered. " +
+                s"This is most likely a bug in the library"
+            )
+        }
+
+      }
+      case Vector() => {
+        val (extraSegmentOpt, newCtx) = ctx.nextPathSegment
+        extraSegmentOpt match {
+          case Some(extraSegment) => {
+            val failure = DecodeInputsResult.Failure(fallbackPathInput.input, DecodeResult.Mismatch("", extraSegment))
+            failure -> newCtx
+          }
+          case None =>
+            evaluatePathDecodingThunks(decodeValues, thunks) -> newCtx
+        }
+      }
+    }
+  }
+
+  @tailrec
+  private def evaluatePathDecodingThunks(
+      values: DecodeInputsResult.Values,
+      thunks: Vector[() => (IndexedBasicInput, DecodeResult[_])]
+  ): DecodeInputsResult = {
+    thunks match {
+      case Vector() => values
+      case t +: ts => {
+        t() match {
+          case (indexedInput, failure: DecodeFailure) => DecodeInputsResult.Failure(indexedInput.input, failure)
+          case (indexedInput, DecodeResult.Value(v))  => evaluatePathDecodingThunks(values.setBasicInputValue(v, indexedInput.index), ts)
+        }
+      }
+    }
+  }
+
+  @tailrec
+  private def collectRemainingPath(acc: Vector[String], c: DecodeInputsContext): (Vector[String], DecodeInputsContext) =
+    c.nextPathSegment match {
+      case (Some(s), c2) => collectRemainingPath(acc :+ s, c2)
+      case (None, c2)    => (acc, c2)
+    }
+
+  @tailrec
+  private def matchOthers(
+      inputs: Vector[IndexedBasicInput],
       values: DecodeInputsResult.Values,
       ctx: DecodeInputsContext
   ): (DecodeInputsResult, DecodeInputsContext) = {
     inputs match {
       case Vector() => (values, ctx)
 
-      case (input @ EndpointInput.FixedMethod(m), _) +: inputsTail =>
-        if (m == ctx.method) apply(inputsTail, values, ctx)
+      case IndexedBasicInput(input @ EndpointInput.FixedMethod(m), _) +: inputsTail =>
+        if (m == ctx.method) matchOthers(inputsTail, values, ctx)
         else (DecodeInputsResult.Failure(input, DecodeResult.Mismatch(m.m, ctx.method.m)), ctx)
 
-      case (input @ EndpointInput.FixedPath(ss), _) +: inputsTail =>
-        ctx.nextPathSegment match {
-          case (Some(`ss`), ctx2)       => apply(inputsTail, values, ctx2)
-          case (None, ctx2) if ss == "" => apply(inputsTail, values, ctx2) // root path
-          case (Some(s), _)             => (DecodeInputsResult.Failure(input, DecodeResult.Mismatch(ss, s)), ctx)
-          case (None, _)                => (DecodeInputsResult.Failure(input, DecodeResult.Missing), ctx)
-        }
-
-      case (input @ EndpointInput.PathCapture(codec, _, _), index) +: inputsTail =>
-        ctx.nextPathSegment match {
-          case (Some(s), ctx2) =>
-            codec.safeDecode(s) match {
-              case DecodeResult.Value(v)  => apply(inputsTail, values.setBasicInputValue(v, index), ctx2)
-              case failure: DecodeFailure => (DecodeInputsResult.Failure(input, failure), ctx)
-            }
-          case (None, _) => (DecodeInputsResult.Failure(input, DecodeResult.Missing), ctx)
-        }
-
-      case (EndpointInput.PathsCapture(_), index) +: inputsTail =>
-        @tailrec
-        def remainingPath(acc: Vector[String], c: DecodeInputsContext): (Vector[String], DecodeInputsContext) = c.nextPathSegment match {
-          case (Some(s), c2) => remainingPath(acc :+ s, c2)
-          case (None, c2)    => (acc, c2)
-        }
-
-        val (ps, ctx2) = remainingPath(Vector.empty, ctx)
-
-        apply(inputsTail, values.setBasicInputValue(ps, index), ctx2)
-
-      case (input @ EndpointInput.Query(name, codec, _), index) +: inputsTail =>
+      case IndexedBasicInput(input @ EndpointInput.Query(name, codec, _), index) +: inputsTail =>
         codec.safeDecode(ctx.queryParameter(name).toList) match {
-          case DecodeResult.Value(v)  => apply(inputsTail, values.setBasicInputValue(v, index), ctx)
+          case DecodeResult.Value(v)  => matchOthers(inputsTail, values.setBasicInputValue(v, index), ctx)
           case failure: DecodeFailure => (DecodeInputsResult.Failure(input, failure), ctx)
         }
 
-      case (EndpointInput.QueryParams(_), index) +: inputsTail =>
-        apply(inputsTail, values.setBasicInputValue(MultiQueryParams.fromMultiMap(ctx.queryParameters), index), ctx)
+      case IndexedBasicInput(EndpointInput.QueryParams(_), index) +: inputsTail =>
+        matchOthers(inputsTail, values.setBasicInputValue(MultiQueryParams.fromMultiMap(ctx.queryParameters), index), ctx)
 
-      case (input @ EndpointInput.Cookie(name, codec, _), index) +: inputsTail =>
+      case IndexedBasicInput(input @ EndpointInput.Cookie(name, codec, _), index) +: inputsTail =>
         val allCookies = DecodeResult.sequence(ctx.headers.filter(_._1 == Cookie.HeaderName).map(p => Cookie.parse(p._2)).toList)
         val cookieValue =
           allCookies.map(_.flatten.find(_.name == name)).flatMap(cookie => codec.safeDecode(cookie.map(_.value)))
         cookieValue match {
-          case DecodeResult.Value(v)  => apply(inputsTail, values.setBasicInputValue(v, index), ctx)
+          case DecodeResult.Value(v)  => matchOthers(inputsTail, values.setBasicInputValue(v, index), ctx)
           case failure: DecodeFailure => (DecodeInputsResult.Failure(input, failure), ctx)
         }
 
-      case (input @ EndpointIO.Header(name, codec, _), index) +: inputsTail =>
+      case IndexedBasicInput(input @ EndpointIO.Header(name, codec, _), index) +: inputsTail =>
         codec.safeDecode(ctx.header(name)) match {
-          case DecodeResult.Value(v)  => apply(inputsTail, values.setBasicInputValue(v, index), ctx)
+          case DecodeResult.Value(v)  => matchOthers(inputsTail, values.setBasicInputValue(v, index), ctx)
           case failure: DecodeFailure => (DecodeInputsResult.Failure(input, failure), ctx)
         }
 
-      case (EndpointIO.Headers(_), index) +: inputsTail =>
-        apply(inputsTail, values.setBasicInputValue(ctx.headers, index), ctx)
+      case IndexedBasicInput(EndpointIO.Headers(_), index) +: inputsTail =>
+        matchOthers(inputsTail, values.setBasicInputValue(ctx.headers, index), ctx)
 
-      case (EndpointInput.ExtractFromRequest(f), index) +: inputsTail =>
-        apply(inputsTail, values.setBasicInputValue(f(ctx.serverRequest), index), ctx)
+      case IndexedBasicInput(EndpointInput.ExtractFromRequest(f), index) +: inputsTail =>
+        matchOthers(inputsTail, values.setBasicInputValue(f(ctx.serverRequest), index), ctx)
 
-      case (input @ EndpointIO.Body(_, _), index) +: inputsTail =>
-        apply(inputsTail, values.addBodyInput(input, index), ctx)
+      case IndexedBasicInput(input @ EndpointIO.Body(_, _), index) +: inputsTail =>
+        matchOthers(inputsTail, values.addBodyInput(input, index), ctx)
 
-      case (EndpointIO.StreamBodyWrapper(_), index) +: inputsTail =>
-        apply(inputsTail, values.setBasicInputValue(ctx.bodyStream, index), ctx)
-    }
-  }
+      case IndexedBasicInput(EndpointIO.StreamBodyWrapper(_), index) +: inputsTail =>
+        matchOthers(inputsTail, values.setBasicInputValue(ctx.bodyStream, index), ctx)
 
-  /**
-    * If there's any path input, the path must match exactly.
-    */
-  private def verifyPathExactMatch(
-      pathInputs: Vector[(EndpointInput.Basic[_], Int)],
-      ctx: DecodeInputsContext
-  ): Option[DecodeInputsResult.Failure] = {
-    pathInputs.lastOption match {
-      case Some((lastPathInput, _)) =>
-        ctx.nextPathSegment._1 match {
-          case Some(nextPathSegment) =>
-            Some(DecodeInputsResult.Failure(lastPathInput, DecodeResult.Mismatch("", nextPathSegment)))
-          case None => None
-        }
-
-      case None => None
+      case indexedInput +: _ =>
+        throw new Error(
+          s"Unexpected EndpointInput ${indexedInput.input.show} encountered. " +
+            s"This is most likely a bug in the library"
+        )
     }
   }
 
@@ -221,13 +290,13 @@ object DecodeInputs {
   private def assignInputIndexes(
       inputs: Vector[EndpointInput.Basic[_]],
       nextIndex: Int,
-      acc: Vector[(EndpointInput.Basic[_], Int)]
-  ): Vector[(EndpointInput.Basic[_], Int)] = {
+      acc: Vector[IndexedBasicInput]
+  ): Vector[IndexedBasicInput] = {
     inputs match {
       case Vector()                                   => acc
-      case (input: EndpointInput.FixedMethod) +: tail => assignInputIndexes(tail, nextIndex, acc :+ ((input, NoIndex)))
-      case (input: EndpointInput.FixedPath) +: tail   => assignInputIndexes(tail, nextIndex, acc :+ ((input, NoIndex)))
-      case input +: tail                              => assignInputIndexes(tail, nextIndex + 1, acc :+ ((input, nextIndex)))
+      case (input: EndpointInput.FixedMethod) +: tail => assignInputIndexes(tail, nextIndex, acc :+ IndexedBasicInput(input, NoIndex))
+      case (input: EndpointInput.FixedPath) +: tail   => assignInputIndexes(tail, nextIndex, acc :+ IndexedBasicInput(input, NoIndex))
+      case input +: tail                              => assignInputIndexes(tail, nextIndex + 1, acc :+ IndexedBasicInput(input, nextIndex))
     }
   }
 
@@ -239,4 +308,5 @@ object DecodeInputs {
       case _                  => Some(v)
     }
   }
+
 }

--- a/core/src/main/scala/tapir/server/ServerDefaults.scala
+++ b/core/src/main/scala/tapir/server/ServerDefaults.scala
@@ -8,7 +8,7 @@ object ServerDefaults {
   def decodeFailureHandlerUsingResponse[REQUEST](
       response: (StatusCode, String) => DecodeFailureHandling
   ): DecodeFailureHandler[REQUEST] =
-    (_, input, failure) => {
+    (_, input, _) => {
       input match {
         case EndpointInput.Query(name, _, _)       => response(StatusCodes.BadRequest, s"Invalid value for: query parameter $name")
         case _: EndpointInput.QueryParams          => response(StatusCodes.BadRequest, "Invalid value for: query parameters")
@@ -17,6 +17,7 @@ object ServerDefaults {
         case _: EndpointIO.Headers                 => response(StatusCodes.BadRequest, s"Invalid value for: headers")
         case _: EndpointIO.Body[_, _, _]           => response(StatusCodes.BadRequest, s"Invalid value for: body")
         case _: EndpointIO.StreamBodyWrapper[_, _] => response(StatusCodes.BadRequest, s"Invalid value for: body")
+        case in: EndpointInput.PathCapture[_]      => response(StatusCodes.BadRequest, s"Invalid path parameter ${in.show}")
         case _                                     => DecodeFailureHandling.noMatch
       }
     }

--- a/tests/src/main/scala/tapir/tests/AlwaysSuccess.scala
+++ b/tests/src/main/scala/tapir/tests/AlwaysSuccess.scala
@@ -1,0 +1,10 @@
+package tapir.tests
+
+import tapir.Codec
+import tapir.Codec.PlainCodec
+
+final case class AlwaysSuccess()
+
+object AlwaysSuccess {
+  implicit val codec: PlainCodec[AlwaysSuccess] = Codec.stringPlainCodecUtf8.map(_ => AlwaysSuccess())(_ => "")
+}

--- a/tests/src/main/scala/tapir/tests/package.scala
+++ b/tests/src/main/scala/tapir/tests/package.scala
@@ -25,7 +25,10 @@ package object tests {
   val in_two_path_capture: Endpoint[(Int, Int), Unit, (Int, Int), Nothing] = endpoint
     .in("in" / path[Int] / path[Int])
     .out(header[Int]("a") and header[Int]("b"))
+
   val in_string_out_string: Endpoint[String, Unit, String, Nothing] = endpoint.post.in("api" / "echo").in(stringBody).out(stringBody)
+
+  val in_path_with_always_success_codec: Endpoint[AlwaysSuccess, Unit, Unit, Nothing] = endpoint.get.in("api").in(path[AlwaysSuccess])
 
   val in_mapped_query_out_string: Endpoint[List[Char], Unit, String, Nothing] =
     endpoint.in(query[String]("fruit").map(_.toList)(_.mkString(""))).out(stringBody)
@@ -85,6 +88,14 @@ package object tests {
 
   val in_paths_out_string: Endpoint[Seq[String], Unit, String, Nothing] =
     endpoint.get.in(paths).out(stringBody)
+
+  val in_paths_before_path_capture: Endpoint[(Seq[String], String), Unit, Unit, Nothing] = endpoint.get.in(paths).in(path[String]("cap"))
+
+  val in_paths_after_capture: Endpoint[(Int, Seq[String]), Unit, (Int, String), Nothing] =
+    endpoint.get.in("api").in(path[Int]).in("and").in(paths).out(header[Int]("IntPath") and stringBody)
+
+  val in_path_multiple_capture: Endpoint[(Int, Int), Unit, Unit, Nothing] =
+    endpoint.get.in("customer" / path[Int]("customer_id") / "orders" / path[Int]("order_id"))
 
   val in_query_list_out_header_list: Endpoint[List[String], Unit, List[String], Nothing] =
     endpoint.get.in("api" / "echo" / "param-to-header").in(query[List[String]]("qq")).out(header[List[String]]("hh"))


### PR DESCRIPTION
Implement route matching which matches the "shape" of a route where the shape is determined by matching the constant segments and wildcard segments (path parameters).

e.g. A path of /"customer"/path[String]/"orders"/path[Int] has the shape of /customer/*/orders/*

Any request URI the path shape with invalid path parameters will return a 400 BadRequest instead of DecodeFailureHandling.NoMatch

To obtain the original behaviour where an invalid path parameter results in NoMatch (i.e. tries to match later routes), the user can override `decodeFailureHandler` to not fail on an error resulting from `EndpointInput.PathCapture[_]`