### PR TITLE
Compile sttp client for ScalaJS and Scala Native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
+
 val scala2_12 = "2.12.8"
 val scala2_13 = "2.13.0"
 
@@ -35,8 +37,8 @@ lazy val rootProject = (project in file("."))
   .settings(commonSettings)
   .settings(publishArtifact := false, name := "tapir")
   .aggregate(
-    core,
-    circeJson,
+    core.jvm,
+    circeJson.jvm,
     openapiModel,
     openapiCirce,
     openapiCirceYaml,
@@ -46,26 +48,31 @@ lazy val rootProject = (project in file("."))
     serverTests,
     akkaHttpServer,
     http4sServer,
-    sttpClient,
-    tests,
+    sttpClient.jvm,
+    tests.jvm,
     examples,
     playground
   )
 
 // core
 
-lazy val core: Project = (project in file("core"))
+lazy val core = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("core"))
   .settings(commonSettings)
   .settings(
     name := "tapir-core",
+    boilerplateSource in Compile := baseDirectory.value.getParentFile / "src" / "main" / "boilerplate",
     libraryDependencies ++= Seq(
-      "com.propensive" %% "magnolia" % "0.11.0",
+      "com.propensive" %%% "magnolia" % "0.11.0",
       scalaTest % "test"
     )
   )
   .enablePlugins(spray.boilerplate.BoilerplatePlugin)
 
-lazy val tests: Project = (project in file("tests"))
+lazy val tests = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("tests"))
   .settings(commonSettings)
   .settings(
     name := "tapir-tests",
@@ -80,7 +87,9 @@ lazy val tests: Project = (project in file("tests"))
 
 // json
 
-lazy val circeJson: Project = (project in file("json/circe"))
+lazy val circeJson = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("json/circe"))
   .settings(commonSettings)
   .settings(
     name := "tapir-json-circe",
@@ -129,7 +138,7 @@ lazy val openapiDocs: Project = (project in file("docs/openapi-docs"))
   .settings(
     name := "tapir-openapi-docs"
   )
-  .dependsOn(openapiModel, core, tests % "test", openapiCirceYaml % "test")
+  .dependsOn(openapiModel, core.jvm, tests.jvm % "test", openapiCirceYaml % "test")
 
 lazy val swaggerUiAkka: Project = (project in file("docs/swagger-ui-akka-http"))
   .settings(commonSettings)
@@ -162,7 +171,7 @@ lazy val serverTests: Project = (project in file("server/tests"))
     libraryDependencies ++=
       Seq("com.softwaremill.sttp" %% "async-http-client-backend-cats" % Versions.sttp)
   )
-  .dependsOn(tests)
+  .dependsOn(tests.jvm)
 
 lazy val akkaHttpServer: Project = (project in file("server/akka-http-server"))
   .settings(commonSettings)
@@ -173,7 +182,7 @@ lazy val akkaHttpServer: Project = (project in file("server/akka-http-server"))
       "com.typesafe.akka" %% "akka-stream" % Versions.akkaStreams
     )
   )
-  .dependsOn(core, serverTests % "test")
+  .dependsOn(core.jvm, serverTests % "test")
 
 lazy val http4sServer: Project = (project in file("server/http4s-server"))
   .settings(commonSettings)
@@ -183,11 +192,13 @@ lazy val http4sServer: Project = (project in file("server/http4s-server"))
       "org.http4s" %% "http4s-blaze-server" % Versions.http4s(_)
     )
   )
-  .dependsOn(core, serverTests % "test")
+  .dependsOn(core.jvm, serverTests % "test")
 
 // client
 
-lazy val clientTests: Project = (project in file("client/tests"))
+lazy val clientTests = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("client/tests"))
   .settings(commonSettings)
   .settings(
     name := "tapir-client-tests",
@@ -200,7 +211,9 @@ lazy val clientTests: Project = (project in file("client/tests"))
   )
   .dependsOn(tests)
 
-lazy val sttpClient: Project = (project in file("client/sttp-client"))
+lazy val sttpClient = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("client/sttp-client"))
   .settings(commonSettings)
   .settings(
     name := "tapir-sttp-client",
@@ -227,7 +240,7 @@ lazy val examples: Project = (project in file("examples"))
     publishArtifact := false
   )
   .settings(only2_12settings)
-  .dependsOn(akkaHttpServer, http4sServer, sttpClient, openapiCirceYaml, openapiDocs, circeJson, swaggerUiAkka, swaggerUiHttp4s)
+  .dependsOn(akkaHttpServer, http4sServer, sttpClient.jvm, openapiCirceYaml, openapiDocs, circeJson.jvm, swaggerUiAkka, swaggerUiHttp4s)
 
 lazy val playground: Project = (project in file("playground"))
   .settings(commonSettings)
@@ -244,4 +257,4 @@ lazy val playground: Project = (project in file("playground"))
     publishArtifact := false
   )
   .settings(only2_12settings)
-  .dependsOn(akkaHttpServer, http4sServer, sttpClient, openapiCirceYaml, openapiDocs, circeJson, swaggerUiAkka, swaggerUiHttp4s)
+  .dependsOn(akkaHttpServer, http4sServer, sttpClient.jvm, openapiCirceYaml, openapiDocs, circeJson.jvm, swaggerUiAkka, swaggerUiHttp4s)

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val rootProject = (project in file("."))
 
 // core
 
-lazy val core = crossProject(JSPlatform, JVMPlatform)
+lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("core"))
   .settings(commonSettings)
@@ -70,7 +70,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   )
   .enablePlugins(spray.boilerplate.BoilerplatePlugin)
 
-lazy val tests = crossProject(JSPlatform, JVMPlatform)
+lazy val tests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("tests"))
   .settings(commonSettings)
@@ -87,7 +87,7 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform)
 
 // json
 
-lazy val circeJson = crossProject(JSPlatform, JVMPlatform)
+lazy val circeJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("json/circe"))
   .settings(commonSettings)
@@ -196,7 +196,7 @@ lazy val http4sServer: Project = (project in file("server/http4s-server"))
 
 // client
 
-lazy val clientTests = crossProject(JSPlatform, JVMPlatform)
+lazy val clientTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("client/tests"))
   .settings(commonSettings)
@@ -211,7 +211,7 @@ lazy val clientTests = crossProject(JSPlatform, JVMPlatform)
   )
   .dependsOn(tests)
 
-lazy val sttpClient = crossProject(JSPlatform, JVMPlatform)
+lazy val sttpClient = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("client/sttp-client"))
   .settings(commonSettings)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
 addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill" % "1.7.5")
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,4 @@
 addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill" % "1.7.5")
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")


### PR DESCRIPTION
You will probably need to ask the macwire team to publish a ScalaJS/Scala Native version but it doesn't seem to prevent sttp client from being generated.