### PR TITLE
Add minLength and maxLength validators

### DIFF
--- a/core/src/main/scala/tapir/Validator.scala
+++ b/core/src/main/scala/tapir/Validator.scala
@@ -29,6 +29,8 @@ object Validator extends ValidatorMagnoliaDerivation with ValidatorEnumMacro {
   def min[T: Numeric](value: T, exclusive: Boolean = false): Validator.Primitive[T] = Min(value, exclusive)
   def max[T: Numeric](value: T, exclusive: Boolean = false): Validator.Primitive[T] = Max(value, exclusive)
   def pattern[T <: String](value: String): Validator.Primitive[T] = Pattern(value)
+  def minLength[T <: String](value: Int): Validator.Primitive[T] = MinLength(value)
+  def maxLength[T <: String](value: Int): Validator.Primitive[T] = MaxLength(value)
   def minSize[T, C[_] <: Iterable[_]](value: Int): Validator.Primitive[C[T]] = MinSize(value)
   def maxSize[T, C[_] <: Iterable[_]](value: Int): Validator.Primitive[C[T]] = MaxSize(value)
   def custom[T](doValidate: T => Boolean, message: String): Validator.Primitive[T] = Custom(doValidate, message)
@@ -74,6 +76,26 @@ object Validator extends ValidatorMagnoliaDerivation with ValidatorEnumMacro {
       }
     }
     override def show: Option[String] = Some(s"~$value")
+  }
+  case class MinLength[T <: String](value: Int) extends Primitive[T] {
+    override def validate(t: T): List[ValidationError[_]] = {
+      if (t.size >= value) {
+        List.empty
+      } else {
+        List(ValidationError(this, t))
+      }
+    }
+    override def show: Option[String] = Some(s"length>=$value")
+  }
+  case class MaxLength[T <: String](value: Int) extends Primitive[T] {
+    override def validate(t: T): List[ValidationError[_]] = {
+      if (t.size <= value) {
+        List.empty
+      } else {
+        List(ValidationError(this, t))
+      }
+    }
+    override def show: Option[String] = Some(s"length<=$value")
   }
   case class MinSize[T, C[_] <: Iterable[_]](value: Int) extends Primitive[C[T]] {
     override def validate(t: C[T]): List[ValidationError[_]] = {

--- a/core/src/main/scala/tapir/server/ServerDefaults.scala
+++ b/core/src/main/scala/tapir/server/ServerDefaults.scala
@@ -56,6 +56,8 @@ object ServerDefaults {
     case Validator.Min(value, exclusive) => s"expected ${ve.invalidValue} to be greater than ${if (exclusive) "" else "or equal to "}$value"
     case Validator.Max(value, exclusive) => s"expected ${ve.invalidValue} to be less than ${if (exclusive) "" else "or equal to "}$value"
     case Validator.Pattern(value)        => s"expected '${ve.invalidValue}' to match '$value'"
+    case Validator.MinLength(value)      => s"expected size of ${ve.invalidValue} to be greater than or equal to $value "
+    case Validator.MaxLength(value)      => s"expected size of ${ve.invalidValue} to be less than or equal to $value "
     case Validator.MinSize(value)        => s"expected collection (${ve.invalidValue}) to be greater than or equal to $value"
     case Validator.MaxSize(value)        => s"expected collection (${ve.invalidValue}) to be less than or equal to $value"
     case Validator.Custom(_, message)    => s"expected '${ve.invalidValue}' to pass custom validation: $message"

--- a/core/src/test/scala/tapir/ValidatorTest.scala
+++ b/core/src/test/scala/tapir/ValidatorTest.scala
@@ -61,6 +61,20 @@ class ValidatorTest extends FlatSpec with Matchers {
     Validator.pattern(expected).validate("banana") shouldBe empty
   }
 
+  it should "validate for minLength of string" in {
+    val expected = 3
+    val v = Validator.minLength[String](expected)
+    v.validate("ab") shouldBe List(ValidationError(v, "ab"))
+    v.validate("abc") shouldBe empty
+  }
+
+  it should "validate for maxLength of string" in {
+    val expected = 1
+    val v = Validator.maxLength[String](expected)
+    v.validate("ab") shouldBe List(ValidationError(v, "ab"))
+    v.validate("a") shouldBe empty
+  }
+
   it should "validate with any of validators" in {
     val validator = Validator.any(Validator.max(5), Validator.max(10))
     validator.validate(4) shouldBe empty

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
@@ -80,10 +80,12 @@ private[schema] class TSchemaToOSchema(schemaReferenceMapper: SchemaReferenceMap
         } else {
           oschema.copy(maximum = Some(toBigDecimal(v, m.valueIsNumeric, wholeNumbers)))
         }
-      case Validator.Pattern(value) => oschema.copy(pattern = Some(value))
-      case Validator.MinSize(value) => oschema.copy(minItems = Some(value))
-      case Validator.MaxSize(value) => oschema.copy(maxItems = Some(value))
-      case Validator.Custom(_, _)   => oschema
+      case Validator.Pattern(value)   => oschema.copy(pattern = Some(value))
+      case Validator.MinLength(value) => oschema.copy(minLength = Some(value))
+      case Validator.MaxLength(value) => oschema.copy(maxLength = Some(value))
+      case Validator.MinSize(value)   => oschema.copy(minItems = Some(value))
+      case Validator.MaxSize(value)   => oschema.copy(maxItems = Some(value))
+      case Validator.Custom(_, _)     => oschema
       case Validator.Enum(v) =>
         val values = v.flatMap(x => encode.asInstanceOf[Any => Option[Any]].apply(x)).map(_.toString)
         oschema.copy(enum = if (values.nonEmpty) Some(values) else None)

--- a/docs/openapi-docs/src/test/resources/expected_valid_body_collection.yml
+++ b/docs/openapi-docs/src/test/resources/expected_valid_body_collection.yml
@@ -35,6 +35,7 @@ components:
       properties:
         fruit:
           type: string
+          minLength: 4
         amount:
           type: integer
           minimum: 1

--- a/docs/openapi-docs/src/test/resources/expected_valid_body_wrapped.yml
+++ b/docs/openapi-docs/src/test/resources/expected_valid_body_wrapped.yml
@@ -25,6 +25,7 @@ components:
       properties:
         fruit:
           type: string
+          minLength: 4
         amount:
           type: integer
           minimum: 1

--- a/openapi/openapi-model/src/main/scala/tapir/openapi/OpenAPI.scala
+++ b/openapi/openapi-model/src/main/scala/tapir/openapi/OpenAPI.scala
@@ -208,6 +208,8 @@ case class Schema(
     discriminator: Option[Discriminator] = None,
     additionalProperties: Option[ReferenceOr[Schema]] = None,
     pattern: Option[String] = None,
+    minLength: Option[Int] = None,
+    maxLength: Option[Int] = None,
     minimum: Option[BigDecimal] = None,
     exclusiveMinimum: Option[BigDecimal] = None,
     maximum: Option[BigDecimal] = None,

--- a/tests/src/main/scala/tapir/tests/FruitAmount.scala
+++ b/tests/src/main/scala/tapir/tests/FruitAmount.scala
@@ -4,4 +4,6 @@ case class FruitAmount(fruit: String, amount: Int)
 
 case class IntWrapper(v: Int) extends AnyVal
 
-case class ValidFruitAmount(fruit: String, amount: IntWrapper)
+case class StringWrapper(v: String) extends AnyVal
+
+case class ValidFruitAmount(fruit: StringWrapper, amount: IntWrapper)

--- a/tests/src/main/scala/tapir/tests/package.scala
+++ b/tests/src/main/scala/tapir/tests/package.scala
@@ -213,9 +213,12 @@ package object tests {
 
     val in_json_wrapper: Endpoint[ValidFruitAmount, Unit, Unit, Nothing] = {
       implicit val schemaForIntWrapper: SchemaFor[IntWrapper] = SchemaFor(Schema.SInteger)
-      implicit val encoder: Encoder[IntWrapper] = Encoder.encodeInt.contramap(_.v)
-      implicit val decode: Decoder[IntWrapper] = Decoder.decodeInt.map(IntWrapper.apply)
-      implicit val v: Validator[IntWrapper] = Validator.min(1).contramap(_.v)
+      implicit val intEncoder: Encoder[IntWrapper] = Encoder.encodeInt.contramap(_.v)
+      implicit val intDecoder: Decoder[IntWrapper] = Decoder.decodeInt.map(IntWrapper.apply)
+      implicit val stringEncoder: Encoder[StringWrapper] = Encoder.encodeString.contramap(_.v)
+      implicit val stringDecoder: Decoder[StringWrapper] = Decoder.decodeString.map(StringWrapper.apply)
+      implicit val intValidator: Validator[IntWrapper] = Validator.min(1).contramap(_.v)
+      implicit val stringValidator: Validator[StringWrapper] = Validator.minLength(4).contramap(_.v)
       endpoint.in(jsonBody[ValidFruitAmount])
     }
 
@@ -231,6 +234,10 @@ package object tests {
       implicit val encoder: Encoder[IntWrapper] = Encoder.encodeInt.contramap(_.v)
       implicit val decode: Decoder[IntWrapper] = Decoder.decodeInt.map(IntWrapper.apply)
       implicit val v: Validator[IntWrapper] = Validator.min(1).contramap(_.v)
+
+      implicit val stringEncoder: Encoder[StringWrapper] = Encoder.encodeString.contramap(_.v)
+      implicit val stringDecoder: Decoder[StringWrapper] = Decoder.decodeString.map(StringWrapper.apply)
+      implicit val stringValidator: Validator[StringWrapper] = Validator.minLength(4).contramap(_.v)
 
       import tapir.tests.BasketOfFruits._
       implicit def validatedListEncoder[T: Encoder]: Encoder[ValidatedList[T]] = implicitly[Encoder[List[T]]].contramap(identity)


### PR DESCRIPTION
This PR allows to support `minLength` and `maxLength` validators on strings, defined by OpenAPI https://swagger.io/docs/specification/data-models/data-types/#string