### PR TITLE
http4s-0.21.0-M5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,8 +187,9 @@ lazy val serverTests: Project = (project in file("server/tests"))
   .settings(
     name := "tapir-server-tests",
     publishArtifact := false,
-    libraryDependencies ++=
-      Seq("com.softwaremill.sttp" %% "async-http-client-backend-cats" % Versions.sttp)
+    libraryDependencies ++= dependenciesFor(scalaVersion.value)(
+      "com.softwaremill.sttp" %% "async-http-client-backend-cats" % Versions.sttp(_)
+    )
   )
   .dependsOn(tests)
 
@@ -232,9 +233,9 @@ lazy val sttpClient: Project = (project in file("client/sttp-client"))
   .settings(commonSettings)
   .settings(
     name := "tapir-sttp-client",
-    libraryDependencies ++= Seq(
-      "com.softwaremill.sttp" %% "core" % Versions.sttp,
-      "com.softwaremill.sttp" %% "async-http-client-backend-fs2" % Versions.sttp % "test"
+    libraryDependencies ++= dependenciesFor(scalaVersion.value)(
+      "com.softwaremill.sttp" %% "core" % Versions.sttp(_),
+      "com.softwaremill.sttp" %% "async-http-client-backend-fs2" % Versions.sttp(_) % "test"
     )
   )
   .dependsOn(core, clientTests % "test")
@@ -262,11 +263,13 @@ lazy val playground: Project = (project in file("playground"))
   .settings(
     name := "tapir-playground",
     libraryDependencies ++= Seq(
-      "com.softwaremill.sttp" %% "akka-http-backend" % Versions.sttp,
       "dev.zio" %% "zio" % "1.0.0-RC13",
       "dev.zio" %% "zio-interop-cats" % "2.0.0.0-RC4",
       "org.typelevel" %% "cats-effect" % "2.0.0",
       "io.swagger" % "swagger-annotations" % "1.5.23"
+    ),
+    libraryDependencies ++= dependenciesFor(scalaVersion.value)(
+      "com.softwaremill.sttp" %% "akka-http-backend" % Versions.sttp(_),
     ),
     libraryDependencies ++= loggerDependencies,
     publishArtifact := false

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,12 +3,15 @@ object Versions {
   type Version = Option[(Long, Long)] => String
 
   val http4s: Version = {
-    case Some((2, 13)) => "0.21.0-M4"
+    case Some((2, 13)) => "0.21.0-M5"
     case _             => "0.20.10"
+  }
+  val sttp: Version = {
+    case Some((2, 13)) => "1.6.7"
+    case _             => "1.6.6"
   }
   val circe = "0.12.1"
   val circeYaml = "0.11.0-M1"
-  val sttp = "1.6.6"
   val akkaHttp = "10.1.9"
   val akkaStreams = "2.5.25"
   val swaggerUi = "3.23.8"


### PR DESCRIPTION
this version introduced a binary incompatibility.

it also pulls cats-2.

PR also updates sttp to 1.6.7 since it has the same dependencies.