### PR TITLE
Enable workaround for Validator.Enum

### DIFF
--- a/core/src/main/scala/tapir/Codec.scala
+++ b/core/src/main/scala/tapir/Codec.scala
@@ -60,7 +60,16 @@ trait Codec[T, M <: MediaType, R] extends Decode[T, R] { outer =>
   def validate(v: Validator[T]): Codec[T, M, R] = new Codec[T, M, R] {
     override def encode(t: T): R = outer.encode(t)
     override def rawDecode(s: R): DecodeResult[T] = outer.rawDecode(s)
-    override def meta: CodecMeta[T, M, R] = outer.meta.validate(v)
+    override def meta: CodecMeta[T, M, R] = {
+      val withEnumValidator = (outer.meta.rawValueType, v) match {
+        case (_: StringValueType, v @ Validator.Enum(_, None)) =>
+          v.copy(encode = Some({ s: T =>
+            Some(encode(s))
+          }))
+        case _ => v
+      }
+      outer.meta.validate(withEnumValidator)
+    }
   }
 }
 
@@ -349,7 +358,9 @@ case class CodecMeta[T, M <: MediaType, R] private (
     rawValueType: RawValueType[R],
     validator: Validator[T]
 ) {
-  def validate(v: Validator[T]): CodecMeta[T, M, R] = copy(validator = validator.and(v))
+  def validate(v: Validator[T]): CodecMeta[T, M, R] = {
+    copy(validator = validator.and(v))
+  }
 }
 object CodecMeta {
   def apply[T, M <: MediaType, R](

--- a/core/src/main/scala/tapir/generic/ValidatorEnumMacro.scala
+++ b/core/src/main/scala/tapir/generic/ValidatorEnumMacro.scala
@@ -9,6 +9,7 @@ trait ValidatorEnumMacro {
 
   def validatorForEnum[E: c.WeakTypeTag](c: blackbox.Context): c.Expr[Validator.Primitive[E]] = {
     import c.universe._
+
     val symbol = weakTypeOf[E].typeSymbol.asClass
     if (!symbol.isClass || !symbol.isSealed) {
       c.abort(c.enclosingPosition, "Can only enumerate values of a sealed trait or class.")
@@ -18,7 +19,7 @@ trait ValidatorEnumMacro {
         c.abort(c.enclosingPosition, "All children must be objects.")
       } else {
         val instances = subclasses.map(x => Ident(x.asInstanceOf[scala.reflect.internal.Symbols#Symbol].sourceModule.asInstanceOf[Symbol]))
-        c.Expr[Validator.Primitive[E]](q"tapir.Validator.Enum($instances)")
+        c.Expr[Validator.Primitive[E]](q"tapir.Validator.enum($instances)")
       }
     }
   }

--- a/core/src/main/scala/tapir/server/ServerDefaults.scala
+++ b/core/src/main/scala/tapir/server/ServerDefaults.scala
@@ -53,15 +53,15 @@ object ServerDefaults {
     decodeFailureHandlerUsingResponse(failureResponse, badRequestOnPathFailureIfPathShapeMatches = false, validationErrorToMessage)
 
   def validationErrorToMessage(ve: ValidationError[_]): String = ve.validator match {
-    case Validator.Min(value, exclusive) => s"expected ${ve.invalidValue} to be greater than ${if (exclusive) "" else "or equal to "}$value"
-    case Validator.Max(value, exclusive) => s"expected ${ve.invalidValue} to be less than ${if (exclusive) "" else "or equal to "}$value"
-    case Validator.Pattern(value)        => s"expected '${ve.invalidValue}' to match '$value'"
-    case Validator.MinLength(value)      => s"expected length of ${ve.invalidValue} to be greater than or equal to $value "
-    case Validator.MaxLength(value)      => s"expected length of ${ve.invalidValue} to be less than or equal to $value "
-    case Validator.MinSize(value)        => s"expected size of collection (${ve.invalidValue}) to be greater than or equal to $value"
-    case Validator.MaxSize(value)        => s"expected size of collection (${ve.invalidValue}) to be less than or equal to $value"
-    case Validator.Custom(_, message)    => s"expected '${ve.invalidValue}' to pass custom validation: $message"
-    case Validator.Enum(possibleValues)  => s"expected '${ve.invalidValue}' to be within $possibleValues"
+    case Validator.Min(value, exclusive)   => s"expected ${ve.invalidValue} to be greater than ${if (exclusive) "" else "or equal to "}$value"
+    case Validator.Max(value, exclusive)   => s"expected ${ve.invalidValue} to be less than ${if (exclusive) "" else "or equal to "}$value"
+    case Validator.Pattern(value)          => s"expected '${ve.invalidValue}' to match '$value'"
+    case Validator.MinLength(value)        => s"expected length of ${ve.invalidValue} to be greater than or equal to $value "
+    case Validator.MaxLength(value)        => s"expected length of ${ve.invalidValue} to be less than or equal to $value "
+    case Validator.MinSize(value)          => s"expected size of collection (${ve.invalidValue}) to be greater than or equal to $value"
+    case Validator.MaxSize(value)          => s"expected size of collection (${ve.invalidValue}) to be less than or equal to $value"
+    case Validator.Custom(_, message)      => s"expected '${ve.invalidValue}' to pass custom validation: $message"
+    case Validator.Enum(possibleValues, _) => s"expected '${ve.invalidValue}' to be within $possibleValues"
   }
 
   val failureOutput: EndpointOutput[(StatusCode, String)] = statusCode.and(stringBody)

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/package.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/package.scala
@@ -1,5 +1,6 @@
 package tapir.docs
 
+import tapir.Validator.EncodeToAny
 import tapir.{Codec, CodecForMany, CodecForOptional, EndpointInput}
 import tapir.openapi.{ExampleValue, SecurityScheme}
 
@@ -16,11 +17,6 @@ package object openapi extends TapirOpenAPIDocs {
     }
     result
   }
-
-  /**
-    * Used to encode examples and enum values
-    */
-  type EncodeToAny[T] = T => Option[Any]
 
   private def encodeValue[T](v: Any): Any = v.toString
   private[openapi] def encodeAny[T](codec: Codec[T, _, _]): EncodeToAny[T] = e => Some(encodeValue(codec.encode(e)))

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
@@ -42,16 +42,16 @@ object ObjectSchemasForEndpoints {
 
   private def objectSchemas(typeData: AnyTypeData[_]): List[ObjectTypeData[_]] = {
     typeData match {
-      case TypeData(s: TSchema.SProduct, validator, encode) =>
-        List(TypeData(s, validator, encode): ObjectTypeData[_]) ++ fieldsSchemaWithValidator(s, validator)
+      case TypeData(s: TSchema.SProduct, validator) =>
+        List(TypeData(s, validator): ObjectTypeData[_]) ++ fieldsSchemaWithValidator(s, validator)
           .flatMap(objectSchemas)
           .toList
-      case TypeData(TSchema.SArray(o), validator, _) =>
+      case TypeData(TSchema.SArray(o), validator) =>
         objectSchemas(TypeData(o, elementValidator(validator)))
-      case TypeData(s: TSchema.SCoproduct, validator, encode) =>
-        (TypeData(s, validator, encode): ObjectTypeData[_]) +: s.schemas.flatMap(c => objectSchemas(TypeData(c, Validator.pass))).toList
-      case TypeData(s: TSchema.SOpenProduct, validator, encode) =>
-        (TypeData(s, validator, encode): ObjectTypeData[_]) +: objectSchemas(TypeData(s.valueSchema, elementValidator(validator)))
+      case TypeData(s: TSchema.SCoproduct, validator) =>
+        (TypeData(s, validator): ObjectTypeData[_]) +: s.schemas.flatMap(c => objectSchemas(TypeData(c, Validator.pass))).toList
+      case TypeData(s: TSchema.SOpenProduct, validator) =>
+        (TypeData(s, validator): ObjectTypeData[_]) +: objectSchemas(TypeData(s.valueSchema, elementValidator(validator)))
       case _ => List.empty
     }
   }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TSchemaToOSchema.scala
@@ -1,6 +1,5 @@
 package tapir.docs.openapi.schema
 
-import tapir.docs.openapi.EncodeToAny
 import tapir.openapi.OpenAPI.ReferenceOr
 import tapir.openapi.{Schema => OSchema, _}
 import tapir.{Validator, Schema => TSchema}
@@ -55,18 +54,17 @@ private[schema] class TSchemaToOSchema(schemaReferenceMapper: SchemaReferenceMap
     }
 
     result.map(
-      addConstraints(_, asPrimitiveValidators(typeData.validator), typeData.schema.isInstanceOf[TSchema.SInteger.type], typeData.encode)
+      addConstraints(_, asPrimitiveValidators(typeData.validator), typeData.schema.isInstanceOf[TSchema.SInteger.type])
     )
   }
 
   private def addConstraints(
       oschema: OSchema,
       vs: Seq[Validator.Primitive[_]],
-      wholeNumbers: Boolean,
-      codec: EncodeToAny[_]
-  ): OSchema = vs.foldLeft(oschema)(addConstraints(_, _, wholeNumbers, codec))
+      wholeNumbers: Boolean
+  ): OSchema = vs.foldLeft(oschema)(addConstraints(_, _, wholeNumbers))
 
-  private def addConstraints(oschema: OSchema, v: Validator.Primitive[_], wholeNumbers: Boolean, encode: EncodeToAny[_]): OSchema = {
+  private def addConstraints(oschema: OSchema, v: Validator.Primitive[_], wholeNumbers: Boolean): OSchema = {
     v match {
       case m @ Validator.Min(v, exclusive) =>
         if (exclusive) {
@@ -86,8 +84,9 @@ private[schema] class TSchemaToOSchema(schemaReferenceMapper: SchemaReferenceMap
       case Validator.MinSize(value)   => oschema.copy(minItems = Some(value))
       case Validator.MaxSize(value)   => oschema.copy(maxItems = Some(value))
       case Validator.Custom(_, _)     => oschema
-      case Validator.Enum(v) =>
-        val values = v.flatMap(x => encode.asInstanceOf[Any => Option[Any]].apply(x)).map(_.toString)
+      case Validator.Enum(_, None)    => oschema
+      case Validator.Enum(v, Some(encode)) =>
+        val values = v.flatMap(x => encode(x).map(_.toString))
         oschema.copy(enum = if (values.nonEmpty) Some(values) else None)
     }
   }

--- a/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TypeData.scala
+++ b/docs/openapi-docs/src/main/scala/tapir/docs/openapi/schema/TypeData.scala
@@ -1,18 +1,17 @@
 package tapir.docs.openapi.schema
 
-import tapir.docs.openapi._
 import tapir.{Codec, CodecForMany, CodecForOptional, Validator, Schema => TSchema}
 
-case class TypeData[TS <: TSchema, T](schema: TS, validator: Validator[T], encode: EncodeToAny[T] = (_: T) => None)
+case class TypeData[TS <: TSchema, T](schema: TS, validator: Validator[T])
 
 object TypeData {
   def apply[T](tm: Codec[T, _, _]): AnyTypeData[T] = {
-    TypeData(tm.meta.schema, tm.validator, encodeAny(tm))
+    TypeData(tm.meta.schema, tm.validator)
   }
   def apply[T](tm: CodecForOptional[T, _, _]): AnyTypeData[T] = {
-    TypeData(tm.meta.schema, tm.validator, encodeAny(tm))
+    TypeData(tm.meta.schema, tm.validator)
   }
   def apply[T](tm: CodecForMany[T, _, _]): AnyTypeData[T] = {
-    TypeData(tm.meta.schema, tm.validator, encodeAny(tm))
+    TypeData(tm.meta.schema, tm.validator)
   }
 }

--- a/docs/openapi-docs/src/test/resources/expected_valid_enum_object.yml
+++ b/docs/openapi-docs/src/test/resources/expected_valid_enum_object.yml
@@ -28,3 +28,4 @@ components:
             - red
         value:
           type: integer
+  

--- a/docs/openapi-docs/src/test/resources/expected_valid_enum_object.yml
+++ b/docs/openapi-docs/src/test/resources/expected_valid_enum_object.yml
@@ -1,0 +1,30 @@
+openapi: 3.0.1
+info:
+  title: Entities
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ColorValue'
+components:
+  schemas:
+    ColorValue:
+      required:
+        - color
+        - value
+      type: object
+      properties:
+        color:
+          type: string
+          enum:
+            - blue
+            - red
+        value:
+          type: integer

--- a/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
@@ -472,6 +472,18 @@ class VerifyYamlTest extends FunSuite with Matchers {
     actualYamlNoIndent shouldBe expectedYaml
   }
 
+  test("use enum in object in output response") {
+    val expectedYaml = loadYaml("expected_valid_enum_object.yml")
+
+    val actualYaml = Validation.out_enum_object
+      .toOpenAPI(Info("Entities", "1.0"))
+      .toYaml
+    println(actualYaml)
+    val actualYamlNoIndent = noIndentation(actualYaml)
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+
   private def loadYaml(fileName: String): String = {
     noIndentation(Source.fromInputStream(getClass.getResourceAsStream(s"/$fileName")).getLines().mkString("\n"))
   }

--- a/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
@@ -478,11 +478,9 @@ class VerifyYamlTest extends FunSuite with Matchers {
     val actualYaml = Validation.out_enum_object
       .toOpenAPI(Info("Entities", "1.0"))
       .toYaml
-    println(actualYaml)
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
-
 
   private def loadYaml(fileName: String): String = {
     noIndentation(Source.fromInputStream(getClass.getResourceAsStream(s"/$fileName")).getLines().mkString("\n"))

--- a/tests/src/main/scala/tapir/tests/package.scala
+++ b/tests/src/main/scala/tapir/tests/package.scala
@@ -271,6 +271,20 @@ package object tests {
       endpoint.in(query[Color]("color"))
     }
 
+
+    val out_enum_object: Endpoint[Unit, Unit, ColorValue, Nothing] = {
+      implicit def schemaForColor: SchemaFor[Color] = SchemaFor(Schema.SString)
+      implicit def plainCodecForColor: PlainCodec[Color] = {
+        Codec.stringPlainCodecUtf8
+          .map[Color]({
+          case "red"  => Red
+          case "blue" => Blue
+        })(_.toString.toLowerCase)
+      }
+      implicit def validatorForColor: Validator[Color] = Validator.enum
+      endpoint.out(jsonBody[ColorValue])
+    }
+
     val in_enum_values: Endpoint[IntWrapper, Unit, Unit, Nothing] = {
       implicit val schemaForIntWrapper: SchemaFor[IntWrapper] = SchemaFor(Schema.SInteger)
       implicit def plainCodecForWrapper(implicit uc: PlainCodec[Int]): PlainCodec[IntWrapper] =
@@ -301,6 +315,8 @@ package object tests {
     }
   }
 }
+
+case class ColorValue(color: Color, value: Int)
 
 sealed trait Color
 case object Blue extends Color

--- a/tests/src/main/scala/tapir/tests/package.scala
+++ b/tests/src/main/scala/tapir/tests/package.scala
@@ -271,17 +271,19 @@ package object tests {
       endpoint.in(query[Color]("color"))
     }
 
-
     val out_enum_object: Endpoint[Unit, Unit, ColorValue, Nothing] = {
       implicit def schemaForColor: SchemaFor[Color] = SchemaFor(Schema.SString)
       implicit def plainCodecForColor: PlainCodec[Color] = {
         Codec.stringPlainCodecUtf8
           .map[Color]({
-          case "red"  => Red
-          case "blue" => Blue
-        })(_.toString.toLowerCase)
+            case "red"  => Red
+            case "blue" => Blue
+          })(_.toString.toLowerCase)
       }
-      implicit def validatorForColor: Validator[Color] = Validator.enum
+      implicit def validatorForColor: Validator[Color] =
+        Validator.enum(List(Blue, Red), { c =>
+          Some(plainCodecForColor.encode(c))
+        })
       endpoint.out(jsonBody[ColorValue])
     }
 


### PR DESCRIPTION
Currently there is no way to make an Enum within in a parent object render correctly (AFAICS).

The main issue for Enums seems to be that the TSchemaToOSchema.apply will call itself, without the encodeToAny parameters, so every nested Enum will not have any values.

See b75346a4e39f09c6e4a49e10b58848a17e8fa895 for a test demonstrating the issue.

This PR also includes a "fix" - it doesn't solve all problems but it let you implements workarounds for it.
It is fine by me if this is solved properly instead of using this workaround. I can't spend more time on this though, so I defer to you guys :)

I think the issue for #237 is related to this. Maybe @mpapillon wants to see if this works for him or not. Again: it is not a complete solution though.

