### PR TITLE
Add Redoc-powered UI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,6 +50,7 @@ lazy val rootProject = (project in file("."))
     openapiDocs,
     swaggerUiAkka,
     swaggerUiHttp4s,
+    redocHttp4s,
     serverTests,
     akkaHttpServer,
     http4sServer,
@@ -178,6 +179,13 @@ lazy val swaggerUiHttp4s: Project = (project in file("docs/swagger-ui-http4s"))
       "org.http4s" %% "http4s-dsl" % Versions.http4s(_),
       _ => "org.webjars" % "swagger-ui" % Versions.swaggerUi
     )
+  )
+
+lazy val redocHttp4s: Project = (project in file("docs/redoc-http4s"))
+  .settings(commonSettings)
+  .settings(
+    name := "tapir-redoc-http4s",
+    libraryDependencies ++= dependenciesFor(scalaVersion.value)("org.http4s" %% "http4s-dsl" % Versions.http4s(_))
   )
 
 // server

--- a/doc/openapi.md
+++ b/doc/openapi.md
@@ -44,12 +44,14 @@ instance of `OpenAPIDocsOptions`.
 
 ## Exposing OpenAPI documentation
 
-Exposing the OpenAPI documentation can be very application-specific. However, tapir contains two modules which contain
-akka-http/http4s routes for exposing documentation using the swagger ui:
+Exposing the OpenAPI documentation can be very application-specific. However, tapir contains modules which contain
+akka-http/http4s routes for exposing documentation using [Swagger UI](https://swagger.io/tools/swagger-ui/) or 
+[Redoc](https://github.com/Redocly/redoc):
 
 ```scala
 "com.softwaremill.tapir" %% "tapir-swagger-ui-akka-http" % "0.11.4"
 "com.softwaremill.tapir" %% "tapir-swagger-ui-http4s" % "0.11.4"
+"com.softwaremill.tapir" %% "tapir-redoc-http4s" % "0.11.4"
 ```
 
 Usage example for akka-http:
@@ -64,4 +66,4 @@ val docsAsYaml: String = myEndpoints.toOpenAPI("My App", "1.0").toYaml
 new SwaggerAkka(docsAsYaml).routes
 ```
 
-For http4s, use the `SwaggerHttp4s` class.
+For http4s, use the `SwaggerHttp4s` or `RedocHttp4s` classes.

--- a/docs/redoc-http4s/src/main/resources/redoc.html
+++ b/docs/redoc-http4s/src/main/resources/redoc.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{title}}}</title>
+  <!-- needed for adaptive design -->
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+  <!--
+  ReDoc doesn't change outer page styles
+  -->
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+<body>
+<redoc spec-url='{{docsPath}}' expand-responses="200,201"></redoc>
+<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js"></script>
+</body>
+</html>

--- a/docs/redoc-http4s/src/main/scala/tapir/redoc/http4s/RedocHttp4s.scala
+++ b/docs/redoc-http4s/src/main/scala/tapir/redoc/http4s/RedocHttp4s.scala
@@ -1,0 +1,44 @@
+package tapir.redoc.http4s
+
+import cats.effect.{ContextShift, Sync}
+import org.http4s.dsl.Http4sDsl
+import org.http4s.headers._
+import org.http4s.{Charset, HttpRoutes, MediaType}
+
+import scala.io.Source
+
+/**
+  * Usage: add `new RedocHttp4s(title, yaml).routes[F]` to your http4s router. For example:
+  * `Router("/docs" -> new RedocHttp4s(yaml).routes[IO])`.
+  *
+  * @param title       The title of the HTML page.
+  * @param yaml        The yaml with the OpenAPI documentation.
+  * @param yamlName    The name of the file, through which the yaml documentation will be served. Defaults to `docs.yaml`.
+  */
+class RedocHttp4s(title: String, yaml: String, yamlName: String = "docs.yaml") {
+
+  private lazy val html = {
+    val fileName = "redoc.html"
+    val is = getClass.getClassLoader.getResourceAsStream(fileName)
+    assert(Option(is).nonEmpty, s"Could not find file ${fileName} on classpath.")
+    val rawHtml = Source.fromInputStream(is).mkString
+    // very poor man's templating engine
+    rawHtml.replaceAllLiterally("{{docsPath}}", yamlName).replaceAllLiterally("{{title}}", title)
+  }
+
+  def routes[F[_]: ContextShift: Sync]: HttpRoutes[F] = {
+    val dsl = Http4sDsl[F]
+    import dsl._
+
+    HttpRoutes.of[F] {
+      case req @ GET -> Root if req.pathInfo.endsWith("/") =>
+        Ok(html, `Content-Type`(MediaType.text.html, Charset.`UTF-8`))
+      // as the url to the yaml file is relative, it is important that there is a trailing slash
+      case req @ GET -> Root =>
+        val uri = req.uri
+        PermanentRedirect(Location(uri.withPath(uri.path.concat("/"))))
+      case GET -> Root / `yamlName` =>
+        Ok(yaml, `Content-Type`(MediaType.text.yaml, Charset.`UTF-8`))
+    }
+  }
+}


### PR DESCRIPTION
As already discussed on gitter, I would like to a module to tapir that uses Redoc to display a OpenAPI UI.

Since the website already needs an internet connection to download fonts from Google Fonts, I opted to download the main JS file from a CDN as well, instead of loading it from a webjar. Is this a problem?