### PR TITLE
Add a SchemaFor[ZoneOffset]

### DIFF
--- a/core/src/main/scala/tapir/SchemaFor.scala
+++ b/core/src/main/scala/tapir/SchemaFor.scala
@@ -40,6 +40,7 @@ object SchemaFor extends SchemaForMagnoliaDerivation {
   implicit val schemaForDate: SchemaFor[Date] = SchemaFor(SDateTime)
   implicit val schemaForLocalDateTime: SchemaFor[LocalDateTime] = SchemaFor(SDateTime)
   implicit val schemaForLocalDate: SchemaFor[LocalDate] = SchemaFor(SDate)
+  implicit val schemaForZoneOffset: SchemaFor[ZoneOffset] = SchemaFor(SString)
   implicit val schemaForJavaDuration: SchemaFor[Duration] = SchemaFor(SString)
   implicit val schemaForScalaDuration: SchemaFor[scala.concurrent.duration.Duration] = SchemaFor(SString)
   implicit val schemaForUUID: SchemaFor[UUID] = SchemaFor(SString)


### PR DESCRIPTION
ZoneOffset is often used in APIs involving time data if separating the time from the time zone, for example providing a field that is always in UTC and another field to indicate the time zone.

Time Zone offsets are usually sent in the format: `"[-+]?\d\d:\d\d"` and so can reuse the `SchemaFor(SString)`