### PR TITLE
Add breaking test with enum in body

### DIFF
--- a/docs/openapi-docs/src/test/resources/expected_valid_body_enum.yml
+++ b/docs/openapi-docs/src/test/resources/expected_valid_body_enum.yml
@@ -1,0 +1,37 @@
+openapi: 3.0.1
+info:
+  title: Fruits
+  version: '1.0'
+paths:
+  /add/path:
+    get:
+      operationId: getAddPath
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidFruitAmountEnum'
+        required: true
+      responses:
+        '200':
+          description: ''
+components:
+  schemas:
+    ValidFruitAmountEnum:
+      required:
+        - fruit
+        - amount
+        - color
+      type: object
+      properties:
+        fruit:
+          type: string
+          minLength: 4
+        amount:
+          type: integer
+          minimum: 1
+        color:
+          type: string
+          enum:
+            - blue
+            - red

--- a/docs/openapi-docs/src/test/resources/expected_valid_enum_class.yml
+++ b/docs/openapi-docs/src/test/resources/expected_valid_enum_class.yml
@@ -13,8 +13,8 @@ paths:
           schema:
             type: string
             enum:
-              - red
               - blue
+              - red
       responses:
         '200':
           description: ''

--- a/docs/openapi-docs/src/test/resources/expected_valid_enum_class_wrapped_in_option.yml
+++ b/docs/openapi-docs/src/test/resources/expected_valid_enum_class_wrapped_in_option.yml
@@ -13,8 +13,8 @@ paths:
           schema:
             type: string
             enum:
-              - red
               - blue
+              - red
       responses:
         '200':
           description: ''

--- a/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/tapir/docs/openapi/VerifyYamlTest.scala
@@ -419,6 +419,18 @@ class VerifyYamlTest extends FunSuite with Matchers {
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
+  test("validator with enum type in body") {
+    val expectedYaml = loadYaml("expected_valid_body_enum.yml")
+
+    val actualYaml = Validation.in_json_wrapper_enum
+      .in("add")
+      .in("path")
+      .toOpenAPI(Info("Fruits", "1.0"))
+      .toYaml
+
+    noIndentation(actualYaml) shouldBe expectedYaml
+  }
+
   test("validator with wrappers type in query") {
     val expectedYaml = loadYaml("expected_valid_query_wrapped.yml")
 

--- a/tests/src/main/scala/tapir/tests/FruitAmount.scala
+++ b/tests/src/main/scala/tapir/tests/FruitAmount.scala
@@ -1,5 +1,7 @@
 package tapir.tests
 
+import tapir._
+
 case class FruitAmount(fruit: String, amount: Int)
 
 case class IntWrapper(v: Int) extends AnyVal
@@ -7,3 +9,5 @@ case class IntWrapper(v: Int) extends AnyVal
 case class StringWrapper(v: String) extends AnyVal
 
 case class ValidFruitAmount(fruit: StringWrapper, amount: IntWrapper)
+
+case class ValidFruitAmountEnum(fruit: StringWrapper, amount: IntWrapper, color: Color)

--- a/tests/src/main/scala/tapir/tests/package.scala
+++ b/tests/src/main/scala/tapir/tests/package.scala
@@ -211,6 +211,21 @@ package object tests {
       endpoint.in(query[Int]("amount").validate(Validator.min(0)))
     }
 
+    val in_json_wrapper_enum: Endpoint[ValidFruitAmountEnum, Unit, Unit, Nothing] = {
+      implicit val schemaForIntWrapper: SchemaFor[IntWrapper] = SchemaFor(Schema.SInteger)
+      implicit val intEncoder: Encoder[IntWrapper] = Encoder.encodeInt.contramap(_.v)
+      implicit val intDecoder: Decoder[IntWrapper] = Decoder.decodeInt.map(IntWrapper.apply)
+      implicit val stringEncoder: Encoder[StringWrapper] = Encoder.encodeString.contramap(_.v)
+      implicit val stringDecoder: Decoder[StringWrapper] = Decoder.decodeString.map(StringWrapper.apply)
+      implicit val intValidator: Validator[IntWrapper] = Validator.min(1).contramap(_.v)
+      implicit val stringValidator: Validator[StringWrapper] = Validator.minLength(4).contramap(_.v)
+
+      implicit def schemaForColor: SchemaFor[Color] = SchemaFor(Schema.SString)
+      implicit def validatorColor: Validator[Color] = Validator.enum
+
+      endpoint.in(jsonBody[ValidFruitAmountEnum])
+    }
+
     val in_json_wrapper: Endpoint[ValidFruitAmount, Unit, Unit, Nothing] = {
       implicit val schemaForIntWrapper: SchemaFor[IntWrapper] = SchemaFor(Schema.SInteger)
       implicit val intEncoder: Encoder[IntWrapper] = Encoder.encodeInt.contramap(_.v)


### PR DESCRIPTION
Breaking test to help diagnose the issue in #260 

```
[info] - validator with enum type in body *** FAILED ***
[info]   "...1
[info]   color:
[info]   type:string[]" was not equal to "...1
[info]   color:
[info]   type:string[
[info]   enum:
[info]   -blue
[info]   -red]" (VerifyYamlTest.scala:431)
```