### PR TITLE
Use a newer version of Redoc

### DIFF
--- a/docs/redoc-http4s/src/main/resources/redoc.html
+++ b/docs/redoc-http4s/src/main/resources/redoc.html
@@ -19,6 +19,6 @@
 </head>
 <body>
 <redoc spec-url='{{docsPath}}' expand-responses="200,201"></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.18/bundles/redoc.standalone.js"></script>
 </body>
 </html>


### PR DESCRIPTION
I noticed that the version I originally added is a few months old and much never one exists.