### PR TITLE
Add cats module with instances for SchemaFor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ lazy val rootProject = (project in file("."))
   .settings(publishArtifact := false, name := "tapir")
   .aggregate(
     core,
+    tapirCats,
     circeJson,
     playJson,
     uPickleJson,
@@ -85,6 +86,19 @@ lazy val tests: Project = (project in file("tests"))
     libraryDependencies ++= loggerDependencies
   )
   .dependsOn(core, circeJson)
+
+// cats
+
+lazy val tapirCats: Project = (project in file("cats"))
+  .settings(commonSettings)
+  .settings(
+    name := "tapir-cats",
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "cats-core" % Versions.cats,
+      scalaTest % "test"
+    )
+  )
+  .dependsOn(core)
 
 // json
 

--- a/cats/src/main/scala/tapir/cats/CatsSchemaFor.scala
+++ b/cats/src/main/scala/tapir/cats/CatsSchemaFor.scala
@@ -1,0 +1,18 @@
+package tapir
+package cats
+
+import _root_.cats.data.{NonEmptyChain, NonEmptyList, NonEmptySet}
+
+trait CatsSchemaFor {
+  implicit def schemaForNec[T: SchemaFor]: SchemaFor[NonEmptyChain[T]] = new SchemaFor[NonEmptyChain[T]] {
+    def schema: Schema = Schema.SArray(implicitly[SchemaFor[T]].schema)
+  }
+
+  implicit def schemaForNes[T: SchemaFor]: SchemaFor[NonEmptySet[T]] = new SchemaFor[NonEmptySet[T]] {
+    def schema: Schema = Schema.SArray(implicitly[SchemaFor[T]].schema)
+  }
+
+  implicit def schemaForNel[T: SchemaFor]: SchemaFor[NonEmptyList[T]] = new SchemaFor[NonEmptyList[T]] {
+    def schema: Schema = Schema.SArray(implicitly[SchemaFor[T]].schema)
+  }
+}

--- a/cats/src/main/scala/tapir/cats/package.scala
+++ b/cats/src/main/scala/tapir/cats/package.scala
@@ -1,0 +1,5 @@
+package tapir
+
+package object cats {
+  object schemaFor extends CatsSchemaFor
+}

--- a/cats/src/test/scala/tapir/cats/SchemaForTest.scala
+++ b/cats/src/test/scala/tapir/cats/SchemaForTest.scala
@@ -1,0 +1,22 @@
+package tapir.cats
+
+import cats.data.{NonEmptyChain, NonEmptyList, NonEmptySet}
+import org.scalatest.{FlatSpec, Matchers}
+import tapir.Schema.{SArray, SString}
+import tapir.SchemaFor
+import tapir.cats.schemaFor._
+
+class SchemaForTest extends FlatSpec with Matchers {
+
+  it should "find schema for cats collections" in {
+    implicitly[SchemaFor[NonEmptyList[String]]].schema shouldBe SArray(SString)
+    implicitly[SchemaFor[NonEmptyList[String]]].isOptional shouldBe false
+
+    implicitly[SchemaFor[NonEmptySet[String]]].schema shouldBe SArray(SString)
+    implicitly[SchemaFor[NonEmptySet[String]]].isOptional shouldBe false
+
+    implicitly[SchemaFor[NonEmptyChain[String]]].schema shouldBe SArray(SString)
+    implicitly[SchemaFor[NonEmptyChain[String]]].isOptional shouldBe false
+  }
+
+}

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -10,6 +10,7 @@ object Versions {
     case Some((2, 13)) => "1.6.7"
     case _             => "1.6.6"
   }
+  val cats = "2.0.0"
   val circe = "0.12.2"
   val circeYaml = "0.11.0-M1"
   val akkaHttp = "10.1.10"


### PR DESCRIPTION
This PR adds a new module "tapir-cats" for some cats integrations. Initially it contains SchemaFor instances for NonEmptyList, NonEmptyChain and NonEmptySet.