### PR TITLE
Upgrade scala 2.12 http4s and sttp client versions

### DIFF
--- a/docs/swagger-ui-http4s/src/main/scala/tapir/swagger/http4s/SwaggerHttp4s.scala
+++ b/docs/swagger-ui-http4s/src/main/scala/tapir/swagger/http4s/SwaggerHttp4s.scala
@@ -2,7 +2,7 @@ package tapir.swagger.http4s
 
 import java.util.Properties
 
-import cats.effect.{ContextShift, Sync}
+import cats.effect.{Blocker, ContextShift, Sync}
 import org.http4s.{HttpRoutes, StaticFile, Uri}
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Location
@@ -40,7 +40,7 @@ class SwaggerHttp4s(yaml: String, contextPath: String = "docs", yamlName: String
         Ok(yaml)
       case r =>
         StaticFile
-          .fromResource(s"/META-INF/resources/webjars/swagger-ui/$swaggerVersion${r.pathInfo}", ExecutionContext.global)
+          .fromResource(s"/META-INF/resources/webjars/swagger-ui/$swaggerVersion${r.pathInfo}", Blocker.liftExecutionContext(ExecutionContext.global))
           .getOrElseF(NotFound())
     }
   }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,12 +3,12 @@ object Versions {
   type Version = Option[(Long, Long)] => String
 
   val http4s: Version = {
-    case Some((2, 13)) => "0.21.0-M5"
-    case _             => "0.20.10"
+    case Some((2, 11)) => "0.20.10"
+    case _             => "0.21.0-M5"
   }
   val sttp: Version = {
-    case Some((2, 13)) => "1.6.7"
-    case _             => "1.6.6"
+    case Some((2, 11)) => "1.6.6"
+    case _             => "1.6.7"
   }
   val cats = "2.0.0"
   val circe = "0.12.2"


### PR DESCRIPTION
This PR upgrades http4s and sttpClient in Scala 2.12. It doesn't choose any exotic versions, just the same versions as chosen in Scala 2.13. It also upgrades sttpClient in Scala 2.12 -- I wasn't sure if that was the source of a binary compatibility issue or if I'd just needed a full clean in the testing artifacts. Anyway, apparently it didn't hurt anything.

Since http4s has dropped future support for Scala 2.11 and there's already a healthy tapir release out on http4s for people who specifically want not to be on a milestone release, it should be safe to push to the next milestone for people who need to keep their versions in sync for other reasons (for example, I can't serve docs in https://github.com/raster-foundry/granary/ due to a binary compatibility issue, and I _think_ it stems from the http4s version mismatch).

No tests were harmed in the creation of this PR.