### PR TITLE
Add information about excluding Akka 2.6

### DIFF
--- a/doc/openapi.md
+++ b/doc/openapi.md
@@ -54,6 +54,13 @@ akka-http/http4s routes for exposing documentation using [Swagger UI](https://sw
 "com.softwaremill.sttp.tapir" %% "tapir-redoc-http4s" % "0.12.0"
 ```
 
+Note: `tapir-swagger-ui-akka-http` transitively pulls some Akka modules in version 2.6. If you want to force
+your own Akka version (for example 2.5), use sbt exclusion.  Mind the Scala version in artifact name:
+
+```scala
+"com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-akka-http" % "0.12.0" exclude("com.typesafe.akka", "akka-stream_2.12")
+```
+
 Usage example for akka-http:
 
 ```scala

--- a/doc/server/akkahttp.md
+++ b/doc/server/akkahttp.md
@@ -7,7 +7,15 @@ dependency:
 "com.softwaremill.sttp.tapir" %% "tapir-akka-http-server" % "0.12.0"
 ```
 
-and import the package:
+This will transitively pull some Akka modules in version 2.6. If you want to force
+your own Akka version (for example 2.5), use sbt exclusion.  Mind the Scala version in artifact name:
+
+```scala
+"com.softwaremill.sttp.tapir" %% "tapir-akka-http-server" % "0.12.0" exclude("com.typesafe.akka", "akka-stream_2.12")
+```
+
+
+Now import the package:
 
 ```scala
 import sttp.tapir.server.akkahttp._


### PR DESCRIPTION
Since 0.12, Tapir Akka modules depend on Akka 2.6 which is very fresh and may require more careful migration. However, due to good binary compatibility, for some projects forcing Akka 2.5 may be good enough, so it's worth mentioning in the docs.