### PR TITLE
Support newer (after 19.8.0) Finatra

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -10,6 +10,6 @@ object Versions {
   val upickle = "0.8.0"
   val playJson = "2.7.4"
   val silencer = "1.4.4"
-  val finatra = "19.4.0"
+  val finatra = "19.11.0"
   val sprayJson = "1.3.5"
 }

--- a/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraRoute.scala
+++ b/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraRoute.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.server.finatra
 
-import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.http.{Method, Request, Response}
 import com.twitter.util.Future
 
-case class FinatraRoute(handler: Request => Future[Response], path: String)
+case class FinatraRoute(handler: Request => Future[Response], method: Method, path: String)

--- a/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/OutputToFinatraResponse.scala
+++ b/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/OutputToFinatraResponse.scala
@@ -74,16 +74,16 @@ object OutputToFinatraResponse {
     codecMeta.rawValueType match {
       case StringValueType(charset) =>
         FinatraContentBuf(Buf.ByteArray.Owned(r.toString.getBytes(charset))) -> ct
-      case ByteArrayValueType  => FinatraContentBuf(Buf.ByteArray.Owned(r)) -> ct
-      case ByteBufferValueType => FinatraContentBuf(Buf.ByteBuffer.Owned(r)) -> ct
+      case ByteArrayValueType  => FinatraContentBuf(Buf.ByteArray.Owned(r.asInstanceOf[Array[Byte]])) -> ct
+      case ByteBufferValueType => FinatraContentBuf(Buf.ByteBuffer.Owned(r.asInstanceOf[ByteBuffer])) -> ct
       case InputStreamValueType =>
-        FinatraContentReader(Reader.fromStream(r: InputStream)) -> ct
+        FinatraContentReader(Reader.fromStream(r.asInstanceOf[InputStream])) -> ct
       case FileValueType =>
-        FinatraContentReader(Reader.fromFile(r: File)) -> ct
+        FinatraContentReader(Reader.fromFile(r.asInstanceOf[File])) -> ct
       case mvt: MultipartValueType =>
         val entity = MultipartEntityBuilder.create()
 
-        (r: Seq[RawPart]).flatMap(rawPartToFormBodyPart(mvt, _)).foreach { formBodyPart: FormBodyPart =>
+        r.asInstanceOf[Seq[RawPart]].flatMap(rawPartToFormBodyPart(mvt, _)).foreach { formBodyPart: FormBodyPart =>
           entity.addPart(formBodyPart)
         }
 
@@ -101,18 +101,18 @@ object OutputToFinatraResponse {
       case StringValueType(charset) =>
         new StringBody(r.toString, ContentType.create(contentType, charset))
       case ByteArrayValueType =>
-        new ByteArrayBody(r: Array[Byte], ContentType.create(contentType), part.fileName.get)
+        new ByteArrayBody(r.asInstanceOf[Array[Byte]], ContentType.create(contentType), part.fileName.get)
       case ByteBufferValueType =>
-        val array: Array[Byte] = new Array[Byte]((r: ByteBuffer).remaining)
-        (r: ByteBuffer).get(array)
+        val array: Array[Byte] = new Array[Byte]((r.asInstanceOf[ByteBuffer]).remaining)
+        r.asInstanceOf[ByteBuffer].get(array)
         new ByteArrayBody(array, ContentType.create(contentType), part.fileName.get)
       case FileValueType =>
         part.fileName match {
-          case Some(filename) => new FileBody(r: File, ContentType.create(contentType), filename)
-          case None           => new FileBody(r: File, ContentType.create(contentType))
+          case Some(filename) => new FileBody(r.asInstanceOf[File], ContentType.create(contentType), filename)
+          case None           => new FileBody(r.asInstanceOf[File], ContentType.create(contentType))
         }
       case InputStreamValueType =>
-        new InputStreamBody(r: InputStream, ContentType.create(contentType), part.fileName.get)
+        new InputStreamBody(r.asInstanceOf[InputStream], ContentType.create(contentType), part.fileName.get)
       case _: MultipartValueType =>
         throw new UnsupportedOperationException("Nested multipart messages are not supported.")
     }

--- a/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/TapirController.scala
+++ b/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/TapirController.scala
@@ -1,10 +1,36 @@
 package sttp.tapir.server.finatra
 
+import com.twitter.finagle.http.Method._
 import com.twitter.finatra.http.Controller
 
 trait TapirController { self: Controller =>
   def addTapirRoute(route: FinatraRoute): Unit = {
-    any(route.path)(route.handler)
-    any(route.path + "/")(route.handler)
+    route.method match {
+      case Get =>
+        get(route.path + "/?")(route.handler)
+      case Post =>
+        post(route.path + "/?")(route.handler)
+      case Put =>
+        put(route.path + "/?")(route.handler)
+      case Head =>
+        head(route.path + "/?")(route.handler)
+      case Patch =>
+        patch(route.path + "/?")(route.handler)
+      case Delete =>
+        delete(route.path + "/?")(route.handler)
+      case Trace =>
+        // TODO - function name: trace conflicts with Logging's
+        any(route.path + "/?")(route.handler)
+      case Options =>
+        options(route.path + "/?")(route.handler)
+      case _ =>
+        get(route.path + "/?")(route.handler)
+        post(route.path + "/?")(route.handler)
+        put(route.path + "/?")(route.handler)
+        head(route.path + "/?")(route.handler)
+        patch(route.path + "/?")(route.handler)
+        delete(route.path + "/?")(route.handler)
+        options(route.path + "/?")(route.handler)
+    }
   }
 }


### PR DESCRIPTION
Updated Tapir’s good Finatra support to accommodate newer Finatra version’s internal RouteDSL’s changes.