### PR TITLE
Update akka-http Route generation example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ def bookListingLogic(bfy: BooksFromYear,
                      limit: Limit,  
                      at: AuthToken): Future[Either[String, List[Book]]] =
   Future.successful(Right(List(Book("The Sorrows of Young Werther"))))
-val booksListingRoute: Route = booksListing.toRoute(bookListingLogic _)
+val booksListingRoute: Route = booksListing.toRoute((bookListingLogic _).tupled)
 
 //
 


### PR DESCRIPTION
The current example makes a compilation error:
```
found   : (sample.Main.BooksFromYear, sample.Main.Limit, sample.Main.AuthToken) => scala.concurrent.Future[Either[String,List[sample.Main.Book]]]
   (which expands to)  (sample.Main.BooksFromYear, Int, String) => scala.concurrent.Future[Either[String,List[sample.Main.Book]]]
required: ((sample.Main.BooksFromYear, sample.Main.Limit, sample.Main.AuthToken)) => scala.concurrent.Future[Either[String,List[sample.Main.Book]]]
   (which expands to)  ((sample.Main.BooksFromYear, Int, String)) => scala.concurrent.Future[Either[String,List[sample.Main.Book]]]
```
We need to define the function as:
```scala
def bookListingLogic(x: (BooksFromYear, Limit, AuthToken)): Future[Either[String, List[Book]]] = 
  Future.successful(Right(List(Book("The Sorrows of Young Werther"))))
```
or tupling as follows:
```scala
def bookListingLogic(x: BooksFromYear, y:Limit, z: AuthToken): Future[Either[String, List[Book]]] = 
  Future.successful(Right(List(Book("The Sorrows of Young Werther"))))

val booksListingRoute: Route = booksListing.toRoute((bookListingLogic _).tupled)
```