### PR TITLE
Solving type erasure issue

### DIFF
--- a/core/src/main/scala/sttp/tapir/Endpoint.scala
+++ b/core/src/main/scala/sttp/tapir/Endpoint.scala
@@ -2,12 +2,10 @@ package sttp.tapir
 
 import sttp.model.Method
 import sttp.tapir.EndpointInput.FixedMethod
-import sttp.tapir.EndpointOutput.{StatusMapping, TypeStatusMapping}
+import sttp.tapir.EndpointOutput.StatusMapping
 import sttp.tapir.RenderPathTemplate.{RenderPathParam, RenderQueryParam}
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.typelevel.{FnComponents, ParamConcat}
-
-import scala.reflect.ClassTag
 
 /**
   * @tparam I Input parameter types.
@@ -101,7 +99,7 @@ case class Endpoint[I, E, O, +S](input: EndpointInput[I], errorOutput: EndpointO
           EndpointOutput.Multiple(defaultOutputs.sortByType).show
         case _ =>
           val mappings = basicOutputsMap.map {
-            case (sc, os) => TypeStatusMapping(sc, ClassTag.Any, EndpointOutput.Multiple(os.sortByType))
+            case (sc, os) => StatusMapping(sc, EndpointOutput.Multiple(os.sortByType), (_=> true))
           }
           EndpointOutput.OneOf(mappings.toSeq).show
       }

--- a/core/src/main/scala/sttp/tapir/Endpoint.scala
+++ b/core/src/main/scala/sttp/tapir/Endpoint.scala
@@ -2,7 +2,7 @@ package sttp.tapir
 
 import sttp.model.Method
 import sttp.tapir.EndpointInput.FixedMethod
-import sttp.tapir.EndpointOutput.StatusMapping
+import sttp.tapir.EndpointOutput.{StatusMapping, TypeStatusMapping}
 import sttp.tapir.RenderPathTemplate.{RenderPathParam, RenderQueryParam}
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.typelevel.{FnComponents, ParamConcat}
@@ -101,7 +101,7 @@ case class Endpoint[I, E, O, +S](input: EndpointInput[I], errorOutput: EndpointO
           EndpointOutput.Multiple(defaultOutputs.sortByType).show
         case _ =>
           val mappings = basicOutputsMap.map {
-            case (sc, os) => StatusMapping(sc, ClassTag.Any, EndpointOutput.Multiple(os.sortByType))
+            case (sc, os) => TypeStatusMapping(sc, ClassTag.Any, EndpointOutput.Multiple(os.sortByType))
           }
           EndpointOutput.OneOf(mappings.toSeq).show
       }

--- a/core/src/main/scala/sttp/tapir/Tapir.scala
+++ b/core/src/main/scala/sttp/tapir/Tapir.scala
@@ -6,11 +6,9 @@ import sttp.model.{Cookie, CookieValueWithMeta, CookieWithMeta, HeaderNames, Sta
 import sttp.tapir.Codec.PlainCodec
 import sttp.tapir.CodecForMany.PlainCodecForMany
 import sttp.tapir.CodecForOptional.PlainCodecForOptional
-import sttp.tapir.EndpointOutput.{PartialStatusMapping, StatusMapping, TypeStatusMapping}
+import sttp.tapir.EndpointOutput.StatusMapping
 import sttp.tapir.model.ServerRequest
-
-import scala.reflect.ClassTag
-import scala.reflect.runtime.universe.{TypeTag, typeOf}
+import sttp.tapir.typelevel.MatchType
 
 trait Tapir extends TapirDerivedInputs {
   implicit def stringToPath(s: String): EndpointInput[Unit] = EndpointInput.FixedPath(s)
@@ -98,21 +96,21 @@ trait Tapir extends TapirDerivedInputs {
   /**
     * Create a mapping to be used in [[oneOf]] output descriptions.
     */
-  def statusMapping[O: ClassTag: TypeTag](statusCode: StatusCode, output: EndpointOutput[O]): StatusMapping[O] = {
-    val t = typeOf[O]
-    if (!(t =:= t.erasure)) {
-      throw new IllegalArgumentException(f"Constructing statusMapping on type $t is not allowed because $t is subject to type erasure, please use partialStatusMapping instead")
-    }
-    TypeStatusMapping(Some(statusCode), implicitly[ClassTag[O]], output)
+  def statusMappingTypeMatcher[O: MatchType](statusCode: StatusCode, output: EndpointOutput[O]): StatusMapping[O] = {
+    val matchType: MatchType[O] = implicitly
+    StatusMapping(Some(statusCode), output, matchType.apply)
   }
 
-  def partialStatusMapping[O: ClassTag](statusCode: StatusCode, output: EndpointOutput[O])(matcher: PartialFunction[Any, Boolean]): StatusMapping[O] =
-    PartialStatusMapping(Some(statusCode), implicitly[ClassTag[O]], output)(matcher)
+  def statusMappingValueMatcher[O](statusCode: StatusCode, output: EndpointOutput[O])(matcher: PartialFunction[Any, Boolean]): StatusMapping[O] =
+    StatusMapping(Some(statusCode), output, matcher.lift.andThen(_.getOrElse(false)))
 
   /**
     * Create a fallback mapping to be used in [[oneOf]] output descriptions.
     */
-  def statusDefaultMapping[O: ClassTag](output: EndpointOutput[O]): StatusMapping[O] = TypeStatusMapping(None, implicitly[ClassTag[O]], output)
+  def statusDefaultMapping[O: MatchType](output: EndpointOutput[O]): StatusMapping[O] = {
+    val matchType: MatchType[O] = implicitly
+    StatusMapping(None, output, matchType.apply)
+  }
 
   /**
     * An empty output. Useful if one of `oneOf` branches should be mapped to the status code only.

--- a/core/src/main/scala/sttp/tapir/Tapir.scala
+++ b/core/src/main/scala/sttp/tapir/Tapir.scala
@@ -10,6 +10,10 @@ import sttp.tapir.EndpointOutput.StatusMapping
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.typelevel.MatchType
 
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe.TypeTag
+import scala.reflect.runtime.universe.typeOf
+
 trait Tapir extends TapirDerivedInputs {
   implicit def stringToPath(s: String): EndpointInput[Unit] = EndpointInput.FixedPath(s)
 
@@ -96,20 +100,30 @@ trait Tapir extends TapirDerivedInputs {
   /**
     * Create a mapping to be used in [[oneOf]] output descriptions.
     */
-  def statusMappingTypeMatcher[O: MatchType](statusCode: StatusCode, output: EndpointOutput[O]): StatusMapping[O] = {
-    val matchType: MatchType[O] = implicitly
-    StatusMapping(Some(statusCode), output, matchType.apply)
+  def statusMapping[O: ClassTag: TypeTag](statusCode: StatusCode, output: EndpointOutput[O]): StatusMapping[O] = {
+    val t= typeOf[O]
+    if (!( t =:= t.erasure)) {
+      throw new IllegalArgumentException(f"Constructing statusMapping on type $t is not allowed because $t is subject to type erasure, please use statusMappingValueMatcher instead")
+    }
+    val classTag: ClassTag[O] = implicitly[ClassTag[O]]
+    StatusMapping(Some(statusCode), output, {a: Any => classTag.runtimeClass.isInstance(a)})
   }
 
   def statusMappingValueMatcher[O](statusCode: StatusCode, output: EndpointOutput[O])(matcher: PartialFunction[Any, Boolean]): StatusMapping[O] =
     StatusMapping(Some(statusCode), output, matcher.lift.andThen(_.getOrElse(false)))
 
   /**
+    * Experimental: create a mapping deriving the value matcher using the experimental MatchType type class derivation
+    */
+  def statusMappingFromMatchType[O: MatchType](statusCode: StatusCode, output: EndpointOutput[O]): StatusMapping[O] =
+    statusMappingValueMatcher(statusCode, output) (implicitly[MatchType[O]].partial)
+
+  /**
     * Create a fallback mapping to be used in [[oneOf]] output descriptions.
     */
-  def statusDefaultMapping[O: MatchType](output: EndpointOutput[O]): StatusMapping[O] = {
-    val matchType: MatchType[O] = implicitly
-    StatusMapping(None, output, matchType.apply)
+  def statusDefaultMapping[O: ClassTag](output: EndpointOutput[O]): StatusMapping[O] = {
+    val classTag: ClassTag[O] = implicitly[ClassTag[O]]
+    StatusMapping(None, output, {a: Any => classTag.runtimeClass.isInstance(a)})
   }
 
   /**

--- a/core/src/main/scala/sttp/tapir/server/internal/EncodeOutputs.scala
+++ b/core/src/main/scala/sttp/tapir/server/internal/EncodeOutputs.scala
@@ -47,7 +47,7 @@ class EncodeOutputs[B](encodeOutputBody: EncodeOutputBody[B]) {
               throw new IllegalStateException("Already handled") // to make the exhaustiveness checker happy
             case EndpointOutput.OneOf(mappings) =>
               val mapping = mappings
-                .find(mapping => mapping.ct.runtimeClass.isInstance(vsHead))
+                .find(mapping => mapping.applyTo(vsHead))
                 .getOrElse(throw new IllegalArgumentException(s"No status code mapping for value: $vsHead, in output: $output"))
               apply(mapping.output, vsHead, mapping.statusCode.map(ov.withStatusCode).getOrElse(ov))
             case EndpointOutput.Mapped(wrapped, _, g) =>

--- a/core/src/main/scala/sttp/tapir/typelevel/RuntimeMatch.scala
+++ b/core/src/main/scala/sttp/tapir/typelevel/RuntimeMatch.scala
@@ -8,6 +8,9 @@ import scala.reflect.runtime.universe.typeOf
 
 trait MatchType[T] {
   def apply(a: Any): Boolean
+  def partial: PartialFunction[Any, Boolean] = {
+    case a: Any => apply(a)
+  }
 }
 
 private[typelevel] trait GenericMatchType {

--- a/core/src/main/scala/sttp/tapir/typelevel/RuntimeMatch.scala
+++ b/core/src/main/scala/sttp/tapir/typelevel/RuntimeMatch.scala
@@ -1,0 +1,46 @@
+package sttp.tapir.typelevel
+
+import magnolia.{CaseClass, Magnolia, SealedTrait}
+
+import scala.reflect.ClassTag
+
+trait MatchType[T] {
+  def apply(a: Any): Boolean
+}
+
+trait GenericMatchType {
+  type Typeclass[T] = MatchType[T]
+
+  def combine[T: ClassTag](ctx: CaseClass[Typeclass, T]): Typeclass[T] = { value: Any =>
+    val ct = implicitly[ClassTag[T]]
+    ct.runtimeClass.isInstance(value) && ctx.parameters.forall {
+      param => param.typeclass(param.dereference(value.asInstanceOf[T]))
+    }
+  }
+
+  def dispatch[T: ClassTag](ctx: SealedTrait[Typeclass, T]): Typeclass[T] = { value: Any =>
+    val ct = implicitly[ClassTag[T]]
+    ct.runtimeClass.isInstance(value) && ctx.dispatch(value.asInstanceOf[T]) { sub =>
+      sub.typeclass(sub.cast(value.asInstanceOf[T]))
+    }
+  }
+
+  implicit def gen[T]: MatchType[T] = macro Magnolia.gen[T]
+}
+
+object MatchType extends GenericMatchType {
+
+  implicit val string: MatchType[String] = matchTypeFromPartial{case _:String => true}
+  implicit val bool: MatchType[Boolean] = matchTypeFromPartial[Boolean]{case _:Boolean => true}
+  implicit val char: MatchType[Char] = matchTypeFromPartial[Char]{case _:Char => true}
+  implicit val byte: MatchType[Byte] = matchTypeFromPartial[Byte]{case _:Byte => true}
+  implicit val short: MatchType[Short] = matchTypeFromPartial[Short]{case _:Short => true}
+  implicit val long: MatchType[Long] = matchTypeFromPartial{case _:Long => true}
+  implicit val float: MatchType[Float] = matchTypeFromPartial[Float]{case _:Float => true}
+  implicit val double: MatchType[Double] = matchTypeFromPartial[Double]{case _:Double => true}
+  implicit val int: MatchType[Int] = matchTypeFromPartial[Int]{case _:Int => true}
+
+  private def matchTypeFromPartial[T](pf: PartialFunction[Any, Boolean]): MatchType[T] =  { a =>
+    pf.lift(a).getOrElse(false)
+  }
+}

--- a/core/src/test/scala/sttp/tapir/typelevel/MatchTypeTest.scala
+++ b/core/src/test/scala/sttp/tapir/typelevel/MatchTypeTest.scala
@@ -1,0 +1,93 @@
+package sttp.tapir.typelevel
+
+import org.scalatest.{AppendedClues, FlatSpec, Matchers}
+
+class MatchTypeTest extends FlatSpec with Matchers with AppendedClues {
+  "MatchType" should "provide implicit for basic type" in {
+
+    val string: Any = "String"
+    val bool: Any = true
+    val int: Any = 42
+
+    val matchTypeString: MatchType[String] = implicitly
+    val matchTypeBool: MatchType[Boolean] = implicitly
+    val matchTypeInt: MatchType[Int] = implicitly
+
+    matchTypeString(string) shouldBe true
+    matchTypeString(bool) shouldBe false
+
+    matchTypeBool(string) shouldBe false
+    matchTypeBool(bool) shouldBe true
+
+    matchTypeInt(string) shouldBe false
+    matchTypeInt(bool) shouldBe false
+    matchTypeInt(int) shouldBe true
+  }
+
+  val t: Byte = 0xF.toByte
+  val s: Short = 1
+
+  val matcherAndTypes : Seq[(MatchType[_], Any)] = Seq(
+    implicitly[MatchType[String]] -> "string",
+    implicitly[MatchType[Boolean]] -> true,
+    implicitly[MatchType[Char]] -> 'c',
+    implicitly[MatchType[Byte]] -> t,
+    implicitly[MatchType[Short]] -> s,
+    implicitly[MatchType[Float]] -> 42.2f,
+    implicitly[MatchType[Double]] -> 42.2d,
+    implicitly[MatchType[Int]] -> 42,
+  )
+
+  it should "provide implicit for all primitive class returning true for other primitive type" in {
+    matcherAndTypes.foreach({ (matcher: MatchType[_], a: Any) =>
+      (matcher(a) shouldBe true) withClue  (s"Matcher $matcher did not recognize $a")
+      }.tupled)
+  }
+
+  it should "provide implicit for all primitive class returning false for any other primitive type" in {
+    matcherAndTypes.permutations.foreach({ case (matcher, _)::tl =>
+      tl.map(_._2).foreach{ badValue =>
+        (matcher(badValue) shouldBe false) withClue  (s"Matcher $matcher did not reject $badValue")
+      }
+    })
+  }
+
+  it should "provide implicit for case class" in {
+    val matchTypeLeftInt: MatchType[Left[Int, Nothing]] = implicitly
+    val leftInt: Any = Left(42)
+    val leftString: Any = Left("string")
+    val rightInt: Any = Right(42)
+
+    matchTypeLeftInt(leftInt) shouldBe true
+    matchTypeLeftInt(leftString) shouldBe false
+    matchTypeLeftInt(rightInt) shouldBe false
+  }
+
+  it should "provide implicit for sealed stuff" in {
+    val matchTypeLeftInt: MatchType[Either[String, Int]] = implicitly
+    val leftInt: Any = Left(42)
+    val leftString: Any = Left("string")
+    val rightInt: Any = Right(42)
+
+    matchTypeLeftInt(leftInt) shouldBe false
+    matchTypeLeftInt(leftString) shouldBe true
+    matchTypeLeftInt(rightInt) shouldBe true
+  }
+
+  it should "provide implicit for complex nested type" in {
+    val matchType: MatchType[Left[Right[String, Some[Int]], String]] = implicitly
+    var a: Any = null
+
+    a = Left(Right(Some(42)))
+    matchType(a) shouldBe true
+
+    a = Left(Right(Some(true)))
+    matchType(a) shouldBe false
+
+    a = Left(Right(None))
+    matchType(a) shouldBe false
+
+    a = Left(Left("plop"))
+    matchType(a) shouldBe false
+  }
+}

--- a/core/src/test/scala/sttp/tapir/typelevel/MatchTypeTest.scala
+++ b/core/src/test/scala/sttp/tapir/typelevel/MatchTypeTest.scala
@@ -90,4 +90,20 @@ class MatchTypeTest extends FlatSpec with Matchers with AppendedClues {
     a = Left(Left("plop"))
     matchType(a) shouldBe false
   }
+
+  it should "work for list" in {
+    val matchType: MatchType[List[Int]] = implicitly
+
+    var a: Any = List(1)
+    matchType(a) shouldBe true
+
+    a = List(1, 2, 3)
+    matchType(a) shouldBe true
+
+    a = List("plop")
+    matchType(a) shouldBe false
+
+    a = List()
+    matchType(a) shouldBe true
+  }
 }

--- a/doc/endpoint/statuscodes.md
+++ b/doc/endpoint/statuscodes.md
@@ -26,9 +26,9 @@ case object NoContent extends ErrorInfo
 
 val baseEndpoint = endpoint.errorOut(
   oneOf(
-    statusMapping(StatusCodes.NotFound, jsonBody[NotFound].description("not found")),
-    statusMapping(StatusCodes.Unauthorized, jsonBody[Unauthorized].description("unauthorized")),
-    statusMapping(StatusCodes.NoContent, emptyOutput.map(_ => NoContent)(_ => ())),
+    statusMapping(StatusCode.NotFound, jsonBody[NotFound].description("not found")),
+    statusMapping(StatusCode.Unauthorized, jsonBody[Unauthorized].description("unauthorized")),
+    statusMapping(StatusCode.NoContent, emptyOutput.map(_ => NoContent)(_ => ())),
     statusDefaultMapping(jsonBody[Unknown].description("unknown"))
   )
 )
@@ -40,6 +40,63 @@ the status code. Moreover, default mappings can be defined using `statusDefaultM
 * for servers, the default status code for error outputs is `400`, and for normal outputs `200` (unless a `statusCode` 
   is used in the nested output)
 * for clients, a default mapping is a catch-all. 
+
+## Status mapping and type erasure
+
+Sometime at runtime status mapping resolution can not work properly because of type erasure.
+For example this code will fail at startup type because of type erasure `Right[NotFound]` and `Right[BadRequest]` will become `Right[Any]`, thefore the code would not be able to infer correct mapping for a value.
+```scala
+case class ServerError(what: String)
+
+sealed trait UserError
+case class BadRequest(what: String) extends UserError
+case class NotFound(what: String) extends UserError
+
+val baseEndpoint = endpoint.errorOut(
+  oneOf[Either[ServerError, UserError]](
+    statusMapping(StatusCode.NotFound, jsonBody[Right[ServerError, NotFound]].description("not found")),
+    statusMapping(StatusCode.BadRequest, jsonBody[Right[ServerError, BadRequest]].description("unauthorized")),
+    statusMapping(StatusCode.InternalServerError, jsonBody[Left[ServerError, UserError]].description("unauthorized")),
+  )
+)
+```
+If you try this code, you will have the following error:
+```
+Exception in thread "main" java.lang.IllegalArgumentException: Constructing statusMapping on type Right[sttp.tapir.examples.TestTestExample.ServerError,sttp.tapir.examples.TestTestExample.NotFound] is not allowed because Right[sttp.tapir.examples.TestTestExample.ServerError,sttp.tapir.examples.TestTestExample.NotFound] is subject to type erasure, please use statusMappingValueMatcher instead
+```
+
+The solution is thefore to handwrite a function checking that a val of type Any is of the correct type:
+```
+val baseEndpoint = endpoint.errorOut(
+  oneOf[Either[ServerError, UserError]](
+    statusMappingValueMatcher(StatusCode.NotFound, jsonBody[Right[ServerError, NotFound]].description("not found")) {
+      case Right(NotFound(_)) => true
+    },
+    statusMappingValueMatcher(StatusCode.BadRequest, jsonBody[Right[ServerError, BadRequest]].description("unauthorized")) {
+      case Right(BadRequest(_)) => true
+    },
+    statusMappingValueMatcher(StatusCode.InternalServerError, jsonBody[Left[ServerError, UserError]].description("unauthorized")) {
+      case Left(ServerError(_)) => true
+    }
+  )
+)
+```
+
+Of course you could use `statusMappingValueMatcher` to do runtime filtering for other purpose than solving type erasure.
+
+In the case of solving type erasure, writting by hand partial function to match value against composition of case class and sealed trait can be repetitive.
+To make that more easy, we provide a `experimental` typeclass for that `MatchType` so you can automatically derive that partial function:
+```
+import sttp.tapir.typelevel.MatchType
+
+val baseEndpoint = endpoint.errorOut(
+  oneOf[Either[ServerError, UserError]](
+    statusMappingFromMatchType(StatusCode.NotFound, jsonBody[Right[ServerError, NotFound]].description("not found")),
+    statusMappingFromMatchType(StatusCode.BadRequest, jsonBody[Right[ServerError, BadRequest]].description("unauthorized")),
+    statusMappingFromMatchType(StatusCode.InternalServerError, jsonBody[Left[ServerError, UserError]].description("unauthorized"))
+  )
+)
+```
 
 ## Server interpreters
 

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -142,8 +142,8 @@ class VerifyYamlTest extends FunSuite with Matchers {
 
     val e = endpoint.errorOut(
       sttp.tapir.oneOf(
-        statusMappingTypeMatcher(StatusCode.NotFound, jsonBody[NotFound].description("not found")),
-        statusMappingTypeMatcher(StatusCode.Unauthorized, jsonBody[Unauthorized].description("unauthorized")),
+        statusMapping(StatusCode.NotFound, jsonBody[NotFound].description("not found")),
+        statusMapping(StatusCode.Unauthorized, jsonBody[Unauthorized].description("unauthorized")),
         statusDefaultMapping(jsonBody[Unknown].description("unknown"))
       )
     )

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -142,8 +142,8 @@ class VerifyYamlTest extends FunSuite with Matchers {
 
     val e = endpoint.errorOut(
       sttp.tapir.oneOf(
-        statusMapping(StatusCode.NotFound, jsonBody[NotFound].description("not found")),
-        statusMapping(StatusCode.Unauthorized, jsonBody[Unauthorized].description("unauthorized")),
+        statusMappingTypeMatcher(StatusCode.NotFound, jsonBody[NotFound].description("not found")),
+        statusMappingTypeMatcher(StatusCode.Unauthorized, jsonBody[Unauthorized].description("unauthorized")),
         statusDefaultMapping(jsonBody[Unknown].description("unknown"))
       )
     )

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
@@ -24,6 +24,14 @@ import scala.reflect.ClassTag
 trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndAfterAll with StrictLogging {
   private val basicStringRequest = basicRequest.response(asStringAlways)
 
+
+  testServer(in_string_out_status_from_type_erasure)(
+    (v: String) => pureResult((if (v == "right") Some(Right("right")) else if (v == "left") Some(Left(42)) else None).asRight[Unit])
+  ) { baseUri =>
+    basicRequest.get(uri"$baseUri?fruit=nothing").send().map(_.code shouldBe StatusCode.NoContent) >>
+      basicRequest.get(uri"$baseUri?fruit=right").send().map(_.code shouldBe StatusCode.Ok) >>
+      basicRequest.get(uri"$baseUri?fruit=left").send().map(_.code shouldBe StatusCode.Accepted)
+  }
   // method matching
 
   testServer(endpoint, "GET empty endpoint")((_: Unit) => pureResult(().asRight[Unit])) { baseUri =>

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
@@ -25,7 +25,7 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
   private val basicStringRequest = basicRequest.response(asStringAlways)
 
 
-  testServer(in_string_out_status_from_type_erasure)(
+  testServer(in_string_out_status_from_type_erasure_using_partial_matcher)(
     (v: String) => pureResult((if (v == "right") Some(Right("right")) else if (v == "left") Some(Left(42)) else None).asRight[Unit])
   ) { baseUri =>
     basicRequest.get(uri"$baseUri?fruit=nothing").send().map(_.code shouldBe StatusCode.NoContent) >>

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -164,8 +164,8 @@ package object tests {
       .in(query[String]("fruit"))
       .out(
         oneOf[Either[Int, String]](
-          partialStatusMapping(StatusCode.Accepted, plainBody[Int].map(Left(_))(_.value)){case Left(_:Int) => true},
-          partialStatusMapping(StatusCode.Ok, plainBody[String].map(Right(_))(_.value)){case Right(_:String) => true}
+          statusMappingValueMatcher(StatusCode.Accepted, plainBody[Int].map(Left(_))(_.value)){case Left(_:Int) => true},
+          statusMappingValueMatcher(StatusCode.Ok, plainBody[String].map(Right(_))(_.value)){case Right(_:String) => true}
         )
       )
 
@@ -174,14 +174,10 @@ package object tests {
       .in(query[String]("fruit"))
       .out(
         oneOf[Option[Either[Int, String]]](
-          statusMapping[None.type](StatusCode.NoContent, emptyOutput.map[None.type](_ => None)(_ => ())),
+          statusMappingTypeMatcher(StatusCode.NoContent, emptyOutput.map[None.type](_ => None)(_ => ())),
 
-          partialStatusMapping(StatusCode.Accepted, jsonBody[Some[Left[Int, String]]]){
-            case Some(Left(_: Int)) => true
-          },
-          partialStatusMapping(StatusCode.Ok, jsonBody[Some[Right[Int, String]]]){
-            case Some(Right(_: String)) => true
-          }
+          statusMappingTypeMatcher(StatusCode.Accepted, jsonBody[Some[Left[Int, String]]]),
+          statusMappingTypeMatcher(StatusCode.Ok, jsonBody[Some[Right[Int, String]]])
         )
       )
   val in_string_out_status_from_string_one_empty: Endpoint[String, Unit, Either[Unit, String], Nothing] =
@@ -189,8 +185,8 @@ package object tests {
       .in(query[String]("fruit"))
       .out(
         oneOf[Either[Unit, String]](
-          partialStatusMapping(StatusCode.Accepted, emptyOutput.map(Left(_))(_.value)){case Left(_: Unit) => true},
-          partialStatusMapping(StatusCode.Ok, plainBody[String].map(Right(_))(_.value)){case Right(_: String) => true}
+          statusMappingValueMatcher(StatusCode.Accepted, emptyOutput.map(Left(_))(_.value)){case Left(_: Unit) => true},
+          statusMappingValueMatcher(StatusCode.Ok, plainBody[String].map(Right(_))(_.value)){case Right(_: String) => true}
         )
       )
 

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -169,6 +169,16 @@ package object tests {
         )
       )
 
+  val in_string_out_status_from_type_erasure: Endpoint[String, Unit, Option[Either[Int, String]], Nothing] =
+    endpoint
+      .in(query[String]("fruit"))
+      .out(
+        oneOf[Option[Either[Int, String]]](
+          statusMapping(StatusCode.NoContent, emptyOutput.map(_ => None)(_ => ())),
+          statusMapping(StatusCode.Accepted, jsonBody[Some[Left[Int, String]]]),
+          statusMapping(StatusCode.Ok, jsonBody[Some[Right[Int, String]]])
+        )
+      )
   val in_string_out_status_from_string_one_empty: Endpoint[String, Unit, Either[Unit, String], Nothing] =
     endpoint
       .in(query[String]("fruit"))

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -164,8 +164,8 @@ package object tests {
       .in(query[String]("fruit"))
       .out(
         oneOf[Either[Int, String]](
-          statusMapping(StatusCode.Accepted, plainBody[Int].map(Left(_))(_.value)),
-          statusMapping(StatusCode.Ok, plainBody[String].map(Right(_))(_.value))
+          partialStatusMapping(StatusCode.Accepted, plainBody[Int].map(Left(_))(_.value)){case Left(_:Int) => true},
+          partialStatusMapping(StatusCode.Ok, plainBody[String].map(Right(_))(_.value)){case Right(_:String) => true}
         )
       )
 
@@ -174,9 +174,14 @@ package object tests {
       .in(query[String]("fruit"))
       .out(
         oneOf[Option[Either[Int, String]]](
-          statusMapping(StatusCode.NoContent, emptyOutput.map(_ => None)(_ => ())),
-          statusMapping(StatusCode.Accepted, jsonBody[Some[Left[Int, String]]]),
-          statusMapping(StatusCode.Ok, jsonBody[Some[Right[Int, String]]])
+          statusMapping[None.type](StatusCode.NoContent, emptyOutput.map[None.type](_ => None)(_ => ())),
+
+          partialStatusMapping(StatusCode.Accepted, jsonBody[Some[Left[Int, String]]]){
+            case Some(Left(_: Int)) => true
+          },
+          partialStatusMapping(StatusCode.Ok, jsonBody[Some[Right[Int, String]]]){
+            case Some(Right(_: String)) => true
+          }
         )
       )
   val in_string_out_status_from_string_one_empty: Endpoint[String, Unit, Either[Unit, String], Nothing] =
@@ -184,8 +189,8 @@ package object tests {
       .in(query[String]("fruit"))
       .out(
         oneOf[Either[Unit, String]](
-          statusMapping(StatusCode.Accepted, emptyOutput.map(Left(_))(_.value)),
-          statusMapping(StatusCode.Ok, plainBody[String].map(Right(_))(_.value))
+          partialStatusMapping(StatusCode.Accepted, emptyOutput.map(Left(_))(_.value)){case Left(_: Unit) => true},
+          partialStatusMapping(StatusCode.Ok, plainBody[String].map(Right(_))(_.value)){case Right(_: String) => true}
         )
       )
 

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -169,17 +169,20 @@ package object tests {
         )
       )
 
-  val in_string_out_status_from_type_erasure: Endpoint[String, Unit, Option[Either[Int, String]], Nothing] =
+  val in_string_out_status_from_type_erasure_using_partial_matcher: Endpoint[String, Unit, Option[Either[Int, String]], Nothing] = {
+    import sttp.tapir.typelevel.MatchType
+
     endpoint
       .in(query[String]("fruit"))
       .out(
         oneOf[Option[Either[Int, String]]](
-          statusMappingTypeMatcher(StatusCode.NoContent, emptyOutput.map[None.type](_ => None)(_ => ())),
+          statusMapping(StatusCode.NoContent, emptyOutput.map[None.type](_ => None)(_ => ())),
 
-          statusMappingTypeMatcher(StatusCode.Accepted, jsonBody[Some[Left[Int, String]]]),
-          statusMappingTypeMatcher(StatusCode.Ok, jsonBody[Some[Right[Int, String]]])
+          statusMappingValueMatcher(StatusCode.Accepted, jsonBody[Some[Left[Int, String]]])(implicitly[MatchType[Some[Left[Int, String]]]].partial),
+          statusMappingValueMatcher(StatusCode.Ok, jsonBody[Some[Right[Int, String]]])(implicitly[MatchType[Some[Right[Int, String]]]].partial)
         )
       )
+  }
   val in_string_out_status_from_string_one_empty: Endpoint[String, Unit, Either[Unit, String], Nothing] =
     endpoint
       .in(query[String]("fruit"))


### PR DESCRIPTION
I discover than type erasure can cause problem when mapping output to status code.
To explain my problem, I wrote a test for it. I wrote another commit to propose a solution for this problem.
But in some word, when we define a status mapping for a type such as M[X], because of type erasure it become M[_] and when mapping concrete value a output of M[X] can be applied on a value of type M[D].
I am not a huge fan of it, we should be able to have something better.
I also try playing with TypeTag (https://github.com/softwaremill/tapir/compare/master...strokyl:investigate_type_tag?expand=1) without a lot of success:
- would probably need to much modification one the code
- issue with mapped output
- it seems that we always finish to loose some type information (for example: Left[String, Bool] becoming Either[String, Bool]) maybe because of type inference.