### PR TITLE
WIP: Duplicate content type in multipart

### DIFF
--- a/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
+++ b/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
@@ -194,7 +194,10 @@ class EndpointToSttpClient(clientOptions: SttpClientOptions) {
                       .copy(headers = sttpPart1.headers.filterNot(_.is(HeaderNames.ContentType)))
                       .contentType(partCodecMeta.format.mediaType.copy(charset = None))
                   } else sttpPart1
-                val sttpPart3 = p.headers.foldLeft(sttpPart2)(_.header(_))
+                val sttpPart3 = p.headers.foldLeft(sttpPart2)(_.header(_, true))
+                println(sttpPart1)
+                println(sttpPart2)
+                println(sttpPart3)
                 p.fileName.map(sttpPart3.fileName).getOrElse(sttpPart3)
               }
             }

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -129,6 +129,12 @@ package object tests {
   val in_file_multipart_out_multipart: Endpoint[FruitData, Unit, FruitData, Nothing] =
     endpoint.post.in("api" / "echo" / "multipart").in(multipartBody[FruitData]).out(multipartBody[FruitData]).name("echo file")
 
+  val in_multipart_with_content_type_headers_multipart_out_content_type: Endpoint[FruitData, Unit, List[String], Nothing] = {
+    endpoint.post.in("api" / "echo" / "multipart" / "content-type")
+      .in(multipartBody[FruitData]).out(
+      stringBody.map[List[String]](_.split(',').toList)(_.mkString(","))).name("echo content type headers")
+  }
+
   val in_cookie_cookie_out_header: Endpoint[(Int, String), Unit, List[String], Nothing] =
     endpoint.get
       .in("api" / "echo" / "headers")


### PR DESCRIPTION
Hello,
I had the same issue as described in https://github.com/softwaremill/tapir/issues/184

This is a PoC PR to demonstrate the issue but I don't think this needs to be necessarily merged/fixed into tapir. To explain

Following @adamw comment on replicating the issue, it is hard to replicate without an http echo service. This is because http4s removes the duplicate headers so a test is not possible without major design changes in the test code. However, it is possible to demonstrate an inconsistency with the test given in this PR. However, this can be misinterpreted as an issue with replacing the header.

I left the print statements for now in, as ```println(sttpPart3)``` shows the duplicated headers
(if you switch the header call method to the previous version).

This I believe, is a bug initially in sttp client in the model module here
```
https://github.com/softwaremill/sttp/blob/master/model/shared/src/main/scala/sttp/model/Part.scala#L23
```
The Part seems to be adding a duplicate header instead of discarding it if replace non existing is false and the header already is in the list.


Note for any users that end up here and want to change the content type of a part:
I believe the best approach is to have a tapir codec, pointing to the content type like this
```
 val imageJpegCodecFormat = new CodecFormat {
    override def mediaType: MediaType = MediaType.ImageJpeg
  }
  implicit val imageCodec =
    Codec.inputStreamCodec.codecFormat(imageJpegCodecFormat)
      .map(Image)(_.stream)
```

I love tapir and I'm willing to do any changes you recommend which could be:
- Update the multipart documentation with the above
- Fix Part in sttp model to properly discard duplicate headers
- Fix the api call in tapir to do the content type update last (which has replace existing as true in sttp code)  https://github.com/softwaremill/sttp/blob/master/model/shared/src/main/scala/sttp/model/Part.scala#L19
- Define a clear presence on headers coming from codecs or parts
- Define a clearer separation on the multipart domain (between Tapir and the sttp client)
Thank you again for this awesome library and please let me know what you think