### PR TITLE
Upgraded Finatra version 19.11.0 → 19.12.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -297,8 +297,8 @@ lazy val finatraServerCats: Project =
       name := "tapir-finatra-server-cats",
       libraryDependencies ++= Seq(
         "org.typelevel" %% "cats-effect" % Versions.cats,
-        "io.catbird" %% "catbird-finagle" % Versions.finatra,
-        "io.catbird" %% "catbird-effect" % Versions.finatra
+        "io.catbird" %% "catbird-finagle" % "19.11.0",
+        "io.catbird" %% "catbird-effect" % "19.11.0"
       )
     )
     .settings(only2_12settings)

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -10,6 +10,6 @@ object Versions {
   val upickle = "0.8.0"
   val playJson = "2.8.1"
   val silencer = "1.4.4"
-  val finatra = "19.11.0"
+  val finatra = "19.12.0"
   val sprayJson = "1.3.5"
 }


### PR DESCRIPTION
+ 19.12.0 introduced some break changes in finatra-http, thus projects must be compiled against Finatra 19.12.0