### PR TITLE
Render field validator when used inside of coproduct

### DIFF
--- a/core/src/main/scala/sttp/tapir/Validator.scala
+++ b/core/src/main/scala/sttp/tapir/Validator.scala
@@ -1,6 +1,6 @@
 package sttp.tapir
 
-import magnolia.SealedTrait
+import sttp.tapir.generic.SealedTrait
 import sttp.tapir.generic.internal.{ValidatorEnumMacro, ValidatorMagnoliaDerivation}
 
 import scala.collection.immutable
@@ -173,13 +173,10 @@ object Validator extends ValidatorMagnoliaDerivation with ValidatorEnumMacro {
 
   case class Coproduct[T](ctx: SealedTrait[Validator, T]) extends Single[T] {
     override def validate(t: T): List[ValidationError[_]] = {
-      ctx.dispatch(t) { v =>
-        v.typeclass.validate(v.cast(t))
-      }
+      ctx.dispatch(t).validate(t)
     }
 
-    def subtypes: Map[String, Validator[scala.Any]] =
-      ctx.subtypes.map(st => st.typeName.full -> st.typeclass.asInstanceOf[Validator[scala.Any]]).toMap
+    def subtypes: Map[String, Validator[scala.Any]] = ctx.subtypes
   }
 
   case class OpenProduct[E](elementValidator: Validator[E]) extends Single[Map[String, E]] {

--- a/core/src/main/scala/sttp/tapir/generic/SealedTrait.scala
+++ b/core/src/main/scala/sttp/tapir/generic/SealedTrait.scala
@@ -1,0 +1,7 @@
+package sttp.tapir.generic
+
+trait SealedTrait[TypeClass[_], T] {
+  def dispatch(t: T): TypeClass[T]
+
+  def subtypes: Map[String, TypeClass[scala.Any]]
+}

--- a/core/src/main/scala/sttp/tapir/generic/internal/ValidatorMagnoliaDerivation.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/ValidatorMagnoliaDerivation.scala
@@ -20,7 +20,7 @@ trait ValidatorMagnoliaDerivation {
   }
 
   @silent("never used")
-  def dispatch[T](ctx: SealedTrait[Validator, T]): Validator[T] = Validator.pass
+  def dispatch[T](ctx: SealedTrait[Validator, T]): Validator[T] = Validator.Coproduct(ctx)
 
   implicit def validatorForCaseClass[T]: Validator[T] = macro Magnolia.gen[T]
 

--- a/core/src/main/scala/sttp/tapir/generic/internal/ValidatorMagnoliaDerivation.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/ValidatorMagnoliaDerivation.scala
@@ -2,7 +2,7 @@ package sttp.tapir.generic.internal
 
 import com.github.ghik.silencer.silent
 import magnolia.{CaseClass, Magnolia, SealedTrait}
-import sttp.tapir.Validator
+import sttp.tapir.{Validator, generic}
 import sttp.tapir.generic.Configuration
 
 trait ValidatorMagnoliaDerivation {
@@ -20,7 +20,15 @@ trait ValidatorMagnoliaDerivation {
   }
 
   @silent("never used")
-  def dispatch[T](ctx: SealedTrait[Validator, T]): Validator[T] = Validator.Coproduct(ctx)
+  def dispatch[T](ctx: SealedTrait[Validator, T]): Validator[T] =
+    Validator.Coproduct(new generic.SealedTrait[Validator, T] {
+      override def dispatch(t: T): Typeclass[T] = ctx.dispatch(t) { v =>
+        v.typeclass.asInstanceOf[Validator[T]]
+      }
+
+      override def subtypes: Map[String, Typeclass[Any]] =
+        ctx.subtypes.map(st => st.typeName.full -> st.typeclass.asInstanceOf[Validator[scala.Any]]).toMap
+    })
 
   implicit def validatorForCaseClass[T]: Validator[T] = macro Magnolia.gen[T]
 

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
@@ -7,7 +7,6 @@ import sttp.tapir.openapi.OpenAPI.ReferenceOr
 import sttp.tapir.openapi.{Reference, Schema => OSchema}
 import sttp.tapir.{Schema => TSchema, SchemaType => TSchemaType, _}
 
-import scala.collection.immutable
 import scala.collection.immutable.ListMap
 import scala.collection.mutable.ListBuffer
 

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
@@ -95,6 +95,10 @@ object ObjectSchemasForEndpoints {
         (st.info -> TypeData(s, validator): ObjectTypeData) +: subtypesSchemaWithValidator(st, validator)
           .flatMap(objectSchemas)
           .toList
+      case TypeData(s @ TSchema(st: TSchemaType.SCoproduct, _, _, _), v @ Validator.CollectionElements(ev: Validator.Coproduct[_], _)) =>
+        (st.info -> TypeData(s, v: Validator[_]): ObjectTypeData) +: subtypesSchemaWithValidator(st, ev)
+          .flatMap(objectSchemas)
+          .toList
       case TypeData(s @ TSchema(st: TSchemaType.SOpenProduct, _, _, _), validator) =>
         (st.info -> TypeData(s, validator): ObjectTypeData) +: objectSchemas(
           TypeData(st.valueSchema, elementValidator(validator))

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
@@ -7,6 +7,7 @@ import sttp.tapir.openapi.OpenAPI.ReferenceOr
 import sttp.tapir.openapi.{Reference, Schema => OSchema}
 import sttp.tapir.{Schema => TSchema, SchemaType => TSchemaType, _}
 
+import scala.collection.immutable
 import scala.collection.immutable.ListMap
 import scala.collection.mutable.ListBuffer
 
@@ -81,7 +82,7 @@ object ObjectSchemasForEndpoints {
 
   private def objectSchemas(typeData: TypeData[_]): List[ObjectTypeData] = {
     typeData match {
-      case TypeData(s @ TSchema(st: TSchemaType.SProduct, _, _, _), validator: Validator.Product[_]) =>
+      case TypeData(s @ TSchema(st: TSchemaType.SProduct, _, _, _), validator) =>
         List(st.info -> TypeData(s, validator): ObjectTypeData) ++ fieldsSchemaWithValidator(st, validator)
           .flatMap(objectSchemas)
           .toList
@@ -99,12 +100,15 @@ object ObjectSchemasForEndpoints {
     }
   }
 
-  private def fieldsSchemaWithValidator(p: TSchemaType.SProduct, v: Validator.Product[_]): Seq[TypeData[_]] = {
-    p.fields.map { f =>
-      TypeData(f._2, v.fields(f._1).validator)
-    }.toList
+  private def fieldsSchemaWithValidator(p: TSchemaType.SProduct, v: Validator[_]): immutable.Seq[TypeData[_]] = {
+    v match {
+      case Validator.Product(validatedFields) =>
+        p.fields.map { f =>
+          TypeData(f._2, validatedFields.get(f._1).map(_.validator).getOrElse(Validator.pass))
+        }.toList
+      case _ => p.fields.map(f => TypeData(f._2, Validator.pass)).toList
+    }
   }
-
   private def subtypesSchemaWithValidator(st: TSchemaType.SCoproduct, v: Validator.Coproduct[_]): Seq[TypeData[_]] = {
     st.schemas.collect {
       case s @ TSchema(st: TSchemaType.SProduct, _, _, _) => TypeData(s, v.subtypes(st.info.fullName))

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
@@ -5,7 +5,7 @@ import sttp.tapir.CodecForMany.PlainCodecForMany
 import sttp.tapir.docs.openapi.{OpenAPIDocsOptions, uniqueName}
 import sttp.tapir.openapi.OpenAPI.ReferenceOr
 import sttp.tapir.openapi.{Reference, Schema => OSchema}
-import sttp.tapir.{SchemaType, Schema => TSchema, SchemaType => TSchemaType, _}
+import sttp.tapir.{Schema => TSchema, SchemaType => TSchemaType, _}
 
 import scala.collection.immutable.ListMap
 import scala.collection.mutable.ListBuffer
@@ -99,13 +99,13 @@ object ObjectSchemasForEndpoints {
     }
   }
 
-  private def productSchemas(s: TSchema[_], st: SchemaType.SProduct, validator: Validator.Product[_]): List[ObjectTypeData] = {
+  private def productSchemas(s: TSchema[_], st: TSchemaType.SProduct, validator: Validator.Product[_]): List[ObjectTypeData] = {
     (st.info -> TypeData(s, validator): ObjectTypeData) +: fieldsSchemaWithValidator(st, validator)
       .flatMap(objectSchemas)
       .toList
   }
 
-  private def coproductSchemas(s: TSchema[_], st: SchemaType.SCoproduct, validator: Validator.Coproduct[_]): List[ObjectTypeData] = {
+  private def coproductSchemas(s: TSchema[_], st: TSchemaType.SCoproduct, validator: Validator.Coproduct[_]): List[ObjectTypeData] = {
     (st.info -> TypeData(s, validator): ObjectTypeData) +: subtypesSchemaWithValidator(st, validator)
       .flatMap(objectSchemas)
       .toList

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
@@ -7,7 +7,6 @@ import sttp.tapir.openapi.OpenAPI.ReferenceOr
 import sttp.tapir.openapi.{Reference, Schema => OSchema}
 import sttp.tapir.{Schema => TSchema, SchemaType => TSchemaType, _}
 
-import scala.collection.immutable
 import scala.collection.immutable.ListMap
 import scala.collection.mutable.ListBuffer
 
@@ -82,12 +81,16 @@ object ObjectSchemasForEndpoints {
 
   private def objectSchemas(typeData: TypeData[_]): List[ObjectTypeData] = {
     typeData match {
-      case TypeData(s @ TSchema(st: TSchemaType.SProduct, _, _, _), validator) =>
-        List(st.info -> TypeData(s, validator): ObjectTypeData) ++ fieldsSchemaWithValidator(st, validator)
-          .flatMap(objectSchemas)
-          .toList
       case TypeData(TSchema(TSchemaType.SArray(o), _, _, _), validator) =>
         objectSchemas(TypeData(o, elementValidator(validator)))
+      case TypeData(s @ TSchema(st: TSchemaType.SProduct, _, _, _), validator: Validator.Product[_]) =>
+        (st.info -> TypeData(s, validator): ObjectTypeData) +: fieldsSchemaWithValidator(st, validator)
+          .flatMap(objectSchemas)
+          .toList
+      case TypeData(s @ TSchema(st: TSchemaType.SProduct, _, _, _), Validator.CollectionElements(ev: Validator.Product[_], _)) =>
+        (st.info -> TypeData(s, ev: Validator[_]): ObjectTypeData) +: fieldsSchemaWithValidator(st, ev)
+          .flatMap(objectSchemas)
+          .toList
       case TypeData(s @ TSchema(st: TSchemaType.SCoproduct, _, _, _), validator: Validator.Coproduct[_]) =>
         (st.info -> TypeData(s, validator): ObjectTypeData) +: subtypesSchemaWithValidator(st, validator)
           .flatMap(objectSchemas)
@@ -100,15 +103,12 @@ object ObjectSchemasForEndpoints {
     }
   }
 
-  private def fieldsSchemaWithValidator(p: TSchemaType.SProduct, v: Validator[_]): immutable.Seq[TypeData[_]] = {
-    v match {
-      case Validator.Product(validatedFields) =>
-        p.fields.map { f =>
-          TypeData(f._2, validatedFields.get(f._1).map(_.validator).getOrElse(Validator.pass))
-        }.toList
-      case _ => p.fields.map(f => TypeData(f._2, Validator.pass)).toList
-    }
+  private def fieldsSchemaWithValidator(p: TSchemaType.SProduct, v: Validator.Product[_]): Seq[TypeData[_]] = {
+    p.fields.map { f =>
+      TypeData(f._2, v.fields(f._1).validator)
+    }.toList
   }
+
   private def subtypesSchemaWithValidator(st: TSchemaType.SCoproduct, v: Validator.Coproduct[_]): Seq[TypeData[_]] = {
     st.schemas.collect {
       case s @ TSchema(st: TSchemaType.SProduct, _, _, _) => TypeData(s, v.subtypes(st.info.fullName))

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/package.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/package.scala
@@ -29,6 +29,7 @@ package object schema {
       case Validator.Any(validators)                => validators.flatMap(asPrimitiveValidators)
       case Validator.CollectionElements(wrapped, _) => asPrimitiveValidators(wrapped)
       case Validator.Product(_)                     => Nil
+      case Validator.Coproduct(_)                   => Nil
       case Validator.OpenProduct(_)                 => Nil
       case bv: Validator.Primitive[_]               => List(bv)
     }

--- a/docs/openapi-docs/src/test/resources/expected_valid_coproduct.yml
+++ b/docs/openapi-docs/src/test/resources/expected_valid_coproduct.yml
@@ -1,0 +1,43 @@
+openapi: 3.0.1
+info:
+  title: Entities
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+components:
+  schemas:
+    Entity:
+      oneOf:
+        - $ref: '#/components/schemas/Organization'
+        - $ref: '#/components/schemas/Person'
+    Organization:
+      allOf:
+        - $ref: '#/components/schemas/Entity'
+        - required:
+            - name
+          type: object
+          properties:
+            name:
+              type: string
+    Person:
+      allOf:
+        - $ref: '#/components/schemas/Entity'
+        - required:
+            - name
+            - age
+          type: object
+          properties:
+            name:
+              type: string
+            age:
+              type: integer
+              minimum: 11

--- a/docs/openapi-docs/src/test/resources/expected_valid_optional_body_wrapped.yml
+++ b/docs/openapi-docs/src/test/resources/expected_valid_optional_body_wrapped.yml
@@ -1,0 +1,31 @@
+openapi: 3.0.1
+info:
+  title: Fruits
+  version: '1.0'
+paths:
+  /add/path:
+    get:
+      operationId: getAddPath
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidFruitAmount'
+        required: false
+      responses:
+        '200':
+          description: ''
+components:
+  schemas:
+    ValidFruitAmount:
+      required:
+        - fruit
+        - amount
+      type: object
+      properties:
+        fruit:
+          type: string
+          minLength: 4
+        amount:
+          type: integer
+          minimum: 1

--- a/docs/openapi-docs/src/test/resources/expected_valid_optional_coproduct.yml
+++ b/docs/openapi-docs/src/test/resources/expected_valid_optional_coproduct.yml
@@ -1,0 +1,45 @@
+openapi: 3.0.1
+info:
+  title: Entities
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Entity'
+          required: false
+      responses:
+        '200':
+          description: ''
+components:
+  schemas:
+    Entity:
+      oneOf:
+        - $ref: '#/components/schemas/Organization'
+        - $ref: '#/components/schemas/Person'
+    Organization:
+      allOf:
+        - $ref: '#/components/schemas/Entity'
+        - required:
+            - name
+          type: object
+          properties:
+            name:
+              type: string
+    Person:
+      allOf:
+        - $ref: '#/components/schemas/Entity'
+        - required:
+            - name
+            - age
+          type: object
+          properties:
+            name:
+              type: string
+            age:
+              type: integer
+              minimum: 11

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -586,6 +586,18 @@ class VerifyYamlTest extends FunSuite with Matchers {
     actualYamlNoIndent shouldBe expectedYaml
   }
 
+  test("render field validator when used inside of coproduct") {
+    implicit val ageValidator: Validator[Int] = Validator.min(11)
+    val expectedYaml = loadYaml("expected_valid_coproduct.yml")
+    val actualYaml = endpoint.get
+      .out(jsonBody[Entity])
+      .toOpenAPI(Info("Entities", "1.0"))
+      .toYaml
+
+    val actualYamlNoIndent = noIndentation(actualYaml)
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
   private def loadYaml(fileName: String): String = {
     noIndentation(Source.fromInputStream(getClass.getResourceAsStream(s"/$fileName")).getLines().mkString("\n"))
   }

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -470,11 +470,23 @@ class VerifyYamlTest extends FunSuite with Matchers {
   test("validator with wrapper type in body") {
     val expectedYaml = loadYaml("expected_valid_body_wrapped.yml")
 
-    val actualYaml = Validation.in_json_wrapper
+    val actualYaml = Validation.in_valid_json
       .in("add")
       .in("path")
       .toOpenAPI(Info("Fruits", "1.0"))
       .toYaml
+    noIndentation(actualYaml) shouldBe expectedYaml
+  }
+
+  test("validator with optional wrapper type in body") {
+    val expectedYaml = loadYaml("expected_valid_optional_body_wrapped.yml")
+
+    val actualYaml = Validation.in_valid_optional_json
+      .in("add")
+      .in("path")
+      .toOpenAPI(Info("Fruits", "1.0"))
+      .toYaml
+    println(actualYaml)
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
@@ -493,7 +505,7 @@ class VerifyYamlTest extends FunSuite with Matchers {
   test("validator with wrappers type in query") {
     val expectedYaml = loadYaml("expected_valid_query_wrapped.yml")
 
-    val actualYaml = Validation.in_query_wrapper
+    val actualYaml = Validation.in_valid_query
       .in("add")
       .in("path")
       .toOpenAPI(Info("Fruits", "1.0"))
@@ -504,7 +516,7 @@ class VerifyYamlTest extends FunSuite with Matchers {
   test("validator with list") {
     val expectedYaml = loadYaml("expected_valid_body_collection.yml")
 
-    val actualYaml = Validation.in_json_collection
+    val actualYaml = Validation.in_valid_json_collection
       .in("add")
       .in("path")
       .toOpenAPI(Info("Fruits", "1.0"))
@@ -515,7 +527,7 @@ class VerifyYamlTest extends FunSuite with Matchers {
   test("render validator for additional properties of map") {
     val expectedYaml = loadYaml("expected_valid_additional_properties.yml")
 
-    val actualYaml = Validation.in_map
+    val actualYaml = Validation.in_valid_map
       .toOpenAPI(Info("Entities", "1.0"))
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -486,7 +486,6 @@ class VerifyYamlTest extends FunSuite with Matchers {
       .in("path")
       .toOpenAPI(Info("Fruits", "1.0"))
       .toYaml
-    println(actualYaml)
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
@@ -610,6 +609,18 @@ class VerifyYamlTest extends FunSuite with Matchers {
     actualYamlNoIndent shouldBe expectedYaml
   }
 
+  test("render field validator when used inside of optional coproduct") {
+    implicit val ageValidator: Validator[Int] = Validator.min(11)
+    val expectedYaml = loadYaml("expected_valid_optional_coproduct.yml")
+    val actualYaml = endpoint.get
+      .in(jsonBody[Option[Entity]])
+      .toOpenAPI(Info("Entities", "1.0"))
+      .toYaml
+
+    val actualYamlNoIndent = noIndentation(actualYaml)
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
   private def loadYaml(fileName: String): String = {
     noIndentation(Source.fromInputStream(getClass.getResourceAsStream(s"/$fileName")).getLines().mkString("\n"))
   }
@@ -621,12 +632,6 @@ case class F1(data: List[F1])
 case class G[T](data: T)
 
 case class NestedEntity(entity: Entity)
-
-sealed trait Entity {
-  def name: String
-}
-case class Person(name: String, age: Int) extends Entity
-case class Organization(name: String) extends Entity
 
 sealed trait ErrorInfo
 case class NotFound(what: String) extends ErrorInfo

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
@@ -580,7 +580,7 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
       basicRequest.get(uri"$baseUri?amount=-3").send().map(_.code shouldBe StatusCode.BadRequest)
   }
 
-  testServer(Validation.in_json_wrapper, "support jsonBody validation with wrapped type")((_: ValidFruitAmount) =>
+  testServer(Validation.in_valid_json, "support jsonBody validation with wrapped type")((_: ValidFruitAmount) =>
     pureResult(().asRight[Unit])
   ) { baseUri =>
     basicRequest.get(uri"$baseUri").body("""{"fruit":"orange","amount":11}""").send().map(_.code shouldBe StatusCode.Ok) >>
@@ -588,14 +588,14 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
       basicRequest.get(uri"$baseUri").body("""{"fruit":"orange","amount":1}""").send().map(_.code shouldBe StatusCode.Ok)
   }
 
-  testServer(Validation.in_query_wrapper, "support query validation with wrapper type")((_: IntWrapper) => pureResult(().asRight[Unit])) {
+  testServer(Validation.in_valid_query, "support query validation with wrapper type")((_: IntWrapper) => pureResult(().asRight[Unit])) {
     baseUri =>
       basicRequest.get(uri"$baseUri?amount=11").send().map(_.code shouldBe StatusCode.Ok) >>
         basicRequest.get(uri"$baseUri?amount=0").send().map(_.code shouldBe StatusCode.BadRequest) >>
         basicRequest.get(uri"$baseUri?amount=1").send().map(_.code shouldBe StatusCode.Ok)
   }
 
-  testServer(Validation.in_json_collection, "support jsonBody validation with list of wrapped type")((_: BasketOfFruits) =>
+  testServer(Validation.in_valid_json_collection, "support jsonBody validation with list of wrapped type")((_: BasketOfFruits) =>
     pureResult(().asRight[Unit])
   ) { baseUri =>
     basicRequest.get(uri"$baseUri").body("""{"fruits":[{"fruit":"orange","amount":11}]}""").send().map(_.code shouldBe StatusCode.Ok) >>

--- a/tests/src/main/scala/sttp/tapir/tests/FruitAmount.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/FruitAmount.scala
@@ -11,3 +11,9 @@ case class StringWrapper(v: String) extends AnyVal
 case class ValidFruitAmount(fruit: StringWrapper, amount: IntWrapper)
 
 case class ColorWrapper(color: Color)
+
+sealed trait Entity {
+  def name: String
+}
+case class Person(name: String, age: Int) extends Entity
+case class Organization(name: String) extends Entity

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -214,6 +214,9 @@ package object tests {
   val in_optional_json_out_optional_json: Endpoint[Option[FruitAmount], Unit, Option[FruitAmount], Nothing] =
     endpoint.post.in("api" / "echo").in(jsonBody[Option[FruitAmount]]).out(jsonBody[Option[FruitAmount]])
 
+  val in_optional_coproduct_json_out_optional_coproduct_json: Endpoint[Option[Entity], Unit, Option[Entity], Nothing] =
+    endpoint.post.in("api" / "echo" / "coproduct").in(jsonBody[Option[Entity]]).out(jsonBody[Option[Entity]])
+
   //
 
   @silent("never used")

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -231,7 +231,7 @@ package object tests {
       endpoint.in(query[Int]("amount").validate(Validator.min(0)))
     }
 
-    val in_json_wrapper: Endpoint[ValidFruitAmount, Unit, Unit, Nothing] = {
+    val in_valid_json: Endpoint[ValidFruitAmount, Unit, Unit, Nothing] = {
       implicit val schemaForIntWrapper: Schema[IntWrapper] = Schema(SchemaType.SInteger)
       implicit val intEncoder: Encoder[IntWrapper] = Encoder.encodeInt.contramap(_.v)
       implicit val intDecoder: Decoder[IntWrapper] = Decoder.decodeInt.map(IntWrapper.apply)
@@ -242,14 +242,25 @@ package object tests {
       endpoint.in(jsonBody[ValidFruitAmount])
     }
 
-    val in_query_wrapper: Endpoint[IntWrapper, Unit, Unit, Nothing] = {
+    val in_valid_optional_json: Endpoint[Option[ValidFruitAmount], Unit, Unit, Nothing] = {
+      implicit val schemaForIntWrapper: Schema[IntWrapper] = Schema(SchemaType.SInteger)
+      implicit val intEncoder: Encoder[IntWrapper] = Encoder.encodeInt.contramap(_.v)
+      implicit val intDecoder: Decoder[IntWrapper] = Decoder.decodeInt.map(IntWrapper.apply)
+      implicit val stringEncoder: Encoder[StringWrapper] = Encoder.encodeString.contramap(_.v)
+      implicit val stringDecoder: Decoder[StringWrapper] = Decoder.decodeString.map(StringWrapper.apply)
+      implicit val intValidator: Validator[IntWrapper] = Validator.min(1).contramap(_.v)
+      implicit val stringValidator: Validator[StringWrapper] = Validator.minLength(4).contramap(_.v)
+      endpoint.in(jsonBody[Option[ValidFruitAmount]])
+    }
+
+    val in_valid_query: Endpoint[IntWrapper, Unit, Unit, Nothing] = {
       implicit val schemaForIntWrapper: Schema[IntWrapper] = Schema(SchemaType.SInteger)
       implicit def plainCodecForWrapper(implicit uc: PlainCodec[Int]): PlainCodec[IntWrapper] =
         uc.map(IntWrapper.apply)(_.v).validate(Validator.min(1).contramap(_.v))
       endpoint.in(query[IntWrapper]("amount"))
     }
 
-    val in_json_collection: Endpoint[BasketOfFruits, Unit, Unit, Nothing] = {
+    val in_valid_json_collection: Endpoint[BasketOfFruits, Unit, Unit, Nothing] = {
       implicit val schemaForIntWrapper: Schema[IntWrapper] = Schema(SchemaType.SInteger)
       implicit val encoder: Encoder[IntWrapper] = Encoder.encodeInt.contramap(_.v)
       implicit val decode: Decoder[IntWrapper] = Decoder.decodeInt.map(IntWrapper.apply)
@@ -269,7 +280,7 @@ package object tests {
       endpoint.in(jsonBody[BasketOfFruits])
     }
 
-    val in_map: Endpoint[Map[String, ValidFruitAmount], Unit, Unit, Nothing] = {
+    val in_valid_map: Endpoint[Map[String, ValidFruitAmount], Unit, Unit, Nothing] = {
       implicit val schemaForIntWrapper: Schema[IntWrapper] = Schema(SchemaType.SInteger)
       implicit val encoder: Encoder[IntWrapper] = Encoder.encodeInt.contramap(_.v)
       implicit val decode: Decoder[IntWrapper] = Decoder.decodeInt.map(IntWrapper.apply)


### PR DESCRIPTION
#363 

Of course I don't like leaking magnolia internals into our validators, but didn't have any other idea.

Update:
While working on it I spotted following code:
```
private def fieldsSchemaWithValidator(p: TSchemaType.SProduct, v: Validator[_]): immutable.Seq[TypeData[_]] = {	  
    v match {	    
      case Validator.Product(validatedFields) =>	
        p.fields.map { f =>	 
          TypeData(f._2, validatedFields.get(f._1).map(_.validator).getOrElse(Validator.pass))	 
        }.toList	
      case _ => p.fields.map(f => TypeData(f._2, Validator.pass)).toList
	}
}
```
I couldn't understand the reason behind the second case and why this function takes `Validator[_]` instead of `Validator.Product[_]`. So I decided to change it and see what's gonna happen. It turned out that this other case was handling situation when we had optional body input. Because in that case schema stays the same, as it has separate field for optionality indication, but Validator changes to `Validator[Optional[T]]` which resolves to `Validator.Collection[T,Option]`. It was clear that we had here an undiscovered bug of not passing validators when top level product body is optional. So I fixed it and also fixed analogical bug in coproducts.


