### PR TITLE
#386: Unset format for array types

### DIFF
--- a/core/src/main/scala/sttp/tapir/Schema.scala
+++ b/core/src/main/scala/sttp/tapir/Schema.scala
@@ -34,8 +34,9 @@ case class Schema[T](
   /**
     * Returns a collection version of this schema, with the schema type wrapped in [[SArray]].
     * Also, sets `isOptional` to true as the collection might be empty.
+    * Also, sets 'format' to None. Formats are only applicable to the array elements, not to the array as a whole.
     */
-  def asArrayElement[U]: Schema[U] = copy(isOptional = true, schemaType = SArray(this))
+  def asArrayElement[U]: Schema[U] = copy(isOptional = true, schemaType = SArray(this), format=None)
 
   def description(d: String): Schema[T] = copy(description = Some(d))
 

--- a/docs/openapi-docs/src/test/resources/expected_array_no_format.yml
+++ b/docs/openapi-docs/src/test/resources/expected_array_no_format.yml
@@ -1,0 +1,27 @@
+openapi: 3.0.1
+ info:
+   title: Entities
+   version: '1.0'
+ paths:
+   /:
+     get:
+       operationId: getRoot
+       parameters:
+         - name: foo
+           in: query
+           required: false
+           schema:
+             type: array
+             items:
+               type: string
+         - name: bar
+           in: query
+           required: false
+           schema:
+             type: array
+             items:
+               type: integer
+               format: int64
+       responses:
+         '200':
+           description: ''

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -645,6 +645,18 @@ class VerifyYamlTest extends FunSuite with Matchers {
     actualYamlNoIndent shouldBe expectedYaml
   }
 
+  test("should not set format for array types ") {
+    val expectedYaml = loadYaml("expected_array_no_format.yml")
+    val actualYaml = endpoint
+      .in(query[List[String]]("foo"))
+      .in(query[List[Long]]("bar"))
+      .toOpenAPI(Info("Entities", "1.0"))
+      .toYaml
+
+    val actualYamlNoIndent = noIndentation(actualYaml)
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
   private def loadYaml(fileName: String): String = {
     noIndentation(Source.fromInputStream(getClass.getResourceAsStream(s"/$fileName")).getLines().mkString("\n"))
   }


### PR DESCRIPTION
As discussed in #386, array types should not have a format. It just confuses the swagger ui.
This PR fixes the issue and adds a testcase