### PR TITLE
Add support for using NonEmptyList as get paramter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
 def dependenciesFor(version: String)(deps: (Option[(Long, Long)] => ModuleID)*): Seq[ModuleID] =
   deps.map(_.apply(CrossVersion.partialVersion(version)))
 
-val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8"
+val scalaTest = "org.scalatest" %% "scalatest" % Versions.scalaTest
 
 lazy val loggerDependencies = Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.3",
@@ -106,6 +106,7 @@ lazy val tapirCats: Project = (project in file("cats"))
     name := "tapir-cats",
     libraryDependencies ++= Seq(
       "org.typelevel" %% "cats-core" % "2.1.0",
+      "org.scalacheck" %% "scalacheck" % Versions.scalaCheck % "test",
       scalaTest % "test"
     )
   )

--- a/cats/src/main/scala/sttp/tapir/codec/cats/TapirCodecCats.scala
+++ b/cats/src/main/scala/sttp/tapir/codec/cats/TapirCodecCats.scala
@@ -1,8 +1,12 @@
 package sttp.tapir.codec.cats
 
 import cats.data.{NonEmptyChain, NonEmptyList, NonEmptySet}
+import sttp.tapir.Codec.PlainCodec
+import sttp.tapir.CodecForMany.PlainCodecForMany
 import sttp.tapir.{Schema, SchemaType}
 import sttp.tapir._
+
+import scala.collection.immutable.SortedSet
 
 trait TapirCodecCats {
   private def nonEmptyValidator[T]: Validator[List[T]] = Validator.minSize[T, List](1)
@@ -24,4 +28,19 @@ trait TapirCodecCats {
 
   implicit def schemaForNes[T: Schema]: Schema[NonEmptySet[T]] =
     Schema[NonEmptySet[T]](SchemaType.SArray(implicitly[Schema[T]])).copy(isOptional = false)
+
+  implicit def codecForNonEmptyList[T, CF <: CodecFormat, R](implicit tm: Codec[T, CF, R]): CodecForMany[NonEmptyList[T], CF, R] = implicitly[CodecForMany[List[T], CF, R]]
+    .mapDecode{l =>
+      DecodeResult.fromOption(NonEmptyList.fromList(l))
+    }(_.toList)
+
+  implicit def codecForNonEmptyChain[T, CF <: CodecFormat, R](implicit tm: Codec[T, CF, R]): CodecForMany[NonEmptyChain[T], CF, R] = implicitly[CodecForMany[List[T], CF, R]]
+    .mapDecode{l =>
+      DecodeResult.fromOption(NonEmptyChain.fromSeq(l))
+    }(_.toNonEmptyList.toList)
+
+  implicit def codecForNonEmptySet[T: Ordering, CF <: CodecFormat, R](implicit tm: Codec[T, CF, R]): CodecForMany[NonEmptySet[T], CF, R] = implicitly[CodecForMany[Set[T], CF, R]]
+    .mapDecode{set =>
+      DecodeResult.fromOption(NonEmptySet.fromSet(set.to[SortedSet]))
+    }(_.toSortedSet)
 }

--- a/cats/src/test/scala/sttp/tapir/codec/cats/TapirCodecCatsTest.scala
+++ b/cats/src/test/scala/sttp/tapir/codec/cats/TapirCodecCatsTest.scala
@@ -1,11 +1,17 @@
 package sttp.tapir.codec.cats
 
 import cats.data.{NonEmptyChain, NonEmptyList, NonEmptySet}
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.{FlatSpec, Matchers}
+import org.scalatestplus.scalacheck.Checkers
+import org.scalacheck.Arbitrary.arbString
+import sttp.tapir.CodecForMany.PlainCodecForMany
 import sttp.tapir.SchemaType.{SArray, SString}
-import sttp.tapir.{Schema, Validator}
+import sttp.tapir.{DecodeResult, Schema, Validator}
 
-class TapirCodecCatsTest extends FlatSpec with Matchers {
+import scala.collection.immutable.SortedSet
+
+class TapirCodecCatsTest extends FlatSpec with Matchers with Checkers {
   case class Test(value: String)
 
   implicit val validatorForTest: Validator[Test] = Validator.minLength(3).contramap(_.value)
@@ -29,5 +35,65 @@ class TapirCodecCatsTest extends FlatSpec with Matchers {
     implicitly[Validator[NonEmptySet[Test]]].show shouldBe expectedValidator.show
 
     implicitly[Validator[NonEmptyChain[Test]]].show shouldBe expectedValidator.show
+  }
+
+  implicit def arbitraryNonEmptyList[T: Arbitrary]: Arbitrary[NonEmptyList[T]] = Arbitrary(
+    Gen.nonEmptyListOf(implicitly[Arbitrary[T]].arbitrary).map(NonEmptyList.fromListUnsafe(_))
+  )
+
+  implicit def arbitraryNonEmptyChain[T: Arbitrary]: Arbitrary[NonEmptyChain[T]] = Arbitrary(
+    Gen.nonEmptyListOf(implicitly[Arbitrary[T]].arbitrary).map(NonEmptyChain.fromSeq(_).get)
+  )
+
+  implicit def arbitraryNonEmptySet[T: Arbitrary: Ordering]: Arbitrary[NonEmptySet[T]] = Arbitrary(
+    Gen.nonEmptyBuildableOf[SortedSet[T], T](implicitly[Arbitrary[T]].arbitrary).map(NonEmptySet.fromSet(_).get)
+  )
+
+  "Provided PlainText coder for non empty list" should "correctly serialize a non empty list" in {
+    val codecForNel = implicitly[PlainCodecForMany[NonEmptyList[String]]]
+    val rawCodec = implicitly[PlainCodecForMany[List[String]]]
+    check((a: NonEmptyList[String]) => codecForNel.encode(a) == rawCodec.encode(a.toList))
+  }
+
+  it should "correctly deserialize everything it serialize" in {
+    val codecForNel = implicitly[PlainCodecForMany[NonEmptyList[String]]]
+    check((a: NonEmptyList[String]) => codecForNel.decode(codecForNel.encode(a)) == DecodeResult.Value(a))
+  }
+
+  it should "fail on empty list" in {
+    val codecForNel = implicitly[PlainCodecForMany[NonEmptyList[String]]]
+    codecForNel.decode(Seq()) shouldBe DecodeResult.Missing
+  }
+
+  "Provided PlainText codec for non empty chain" should "correctly serialize a non empty chain" in {
+    val codecForNec = implicitly[PlainCodecForMany[NonEmptyChain[String]]]
+    val rawCodec = implicitly[PlainCodecForMany[List[String]]]
+    check((a: NonEmptyChain[String]) => codecForNec.encode(a) == rawCodec.encode(a.toNonEmptyList.toList))
+  }
+
+  it should "correctly deserialize everything it serialize" in {
+    val codecForNec = implicitly[PlainCodecForMany[NonEmptyChain[String]]]
+    check((a: NonEmptyChain[String]) => codecForNec.decode(codecForNec.encode(a)) == DecodeResult.Value(a))
+  }
+
+  it should "fail on empty list" in {
+    val codecForNec = implicitly[PlainCodecForMany[NonEmptyChain[String]]]
+    codecForNec.decode(Seq()) shouldBe DecodeResult.Missing
+  }
+
+  "Provided PlainText codec for non empty set" should "correctly serialize a non empty set" in {
+    val codecForNes = implicitly[PlainCodecForMany[NonEmptySet[String]]]
+    val rawCodec = implicitly[PlainCodecForMany[Set[String]]]
+    check((a: NonEmptySet[String]) => codecForNes.encode(a) == rawCodec.encode(a.toSortedSet))
+  }
+
+  it should "correctly deserialize everything it serialize" in {
+    val codecForNes = implicitly[PlainCodecForMany[NonEmptySet[String]]]
+    check((a: NonEmptySet[String]) => codecForNes.decode(codecForNes.encode(a)) == DecodeResult.Value(a))
+  }
+
+  it should "fail on empty list" in {
+    val codecForNec = implicitly[PlainCodecForMany[NonEmptyChain[String]]]
+    codecForNec.decode(Seq()) shouldBe DecodeResult.Missing
   }
 }

--- a/core/src/main/scala/sttp/tapir/DecodeResult.scala
+++ b/core/src/main/scala/sttp/tapir/DecodeResult.scala
@@ -29,4 +29,6 @@ object DecodeResult {
         }
     }
   }
+
+  def fromOption[T](o: Option[T]): DecodeResult[T] = o.map(Value(_)).getOrElse(Missing)
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -13,4 +13,6 @@ object Versions {
   val finatra = "19.12.0"
   val catbird = "19.12.0"
   val sprayJson = "1.3.5"
+  val scalaCheck = "1.14.1"
+  val scalaTest = "3.0.8"
 }


### PR DESCRIPTION
Today, I was writing an endpoint with NonEmptyList as a result for a get parameter.
I had to add this line too make it work.
Would you be interested in providing PlainCodec for NonEmpty collection of cats here ?
If yes is it the correct way to do it ?
And if you want I can write the code for other NonEmpty collecttion.
Also I am not quite sure, how to test codec