### PR TITLE
Upgrade Redoc version

### DIFF
--- a/docs/redoc-http4s/src/main/resources/redoc.html
+++ b/docs/redoc-http4s/src/main/resources/redoc.html
@@ -19,6 +19,6 @@
 </head>
 <body>
 <redoc spec-url='{{docsPath}}' expand-responses="200,201"></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.18/bundles/redoc.standalone.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.22/bundles/redoc.standalone.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The new Redoc version also contains the following fix: https://github.com/Redocly/redoc/commit/52484157912d908daea8255d0b7d684b33258d7a

Will this enable tapir to get rid of the `linkFromChildToParent` property here? https://github.com/softwaremill/tapir/blob/master/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/OpenAPIDocsOptions.scala#L9

Or is the Redoc fix about something else?

In any case, I will try it out once the next tapir release has happened.