### PR TITLE
add support for security requirements on Operations

### DIFF
--- a/core/src/main/scala/sttp/tapir/EndpointIO.scala
+++ b/core/src/main/scala/sttp/tapir/EndpointIO.scala
@@ -109,6 +109,15 @@ object EndpointInput {
         input: EndpointInput.Single[String]
     ) extends Auth[String] {
       def show = s"auth(oauth2, via ${input.show})"
+      def withRequiredScopes(requiredScopes: Seq[String]): ScopedOauth2 = ScopedOauth2(this, requiredScopes)
+    }
+
+    case class ScopedOauth2(oauth2: Oauth2, requiredScopes: Seq[String]) extends Auth[(String, Seq[String])] {
+      require(requiredScopes.forall(oauth2.scopes.keySet.contains), "all requiredScopes have to be defined on outer Oauth2#scopes")
+      def show = s"scoped(${oauth2.show})"
+
+      override def input: Single[(String, Seq[String])] =
+        Mapped[String, (String, Seq[String])](oauth2.input, token => (token, requiredScopes), ts => ts._1)
     }
   }
 

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOpenApiPaths.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOpenApiPaths.scala
@@ -4,7 +4,7 @@ import sttp.model.Method
 import sttp.tapir._
 import sttp.tapir.docs.openapi.schema.ObjectSchemas
 import sttp.tapir.internal._
-import sttp.tapir.openapi.OpenAPI.ReferenceOr
+import sttp.tapir.openapi.OpenAPI.{ReferenceOr, SecurityRequirement}
 import sttp.tapir.openapi.{Schema => OSchema, SchemaType => OSchemaType, _}
 
 import scala.collection.immutable.ListMap
@@ -46,9 +46,10 @@ private[openapi] class EndpointToOpenApiPaths(objectSchemas: ObjectSchemas, secu
     val body: Vector[ReferenceOr[RequestBody]] = operationInputBody(inputs)
     val responses: ListMap[ResponsesKey, ReferenceOr[Response]] = endpointToOperationResponse(e)
 
-    val authNames = e.input.auths.flatMap(auth => securitySchemes.get(auth).map(_._1))
-    // for now, all auths have empty scope
-    val securityRequirement = authNames.map(_ -> Vector.empty).toListMap
+    val securityRequirement: SecurityRequirement = e.input.auths.flatMap {
+      case auth: EndpointInput.Auth.ScopedOauth2 => securitySchemes.get(auth).map(_._1).map((_, auth.requiredScopes.toVector))
+      case auth                                  => securitySchemes.get(auth).map(_._1).map((_, Vector.empty))
+    }.toListMap
 
     Operation(
       e.info.tags.toList,

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/SecuritySchemesForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/SecuritySchemesForEndpoints.scala
@@ -41,9 +41,20 @@ private[openapi] object SecuritySchemesForEndpoints {
       SecurityScheme(
         "oauth2",
         None,
-        Some("Oauth2"),
-        Some("header"),
-        Some("bearer"),
+        None,
+        None,
+        None,
+        None,
+        Some(OAuthFlows(authorizationCode = Some(OAuthFlow(authorizationUrl, tokenUrl, refreshUrl, scopes)))),
+        None
+      )
+    case EndpointInput.Auth.ScopedOauth2(EndpointInput.Auth.Oauth2(authorizationUrl, tokenUrl, scopes, refreshUrl, _), _) =>
+      SecurityScheme(
+        "oauth2",
+        None,
+        None,
+        None,
+        None,
         None,
         Some(OAuthFlows(authorizationCode = Some(OAuthFlow(authorizationUrl, tokenUrl, refreshUrl, scopes)))),
         None

--- a/docs/openapi-docs/src/test/resources/expected_oauth2.yml
+++ b/docs/openapi-docs/src/test/resources/expected_oauth2.yml
@@ -1,0 +1,72 @@
+openapi: 3.0.1
+info:
+  title: Fruits
+  version: '1.0'
+paths:
+  /api1/{p1}:
+    get:
+      operationId: getApi1P1
+      parameters:
+        - name: p1
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            text/plain:
+              schema:
+                type: string
+      security:
+        - oauth2Auth: []
+  /api2/{p1}:
+    get:
+      operationId: getApi2P1
+      parameters:
+        - name: p1
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            text/plain:
+              schema:
+                type: string
+      security:
+        - oauth2Auth:
+            - client
+  /api3/{p1}:
+    get:
+      operationId: getApi3P1
+      parameters:
+        - name: p1
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            text/plain:
+              schema:
+                type: string
+      security:
+        - oauth2Auth:
+            - admin
+components:
+  securitySchemes:
+    oauth2Auth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://example.com/auth
+          tokenUrl: https://example.com/token
+          scopes:
+            client: scope for clients
+            admin: administration scope

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -15,6 +15,7 @@ import sttp.tapir.openapi.circe.yaml._
 import sttp.tapir.openapi.{Contact, Info, License}
 import sttp.tapir.tests.{FruitAmount, _}
 
+import scala.collection.immutable.ListMap
 import scala.io.Source
 
 class VerifyYamlTest extends FunSuite with Matchers {
@@ -121,6 +122,37 @@ class VerifyYamlTest extends FunSuite with Matchers {
     val actualYaml = List(e1, e2, e3).toOpenAPI(Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should support Oauth2") {
+    val expectedYaml = loadYaml("expected_oauth2.yml")
+    val oauth2 =
+      auth.oauth2
+        .authorizationCode(
+          "https://example.com/auth",
+          "https://example.com/token",
+          ListMap("client" -> "scope for clients", "admin" -> "administration scope")
+        )
+
+    val e1 =
+      endpoint
+        .in(oauth2)
+        .in("api1" / path[String])
+        .out(stringBody)
+    val e2 =
+      endpoint
+        .in(oauth2.withRequiredScopes(Seq("client")))
+        .in("api2" / path[String])
+        .out(stringBody)
+    val e3 =
+      endpoint
+        .in(oauth2.withRequiredScopes(Seq("admin")))
+        .in("api3" / path[String])
+        .out(stringBody)
+
+    val actualYaml = List(e1, e2, e3).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
 


### PR DESCRIPTION
I fiddled a little bit around and came up with this. Maybe it is good enough (at least as a discussion base)
---

To add required scopes on an Endpoint, you have to call `.withRequiredScopes` on Oauth2. Those scopes will then be passed with the token and rendered within OpenAPI Operations. Actually, `.withRequiredScopes` uses `Mapped` to map `Auth[String] => Auth[String, Seq[String]]`, where `String` is the _token_ and `Seq[String]` the seq of _required scopes_.

Fixes #422 