### PR TITLE
Update Schema[Json] to be a coproduct

### DIFF
--- a/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
+++ b/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
@@ -22,11 +22,13 @@ trait TapirJsonCirce {
 
   def jsonPrinter: Printer = Printer.noSpaces
 
+  // Json is a coproduct with unknown implementations
   implicit val schemaForCirceJson: Schema[Json] =
     Schema(
-      SProduct(
+      SCoproduct(
         SObjectInfo("io.circe.Json"),
-        List.empty
+        List.empty,
+        None
       )
     )
 }


### PR DESCRIPTION
Fixes #420

Results in the following JSON Schema:

```yaml
components:
  schemas:
    Json: {}
```
Where the empty schema can be read as "any JSON value" which is exactly what we want.