### PR TITLE
Binary compatibility checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.coursier
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION test
+  - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues test

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,8 @@ val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
     compilerPlugin("com.softwaremill.neme" %% "neme-plugin" % "0.0.5"),
     compilerPlugin("com.github.ghik" % "silencer-plugin" % Versions.silencer cross CrossVersion.full),
     "com.github.ghik" % "silencer-lib" % Versions.silencer % Provided cross CrossVersion.full
-  )
+  ),
+  mimaPreviousArtifacts := Set("com.softwaremill.sttp.tapir" %% name.value % "0.12.21")
 )
 
 def dependenciesFor(version: String)(deps: (Option[(Long, Long)] => ModuleID)*): Seq[ModuleID] =
@@ -37,6 +38,7 @@ lazy val loggerDependencies = Seq(
 
 lazy val rootProject = (project in file("."))
   .settings(commonSettings)
+  .settings(mimaPreviousArtifacts := Set.empty)
   .settings(publishArtifact := false, name := "tapir")
   .aggregate(
     core,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("com.softwaremill.sbt-softwaremill" % "sbt-softwaremill" % "1.8.4")
 addSbtPlugin("io.spray" % "sbt-boilerplate" % "0.6.1")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.4")


### PR DESCRIPTION
This PR introduces the sbt-mima-plugin to check for binary compatibility with previous version(s).

As Tapir is still pre-1.0.0 software, the major goal it not to prevent binary incompatibility, but rather to _know_ about binary incompatibilities, and document those in release notes.

Because Tapir had/has no focus on binary compatibility so far, this PR configures mima to only check against the previous version, currently 0.12.21.

In case an incompatibility is introduced, the mima check can be 'disabled' by changing `build.sbt` line 25 to the version currently being released. In addition, please increase either the minor version (when still before 1.0.0) or the major version (when after 1.0.0).

When Tapir 1.0.0 has been released, it might be better to undo this PR and switch to https://github.com/ChristopherDavenport/sbt-mima-version-check. The big advantage of that plugin is that it automates the versions to check compatibility with.

This PR fixes #390. 