### PR TITLE
Add missing server variable to OpenAPI (#11)

### DIFF
--- a/docs/openapi-docs/src/test/resources/expected_multiple_servers.yml
+++ b/docs/openapi-docs/src/test/resources/expected_multiple_servers.yml
@@ -1,0 +1,33 @@
+openapi: 3.0.1
+info:
+  title: Fruits
+  version: '1.0'
+servers:
+  - url: https://development.example.com/v1
+    description: Development server
+  - url: https://staging.example.com/v1
+    description: Staging server
+  - url: https://api.example.com/v1
+    description: Production server
+paths:
+  /:
+    get:
+      operationId: getRoot
+      parameters:
+        - name: fruit
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: amount
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: ''
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/docs/openapi-docs/src/test/resources/expected_single_server_with_variables.yml
+++ b/docs/openapi-docs/src/test/resources/expected_single_server_with_variables.yml
@@ -1,0 +1,40 @@
+openapi: 3.0.1
+info:
+  title: Fruits
+  version: '1.0'
+servers:
+  - url: https://{username}.example.com:{port}/{basePath}
+    description: The production API server
+    variables:
+      username:
+        default: demo
+        description: Username
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '8443'
+      basePath:
+        default: v2
+paths:
+  /:
+    get:
+      operationId: getRoot
+      parameters:
+        - name: fruit
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: amount
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: ''
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -12,7 +12,7 @@ import sttp.tapir.docs.openapi.dtos.b.{Pet => BPet}
 import sttp.tapir.generic.Derived
 import sttp.tapir.json.circe._
 import sttp.tapir.openapi.circe.yaml._
-import sttp.tapir.openapi.{Contact, Info, License}
+import sttp.tapir.openapi.{Contact, Info, License, Server, ServerVariable}
 import sttp.tapir.tests.{FruitAmount, _}
 
 import scala.collection.immutable.ListMap
@@ -686,6 +686,52 @@ class VerifyYamlTest extends FunSuite with Matchers {
       .toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should match the expected yaml for single server with variables") {
+    val expectedYaml = loadYaml("expected_single_server_with_variables.yml")
+
+    val api = Info(
+      "Fruits",
+      "1.0"
+    )
+    val servers = List(Server(
+      "https://{username}.example.com:{port}/{basePath}",
+      Some("The production API server"),
+      Some(ListMap(
+        "username" -> ServerVariable(None, "demo", Some("Username")),
+        "port" -> ServerVariable(Some(List("8443", "443")), "8443", None),
+        "basePath" -> ServerVariable(None, "v2", None)
+      ))
+    ))
+
+    val actualYaml = in_query_query_out_string.toOpenAPI(api).servers(servers).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    println(expectedYaml)
+    println(actualYamlNoIndent)
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should match the expected yaml for multiple servers") {
+    val expectedYaml = loadYaml("expected_multiple_servers.yml")
+
+    val api = Info(
+      "Fruits",
+      "1.0"
+    )
+    val servers = List(
+      Server("https://development.example.com/v1", Some("Development server"), None),
+      Server("https://staging.example.com/v1", Some("Staging server"), None),
+      Server("https://api.example.com/v1", Some("Production server"), None)
+    )
+
+    val actualYaml = in_query_query_out_string.toOpenAPI(api).servers(servers).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    println(expectedYaml)
+    println(actualYamlNoIndent)
     actualYamlNoIndent shouldBe expectedYaml
   }
 

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -735,6 +735,22 @@ class VerifyYamlTest extends FunSuite with Matchers {
     actualYamlNoIndent shouldBe expectedYaml
   }
 
+  test("'default' in ServerVariable should belong to 'enum'") {
+    a[java.lang.IllegalArgumentException] shouldBe thrownBy {
+      Server(
+        "https://{username}.example.com:{port}/{basePath}",
+        None,
+        Some(
+          ListMap(
+            "username" -> ServerVariable(None, "demo", Some("Username")),
+            "port" -> ServerVariable(Some(List("8443", "443")), "80", None),
+            "basePath" -> ServerVariable(None, "v2", None)
+          )
+        )
+      )
+    }
+  }
+
   private def loadYaml(fileName: String): String = {
     noIndentation(Source.fromInputStream(getClass.getResourceAsStream(s"/$fileName")).getLines().mkString("\n"))
   }

--- a/openapi/openapi-circe/src/main/scala/sttp/tapir/openapi/circe/package.scala
+++ b/openapi/openapi-circe/src/main/scala/sttp/tapir/openapi/circe/package.scala
@@ -51,6 +51,7 @@ trait TapirOpenAPICirceEncoders {
   implicit val encoderOperation: Encoder[Operation] = deriveEncoder[Operation]
   implicit val encoderPathItem: Encoder[PathItem] = deriveEncoder[PathItem]
   implicit val encoderComponents: Encoder[Components] = deriveEncoder[Components]
+  implicit val encoderServerVariable: Encoder[ServerVariable] = deriveEncoder[ServerVariable]
   implicit val encoderServer: Encoder[Server] = deriveEncoder[Server]
   implicit val encoderExternalDocumentation: Encoder[ExternalDocumentation] = deriveEncoder[ExternalDocumentation]
   implicit val encoderTag: Encoder[Tag] = deriveEncoder[Tag]

--- a/openapi/openapi-model/src/main/scala/sttp/tapir/openapi/OpenAPI.scala
+++ b/openapi/openapi-model/src/main/scala/sttp/tapir/openapi/OpenAPI.scala
@@ -56,7 +56,9 @@ case class Server(
     variables: Option[ListMap[String, ServerVariable]]
 )
 
-case class ServerVariable(enum: Option[List[String]], default: String, description: Option[String])
+case class ServerVariable(enum: Option[List[String]], default: String, description: Option[String]) {
+  require(`enum`.fold(true)(_.contains(default)), "ServerVariable#default must be one of the values in enum if enum is defined")
+}
 
 // todo: responses, parameters, examples, requestBodies, headers, links, callbacks
 case class Components(

--- a/openapi/openapi-model/src/main/scala/sttp/tapir/openapi/OpenAPI.scala
+++ b/openapi/openapi-model/src/main/scala/sttp/tapir/openapi/OpenAPI.scala
@@ -50,11 +50,13 @@ case class Info(
 case class Contact(name: Option[String], email: Option[String], url: Option[String])
 case class License(name: String, url: Option[String])
 
-// todo: variables
 case class Server(
     url: String,
-    description: Option[String]
+    description: Option[String],
+    variables: Option[ListMap[String, ServerVariable]]
 )
+
+case class ServerVariable(enum: Option[List[String]], default: String, description: Option[String])
 
 // todo: responses, parameters, examples, requestBodies, headers, links, callbacks
 case class Components(


### PR DESCRIPTION
Add missing field 'variables' in Server class from OpenAPI spec. Doesn't handle the restriction of "default" being one of the values in "enum", if "enum" is defined.
Not sure where you'd want the restriction to be applied as per this project's conventions - e.g. maybe throw an exception in constructor of ServerVariable upon violation?

P.S. This is my first ever PR on a proper project, so do let know how if the changes aren't sufficient or something's off