### PR TITLE
Added more information in exceptions during response decoding failure

### DIFF
--- a/client/sttp-client/src/test/scala/sttp/tapir/client/sttp/SttpClientTests.scala
+++ b/client/sttp-client/src/test/scala/sttp/tapir/client/sttp/SttpClientTests.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 
 import cats.effect.{ContextShift, IO}
 import cats.implicits._
-import sttp.tapir.Endpoint
+import sttp.tapir.{DecodeResult, Endpoint}
 import sttp.tapir.client.tests.ClientTests
 import sttp.client._
 import sttp.client.asynchttpclient.fs2.AsyncHttpClientFs2Backend
@@ -25,6 +25,10 @@ class SttpClientTests extends ClientTests[fs2.Stream[IO, ByteBuffer]] {
 
   override def send[I, E, O, FN[_]](e: Endpoint[I, E, O, fs2.Stream[IO, ByteBuffer]], port: Port, args: I): IO[Either[E, O]] = {
     e.toSttpRequestUnsafe(uri"http://localhost:$port").apply(args).send().map(_.body)
+  }
+
+  override def safeSend[I, E, O, FN[_]](e: Endpoint[I, E, O, fs2.Stream[IO, ByteBuffer]], port: Port, args: I): IO[DecodeResult[Either[E, O]]] = {
+    e.toSttpRequest(uri"http://localhost:$port").apply(args).send().map(_.body)
   }
 
   override protected def afterAll(): Unit = {

--- a/client/tests/src/main/scala/sttp/tapir/client/tests/ClientTests.scala
+++ b/client/tests/src/main/scala/sttp/tapir/client/tests/ClientTests.scala
@@ -14,7 +14,7 @@ import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
 import org.http4s.util.CaseInsensitiveString
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
-import sttp.tapir._
+import sttp.tapir.{DecodeResult, _}
 import sttp.tapir.tests._
 import TestUtil._
 import org.http4s.multipart
@@ -136,6 +136,12 @@ trait ClientTests[S] extends FunSuite with Matchers with BeforeAndAfterAll {
     ) shouldBe "mango cranberry"
   }
 
+  test("not existing endpoint, with error output not matching 404") {
+    safeSend(not_existing_endpoint, port, ()).unsafeRunSync() should matchPattern {
+      case DecodeResult.Error(_, _: IllegalArgumentException) =>
+    }
+  }
+
   //
 
   private object fruitParam extends QueryParamDecoderMatcher[String]("fruit")
@@ -194,6 +200,7 @@ trait ClientTests[S] extends FunSuite with Matchers with BeforeAndAfterAll {
   type Port = Int
 
   def send[I, E, O, FN[_]](e: Endpoint[I, E, O, S], port: Port, args: I): IO[Either[E, O]]
+  def safeSend[I, E, O, FN[_]](e: Endpoint[I, E, O, S], port: Port, args: I): IO[DecodeResult[Either[E, O]]]
 
   def testClient[I, E, O, FN[_]](e: Endpoint[I, E, O, S], args: I, expectedResult: Either[E, O]): Unit = {
     test(e.showDetail) {

--- a/core/src/main/scala/sttp/tapir/SchemaType.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaType.scala
@@ -4,7 +4,7 @@ sealed trait SchemaType {
   def show: String
 }
 
-object SchemaType {
+object SchemaType { 
   case object SString extends SchemaType {
     def show: String = "string"
   }

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -217,6 +217,8 @@ package object tests {
   val in_optional_coproduct_json_out_optional_coproduct_json: Endpoint[Option[Entity], Unit, Option[Entity], Nothing] =
     endpoint.post.in("api" / "echo" / "coproduct").in(jsonBody[Option[Entity]]).out(jsonBody[Option[Entity]])
 
+  val not_existing_endpoint: Endpoint[Unit, String, Unit, Nothing] = endpoint.in("api"/ "not-existing").errorOut(oneOf(statusMapping(StatusCode.BadRequest, stringBody)))
+
   //
 
   @silent("never used")


### PR DESCRIPTION
There are cases when client is unable to decode the response, due to server fail (e.g. 404). Then in exception there is not much clue what endpoint is triggered:
`java.lang.IllegalArgumentException: Cannot find mapping for status code 404 in outputs Vector...`

This MR adds wrapper for decoding exceptions with explicit information what's the endpoint address which failed, which helps debugging.