### PR TITLE
add status mapping based on return value

### DIFF
--- a/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
+++ b/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
@@ -68,8 +68,13 @@ class EndpointToSttpClient(clientOptions: SttpClientOptions) {
 
         case EndpointOutput.FixedStatusCode(_, _) =>
           None
+
         case EndpointIO.FixedHeader(_, _, _) =>
           None
+
+        case EndpointOutput.BodyMappedStatusCode(wrapped, _, _) =>
+          val so = if (wrapped.codec.meta.schema.isOptional && body == "") None else Some(body)
+          Some(wrapped.codec.rawDecode(so))
 
         case EndpointOutput.OneOf(mappings) =>
           val mapping = mappings

--- a/core/src/main/scala/sttp/tapir/Tapir.scala
+++ b/core/src/main/scala/sttp/tapir/Tapir.scala
@@ -6,6 +6,7 @@ import sttp.model.{Cookie, CookieValueWithMeta, CookieWithMeta, Header, HeaderNa
 import sttp.tapir.Codec.PlainCodec
 import sttp.tapir.CodecForMany.PlainCodecForMany
 import sttp.tapir.CodecForOptional.PlainCodecForOptional
+import sttp.tapir.EndpointIO.Body
 import sttp.tapir.EndpointOutput.StatusMapping
 import sttp.tapir.internal.{ModifyMacroSupport, StatusMappingMacro}
 import sttp.tapir.model.ServerRequest
@@ -99,6 +100,12 @@ trait Tapir extends TapirDerivedInputs with ModifyMacroSupport {
     EndpointOutput.OneOf[I](firstCase +: otherCases)
 
   /**
+    * Maps the outputs to the status code based on the passed function
+    */
+  def statusFromBody[T, CF <: CodecFormat, R](wrapped: EndpointIO.Body[T, CF, R])(f: T => sttp.model.StatusCode)(
+      ): EndpointOutput.BodyMappedStatusCode[T, CF, R] = EndpointOutput.BodyMappedStatusCode[T, CF, R](wrapped, f)
+
+  /**
     * Create a status mapping which uses `statusCode` and `output` if the class of the provided value (when interpreting
     * as a server) matches the runtime class of `O`.
     *
@@ -122,9 +129,7 @@ trait Tapir extends TapirDerivedInputs with ModifyMacroSupport {
       output: EndpointOutput[O],
       runtimeClass: Class[_]
   ): StatusMapping[O] = {
-    StatusMapping(Some(statusCode), output, { a: Any =>
-      runtimeClass.isInstance(a)
-    })
+    StatusMapping(Some(statusCode), output, { a: Any => runtimeClass.isInstance(a) })
   }
 
   /**

--- a/core/src/main/scala/sttp/tapir/internal/package.scala
+++ b/core/src/main/scala/sttp/tapir/internal/package.scala
@@ -125,13 +125,14 @@ package object internal {
 
   implicit class RichBasicEndpointOutputs(outputs: Vector[EndpointOutput.Basic[_]]) {
     def sortByType: Vector[EndpointOutput.Basic[_]] = outputs.sortBy {
-      case _: EndpointOutput.StatusCode          => 0
-      case _: EndpointOutput.FixedStatusCode     => 0
-      case _: EndpointIO.Header[_]               => 1
-      case _: EndpointIO.Headers                 => 1
-      case _: EndpointIO.FixedHeader             => 1
-      case _: EndpointIO.Body[_, _, _]           => 2
-      case _: EndpointIO.StreamBodyWrapper[_, _] => 2
+      case _: EndpointOutput.StatusCode                    => 0
+      case _: EndpointOutput.FixedStatusCode               => 0
+      case _: EndpointIO.Header[_]                         => 1
+      case _: EndpointIO.Headers                           => 1
+      case _: EndpointIO.FixedHeader                       => 1
+      case _: EndpointIO.Body[_, _, _]                     => 2
+      case _: EndpointIO.StreamBodyWrapper[_, _]           => 2
+      case _: EndpointOutput.BodyMappedStatusCode[_, _, _] => 2
     }
   }
 

--- a/core/src/main/scala/sttp/tapir/server/internal/EncodeOutputs.scala
+++ b/core/src/main/scala/sttp/tapir/server/internal/EncodeOutputs.scala
@@ -52,6 +52,15 @@ class EncodeOutputs[B](encodeOutputBody: EncodeOutputBody[B]) {
               apply(mapping.output, vsHead, mapping.statusCode.map(ov.withStatusCode).getOrElse(ov))
             case EndpointOutput.Mapped(wrapped, _, g) =>
               apply(wrapped, g.asInstanceOf[Any => Any](vsHead), ov)
+
+            case EndpointOutput.BodyMappedStatusCode(wrapped, f, _) =>
+              wrapped.codec
+                .asInstanceOf[CodecForOptional[Any, _, Any]]
+                .encode(vsHead)
+                .map(encodeOutputBody.rawValueToBody(_, wrapped.codec))
+                .map(ov.withBody)
+                .getOrElse(ov)
+                .withStatusCode(f.asInstanceOf[Any => StatusCode](vsHead))
           }
           run(outputsTail, ov2, vsTail)
         case _ =>

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
@@ -120,13 +120,14 @@ object ObjectSchemasForEndpoints {
   }
   private def forOutput(output: EndpointOutput[_]): List[ObjectTypeData] = {
     output match {
-      case EndpointOutput.OneOf(mappings)       => mappings.flatMap(mapping => forOutput(mapping.output)).toList
-      case EndpointOutput.StatusCode(_)         => List.empty
-      case EndpointOutput.FixedStatusCode(_, _) => List.empty
-      case EndpointOutput.Mapped(wrapped, _, _) => forOutput(wrapped)
-      case EndpointOutput.Void()                => List.empty
-      case EndpointOutput.Multiple(outputs)     => outputs.toList.flatMap(forOutput)
-      case op: EndpointIO[_]                    => forIO(op)
+      case EndpointOutput.OneOf(mappings)                     => mappings.flatMap(mapping => forOutput(mapping.output)).toList
+      case EndpointOutput.StatusCode(_)                       => List.empty
+      case EndpointOutput.FixedStatusCode(_, _)               => List.empty
+      case EndpointOutput.Mapped(wrapped, _, _)               => forOutput(wrapped)
+      case EndpointOutput.BodyMappedStatusCode(wrapped, _, _) => forOutput(wrapped)
+      case EndpointOutput.Void()                              => List.empty
+      case EndpointOutput.Multiple(outputs)                   => outputs.toList.flatMap(forOutput)
+      case op: EndpointIO[_]                                  => forIO(op)
     }
   }
 

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
@@ -31,6 +31,13 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
       basicRequest.get(uri"$baseUri?fruit=right").send().map(_.code shouldBe StatusCode.Ok) >>
       basicRequest.get(uri"$baseUri?fruit=left").send().map(_.code shouldBe StatusCode.Accepted)
   }
+
+  testServer(in_string_out_status_from_string_status_mapped)((v: String) =>
+    pureResult((if (v == "right") Right("right") else Left(42)).asRight[Unit])
+  ) { baseUri =>
+    basicRequest.get(uri"$baseUri?fruit=right").send().map(_.code shouldBe StatusCode.Ok) >>
+      basicRequest.get(uri"$baseUri?fruit=left").send().map(_.code shouldBe StatusCode.Accepted)
+  }
   // method matching
 
   testServer(endpoint, "GET empty endpoint")((_: Unit) => pureResult(().asRight[Unit])) { baseUri =>
@@ -56,8 +63,7 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
   }
 
   testServer[String, Nothing, String](in_query_out_infallible_string)((fruit: String) => pureResult(s"fruit: $fruit".asRight[Nothing])) {
-    baseUri =>
-      basicRequest.get(uri"$baseUri?fruit=kiwi").send().map(_.body shouldBe Right("fruit: kiwi"))
+    baseUri => basicRequest.get(uri"$baseUri?fruit=kiwi").send().map(_.body shouldBe Right("fruit: kiwi"))
   }
 
   testServer(in_query_query_out_string) { case (fruit: String, amount: Option[Int]) => pureResult(s"$fruit $amount".asRight[Unit]) } {
@@ -74,9 +80,7 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
     basicRequest.get(uri"$baseUri/fruit/orange/amount/20").send().map(_.body shouldBe Right("orange 20"))
   }
 
-  testServer(in_path, "Empty path should not be passed to path capture decoding") { _ =>
-    pureResult(Right(()))
-  } { baseUri =>
+  testServer(in_path, "Empty path should not be passed to path capture decoding") { _ => pureResult(Right(())) } { baseUri =>
     basicRequest.get(uri"$baseUri/api/").send().map(_.code shouldBe StatusCode.NotFound)
   }
 
@@ -173,9 +177,7 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
 
   testServer(in_input_stream_out_input_stream)((is: InputStream) =>
     pureResult((new ByteArrayInputStream(inputStreamToByteArray(is)): InputStream).asRight[Unit])
-  ) { baseUri =>
-    basicRequest.post(uri"$baseUri/api/echo").body("mango").send().map(_.body shouldBe Right("mango"))
-  }
+  ) { baseUri => basicRequest.post(uri"$baseUri/api/echo").body("mango").send().map(_.body shouldBe Right("mango")) }
 
   testServer(in_unit_out_string, "default status mapper")((_: Unit) => pureResult("".asRight[Unit])) { baseUri =>
     basicRequest.get(uri"$baseUri/not-existing-path").send().map(_.code shouldBe StatusCode.NotFound)
@@ -222,8 +224,7 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
   }
 
   testServer(in_paths_out_string, "paths should match empty path")((ps: Seq[String]) => pureResult(ps.mkString(" ").asRight[Unit])) {
-    baseUri =>
-      basicRequest.get(uri"$baseUri").send().map(_.body shouldBe Right(""))
+    baseUri => basicRequest.get(uri"$baseUri").send().map(_.body shouldBe Right(""))
   }
 
   testServer(in_stream_out_stream[S])((s: S) => pureResult(s.asRight[Unit])) { baseUri =>
@@ -234,9 +235,7 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
     basicRequest
       .get(uri"$baseUri/api/echo/param-to-header?qq=${List("v1", "v2", "v3")}")
       .send()
-      .map { r =>
-        r.headers.filter(_.is("hh")).map(_.value).toList shouldBe List("v3", "v2", "v1", "v0")
-      }
+      .map { r => r.headers.filter(_.is("hh")).map(_.value).toList shouldBe List("v3", "v2", "v1", "v0") }
   }
 
   testServer(in_simple_multipart_out_multipart)((fa: FruitAmount) =>
@@ -291,7 +290,8 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
     }
   }
 
-  testServer(in_set_cookie_value_out_set_cookie_value)((c: CookieValueWithMeta) => pureResult(c.copy(value = c.value.reverse).asRight[Unit])
+  testServer(in_set_cookie_value_out_set_cookie_value)((c: CookieValueWithMeta) =>
+    pureResult(c.copy(value = c.value.reverse).asRight[Unit])
   ) { baseUri =>
     basicRequest.get(uri"$baseUri/api/echo/headers").header("Set-Cookie", "c1=xy; HttpOnly; Path=/").send().map { r =>
       r.cookies.toList shouldBe List(
@@ -316,9 +316,7 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
   }
 
   testServer(in_unit_out_fixed_header)(_ => pureResult(().asRight[Unit])) { baseUri =>
-    basicRequest.get(uri"$baseUri").send().map { r =>
-      r.header("Location") shouldBe Some("Poland")
-    }
+    basicRequest.get(uri"$baseUri").send().map { r => r.header("Location") shouldBe Some("Poland") }
   }
 
   testServer(in_optional_json_out_optional_json)((fa: Option[FruitAmount]) => pureResult(fa.asRight[Unit])) { baseUri =>
@@ -415,7 +413,8 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
       basicStringRequest.post(uri"$baseUri").send().map(_.body shouldBe "POST")
   }
 
-  testServer(in_string_out_status)((v: String) => pureResult((if (v == "apple") StatusCode.Accepted else StatusCode.NotFound).asRight[Unit])
+  testServer(in_string_out_status)((v: String) =>
+    pureResult((if (v == "apple") StatusCode.Accepted else StatusCode.NotFound).asRight[Unit])
   ) { baseUri =>
     basicRequest.get(uri"$baseUri?fruit=apple").send().map(_.code shouldBe StatusCode.Accepted) >>
       basicRequest.get(uri"$baseUri?fruit=orange").send().map(_.code shouldBe StatusCode.NotFound)
@@ -503,9 +502,7 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
       .post(uri"$baseUri/p2")
       .body("a" * 1000000)
       .send()
-      .map { r =>
-        r.body shouldBe "p2 1000000"
-      }
+      .map { r => r.body shouldBe "p2 1000000" }
   }
 
   testServer(
@@ -527,9 +524,7 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
       route(endpoint.get.in("p1").in(query[String]("q1")).out(stringBody), (_: String) => pureResult("e1".asRight[Unit])),
       route(endpoint.get.in("p1" / "p2").out(stringBody), (_: Unit) => pureResult("e2".asRight[Unit]))
     )
-  ) { baseUri =>
-    basicStringRequest.get(uri"$baseUri/p1/p2").send().map(_.body shouldBe "e2")
-  }
+  ) { baseUri => basicStringRequest.get(uri"$baseUri/p1/p2").send().map(_.body shouldBe "e2") }
 
   testServer(
     "two endpoints with validation: should not try the second one if validation fails",

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -186,6 +186,17 @@ package object tests {
         )
       )
   }
+
+  val in_string_out_status_from_string_status_mapped: Endpoint[String, Unit, Either[Int, String], Nothing] = {
+
+    endpoint
+      .in(query[String]("fruit"))
+      .out(statusFromBody(jsonBody[Either[Int, String]]) {
+        case _: Left[_, _]  => StatusCode.Accepted
+        case _: Right[_, _] => StatusCode.Ok
+      })
+
+  }
   val in_string_out_status_from_string_one_empty: Endpoint[String, Unit, Either[Unit, String], Nothing] =
     endpoint
       .in(query[String]("fruit"))
@@ -327,9 +338,7 @@ package object tests {
           })(_.toString.toLowerCase)
       }
       implicit def validatorForColor: Validator[Color] =
-        Validator.enum(List(Blue, Red), { c =>
-          Some(plainCodecForColor.encode(c))
-        })
+        Validator.enum(List(Blue, Red), c => Some(plainCodecForColor.encode(c)))
       endpoint.out(jsonBody[ColorValue])
     }
 


### PR DESCRIPTION
This PR adds a new functionality where based on the return value the api returns different status codes. 

An example of use case:
Return the HTTP status information in the body as well:
```scala
endpoint.post.errorOut(
        oneOf[HttpException](
          statusMapping(StatusCode.BadRequest, jsonBody[HttpExceptions.BadRequest.type]),
          statusMapping(StatusCode.BadRequest, jsonBody[HttpExceptions.InvalidToken.type]),
          statusMapping(StatusCode.Forbidden, jsonBody[HttpExceptions.InvalidCredentials.type])
        )
      )
```
Where:
```scala
sealed abstract class HttpException(val status: StatusCode, val code: String, val detail: Option[String] = None)
    extends Throwable(detail.getOrElse(""))

object HttpExceptions {
case object BadRequest  extends HttpException(StatusCodes.BadRequest, "BadRequest")
case object InvalidToken  extends HttpException(StatusCodes.BadRequest, "InvalidToken")
case object InvalidCredentials extends  HttpException(StatusCodes.Forbidden, "InvalidCredentials")
}
```

Can be replaced with:

```scala
caseclass HttpException(val status: StatusCode, val code: String, val detail: Option[String] = None)
    extends Throwable(detail.getOrElse(""))

object HttpExceptions {
val badRequest  = HttpException(StatusCodes.BadRequest, "BadRequest")
val invalidToken  = HttpException(StatusCodes.BadRequest, "InvalidToken")
val invalidCredentials =  HttpException(StatusCodes.Forbidden, "InvalidCredentials")
}
```

```scala
endpoint.post
.errorOut(statusFromBody(jsonBody[HttpException])(_.status)
```


I'll add tests for the doc generation if the idea is accepted :)
