### PR TITLE
Serialize jsonBody[Unit] to empty object

### DIFF
--- a/client/tests/src/main/scala/sttp/tapir/client/tests/ClientTests.scala
+++ b/client/tests/src/main/scala/sttp/tapir/client/tests/ClientTests.scala
@@ -98,6 +98,8 @@ trait ClientTests[S] extends FunSuite with Matchers with BeforeAndAfterAll {
       .get should contain(("Content-Type", "application/json".reverse))
   }
 
+  testClient[Unit, Unit, Unit, Nothing](in_unit_out_json_unit, (), Right(()))
+
   test(in_simple_multipart_out_raw_string.showDetail) {
     val result = send(in_simple_multipart_out_raw_string, port, FruitAmountWrapper(FruitAmount("apple", 10), "Now!"))
       .unsafeRunSync()
@@ -152,6 +154,7 @@ trait ClientTests[S] extends FunSuite with Matchers with BeforeAndAfterAll {
       }
     case GET -> Root / "fruit" / f                                         => Ok(s"$f")
     case GET -> Root / "fruit" / f / "amount" / amount :? colorOptParam(c) => Ok(s"$f $amount $c")
+    case r @ GET -> Root / "api" / "unit"                                  => Ok("{}")
     case r @ GET -> Root / "api" / "echo" / "params"                       => Ok(r.uri.query.params.toSeq.sortBy(_._1).map(p => s"${p._1}=${p._2}").mkString("&"))
     case r @ GET -> Root / "api" / "echo" / "headers"                      => Ok(headers = r.headers.toList.map(h => Header(h.name.value, h.value.reverse)): _*)
     case r @ GET -> Root / "api" / "echo" / "param-to-header" =>

--- a/core/src/main/boilerplate/sttp/tapir/internal/ParamsToSeq.scala.template
+++ b/core/src/main/boilerplate/sttp/tapir/internal/ParamsToSeq.scala.template
@@ -5,7 +5,6 @@ private[tapir] object ParamsToSeq {
     a match {
       [2..#case ([#v1#]) => Seq([#v1#])#
       ]
-      case ()                       => Seq()
       case v1                       => Seq(v1) // single value is a catch-all so must be last
     }
   }

--- a/core/src/main/scala/sttp/tapir/Schema.scala
+++ b/core/src/main/scala/sttp/tapir/Schema.scala
@@ -80,6 +80,7 @@ object Schema extends SchemaMagnoliaDerivation with LowPrioritySchema {
   implicit val schemaForFloat: Schema[Float] = Schema(SNumber).format("float")
   implicit val schemaForDouble: Schema[Double] = Schema(SNumber).format("double")
   implicit val schemaForBoolean: Schema[Boolean] = Schema(SBoolean)
+  implicit val schemaForUnit: Schema[Unit] = Schema(SProduct.empty)
   implicit val schemaForFile: Schema[File] = Schema(SBinary)
   implicit val schemaForPath: Schema[Path] = Schema(SBinary)
   implicit val schemaForByteArray: Schema[Array[Byte]] = Schema(SBinary)

--- a/core/src/main/scala/sttp/tapir/SchemaType.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaType.scala
@@ -39,6 +39,9 @@ object SchemaType {
     }
     def show: String = s"object(${fields.map(f => s"${f._1}->${f._2.show}").mkString(",")}"
   }
+  object SProduct {
+    def empty: SProduct = SProduct(SEmptyObject, Iterable.empty)
+  }
   case class SCoproduct(info: SObjectInfo, schemas: List[Schema[_]], discriminator: Option[Discriminator]) extends SObject {
     override def show: String = "oneOf:" + schemas.mkString(",")
   }
@@ -51,6 +54,7 @@ object SchemaType {
   }
 
   case class SObjectInfo(fullName: String, typeParameterShortNames: List[String] = Nil)
+  final val SEmptyObject = SObjectInfo(fullName="Unit")
 
   case class Discriminator(propertyName: String, mappingOverride: Map[String, SRef])
 }

--- a/core/src/main/scala/sttp/tapir/server/internal/EncodeOutputs.scala
+++ b/core/src/main/scala/sttp/tapir/server/internal/EncodeOutputs.scala
@@ -13,6 +13,7 @@ class EncodeOutputs[B](encodeOutputBody: EncodeOutputBody[B]) {
     def run(outputs: Vector[EndpointOutput.Single[_]], ov: OutputValues[B], vs: Seq[Any]): OutputValues[B] = {
       (outputs, vs) match {
         case (Vector(), Seq()) => ov
+        case (Vector(), Seq(())) => ov
         case (EndpointOutput.FixedStatusCode(sc, _) +: outputsTail, _) =>
           run(outputsTail, ov.withStatusCode(sc), vs)
         case (EndpointIO.FixedHeader(name, value, _) +: outputsTail, _) =>

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
@@ -178,7 +178,7 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
   }
 
   testServer(in_unit_out_json_unit, "unit json mapper")((_: Unit) => pureResult(().asRight[Unit])) { baseUri =>
-    basicRequest.get(uri"$baseUri/api").send().map(_.body shouldBe Right("{}"))
+    basicRequest.get(uri"$baseUri/api/unit").send().map(_.body shouldBe Right("{}"))
   }
 
   testServer(in_unit_out_string, "default status mapper")((_: Unit) => pureResult("".asRight[Unit])) { baseUri =>

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
@@ -177,6 +177,10 @@ trait ServerTests[R[_], S, ROUTE] extends FunSuite with Matchers with BeforeAndA
     basicRequest.post(uri"$baseUri/api/echo").body("mango").send().map(_.body shouldBe Right("mango"))
   }
 
+  testServer(in_unit_out_json_unit, "unit json mapper")((_: Unit) => pureResult(().asRight[Unit])) { baseUri =>
+    basicRequest.get(uri"$baseUri/api").send().map(_.body shouldBe Right("{}"))
+  }
+
   testServer(in_unit_out_string, "default status mapper")((_: Unit) => pureResult("".asRight[Unit])) { baseUri =>
     basicRequest.get(uri"$baseUri/not-existing-path").send().map(_.code shouldBe StatusCode.NotFound)
   }

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -81,6 +81,9 @@ package object tests {
   val in_file_out_file: Endpoint[File, Unit, File, Nothing] =
     endpoint.post.in("api" / "echo").in(binaryBody[File]).out(binaryBody[File]).name("echo file")
 
+  val in_unit_out_json_unit: Endpoint[Unit, Unit, Unit, Nothing] =
+    endpoint.in("api").out(jsonBody[Unit])
+
   val in_unit_out_string: Endpoint[Unit, Unit, String, Nothing] =
     endpoint.in("api").out(stringBody)
 

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -82,7 +82,7 @@ package object tests {
     endpoint.post.in("api" / "echo").in(binaryBody[File]).out(binaryBody[File]).name("echo file")
 
   val in_unit_out_json_unit: Endpoint[Unit, Unit, Unit, Nothing] =
-    endpoint.in("api").out(jsonBody[Unit])
+    endpoint.in("api" / "unit").out(jsonBody[Unit])
 
   val in_unit_out_string: Endpoint[Unit, Unit, String, Nothing] =
     endpoint.in("api").out(stringBody)


### PR DESCRIPTION
This PR introduces support for serializing `jsonBody[Unit]` as `{}`. Currently event provided with valid `sttp.tapir.Schema[Unit]` (as discussed in [this gitter thread](https://gitter.im/softwaremill/tapir?at=5e774ba7b11a2f7c801fb29c)) tapir would generate valid swagger docs, but server would fail when encoding the response.