### PR TITLE
Do not pretty-print play-json output

### DIFF
--- a/json/playjson/src/main/scala/sttp/tapir/json/play/TapirJsonPlay.scala
+++ b/json/playjson/src/main/scala/sttp/tapir/json/play/TapirJsonPlay.scala
@@ -14,7 +14,7 @@ trait TapirJsonPlay {
       case JsError(errors)     => Error(s, JsResultException(errors))
       case JsSuccess(value, _) => Value(value)
     }
-    override def encode(t: T): String = Json.prettyPrint(Json.toJson(t))
+    override def encode(t: T): String = Json.stringify(Json.toJson(t))
     override def meta: CodecMeta[T, CodecFormat.Json, String] =
       CodecMeta(implicitly[Schema[T]], CodecFormat.Json(), StringValueType(StandardCharsets.UTF_8))
   }

--- a/json/playjson/src/test/scala/sttp/tapir/json/play/TapirJsonPlayTests.scala
+++ b/json/playjson/src/test/scala/sttp/tapir/json/play/TapirJsonPlayTests.scala
@@ -65,4 +65,11 @@ class TapirJsonPlayTests extends FlatSpec with Matchers {
         fail(s"Should not have been able to decode this date: $d")
     }
   }
+
+  it should "encode to non-prettified Json" in {
+    val customer = Customer("Alita", 1985, None)
+    val codec = TapirJsonPlayCodec.readsWritesCodec[Customer]
+    val expected = """{"name":"Alita","yearOfBirth":1985}"""
+    codec.encode(customer) shouldBe expected
+  }
 }


### PR DESCRIPTION
Hello.

I think this PR is pretty self-explanatory.
Currently the play-json bindings call `Json.prettyPrint` to serialize `JsValue`s into strings.
This unnecessarily inflates the size of Json response bodies from Tapir endpoints.

While at it, I checked Circe, Spray Json and µPickle bindings, they correctly use compact (no spaces) stringification.