### PR TITLE
added description macro

### DIFF
--- a/core/src/main/scala/sttp/tapir/Schema.scala
+++ b/core/src/main/scala/sttp/tapir/Schema.scala
@@ -51,6 +51,8 @@ case class Schema[T](
 
   def show: String = s"schema is $schemaType${if (isOptional) " (optional)" else ""}"
 
+  def description[U](path: T => U, description: String): Schema[T] = macro ModifySchemaMacro.descriptionMacro[T, U]
+
   def modifyUnsafe[U](fields: String*)(modify: Schema[U] => Schema[U]): Schema[T] = modifyAtPath(fields.toList, modify)
 
   def modify[U](path: T => U)(modification: Schema[U] => Schema[U]): Schema[T] = macro ModifySchemaMacro.modifyMacro[T, U]

--- a/core/src/main/scala/sttp/tapir/internal/ModifySchemaMacro.scala
+++ b/core/src/main/scala/sttp/tapir/internal/ModifySchemaMacro.scala
@@ -13,6 +13,21 @@ object ModifySchemaMacro {
   )(path: c.Expr[T => U])(modification: c.Expr[Schema[U] => Schema[U]]): c.Tree =
     applyModification[T, U](c)(extractPathFromFunctionCall(c)(path), modification)
 
+  def descriptionMacro[T: c.WeakTypeTag, U: c.WeakTypeTag](c: blackbox.Context)
+                                                          (path: c.Expr[T => U], description: c.Expr[String]): c.Tree =
+    addDescription[T, U](c)(extractPathFromFunctionCall(c)(path), description)
+
+
+  private def addDescription[T: c.WeakTypeTag, U: c.WeakTypeTag](c: blackbox.Context)(
+    path: c.Expr[List[String]],
+    description: c.Expr[String]
+  ): c.Tree = {
+    import c.universe._
+    q"""{
+      ${c.prefix}.modifyUnsafe($path:_*)((v: sttp.tapir.Schema[${c.weakTypeOf[T]}]) => v.description($description))
+     }"""
+  }
+
   private def applyModification[T: c.WeakTypeTag, U: c.WeakTypeTag](c: blackbox.Context)(
       path: c.Expr[List[String]],
       modification: c.Expr[Schema[U] => Schema[U]]

--- a/core/src/test/scala/sttp/tapir/SchemaMacroTest.scala
+++ b/core/src/test/scala/sttp/tapir/SchemaMacroTest.scala
@@ -4,6 +4,8 @@ import org.scalatest.{FlatSpec, Matchers}
 import sttp.tapir.SchemaType._
 
 class SchemaMacroTest extends FlatSpec with Matchers {
+  behavior of "apply modification"
+
   it should "modify basic schema" in {
     implicitly[Schema[String]].modify(x => x)(_.description("test")) shouldBe implicitly[Schema[String]]
       .copy(description = Some("test"))
@@ -89,6 +91,17 @@ class SchemaMacroTest extends FlatSpec with Matchers {
   it should "modify open product" in {
     val schema = implicitly[Schema[Map[String, String]]]
     schema.modify(x => x)(_.description("test")) shouldBe schema.description("test")
+  }
+
+  behavior of "apply description"
+
+  it should "add description to product" in {
+    val expected = Schema(
+      SProduct(SObjectInfo("sttp.tapir.Person"),
+        List(("name", Schema(SString)), ("age", Schema(SInteger).description("test"))))
+    )
+
+    implicitly[Schema[Person]].description(_.age, "test") shouldBe expected
   }
 }
 


### PR DESCRIPTION
I found modification of schema description quite annoying especially for big case classes. 
WDYT about this shortcut for description modification?

```scala
case class Foo(a: Int, b: Int, c: Int)
object Foo {
  Schema.derivedSchema[Foo] 
    .description(_.a, "A")  <--  proposed syntax
    .description(_.b, "B")
    .description(_.c, "C")

  Schema.derivedSchema[Foo]
    .modify(_.a)(_.description("A")) <-- current available
    .modify(_.b)(_.description("B"))
    .modify(_.c)(_.description("C"))
}
```