### PR TITLE
Cache Validator pass/reject instances.

### DIFF
--- a/core/src/main/scala/sttp/tapir/Validator.scala
+++ b/core/src/main/scala/sttp/tapir/Validator.scala
@@ -23,11 +23,21 @@ sealed trait Validator[T] {
 object Validator extends ValidatorMagnoliaDerivation with ValidatorEnumMacro {
   type EncodeToRaw[T] = T => Option[scala.Any]
 
+  private val _pass: Validator[Nothing] = all()
+  private val _reject: Validator[Nothing] = any()
+
   def all[T](v: Validator[T]*): Validator[T] = if (v.size == 1) v.head else All[T](v.toList)
   def any[T](v: Validator[T]*): Validator[T] = if (v.size == 1) v.head else Any[T](v.toList)
 
-  def pass[T]: Validator[T] = all()
-  def reject[T]: Validator[T] = any()
+  /**
+    * A validator instance that always pass.
+    */
+  def pass[T]: Validator[T] = _pass.asInstanceOf[Validator[T]]
+
+  /**
+    * A validator instance that always reject.
+    */
+  def reject[T]: Validator[T] = _reject.asInstanceOf[Validator[T]]
 
   def min[T: Numeric](value: T, exclusive: Boolean = false): Validator.Primitive[T] = Min(value, exclusive)
   def max[T: Numeric](value: T, exclusive: Boolean = false): Validator.Primitive[T] = Max(value, exclusive)


### PR DESCRIPTION
The `Validator.pass` method is used extensively, both in the library and in application code (default auto-derivated validator is killing the compile time, and the byte-code size). It currently creates a new instance at each call. 

This PR is a quick-win to reduce the GC pressure and allocations, caching a single instance of `pass` and `reject`, using a common pattern. 