### PR TITLE
Add codecs for vectors and sets

### DIFF
--- a/core/src/main/scala/sttp/tapir/Codec.scala
+++ b/core/src/main/scala/sttp/tapir/Codec.scala
@@ -256,6 +256,32 @@ object Codec extends MultipartCodecDerivation with FormCodecDerivation {
       .validate(c.validator.asIterableElements[List])
 
   /**
+    * Create a codec which decodes/encodes a list of low-level values to a set of high-level values, using the given
+    * base codec `c`.
+    *
+    * The schema and validator are copied from the base codec.
+    */
+  implicit def set[T, U, CF <: CodecFormat](implicit c: Codec[T, U, CF]): Codec[List[T], Set[U], CF] =
+    Codec
+      .id[List[T], CF](c.format)
+      .mapDecode(ts => DecodeResult.sequence(ts.map(c.decode)).map(_.toSet))(us => us.map(c.encode).toList)
+      .schema(c.schema.map(_.asArrayElement.as[Set[U]]))
+      .validate(c.validator.asIterableElements[Set])
+
+  /**
+    * Create a codec which decodes/encodes a list of low-level values to a vector of high-level values, using the given
+    * base codec `c`.
+    *
+    * The schema and validator are copied from the base codec.
+    */
+  implicit def vector[T, U, CF <: CodecFormat](implicit c: Codec[T, U, CF]): Codec[List[T], Vector[U], CF] =
+    Codec
+      .id[List[T], CF](c.format)
+      .mapDecode(ts => DecodeResult.sequence(ts.map(c.decode)).map(_.toVector))(us => us.map(c.encode).toList)
+      .schema(c.schema.map(_.asArrayElement.as[Vector[U]]))
+      .validate(c.validator.asIterableElements[Vector])
+
+  /**
     * Create a codec which requires that a list of low-level values contains a single element. Otherwise a decode
     * failure is returned. The given base codec `c` is used for decoding/encoding.
     *

--- a/core/src/test/scala/sttp/tapir/generic/FormCodecDerivationTest.scala
+++ b/core/src/test/scala/sttp/tapir/generic/FormCodecDerivationTest.scala
@@ -117,6 +117,38 @@ class FormCodecDerivationTest extends FlatSpec with Matchers {
     codec.decode("f1=10&f1=12") shouldBe DecodeResult.Value(Test1(List(10, 12)))
   }
 
+
+  it should "generate a codec for a one-arg case class with set" in {
+    // given
+    case class Test1(f1: Set[Int])
+    val codec = implicitly[Codec[String, Test1, CodecFormat.XWwwFormUrlencoded]]
+
+    // when
+    codec.encode(Test1(Set.empty)) shouldBe ""
+    codec.encode(Test1(Set(10))) shouldBe "f1=10"
+    codec.encode(Test1(Set(10, 12))) shouldBe "f1=10&f1=12"
+
+    codec.decode("") shouldBe DecodeResult.Value(Test1(Set.empty))
+    codec.decode("f1=10") shouldBe DecodeResult.Value(Test1(Set(10)))
+    codec.decode("f1=10&f1=12") shouldBe DecodeResult.Value(Test1(Set(10, 12)))
+    codec.decode("f1=10&f1=12&f1=12") shouldBe DecodeResult.Value(Test1(Set(10, 12)))
+  }
+
+  it should "generate a codec for a one-arg case class with vector" in {
+    // given
+    case class Test1(f1: Vector[Int])
+    val codec = implicitly[Codec[String, Test1, CodecFormat.XWwwFormUrlencoded]]
+
+    // when
+    codec.encode(Test1(Vector.empty)) shouldBe ""
+    codec.encode(Test1(Vector(10))) shouldBe "f1=10"
+    codec.encode(Test1(Vector(10, 12))) shouldBe "f1=10&f1=12"
+
+    codec.decode("") shouldBe DecodeResult.Value(Test1(Vector.empty))
+    codec.decode("f1=10") shouldBe DecodeResult.Value(Test1(Vector(10)))
+    codec.decode("f1=10&f1=12") shouldBe DecodeResult.Value(Test1(Vector(10, 12)))
+  }
+
   it should "generate a codec for a one-arg case class using implicit validator" in {
     // given
     case class Test1(f1: Int)


### PR DESCRIPTION
After migration to 0.13 there were compilation errors due to lack of `Codec[List[T], Set[U], CF]`, which were present for `CodecForMany` in 0.12. This MR should resolve this.