### PR TITLE
Make Cats NonEmpty collections codecs use appropriate schemas and validators

### DIFF
--- a/integrations/cats/src/main/scala/sttp/tapir/codec/cats/TapirCodecCats.scala
+++ b/integrations/cats/src/main/scala/sttp/tapir/codec/cats/TapirCodecCats.scala
@@ -7,16 +7,20 @@ import sttp.tapir._
 import scala.collection.immutable.SortedSet
 
 trait TapirCodecCats {
-  private def nonEmptyValidator[T]: Validator[List[T]] = Validator.minSize[T, List](1)
 
-  implicit def validatorNel[T](implicit v: Validator[T]): Validator[NonEmptyList[T]] =
-    v.asIterableElements.and(nonEmptyValidator[T]).contramap(_.toList)
+  private def nonEmpty[T, C[X] <: Iterable[X]]: Validator.Primitive[C[T]] = Validator.minSize[T, C](1)
 
-  implicit def validatorNec[T](implicit v: Validator[T]): Validator[NonEmptyChain[T]] =
-    v.asIterableElements.and(nonEmptyValidator[T]).contramap(_.toChain.toList)
+  private def iterableAndNonEmpty[T, C[X] <: Iterable[X]](implicit v: Validator[T]): Validator[C[T]] =
+    v.asIterableElements[C].and(nonEmpty)
 
-  implicit def validatorNes[T](implicit v: Validator[T]): Validator[NonEmptySet[T]] =
-    v.asIterableElements.and(nonEmptyValidator[T]).contramap(_.toSortedSet.toList)
+  implicit def validatorNel[T: Validator]: Validator[NonEmptyList[T]] =
+    iterableAndNonEmpty[T, List].contramap(_.toList)
+
+  implicit def validatorNec[T: Validator]: Validator[NonEmptyChain[T]] =
+    iterableAndNonEmpty[T, List].contramap(_.toChain.toList)
+
+  implicit def validatorNes[T: Validator]: Validator[NonEmptySet[T]] =
+    iterableAndNonEmpty[T, Set].contramap(_.toSortedSet)
 
   implicit def schemaForNel[T: Schema]: Schema[NonEmptyList[T]] =
     Schema[NonEmptyList[T]](SchemaType.SArray(implicitly[Schema[T]])).copy(isOptional = false)
@@ -28,11 +32,17 @@ trait TapirCodecCats {
     Schema[NonEmptySet[T]](SchemaType.SArray(implicitly[Schema[T]])).copy(isOptional = false)
 
   implicit def codecForNonEmptyList[L, H, CF <: CodecFormat](implicit c: Codec[L, List[H], CF]): Codec[L, NonEmptyList[H], CF] =
-    c.mapDecode { l => DecodeResult.fromOption(NonEmptyList.fromList(l)) }(_.toList)
+    c.modifySchema(_.copy(isOptional = false))
+      .validate(nonEmpty)
+      .mapDecode { l => DecodeResult.fromOption(NonEmptyList.fromList(l)) }(_.toList)
 
   implicit def codecForNonEmptyChain[L, H, CF <: CodecFormat](implicit c: Codec[L, List[H], CF]): Codec[L, NonEmptyChain[H], CF] =
-    c.mapDecode { l => DecodeResult.fromOption(NonEmptyChain.fromSeq(l)) }(_.toNonEmptyList.toList)
+    c.modifySchema(_.copy(isOptional = false))
+      .validate(nonEmpty)
+      .mapDecode { l => DecodeResult.fromOption(NonEmptyChain.fromSeq(l)) }(_.toNonEmptyList.toList)
 
   implicit def codecForNonEmptySet[L, H: Ordering, CF <: CodecFormat](implicit c: Codec[L, Set[H], CF]): Codec[L, NonEmptySet[H], CF] =
-    c.mapDecode { set => DecodeResult.fromOption(NonEmptySet.fromSet(SortedSet(set.toSeq: _*))) }(_.toSortedSet)
+    c.modifySchema(_.copy(isOptional = false))
+      .validate(nonEmpty)
+      .mapDecode { set => DecodeResult.fromOption(NonEmptySet.fromSet(SortedSet(set.toSeq: _*))) }(_.toSortedSet)
 }


### PR DESCRIPTION
As discussed on [Gitter](https://gitter.im/softwaremill/tapir?at=5ea6abfc1eb8bd3978fa74de), I think the Cats codecs should use the schema (isOptional = false) and validator (size>=1) defined in the trait, this way the automatic documentation derivation works as expected.