### PR TITLE
Add Schema for io.circe.JsonObject

### DIFF
--- a/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
+++ b/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
@@ -29,4 +29,12 @@ trait TapirJsonCirce {
         None
       )
     )
+
+  implicit val schemaForCirceJsonObject: Schema[JsonObject] =
+    Schema(
+      SProduct(
+        SObjectInfo("io.circe.JsonObject"),
+        Iterable.empty
+      )
+    )
 }


### PR DESCRIPTION
A Product with no fields will encode to a schema of
```
  type: object
```
which is exactly what we want.