### PR TITLE
Add XML body type

### DIFF
--- a/core/src/main/scala/sttp/tapir/CodecFormat.scala
+++ b/core/src/main/scala/sttp/tapir/CodecFormat.scala
@@ -15,6 +15,10 @@ object CodecFormat {
     override val mediaType: MediaType = MediaType.ApplicationJson
   }
 
+  case class Xml() extends CodecFormat {
+    override val mediaType: MediaType = MediaType.ApplicationXml
+  }
+
   case class TextPlain() extends CodecFormat {
     override val mediaType: MediaType = MediaType.TextPlain
   }

--- a/core/src/main/scala/sttp/tapir/Tapir.scala
+++ b/core/src/main/scala/sttp/tapir/Tapir.scala
@@ -6,7 +6,7 @@ import java.nio.charset.{Charset, StandardCharsets}
 import java.nio.file.Path
 
 import sttp.model.{Cookie, CookieValueWithMeta, CookieWithMeta, Header, HeaderNames, QueryParams, StatusCode}
-import sttp.tapir.CodecFormat.{Json, OctetStream, TextPlain}
+import sttp.tapir.CodecFormat.{Json, Xml, OctetStream, TextPlain}
 import sttp.tapir.EndpointOutput.StatusMapping
 import sttp.tapir.internal.{ModifyMacroSupport, StatusMappingMacro}
 import sttp.tapir.model.ServerRequest
@@ -66,7 +66,12 @@ trait Tapir extends TapirDerivedInputs with ModifyMacroSupport {
     *
     * If you have a custom json codec, you should use this method instead.
     */
-  def anyJsonBody[T: Codec[String, *, Json]]: EndpointIO.Body[String, T] = anyFromUtf8StringBody(implicitly[Codec[String, T, Json]])
+  def anyJsonBody[T: Codec.JsonCodec]: EndpointIO.Body[String, T] = anyFromUtf8StringBody(implicitly[Codec[String, T, Json]])
+
+  /**
+    * Implement your own xml codec using `Codec.xml()` before using this method.
+    */
+  def xmlBody[T: Codec.XmlCodec]: EndpointIO.Body[String, T] = anyFromUtf8StringBody(implicitly[Codec[String, T, Xml]])
 
   def rawBinaryBody[R: RawBodyType.Binary](implicit codec: Codec[R, R, OctetStream]): EndpointIO.Body[R, R] =
     EndpointIO.Body(implicitly[RawBodyType.Binary[R]], codec, EndpointIO.Info.empty)


### PR DESCRIPTION
When working with tapir in our services, I realized there was no easy way to have tapir parse XML body.

I thought it would be good to add this feature to the official tapir library, as I'm sure many others can benefit from this, as XML is still used in many places today.

With this Users can simply create their own XML Codec via `Codec.xml()`, and then they will have the ability to use `xmlBody[T]` in both the request and response.