### PR TITLE
Play server crashes on HTML responses

### DIFF
--- a/server/play-server/src/main/scala/sttp/tapir/server/play/OutputToPlayResponse.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/OutputToPlayResponse.scala
@@ -141,6 +141,7 @@ object OutputToPlayResponse {
       case MediaType.ApplicationJson               => ContentTypes.JSON
       case MediaType.TextPlain                     => ContentTypes.TEXT(Codec.javaSupported(format.mediaType.charset.getOrElse("utf-8")))
       case MediaType.TextPlainUtf8                 => ContentTypes.TEXT(Codec.utf_8)
+      case MediaType.TextHtml                      => ContentTypes.HTML(Codec.utf_8)
       case MediaType.ApplicationOctetStream        => ContentTypes.BINARY
       case MediaType.ApplicationXWwwFormUrlencoded => ContentTypes.FORM
       case MediaType.MultipartFormData             => "multipart/form-data"


### PR DESCRIPTION
Hi everyone. There is no HTML case in `OutputToPlayResponse#formatToContentType` in Play server. 

There are also no such cases in akka-http and http4s servers but for them there are cases with `toString`:

```scala
case f                                => parseContentType(f.mediaType.toString())
```

I wonder if Play server should also work this way.