### PR TITLE
Incorrect import declaration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ val booksListingRoute: Route = booksListing.toRoute((bookListingLogic _).tupled)
 //
 
 import sttp.tapir.client.sttp._
-import com.softwaremill.sttp._
+import sttp.client._
 
 val booksListingRequest: Request[Either[String, List[Book]], Nothing] = booksListing
   .toSttpRequest(uri"http://localhost:8080")


### PR DESCRIPTION
Hello. I'm playing with `tapir` and `tapir-sttp-client` and I see there's no such package as `com.softwaremill.sttp` as stated in README.
I believe it could be a typo and it should be `import sttp.client._` instead.

I see the same issue in the docs here: https://tapir.softwaremill.com/en/latest/#code-teaser

Versions used:
```
"com.softwaremill.sttp.tapir" %% "tapir-core" % "0.16.0"
"com.softwaremill.sttp.tapir" %% "tapir-sttp-client" % "0.16.0"
```