### PR TITLE
Apply naming configuration to validators product fields since they ar…

### DIFF
--- a/core/src/main/scala/sttp/tapir/FieldName.scala
+++ b/core/src/main/scala/sttp/tapir/FieldName.scala
@@ -1,0 +1,7 @@
+package sttp.tapir
+
+case class FieldName(name: String, lowLevelName: String)
+
+object FieldName {
+  def apply(name: String) = new FieldName(name, name)
+}

--- a/core/src/main/scala/sttp/tapir/Schema.scala
+++ b/core/src/main/scala/sttp/tapir/Schema.scala
@@ -66,7 +66,7 @@ case class Schema[T](
           case s @ SProduct(_, fields) =>
             s.copy(fields = fields.toList.map {
               case field @ (fieldName, fieldSchema) =>
-                if (fieldName == f) (fieldName, fieldSchema.modifyAtPath(fs, modify)) else field
+                if (fieldName.name == f) (fieldName, fieldSchema.modifyAtPath(fs, modify)) else field
             })
           case s @ SOpenProduct(_, valueSchema) if f == Schema.ModifyCollectionElements =>
             s.copy(valueSchema = valueSchema.modifyAtPath(fs, modify))

--- a/core/src/main/scala/sttp/tapir/SchemaType.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaType.scala
@@ -33,8 +33,8 @@ object SchemaType {
   sealed trait SObject extends SchemaType {
     def info: SObjectInfo
   }
-  case class SProduct(info: SObjectInfo, fields: Iterable[(String, Schema[_])]) extends SObject {
-    def required: Iterable[String] =
+  case class SProduct(info: SObjectInfo, fields: Iterable[(FieldName, Schema[_])]) extends SObject {
+    def required: Iterable[FieldName] =
       fields.collect {
         case (f, s) if !s.isOptional => f
       }

--- a/core/src/main/scala/sttp/tapir/Validator.scala
+++ b/core/src/main/scala/sttp/tapir/Validator.scala
@@ -166,7 +166,6 @@ object Validator extends ValidatorMagnoliaDerivation with ValidatorEnumMacro {
     }
   }
 
-  case class FieldName(name: String, lowLevelName: String)
   trait ProductField[T] {
     type FieldType
     def name: FieldName
@@ -282,6 +281,6 @@ object Validator extends ValidatorMagnoliaDerivation with ValidatorEnumMacro {
   implicit def openProduct[T: Validator]: Validator[Map[String, T]] = OpenProduct(implicitly[Validator[T]])
 }
 
-case class ValidationError[T](validator: Validator.Primitive[T], invalidValue: T, path: List[Validator.FieldName] = Nil) {
-  def prependPath(f: Validator.FieldName): ValidationError[T] = copy(path = f :: path)
+case class ValidationError[T](validator: Validator.Primitive[T], invalidValue: T, path: List[FieldName] = Nil) {
+  def prependPath(f: FieldName): ValidationError[T] = copy(path = f :: path)
 }

--- a/core/src/main/scala/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
@@ -4,7 +4,7 @@ import com.github.ghik.silencer.silent
 import magnolia._
 import sttp.tapir.SchemaType._
 import sttp.tapir.generic.{Configuration, Derived}
-import sttp.tapir.{Schema, SchemaType}
+import sttp.tapir.{FieldName, Schema, SchemaType}
 import SchemaMagnoliaDerivation.deriveInProgress
 
 import scala.collection.mutable
@@ -28,7 +28,7 @@ trait SchemaMagnoliaDerivation {
             Schema[T](
               SProduct(
                 typeNameToObjectInfo(ctx.typeName),
-                ctx.parameters.map(p => (genericDerivationConfig.toLowLevelName(p.label), p.typeclass)).toList
+                ctx.parameters.map(p => (FieldName(p.label, genericDerivationConfig.toLowLevelName(p.label)), p.typeclass)).toList
               )
             )
           }

--- a/core/src/main/scala/sttp/tapir/generic/internal/ValidatorMagnoliaDerivation.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/ValidatorMagnoliaDerivation.scala
@@ -2,7 +2,7 @@ package sttp.tapir.generic.internal
 
 import com.github.ghik.silencer.silent
 import magnolia.{Magnolia, ReadOnlyCaseClass, SealedTrait}
-import sttp.tapir.{Validator, generic}
+import sttp.tapir.{FieldName, Validator, generic}
 import sttp.tapir.generic.Configuration
 
 trait ValidatorMagnoliaDerivation {
@@ -10,9 +10,9 @@ trait ValidatorMagnoliaDerivation {
 
   def combine[T](ctx: ReadOnlyCaseClass[Validator, T])(implicit genericDerivationConfig: Configuration): Validator[T] = {
     Validator.Product(ctx.parameters.map { p =>
-      genericDerivationConfig.toLowLevelName(p.label) -> new Validator.ProductField[T] {
+      p.label -> new Validator.ProductField[T] {
         override type FieldType = p.PType
-        override def name: Validator.FieldName = Validator.FieldName(p.label, genericDerivationConfig.toLowLevelName(p.label))
+        override def name: FieldName = FieldName(p.label, genericDerivationConfig.toLowLevelName(p.label))
         override def get(t: T): FieldType = p.dereference(t)
         override def validator: Typeclass[FieldType] = p.typeclass
       }

--- a/core/src/main/scala/sttp/tapir/generic/internal/ValidatorMagnoliaDerivation.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/ValidatorMagnoliaDerivation.scala
@@ -10,7 +10,7 @@ trait ValidatorMagnoliaDerivation {
 
   def combine[T](ctx: ReadOnlyCaseClass[Validator, T])(implicit genericDerivationConfig: Configuration): Validator[T] = {
     Validator.Product(ctx.parameters.map { p =>
-      p.label -> new Validator.ProductField[T] {
+      genericDerivationConfig.toLowLevelName(p.label) -> new Validator.ProductField[T] {
         override type FieldType = p.PType
         override def name: Validator.FieldName = Validator.FieldName(p.label, genericDerivationConfig.toLowLevelName(p.label))
         override def get(t: T): FieldType = p.dereference(t)

--- a/core/src/test/scala/sttp/tapir/SchemaMacroTest.scala
+++ b/core/src/test/scala/sttp/tapir/SchemaMacroTest.scala
@@ -15,7 +15,7 @@ class SchemaMacroTest extends FlatSpec with Matchers {
     val info1 = SObjectInfo("sttp.tapir.Person")
     implicitly[Schema[Person]]
       .modify(_.age)(_.description("test")) shouldBe Schema(
-      SProduct(info1, List(("name", Schema(SString)), ("age", Schema(SInteger).description("test"))))
+      SProduct(info1, List((FieldName("name"), Schema(SString)), (FieldName("age"), Schema(SInteger).description("test"))))
     )
   }
 
@@ -23,18 +23,19 @@ class SchemaMacroTest extends FlatSpec with Matchers {
     val info1 = SObjectInfo("sttp.tapir.DevTeam")
     val info2 = SObjectInfo("sttp.tapir.Person")
 
-    val expectedNestedProduct = Schema(SProduct(info2, List(("name", Schema(SString)), ("age", Schema(SInteger).description("test")))))
+    val expectedNestedProduct =
+      Schema(SProduct(info2, List((FieldName("name"), Schema(SString)), (FieldName("age"), Schema(SInteger).description("test")))))
 
     implicitly[Schema[DevTeam]]
       .modify(_.p1.age)(_.description("test")) shouldBe
-      Schema(SProduct(info1, List(("p1", expectedNestedProduct), ("p2", implicitly[Schema[Person]]))))
+      Schema(SProduct(info1, List((FieldName("p1"), expectedNestedProduct), (FieldName("p2"), implicitly[Schema[Person]]))))
   }
 
   it should "modify array elements in products" in {
     val info1 = SObjectInfo("sttp.tapir.ArrayWrapper")
     implicitly[Schema[ArrayWrapper]]
       .modify(_.f1.each)(_.format("xyz")) shouldBe Schema(
-      SProduct(info1, List(("f1", Schema(SArray(Schema(SString).format("xyz")), isOptional = true))))
+      SProduct(info1, List((FieldName("f1"), Schema(SArray(Schema(SString).format("xyz")), isOptional = true))))
     )
   }
 
@@ -42,7 +43,7 @@ class SchemaMacroTest extends FlatSpec with Matchers {
     val info1 = SObjectInfo("sttp.tapir.ArrayWrapper")
     implicitly[Schema[ArrayWrapper]]
       .modify(_.f1)(_.format("xyz")) shouldBe Schema(
-      SProduct(info1, List(("f1", Schema(SArray(Schema(SString)), isOptional = true).format("xyz"))))
+      SProduct(info1, List((FieldName("f1"), Schema(SArray(Schema(SString)), isOptional = true).format("xyz"))))
     )
   }
 
@@ -52,14 +53,17 @@ class SchemaMacroTest extends FlatSpec with Matchers {
     implicitly[Schema[DevTeam]]
       .modify(_.p1)(_.format("xyz"))
       .modify(_.p2)(_.format("qwe")) shouldBe Schema(
-      SProduct(info1, List(("p1", implicitly[Schema[Person]].format("xyz")), ("p2", implicitly[Schema[Person]].format("qwe"))))
+      SProduct(
+        info1,
+        List((FieldName("p1"), implicitly[Schema[Person]].format("xyz")), (FieldName("p2"), implicitly[Schema[Person]].format("qwe")))
+      )
     )
   }
 
   it should "modify optional parameter" in {
     implicitly[Schema[Parent]]
       .modify(_.child)(_.format("xyz")) shouldBe Schema(
-      SProduct(SObjectInfo("sttp.tapir.Parent"), List("child" -> implicitly[Schema[Person]].format("xyz").asOptional))
+      SProduct(SObjectInfo("sttp.tapir.Parent"), List(FieldName("child") -> implicitly[Schema[Person]].format("xyz").asOptional))
     )
   }
 
@@ -69,8 +73,11 @@ class SchemaMacroTest extends FlatSpec with Matchers {
       SProduct(
         SObjectInfo("sttp.tapir.Parent"),
         List(
-          "child" -> Schema(
-            SProduct(SObjectInfo("sttp.tapir.Person"), List("name" -> Schema(SString), "age" -> Schema(SInteger).format("xyz"))),
+          FieldName("child") -> Schema(
+            SProduct(
+              SObjectInfo("sttp.tapir.Person"),
+              List(FieldName("name") -> Schema(SString), FieldName("age") -> Schema(SInteger).format("xyz"))
+            ),
             isOptional = true
           )
         )
@@ -83,7 +90,7 @@ class SchemaMacroTest extends FlatSpec with Matchers {
       .modify(_.v.each)(_.description("test")) shouldBe Schema(
       SProduct(
         SObjectInfo("sttp.tapir.Team"),
-        List("v" -> Schema(SOpenProduct(SObjectInfo("Map", List("Person")), implicitly[Schema[Person]].description("test"))))
+        List(FieldName("v") -> Schema(SOpenProduct(SObjectInfo("Map", List("Person")), implicitly[Schema[Person]].description("test"))))
       )
     )
   }
@@ -97,7 +104,10 @@ class SchemaMacroTest extends FlatSpec with Matchers {
 
   it should "add description to product" in {
     val expected = Schema(
-      SProduct(SObjectInfo("sttp.tapir.Person"), List(("name", Schema(SString)), ("age", Schema(SInteger).description("test"))))
+      SProduct(
+        SObjectInfo("sttp.tapir.Person"),
+        List((FieldName("name"), Schema(SString)), (FieldName("age"), Schema(SInteger).description("test")))
+      )
     )
 
     implicitly[Schema[Person]].setDescription(_.age, "test") shouldBe expected

--- a/core/src/test/scala/sttp/tapir/SchemaMacroTest.scala
+++ b/core/src/test/scala/sttp/tapir/SchemaMacroTest.scala
@@ -2,6 +2,7 @@ package sttp.tapir
 
 import org.scalatest.{FlatSpec, Matchers}
 import sttp.tapir.SchemaType._
+import sttp.tapir.generic.{Configuration, D}
 
 class SchemaMacroTest extends FlatSpec with Matchers {
   behavior of "apply modification"
@@ -111,6 +112,15 @@ class SchemaMacroTest extends FlatSpec with Matchers {
     )
 
     implicitly[Schema[Person]].setDescription(_.age, "test") shouldBe expected
+  }
+
+  it should "work with custom naming configuration" in {
+    implicit val customConf: Configuration = Configuration.default.withKebabCaseMemberNames
+    val actual = implicitly[Schema[D]].setDescription(_.someFieldName, "something")
+    actual.schemaType shouldBe SProduct(
+      SObjectInfo("sttp.tapir.generic.D"),
+      List((FieldName("someFieldName", "some-field-name"), Schema(SString).description("something")))
+    )
   }
 }
 

--- a/core/src/test/scala/sttp/tapir/SchemaTest.scala
+++ b/core/src/test/scala/sttp/tapir/SchemaTest.scala
@@ -11,9 +11,9 @@ class SchemaTest extends FlatSpec with Matchers {
 
   it should "modify product schema" in {
     val info1 = SObjectInfo("X")
-    Schema(SProduct(info1, List(("f1", Schema(SString)), ("f2", Schema(SInteger)))))
+    Schema(SProduct(info1, List((FieldName("f1"), Schema(SString)), (FieldName("f2"), Schema(SInteger)))))
       .modifyUnsafe[String]("f2")(_.description("test")) shouldBe Schema(
-      SProduct(info1, List(("f1", Schema(SString)), ("f2", Schema(SInteger).description("test"))))
+      SProduct(info1, List((FieldName("f1"), Schema(SString)), (FieldName("f2"), Schema(SInteger).description("test"))))
     )
   }
 
@@ -21,49 +21,58 @@ class SchemaTest extends FlatSpec with Matchers {
     val info1 = SObjectInfo("X")
     val info2 = SObjectInfo("Y")
 
-    val nestedProduct = Schema(SProduct(info2, List(("f1", Schema(SString)), ("f2", Schema(SInteger)))))
-    val expectedNestedProduct = Schema(SProduct(info2, List(("f1", Schema(SString)), ("f2", Schema(SInteger).description("test")))))
+    val nestedProduct = Schema(SProduct(info2, List((FieldName("f1"), Schema(SString)), (FieldName("f2"), Schema(SInteger)))))
+    val expectedNestedProduct =
+      Schema(SProduct(info2, List((FieldName("f1"), Schema(SString)), (FieldName("f2"), Schema(SInteger).description("test")))))
 
-    Schema(SProduct(info1, List(("f3", Schema(SString)), ("f4", nestedProduct), ("f5", Schema(SBoolean)))))
+    Schema(SProduct(info1, List((FieldName("f3"), Schema(SString)), (FieldName("f4"), nestedProduct), (FieldName("f5"), Schema(SBoolean)))))
       .modifyUnsafe[String]("f4", "f2")(_.description("test")) shouldBe
-      Schema(SProduct(info1, List(("f3", Schema(SString)), ("f4", expectedNestedProduct), ("f5", Schema(SBoolean)))))
+      Schema(
+        SProduct(
+          info1,
+          List((FieldName("f3"), Schema(SString)), (FieldName("f4"), expectedNestedProduct), (FieldName("f5"), Schema(SBoolean)))
+        )
+      )
   }
 
   it should "modify array elements in products" in {
     val info1 = SObjectInfo("X")
-    Schema(SProduct(info1, List(("f1", Schema(SArray(Schema(SString)))))))
+    Schema(SProduct(info1, List((FieldName("f1"), Schema(SArray(Schema(SString)))))))
       .modifyUnsafe[String]("f1", Schema.ModifyCollectionElements)(_.format("xyz")) shouldBe Schema(
-      SProduct(info1, List(("f1", Schema(SArray(Schema(SString).format("xyz"))))))
+      SProduct(info1, List((FieldName("f1"), Schema(SArray(Schema(SString).format("xyz"))))))
     )
   }
 
   it should "modify array in products" in {
     val info1 = SObjectInfo("X")
-    Schema(SProduct(info1, List(("f1", Schema(SArray(Schema(SString)))))))
+    Schema(SProduct(info1, List((FieldName("f1"), Schema(SArray(Schema(SString)))))))
       .modifyUnsafe[String]("f1")(_.format("xyz")) shouldBe Schema(
-      SProduct(info1, List(("f1", Schema(SArray(Schema(SString))).format("xyz"))))
+      SProduct(info1, List((FieldName("f1"), Schema(SArray(Schema(SString))).format("xyz"))))
     )
   }
 
   it should "modify property of optional parameter" in {
     val info1 = SObjectInfo("X")
     val info2 = SObjectInfo("Y")
-    Schema(SProduct(info1, List("f1" -> Schema(SProduct(info2, List("p1" -> Schema(SInteger).asOptional))))))
+    Schema(SProduct(info1, List(FieldName("f1") -> Schema(SProduct(info2, List(FieldName("p1") -> Schema(SInteger).asOptional))))))
       .modifyUnsafe[Int]("f1", "p1")(_.format("xyz")) shouldBe Schema(
-      SProduct(info1, List("f1" -> Schema(SProduct(info2, List("p1" -> Schema(SInteger).asOptional.format("xyz"))))))
+      SProduct(info1, List(FieldName("f1") -> Schema(SProduct(info2, List(FieldName("p1") -> Schema(SInteger).asOptional.format("xyz"))))))
     )
   }
 
   it should "modify property of map value" in {
-    Schema(SOpenProduct(SObjectInfo("Map", List("X")), Schema(SProduct(SObjectInfo("X"), List("f1" -> Schema(SInteger))))))
+    Schema(SOpenProduct(SObjectInfo("Map", List("X")), Schema(SProduct(SObjectInfo("X"), List(FieldName("f1") -> Schema(SInteger))))))
       .modifyUnsafe[Int](Schema.ModifyCollectionElements)(_.description("test")) shouldBe Schema(
-      SOpenProduct(SObjectInfo("Map", List("X")), Schema(SProduct(SObjectInfo("X"), List("f1" -> Schema(SInteger)))).description("test"))
+      SOpenProduct(
+        SObjectInfo("Map", List("X")),
+        Schema(SProduct(SObjectInfo("X"), List(FieldName("f1") -> Schema(SInteger)))).description("test")
+      )
     )
   }
 
   it should "modify open product schema" in {
     val openProductSchema =
-      Schema(SOpenProduct(SObjectInfo("Map", List("X")), Schema(SProduct(SObjectInfo("X"), List("f1" -> Schema(SInteger))))))
+      Schema(SOpenProduct(SObjectInfo("Map", List("X")), Schema(SProduct(SObjectInfo("X"), List(FieldName("f1") -> Schema(SInteger))))))
     openProductSchema
       .modifyUnsafe[Nothing]()(_.description("test")) shouldBe openProductSchema.description("test")
   }

--- a/core/src/test/scala/sttp/tapir/generic/FormCodecDerivationTest.scala
+++ b/core/src/test/scala/sttp/tapir/generic/FormCodecDerivationTest.scala
@@ -6,7 +6,7 @@ import com.github.ghik.silencer.silent
 import org.scalatest.{FlatSpec, Matchers}
 import sttp.tapir.SchemaType.{SObjectInfo, SProduct}
 import sttp.tapir.util.CompileUtil
-import sttp.tapir.{Codec, CodecFormat, DecodeResult, Schema, Validator}
+import sttp.tapir.{Codec, CodecFormat, DecodeResult, FieldName, Schema, Validator}
 
 @silent("never used")
 class FormCodecDerivationTest extends FlatSpec with Matchers {
@@ -77,7 +77,7 @@ class FormCodecDerivationTest extends FlatSpec with Matchers {
     codec.schema.map(_.schemaType) shouldBe Some(
       SProduct(
         SObjectInfo("sttp.tapir.generic.FormCodecDerivationTest.<local FormCodecDerivationTest>.Test6"),
-        List(("f1", implicitly[Schema[String]]), ("f2", implicitly[Schema[Int]]))
+        List((FieldName("f1"), implicitly[Schema[String]]), (FieldName("f2"), implicitly[Schema[Int]]))
       )
     )
   }

--- a/core/src/test/scala/sttp/tapir/generic/MultipartCodecDerivationTest.scala
+++ b/core/src/test/scala/sttp/tapir/generic/MultipartCodecDerivationTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import sttp.model.{Header, MediaType, Part}
 import sttp.tapir.SchemaType._
 import sttp.tapir.util.CompileUtil
-import sttp.tapir.{DecodeResult, MultipartCodec, RawPart, Schema, Validator}
+import sttp.tapir.{DecodeResult, FieldName, MultipartCodec, RawPart, Schema, Validator}
 
 @silent("discarded")
 @silent("never used")
@@ -68,7 +68,7 @@ class MultipartCodecDerivationTest extends FlatSpec with Matchers {
     codec.schema.map(_.schemaType) shouldBe Some(
       SProduct(
         SObjectInfo("sttp.tapir.generic.MultipartCodecDerivationTest.<local MultipartCodecDerivationTest>.Test6"),
-        List(("f1", implicitly[Schema[String]]), ("f2", implicitly[Schema[Int]]))
+        List((FieldName("f1"), implicitly[Schema[String]]), (FieldName("f2"), implicitly[Schema[Int]]))
       )
     )
   }
@@ -82,7 +82,7 @@ class MultipartCodecDerivationTest extends FlatSpec with Matchers {
     codec.schema.map(_.schemaType) shouldBe Some(
       SProduct(
         SObjectInfo("sttp.tapir.generic.MultipartCodecDerivationTest.<local MultipartCodecDerivationTest>.Test1"),
-        List(("f1", implicitly[Schema[File]]), ("f2", implicitly[Schema[Int]]))
+        List((FieldName("f1"), implicitly[Schema[File]]), (FieldName("f2"), implicitly[Schema[Int]]))
       )
     )
   }

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/ObjectSchemasForEndpoints.scala
@@ -85,7 +85,7 @@ object ObjectSchemasForEndpoints {
   }
 
   private def fieldsSchemaWithValidator(p: TSchemaType.SProduct, v: Validator[_]): Seq[TypeData[_]] = {
-    p.fields.map { f => TypeData(f._2, fieldValidator(v, f._1)) }.toList
+    p.fields.map { f => TypeData(f._2, fieldValidator(v, f._1.name)) }.toList
   }
 
   private def subtypesSchemaWithValidator(st: TSchemaType.SCoproduct, v: Validator[_]): Seq[TypeData[_]] = {

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/TSchemaToOSchema.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/schema/TSchemaToOSchema.scala
@@ -18,12 +18,12 @@ private[schema] class TSchemaToOSchema(schemaReferenceMapper: SchemaReferenceMap
       case p @ TSchemaType.SProduct(_, fields) =>
         Right(
           OSchema(SchemaType.Object).copy(
-            required = p.required.toList,
+            required = p.required.map(_.lowLevelName).toList,
             properties = fields.map {
               case (fieldName, TSchema(s: TSchemaType.SObject, _, _, _, _)) =>
-                fieldName -> Left(schemaReferenceMapper.map(s.info))
+                fieldName.lowLevelName -> Left(schemaReferenceMapper.map(s.info))
               case (fieldName, fieldSchema) =>
-                fieldName -> apply(TypeData(fieldSchema, fieldValidator(typeData.validator, fieldName)))
+                fieldName.lowLevelName -> apply(TypeData(fieldSchema, fieldValidator(typeData.validator, fieldName.name)))
             }.toListMap
           )
         )

--- a/docs/openapi-docs/src/test/resources/expected_validator_with_custom_naming.yml
+++ b/docs/openapi-docs/src/test/resources/expected_validator_with_custom_naming.yml
@@ -1,0 +1,26 @@
+openapi: 3.0.1
+info:
+  title: Entities
+  version: '1.0'
+paths:
+  /:
+    post:
+      operationId: postRoot
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MyClass'
+        required: true
+      responses:
+        '200':
+          description: ''
+components:
+  schemas:
+    MyClass:
+      required:
+        - my_attribute
+      type: object
+      properties:
+        my_attribute:
+          type: integer

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -10,7 +10,7 @@ import sttp.tapir._
 import sttp.tapir.docs.openapi.dtos.Book
 import sttp.tapir.docs.openapi.dtos.a.{Pet => APet}
 import sttp.tapir.docs.openapi.dtos.b.{Pet => BPet}
-import sttp.tapir.generic.Derived
+import sttp.tapir.generic.{Configuration, Derived}
 import sttp.tapir.json.circe._
 import sttp.tapir.openapi.circe.yaml._
 import sttp.tapir.openapi.{Contact, Info, License, Server, ServerVariable}
@@ -805,6 +805,17 @@ class VerifyYamlTest extends FunSuite with Matchers {
     actualYamlNoIndent shouldBe expectedYaml
   }
 
+  test("render field validator when using different naming configuration") {
+    val expectedYaml = loadYaml("expected_validator_with_custom_naming.yml")
+
+    implicit val customConfiguration: Configuration = Configuration.default.withSnakeCaseMemberNames
+    val baseEndpoint = endpoint.post.in(jsonBody[MyClass])
+    val actualYaml = baseEndpoint.toOpenAPI(Info("Entities", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
   private def loadYaml(fileName: String): String = {
     noIndentation(Source.fromInputStream(getClass.getResourceAsStream(s"/$fileName")).getLines().mkString("\n"))
   }
@@ -832,3 +843,5 @@ case class ObjectWithList(data: List[FruitAmount])
 sealed trait Clause
 case class Expression(v: String) extends Clause
 case class Not(not: Clause) extends Clause
+
+case class MyClass(myAttribute: Int)

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -332,7 +332,10 @@ class VerifyYamlTest extends FunSuite with Matchers {
     import SchemaType._
     @silent("never used")
     implicit val customFruitAmountSchema: Schema[FruitAmount] = Schema(
-      SProduct(SObjectInfo("tapir.tests.FruitAmount", Nil), List(("fruit", Schema(SString)), ("amount", Schema(SInteger).format("int32"))))
+      SProduct(
+        SObjectInfo("tapir.tests.FruitAmount", Nil),
+        List((FieldName("fruit"), Schema(SString)), (FieldName("amount"), Schema(SInteger).format("int32")))
+      )
     ).description("Amount of fruits")
 
     val actualYaml = endpoint.post


### PR DESCRIPTION
…e to be matched with schemas fields which already have naming configuration applied

This fixes #661

Another option would be to extend schema model by preserving somewhere original fieldName as it is done in validators.