### PR TITLE
Http4s server, add `EndpointToHttp4sServer.toHttp` method

### DIFF
--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/TapirHttp4sServer.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/TapirHttp4sServer.scala
@@ -13,10 +13,8 @@ import sttp.tapir.typelevel.ReplaceFirstInTuple
 import scala.reflect.ClassTag
 
 trait TapirHttp4sServer {
-  implicit class RichHttp4sHttpEndpoint0[I, E, O, F[_], G[_]](e: Endpoint[I, E, O, EntityBody[F]]) {
-    def toHttp(logic: I => G[Either[E, O]])(
-        t: F ~> G
-    )(implicit
+  implicit class RichHttp4sHttpEndpoint[I, E, O, F[_]](e: Endpoint[I, E, O, EntityBody[F]]) {
+    def toHttp[G[_]](t: F ~> G)(logic: I => G[Either[E, O]])(implicit
         serverOptions: Http4sServerOptions[F],
         gs: Sync[G],
         fs: Sync[F],
@@ -25,7 +23,7 @@ trait TapirHttp4sServer {
       new EndpointToHttp4sServer(serverOptions).toHttp(e.serverLogic(logic))(t)
     }
 
-    def toHttpRecoverErrors(logic: I => G[O])(t: F ~> G)(implicit
+    def toHttpRecoverErrors[G[_]](t: F ~> G)(logic: I => G[O])(implicit
         serverOptions: Http4sServerOptions[F],
         gs: Sync[G],
         fs: Sync[F],
@@ -35,9 +33,7 @@ trait TapirHttp4sServer {
     ): Http[OptionT[G, *], F] = {
       new EndpointToHttp4sServer(serverOptions).toHttp(e.serverLogicRecoverErrors(logic))(t)
     }
-  }
 
-  implicit class RichHttp4sHttpEndpoint[I, E, O, F[_]](e: Endpoint[I, E, O, EntityBody[F]]) {
     def toRoutes(
         logic: I => F[Either[E, O]]
     )(implicit serverOptions: Http4sServerOptions[F], fs: Sync[F], fcs: ContextShift[F]): HttpRoutes[F] = {

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/TapirHttp4sServer.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/TapirHttp4sServer.scala
@@ -20,7 +20,7 @@ trait TapirHttp4sServer {
         fs: Sync[F],
         fcs: ContextShift[F]
     ): Http[OptionT[G, *], F] = {
-      new EndpointToHttp4sServer(serverOptions).toHttp0(t)(e.serverLogic(logic))
+      new EndpointToHttp4sServer(serverOptions).toHttp(t, e.serverLogic(logic))
     }
 
     def toHttpRecoverErrors[G[_]](t: F ~> G)(logic: I => G[O])(implicit
@@ -31,7 +31,7 @@ trait TapirHttp4sServer {
         eIsThrowable: E <:< Throwable,
         eClassTag: ClassTag[E]
     ): Http[OptionT[G, *], F] = {
-      new EndpointToHttp4sServer(serverOptions).toHttp0(t)(e.serverLogicRecoverErrors(logic))
+      new EndpointToHttp4sServer(serverOptions).toHttp(t, e.serverLogicRecoverErrors(logic))
     }
 
     def toRoutes(
@@ -60,7 +60,7 @@ trait TapirHttp4sServer {
         fs: Sync[F],
         fcs: ContextShift[F]
     ): Http[OptionT[G, *], F] =
-      new EndpointToHttp4sServer(serverOptions).toHttp0(t)(se)
+      new EndpointToHttp4sServer(serverOptions).toHttp(t, se)
   }
 
   implicit class RichHttp4sServerEndpoint[I, E, O, F[_]](se: ServerEndpoint[I, E, O, EntityBody[F], F]) {

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/TapirHttp4sServer.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/TapirHttp4sServer.scala
@@ -20,7 +20,7 @@ trait TapirHttp4sServer {
         fs: Sync[F],
         fcs: ContextShift[F]
     ): Http[OptionT[G, *], F] = {
-      new EndpointToHttp4sServer(serverOptions).toHttp(e.serverLogic(logic))(t)
+      new EndpointToHttp4sServer(serverOptions).toHttp0(t)(e.serverLogic(logic))
     }
 
     def toHttpRecoverErrors[G[_]](t: F ~> G)(logic: I => G[O])(implicit
@@ -31,7 +31,7 @@ trait TapirHttp4sServer {
         eIsThrowable: E <:< Throwable,
         eClassTag: ClassTag[E]
     ): Http[OptionT[G, *], F] = {
-      new EndpointToHttp4sServer(serverOptions).toHttp(e.serverLogicRecoverErrors(logic))(t)
+      new EndpointToHttp4sServer(serverOptions).toHttp0(t)(e.serverLogicRecoverErrors(logic))
     }
 
     def toRoutes(
@@ -60,7 +60,7 @@ trait TapirHttp4sServer {
         fs: Sync[F],
         fcs: ContextShift[F]
     ): Http[OptionT[G, *], F] =
-      new EndpointToHttp4sServer(serverOptions).toHttp(se)(t)
+      new EndpointToHttp4sServer(serverOptions).toHttp0(t)(se)
   }
 
   implicit class RichHttp4sServerEndpoint[I, E, O, F[_]](se: ServerEndpoint[I, E, O, EntityBody[F], F]) {
@@ -75,7 +75,7 @@ trait TapirHttp4sServer {
         fs: Sync[F],
         fcs: ContextShift[F]
     ): Http[OptionT[G, *], F] = {
-      new EndpointToHttp4sServer[F](serverOptions).toHttp(serverEndpoints)(t)
+      new EndpointToHttp4sServer[F](serverOptions).toHttp(t)(serverEndpoints)
     }
   }
 

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/TapirHttp4sServer.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/TapirHttp4sServer.scala
@@ -14,7 +14,7 @@ import scala.reflect.ClassTag
 
 trait TapirHttp4sServer {
   implicit class RichHttp4sHttpEndpoint0[I, E, O, F[_], G[_]](e: Endpoint[I, E, O, EntityBody[F]]) {
-    def toRoutes(logic: I => G[Either[E, O]])(
+    def toHttp(logic: I => G[Either[E, O]])(
         t: F ~> G
     )(implicit
         serverOptions: Http4sServerOptions[F],
@@ -25,7 +25,7 @@ trait TapirHttp4sServer {
       new EndpointToHttp4sServer(serverOptions).toHttp(e.serverLogic(logic))(t)
     }
 
-    def toRouteRecoverErrors(logic: I => G[O])(t: F ~> G)(implicit
+    def toHttpRecoverErrors(logic: I => G[O])(t: F ~> G)(implicit
         serverOptions: Http4sServerOptions[F],
         gs: Sync[G],
         fs: Sync[F],


### PR DESCRIPTION
Here is implementation of feature which suggested in the [gitter](https://gitter.im/softwaremill/tapir?at=5f19439e7a668c64e9fdbcab) by @nigredo-tori :

```scala
  def toHttp[I, E, O, G[_]: Sync](se: ServerEndpoint[I, E, O, EntityBody[F], G]): Http[OptionT[G, *], F]
```

For instance, when some `Context` required in the server logic we cat consider `G` like `ReaderT[F, Context, *]` and describe server endpoints as `ServerEndpoint[I, E, O, EntityBody[F], ReaderT[F, Context, *]]`.