### PR TITLE
Compile documentation on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ cache:
     - $HOME/.ivy2/cache
     - $HOME/.coursier
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues test
+  - sbt ++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues test compileDocumentation


### PR DESCRIPTION
Follow up to https://github.com/softwaremill/tapir/pull/696

This change will cause the documentation to be compiled during CI runs, thus enforcing that it's always up-to-date.