### PR TITLE
Use `transform` when mapping Map values

### DIFF
--- a/core/src/main/scala/sttp/tapir/generic/internal/FormCodecDerivation.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/FormCodecDerivation.scala
@@ -45,7 +45,7 @@ object FormCodecMacros {
     val codecTree = q"""
       {
         def decode(params: Seq[(String, String)]): sttp.tapir.DecodeResult[$t] = {
-          val paramsMap: Map[String, Seq[String]] = params.groupBy(_._1).mapValues(_.map(_._2)).toMap
+          val paramsMap: Map[String, Seq[String]] = params.groupBy(_._1).transform((_, v) => v.map(_._2))
           val decodeResults = List(..$decodeParams)
           sttp.tapir.DecodeResult.sequence(decodeResults).map { values =>
             ${util.instanceFromValues}


### PR DESCRIPTION
This fixes the following warning generated when tapir is being
used with Scala 2.13:

```
method mapValues in trait MapOps is deprecated (since 2.13.0): Use .view.mapValues(f). A future version will include a strict version of this method (for now, .view.mapValues(f).toMap)
```

I am using tapir in my project with warnings-as-errors enabled. This
warning prevents me from using `.in(formBody[...])` with case
classes.

The idea to switch to `transform` which is compatible with Scala 2.11,
2.12 and 2.13 was originally found here: https://github.com/scala/scala-collection-compat/issues/216#issuecomment-505104324