### PR TITLE
Remove tildes

### DIFF
--- a/docs/redoc-akka-http/src/main/scala/sttp/tapir/redoc/akkahttp/RedocAkkaHttp.scala
+++ b/docs/redoc-akka-http/src/main/scala/sttp/tapir/redoc/akkahttp/RedocAkkaHttp.scala
@@ -35,15 +35,17 @@ class RedocAkkaHttp(title: String, yaml: String, yamlName: String = "docs.yaml",
 
   def routes: Route = {
     get {
-      pathEnd {
-        redirectToTrailingSlashIfMissing(StatusCodes.MovedPermanently) {
-          complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, html))
+      concat(
+        pathEnd {
+          redirectToTrailingSlashIfMissing(StatusCodes.MovedPermanently) {
+            complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, html))
+          }
+        },
+        pathSingleSlash { complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, html)) },
+        path(yamlName) {
+          complete(HttpEntity(MediaType.textWithFixedCharset("yaml", HttpCharsets.`UTF-8`), yaml))
         }
-      } ~ pathSingleSlash {
-        complete(HttpEntity(ContentTypes.`text/html(UTF-8)`, html))
-      } ~ path(yamlName) {
-        complete(HttpEntity(MediaType.textWithFixedCharset("yaml", HttpCharsets.`UTF-8`), yaml))
-      }
+      )
     }
   }
 

--- a/docs/swagger-ui-akka-http/src/main/scala/sttp/tapir/swagger/akkahttp/SwaggerAkka.scala
+++ b/docs/swagger-ui-akka-http/src/main/scala/sttp/tapir/swagger/akkahttp/SwaggerAkka.scala
@@ -31,15 +31,17 @@ class SwaggerAkka(yaml: String, contextPath: String = "docs", yamlName: String =
   }
 
   val routes: Route =
-    pathPrefix(contextPath) {
-      pathEndOrSingleSlash {
-        redirectToIndex
-      } ~ path(yamlName) {
-        complete(yaml)
-      } ~ getFromResourceDirectory(s"META-INF/resources/webjars/swagger-ui/$swaggerVersion/")
-    } ~
+    concat(
+      pathPrefix(contextPath) {
+        concat(
+          pathEndOrSingleSlash { redirectToIndex },
+          path(yamlName) { complete(yaml) },
+          getFromResourceDirectory(s"META-INF/resources/webjars/swagger-ui/$swaggerVersion/")
+        )
+      },
       // needed only if you use oauth2 authorization
       path("oauth2-redirect.html") { request =>
         redirectToOath2(request.request.uri.rawQueryString.map(s => "?" + s).getOrElse(""))(request)
       }
+    )
 }

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
@@ -127,9 +127,11 @@ object BooksExample extends App with StrictLogging {
 
     // interpreting the endpoint description and converting it to an akka-http route, providing the logic which
     // should be run when the endpoint is invoked.
-    addBook.toRoute((bookAddLogic _).tupled) ~
-      booksListing.toRoute(bookListingLogic) ~
+    concat(
+      addBook.toRoute((bookAddLogic _).tupled),
+      booksListing.toRoute(bookListingLogic),
       booksListingByGenre.toRoute(bookListingByGenreLogic)
+    )
   }
 
   def startServer(route: Route, yaml: String): Unit = {
@@ -139,7 +141,7 @@ object BooksExample extends App with StrictLogging {
 
     import scala.concurrent.Await
     import scala.concurrent.duration._
-    val routes = route ~ new SwaggerAkka(yaml).routes
+    val routes = concat(route, new SwaggerAkka(yaml).routes)
     implicit val actorSystem: ActorSystem = ActorSystem()
     Await.result(Http().bindAndHandle(routes, "localhost", 8080), 1.minute)
 

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
@@ -62,7 +62,7 @@ object MultipleEndpointsDocumentationAkkaServer extends App {
 
   val routes = {
     import akka.http.scaladsl.server.Directives._
-    booksListingRoute ~ addBookRoute ~ new SwaggerAkka(openApiYml).routes
+    concat(booksListingRoute, addBookRoute, new SwaggerAkka(openApiYml).routes)
   }
 
   val bindAndCheck = Http().bindAndHandle(routes, "localhost", 8080).map { _ =>

--- a/examples/src/main/scala/sttp/tapir/examples/PartialServerLogicAkka.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/PartialServerLogicAkka.scala
@@ -61,7 +61,7 @@ object PartialServerLogicAkka extends App {
   val helloWorld2Route: Route = secureHelloWorld2WithLogic.toRoute
 
   // starting the server
-  val bindAndCheck = Http().bindAndHandle(helloWorld1Route ~ helloWorld2Route, "localhost", 8080).map { _ =>
+  val bindAndCheck = Http().bindAndHandle(concat(helloWorld1Route, helloWorld2Route), "localhost", 8080).map { _ =>
     // testing
     implicit val backend: SttpBackend[Identity, Nothing, NothingT] = HttpURLConnectionBackend()
 

--- a/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerTests.scala
+++ b/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerTests.scala
@@ -50,7 +50,7 @@ class AkkaHttpServerTests extends ServerTests[Future, AkkaStream, Route] with St
   }
 
   override def server(routes: NonEmptyList[Route], port: Port): Resource[IO, Unit] = {
-    val bind = IO.fromFuture(IO(Http().bindAndHandle(routes.toList.reduce(_ ~ _), "localhost", port)))
+    val bind = IO.fromFuture(IO(Http().bindAndHandle(concat(routes.toList :_*), "localhost", port)))
     Resource.make(bind)(binding => IO.fromFuture(IO(binding.unbind())).void).void
   }
 


### PR DESCRIPTION
According to [akka doc](https://doc.akka.io/docs/akka-http/current/routing-dsl/directives/index.html#composing-directives-with-operator) 

> Gotcha: forgetting the ~ (tilde) character in between directives can result in perfectly valid Scala code that compiles but does not work as expected. What would be intended as a single expression would actually be multiple expressions, and only the final one would be used as the result of the parent directive. Because of this, the recommended way to compose routes is with the the concat combinator.

So i changed all tildes into concats 
