### PR TITLE
Improve inference of codecs while using refined

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -190,11 +190,12 @@ lazy val refined: ProjectMatrix = (projectMatrix in file("integrations/refined")
     name := "tapir-refined",
     libraryDependencies ++= Seq(
       "eu.timepit" %% "refined" % Versions.refined,
-      scalaTest % Test
+      scalaTest % Test,
+      "io.circe" %% "circe-refined" % Versions.circe % Test
     )
   )
   .jvmPlatform(scalaVersions = allScalaVersions)
-  .dependsOn(core)
+  .dependsOn(core, circeJson % "test->compile")
 
 lazy val zio: ProjectMatrix = (projectMatrix in file("integrations/zio"))
   .settings(commonSettings)

--- a/integrations/refined/src/main/scala/sttp/tapir/codec/refined/TapirCodecRefined.scala
+++ b/integrations/refined/src/main/scala/sttp/tapir/codec/refined/TapirCodecRefined.scala
@@ -1,16 +1,19 @@
 package sttp.tapir.codec.refined
 
-import sttp.tapir._
 import eu.timepit.refined.api.{Refined, Validate}
 import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.numeric.{Greater, GreaterEqual, Less, LessEqual}
 import eu.timepit.refined.refineV
 import eu.timepit.refined.string.MatchesRegex
-import eu.timepit.refined.numeric.{Greater, GreaterEqual, Less, LessEqual}
 import shapeless.Witness
+import sttp.tapir._
+import sttp.tapir.internal.RichSchema
 
 import scala.reflect.ClassTag
 
 trait TapirCodecRefined extends LowPriorityValidatorForPredicate {
+  implicit def refinedTapirSchema[V, P](implicit vSchema: Schema[V]): Schema[V Refined P] = vSchema.as[V Refined P]
+
   implicit def codecForRefined[R, V, P, CF <: CodecFormat](implicit
       tm: Codec[R, V, CF],
       refinedValidator: Validate[V, P],


### PR DESCRIPTION
Additional implicit which prevent `diverging implicit expansion for type T` compilation errors. Solves #643.
This PR replaces #752.