### PR TITLE
wordsmith type-erasure issue with status mappings

### DIFF
--- a/doc/endpoint/statuscodes.md
+++ b/doc/endpoint/statuscodes.md
@@ -52,9 +52,8 @@ dynamically assembled (e.g. using a default set of cases, plus endpoint-specific
 
 ## Status mapping and type erasure
 
-Sometime at runtime status mapping resolution can not work properly because of type erasure.
-For example this code will fail at compile time; because of type erasure `Right[NotFound]` and `Right[BadRequest]` will 
-become `Right[Any]`, therefore the code would not be able to find the correct mapping for a value:
+Type erasure may prevent a status mapping from working properly. In the following example, `Right[NotFound]` and `Right[BadRequest]` will 
+become `Right[Any]`:
 
 ```scala mdoc:fail
 import sttp.tapir._

--- a/doc/endpoint/statuscodes.md
+++ b/doc/endpoint/statuscodes.md
@@ -52,8 +52,7 @@ dynamically assembled (e.g. using a default set of cases, plus endpoint-specific
 
 ## Status mapping and type erasure
 
-Type erasure may prevent a status mapping from working properly. In the following example, `Right[NotFound]` and `Right[BadRequest]` will 
-become `Right[Any]`:
+Type erasure may prevent a status mapping from working properly. The following example will fail at compile time because `Right[NotFound]` and `Right[BadRequest]` will become `Right[Any]`:
 
 ```scala mdoc:fail
 import sttp.tapir._


### PR DESCRIPTION
I was going through the docs and was a little confused by the note around type erasure, so I tried to simplify it a bit.