### PR TITLE
Use DateTimeFormatter for javatime codecs

### DIFF
--- a/core/src/main/scala/sttp/tapir/Codec.scala
+++ b/core/src/main/scala/sttp/tapir/Codec.scala
@@ -6,7 +6,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.{Charset, StandardCharsets}
 import java.nio.file.Path
 import java.time._
-import java.time.format.DateTimeParseException
+import java.time.format.{DateTimeFormatter, DateTimeParseException}
 import java.util.{Base64, Date, UUID}
 
 import sttp.model._
@@ -124,15 +124,17 @@ object Codec extends FormCodecDerivation {
   implicit val uuid: Codec[String, UUID, TextPlain] = stringCodec[UUID](UUID.fromString)
   implicit val bigDecimal: Codec[String, BigDecimal, TextPlain] = stringCodec[BigDecimal](BigDecimal(_))
   implicit val javaBigDecimal: Codec[String, JBigDecimal, TextPlain] = stringCodec[JBigDecimal](new JBigDecimal(_))
-  implicit val localTime: Codec[String, LocalTime, TextPlain] = stringCodec[LocalTime](LocalTime.parse)
-  implicit val localDate: Codec[String, LocalDate, TextPlain] = stringCodec[LocalDate](LocalDate.parse)
-  implicit val offsetDateTime: Codec[String, OffsetDateTime, TextPlain] = stringCodec[OffsetDateTime](OffsetDateTime.parse)
-  implicit val zonedDateTime: Codec[String, ZonedDateTime, TextPlain] = offsetDateTime.map(_.toZonedDateTime)(_.toOffsetDateTime)
-  implicit val instant: Codec[String, Instant, TextPlain] = zonedDateTime.map(_.toInstant)(_.atZone(ZoneOffset.UTC))
+  implicit val localTime: Codec[String, LocalTime, TextPlain] = string.map(LocalTime.parse(_))(DateTimeFormatter.ISO_LOCAL_TIME.format)
+  implicit val localDate: Codec[String, LocalDate, TextPlain] = string.map(LocalDate.parse(_))(DateTimeFormatter.ISO_LOCAL_DATE.format)
+  implicit val offsetDateTime: Codec[String, OffsetDateTime, TextPlain] =
+    string.map(OffsetDateTime.parse(_))(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format)
+  implicit val zonedDateTime: Codec[String, ZonedDateTime, TextPlain] =
+    string.map(ZonedDateTime.parse(_))(DateTimeFormatter.ISO_ZONED_DATE_TIME.format)
+  implicit val instant: Codec[String, Instant, TextPlain] = string.map(Instant.parse(_))(DateTimeFormatter.ISO_INSTANT.format)
   implicit val date: Codec[String, Date, TextPlain] = instant.map(Date.from(_))(_.toInstant)
   implicit val zoneOffset: Codec[String, ZoneOffset, TextPlain] = stringCodec[ZoneOffset](ZoneOffset.of)
   implicit val duration: Codec[String, Duration, TextPlain] = stringCodec[Duration](Duration.parse)
-  implicit val offsetTime: Codec[String, OffsetTime, TextPlain] = stringCodec[OffsetTime](OffsetTime.parse)
+  implicit val offsetTime: Codec[String, OffsetTime, TextPlain] = string.map(OffsetTime.parse(_))(DateTimeFormatter.ISO_OFFSET_TIME.format)
   implicit val scalaDuration: Codec[String, SDuration, TextPlain] = stringCodec[SDuration](SDuration.apply)
   implicit val localDateTime: Codec[String, LocalDateTime, TextPlain] = string.mapDecode { l =>
     try {

--- a/core/src/test/scala/sttp/tapir/CodecTest.scala
+++ b/core/src/test/scala/sttp/tapir/CodecTest.scala
@@ -2,10 +2,11 @@ package sttp.tapir
 
 import java.math.{BigDecimal => JBigDecimal}
 import java.time._
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.{Date, UUID}
 
-import com.fortysevendeg.scalacheck.datetime.jdk8.ArbitraryJdk8.{arbLocalDateJdk8, arbLocalDateTimeJdk8, genZonedDateTimeWithZone}
+import com.fortysevendeg.scalacheck.datetime.jdk8.ArbitraryJdk8.{arbLocalDateTimeJdk8, genZonedDateTimeWithZone}
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.Assertion
 import org.scalatestplus.scalacheck.Checkers
@@ -73,13 +74,7 @@ class CodecTest extends AnyFlatSpec with Matchers with Checkers {
     checkEncodeDecodeToString[Uri]
     checkEncodeDecodeToString[BigDecimal]
     checkEncodeDecodeToString[JBigDecimal]
-    checkEncodeDecodeToString[LocalTime]
-    checkEncodeDecodeToString[LocalDate]
-    checkEncodeDecodeToString[OffsetDateTime]
-    checkEncodeDecodeToString[Instant]
-    checkEncodeDecodeToString[ZoneOffset]
     checkEncodeDecodeToString[Duration]
-    checkEncodeDecodeToString[OffsetTime]
     checkEncodeDecodeToString[SDuration]
   }
 
@@ -90,7 +85,9 @@ class CodecTest extends AnyFlatSpec with Matchers with Checkers {
   }
 
   it should "decode LocalDateTime from string with timezone" in {
-    check((zdt: ZonedDateTime) => localDateTimeCodec.decode(zdt.toOffsetDateTime.toString) == Value(zdt.toLocalDateTime))
+    check((zdt: ZonedDateTime) =>
+      localDateTimeCodec.decode(DateTimeFormatter.ISO_ZONED_DATE_TIME.format(zdt)) == Value(zdt.toLocalDateTime)
+    )
   }
 
   it should "correctly encode and decode ZonedDateTime" in {
@@ -110,7 +107,8 @@ class CodecTest extends AnyFlatSpec with Matchers with Checkers {
   it should "correctly encode and decode example Instants" in {
     val codec = implicitly[Codec[String, Instant, TextPlain]]
     codec.encode(Instant.ofEpochMilli(1583760958000L)) shouldBe "2020-03-09T13:35:58Z"
-    codec.decode("2020-02-19T12:35:58Z") shouldBe (Value(Instant.ofEpochMilli(1582115758000L)))
+    codec.encode(Instant.EPOCH) shouldBe "1970-01-01T00:00:00Z"
+    codec.decode("2020-02-19T12:35:58Z") shouldBe Value(Instant.ofEpochMilli(1582115758000L))
   }
 
   it should "correctly encode and decode example Durations" in {


### PR DESCRIPTION
Javatime codecs should serialize dates and times with formats that are used to parse them. 
Tapir uses OffsetDateTime's .toString to encode Instants, but you can't parse back some of its outputs:
```scala
import java.time.Instant
import sttp.tapir.Codec.instant

val epoch = instant.encode(Instant.EPOCH)
// epoch: String = 1970-01-01T00:00Z
Instant.parse(epoch)
// java.time.format.DateTimeParseException: Text '1970-01-01T00:00Z' could not be parsed at index 16
```

I think it's better to be more explicit about formats and not to rely on .toString for javatime codecs.