### PR TITLE
remove tapir-gen from the docs

### DIFF
--- a/generated-doc/out/other_interpreters.md
+++ b/generated-doc/out/other_interpreters.md
@@ -1,16 +1,12 @@
-# Other interpreters
+# Other integrations
 
 At its core, tapir creates a data structure describing the HTTP endpoints. This data structure can be freely 
-interpreted also by code not included in the library. Below is a list of projects, which provide tapir interpreters.
+interpreted by other libraries and frameworks. Below is a list of projects that provide tapir integrations.
 
 ## GraphQL
 
 [Caliban](https://github.com/ghostdogpr/caliban) allows you to easily turn your Tapir endpoints into a GraphQL API. More details in the [documentation](https://ghostdogpr.github.io/caliban/docs/interop.html#tapir).
 
-## tapir-gen
+## Scala Opentracing (Http4s)
 
-[tapir-gen](https://github.com/xplosunn/tapir-gen) extends tapir to do client code generation. The goal is to 
-auto-generate clients in multiple-languages with multiple libraries.
-
-[scala-opentracing](https://github.com/Colisweb/scala-opentracing) contains a module which provides a small integration 
-layer that allows you to create traced http endpoints from tapir Endpoint definitions.
+[scala-opentracing](https://github.com/Colisweb/scala-opentracing) contains a module which provides a small integration layer that allows you to create traced http endpoints from tapir Endpoint definitions.


### PR DESCRIPTION
It's fairly clear that [tapir-gen](https://github.com/xplosunn/tapir-gen) is a dead project so I've removed it from the docs. If it ever starts up again, we can add it back.  