### PR TITLE
Openapi codegen tests and better class generator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,7 @@ lazy val rootProject = (project in file("."))
       examples.projectRefs ++
       playground.projectRefs ++
       documentation.projectRefs ++
-      List(openapiCodegen.project): _*
+      openapiCodegen.projectRefs: _*
   )
 
 // core
@@ -632,9 +632,10 @@ lazy val sttpClient: ProjectMatrix = (projectMatrix in file("client/sttp-client"
   .dependsOn(core, clientTests % Test)
 
 import scala.collection.JavaConverters._
-lazy val openapiCodegen = (project in file("sbt/sbt-openapi-codegen"))
+lazy val openapiCodegen = (projectMatrix in file("sbt/sbt-openapi-codegen"))
   .enablePlugins(SbtPlugin)
   .settings(commonSettings)
+  .jvmPlatform(scalaVersions = scala2_12Versions)
   .settings(
     name := "sbt-openapi-codegen",
     organization := "com.softwaremill.sttp.tapir",
@@ -655,8 +656,7 @@ lazy val openapiCodegen = (project in file("sbt/sbt-openapi-codegen"))
       "com.47deg" %% "scalacheck-toolbox-datetime" % "0.4.0" % Test,
       "org.scala-lang" % "scala-compiler" % scalaVersion.value % Test
     ),
-    scalaVersion := scala2_12
-  )
+  ).dependsOn(core % Test, circeJson % Test)
 
 // other
 

--- a/sbt/sbt-openapi-codegen/src/main/scala/OpenapiCodegenPlugin.scala
+++ b/sbt/sbt-openapi-codegen/src/main/scala/OpenapiCodegenPlugin.scala
@@ -1,5 +1,4 @@
 import sbt._, Keys._
-import sbt.io.{IO, Path}
 
 object OpenapiCodegenPlugin extends AutoPlugin {
 

--- a/sbt/sbt-openapi-codegen/src/main/scala/OpenapiCodegenTask.scala
+++ b/sbt/sbt-openapi-codegen/src/main/scala/OpenapiCodegenTask.scala
@@ -1,4 +1,4 @@
-import sbt._, Keys._
+import sbt._
 import codegen._
 
 case class OpenapiCodegenTask(
@@ -22,7 +22,7 @@ case class OpenapiCodegenTask(
   }
 
   val cachedCopyFile =
-    inputChanged(cacheDir / "sbt-openapi-codegen-inputs") { (inChanged, input: HashFileInfo) =>
+    inputChanged(cacheDir / "sbt-openapi-codegen-inputs") { (inChanged, _: HashFileInfo) =>
       if (inChanged || !outFile.exists) {
         IO.copyFile(tempFile, outFile, preserveLastModified = true)
       } // if

--- a/sbt/sbt-openapi-codegen/src/main/scala/codegen/BasicGenerator.scala
+++ b/sbt/sbt-openapi-codegen/src/main/scala/codegen/BasicGenerator.scala
@@ -24,143 +24,40 @@ import codegen.openapi.models.OpenapiSchemaType.{
 
 object BasicGenerator {
 
+  val classGenerator = new ClassDefinitionGenerator()
+  val endpointGenerator = new EndpointGenerator()
+
   def generateObjects(doc: OpenapiDocument) = {
     s"""|
         |$packageStr
         |
-        |object $obbjName {
+        |object $objName {
         |
         |${indent(2)(imports)}
         |
-        |${indent(2)(classDefs(doc))}
+        |${indent(2)(classGenerator.classDefs(doc))}
         |
-        |${indent(2)(endpointDefs(doc))}
+        |${indent(2)(endpointGenerator.endpointDefs(doc))}
         |
         |}
         |""".stripMargin
   }
 
-  def packageStr: String = "package sttp.tapir.generated"
+  private[codegen] def packageStr: String = "package sttp.tapir.generated"
 
-  def obbjName = "TapirGeneratedEndpoints"
+  private[codegen] def objName = "TapirGeneratedEndpoints"
 
-  def imports: String =
+  private[codegen] def imports: String =
     """import sttp.tapir._
       |import sttp.tapir.json.circe._
       |import io.circe.generic.auto._
       |""".stripMargin
 
-  def allEndpoints: String = "generatedEndpoints"
-
   def indent(i: Int)(str: String): String = {
     str.linesIterator.map(" " * i + _ + "\n").mkString
   }
 
-  def urlMapper(url: String, parameters: Seq[OpenapiParameter]): String = {
-    //.in(("books" / path[String]("genre") / path[Int]("year")).mapTo(BooksFromYear))
-    val inPath = url.split('/').filter(_.nonEmpty) map { segment =>
-      if (segment.startsWith("{")) {
-        val name = segment.drop(1).dropRight(1)
-        val param = parameters.find(_.name == name)
-        param.fold(throw new Error("URLParam not found!")) { p =>
-          p.schema match {
-            case st: OpenapiSchemaSimpleType =>
-              val (t, _) = mapSchemaSimpleTypeToType(st)
-              val desc = p.description.fold("")(d => s""".description("$d")""")
-              s"""path[$t]("$name")$desc"""
-            case _ => throw new NotImplementedError("Can't create non-simple params to url yet")
-          }
-        }
-      } else {
-        '"' + segment + '"'
-      }
-    }
-    ".in((" + inPath.mkString(" / ") + "))"
-  }
-
-  def ins(parameters: Seq[OpenapiParameter], requestBody: Option[OpenapiRequestBody]): String = {
-    //.in(query[Limit]("limit").description("Maximum number of books to retrieve"))
-    //.in(header[AuthToken]("X-Auth-Token"))
-    val params = parameters
-      .filter(_.in != "path")
-      .map { param =>
-        param.schema match {
-          case st: OpenapiSchemaSimpleType =>
-            val (t, _) = mapSchemaSimpleTypeToType(st)
-            val desc = param.description.fold("")(d => s""".description("$d")""")
-            s""".in(${param.in}[$t]("${param.name}")$desc)"""
-          case _ => throw new NotImplementedError("Can't create non-simple params to input")
-        }
-      }
-      .mkString("\n")
-
-    val rqBody = requestBody.fold("") { b =>
-      s"\n.in(${contentTypeMapper(b.contentType, b.schema, b.required)})"
-    }
-
-    params + rqBody
-  }
-
-  def contentTypeMapper(contentType: String, schema: OpenapiSchemaType, required: Boolean = true) = {
-    contentType match {
-      case "text/plain" =>
-        "stringBody"
-      case "application/json" =>
-        val outT = schema match {
-          case st: OpenapiSchemaSimpleType =>
-            val (t, _) = mapSchemaSimpleTypeToType(st)
-            t
-          case OpenapiSchemaArray(st: OpenapiSchemaSimpleType, _) =>
-            val (t, _) = mapSchemaSimpleTypeToType(st)
-            s"List[$t]"
-          case _ => throw new NotImplementedError("Can't create non-simple or array params as output")
-        }
-        val req = if (required) outT else s"Option[$outT]"
-        s"jsonBody[$req]"
-      case _ => throw new NotImplementedError("We only handle json and text!")
-    }
-  }
-  def outs(responses: Seq[OpenapiResponse]) = {
-    //.errorOut(stringBody)
-    //.out(jsonBody[List[Book]])
-    responses
-      .map { resp =>
-        if (resp.content.size != 1) throw new NotImplementedError("We can handle only one return content!")
-        resp.code match {
-          case "200" =>
-            val content = resp.content.head
-            s".out(${contentTypeMapper(content.contentType, content.schema)})"
-          case "default" =>
-            val content = resp.content.head
-            s".errorOut(${contentTypeMapper(content.contentType, content.schema)})"
-          case _ =>
-            throw new NotImplementedError("Statuscode mapping is incomplete!")
-        }
-      }
-      .sorted
-      .mkString("\n")
-  }
-  def generatedEndpoints(p: OpenapiPath): Seq[(String, String)] = {
-    p.methods.map { m =>
-      val definition =
-        s"""|endpoint
-            |  .${m.methodType}
-            |  ${urlMapper(p.url, m.parameters)}
-            |${indent(2)(ins(m.parameters, m.requestBody))}
-            |${indent(2)(outs(m.responses))}
-            |""".stripMargin
-
-      val name = m.methodType + p.url.split('/').map(_.replace("{", "").replace("}", "").toLowerCase.capitalize).mkString
-      (name, definition)
-    }
-  }
-
-  private def innerTypePrinter(key: String, tp: String, optional: Boolean) = {
-    val fixedType = if (optional) s"Option[$tp]" else tp
-    s"$key: $fixedType"
-  }
-
-  private def mapSchemaSimpleTypeToType(osst: OpenapiSchemaSimpleType): (String, Boolean) = {
+  def mapSchemaSimpleTypeToType(osst: OpenapiSchemaSimpleType): (String, Boolean) = {
     osst match {
       case OpenapiSchemaDouble(nb) =>
         ("Double", nb)
@@ -178,38 +75,5 @@ object BasicGenerator {
         (t.split('/').last, false)
       case _ => throw new NotImplementedError("Not all simple types supported!")
     }
-  }
-  def classDefs(doc: OpenapiDocument): String = {
-    val classes = doc.components.schemas.map {
-      case (name, OpenapiSchemaObject(fields, required, _)) =>
-        val fs = fields.map {
-          case (k, st: OpenapiSchemaSimpleType) =>
-            val t = mapSchemaSimpleTypeToType(st)
-            innerTypePrinter(k, t._1, t._2)
-          case _ => throw new NotImplementedError("Only nonnested simple types supported!")
-        }
-        s"""|case class $name (
-            |${indent(2)(fs.mkString(",\n"))}
-            |)""".stripMargin
-      case _ => throw new NotImplementedError("Only objects supported!")
-    }
-    classes.mkString("\n")
-  }
-
-  def endpointDefs(doc: OpenapiDocument): String = {
-    val ge = doc.paths.flatMap(generatedEndpoints)
-    val definitions = ge
-      .map { case (name, definition) =>
-        s"""|val $name =
-            |${indent(2)(definition)}
-            |""".stripMargin
-      }
-      .mkString("\n")
-    val allEP = s"val $allEndpoints = List(${ge.map(_._1).mkString(", ")})"
-
-    s"""|$definitions
-        |
-        |$allEP
-        |""".stripMargin
   }
 }

--- a/sbt/sbt-openapi-codegen/src/main/scala/codegen/BasicGenerator.scala
+++ b/sbt/sbt-openapi-codegen/src/main/scala/codegen/BasicGenerator.scala
@@ -1,22 +1,12 @@
 package codegen
 
-import codegen.openapi.models.OpenapiModels.{
-  OpenapiDocument,
-  OpenapiParameter,
-  OpenapiPath,
-  OpenapiRequestBody,
-  OpenapiResponse,
-  OpenapiResponseContent
-}
-import codegen.openapi.models.OpenapiSchemaType
+import codegen.openapi.models.OpenapiModels.OpenapiDocument
 import codegen.openapi.models.OpenapiSchemaType.{
-  OpenapiSchemaArray,
   OpenapiSchemaBoolean,
   OpenapiSchemaDouble,
   OpenapiSchemaFloat,
   OpenapiSchemaInt,
   OpenapiSchemaLong,
-  OpenapiSchemaObject,
   OpenapiSchemaRef,
   OpenapiSchemaSimpleType,
   OpenapiSchemaString
@@ -54,7 +44,7 @@ object BasicGenerator {
       |""".stripMargin
 
   def indent(i: Int)(str: String): String = {
-    str.linesIterator.map(" " * i + _ + "\n").mkString
+    str.linesIterator.map(" " * i + _).mkString("\n")
   }
 
   def mapSchemaSimpleTypeToType(osst: OpenapiSchemaSimpleType): (String, Boolean) = {

--- a/sbt/sbt-openapi-codegen/src/main/scala/codegen/ClassDefinitionGenerator.scala
+++ b/sbt/sbt-openapi-codegen/src/main/scala/codegen/ClassDefinitionGenerator.scala
@@ -1,0 +1,29 @@
+package codegen
+
+import codegen.BasicGenerator.{indent, mapSchemaSimpleTypeToType}
+import codegen.openapi.models.OpenapiModels.OpenapiDocument
+import codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaObject, OpenapiSchemaSimpleType}
+
+class ClassDefinitionGenerator {
+  def classDefs(doc: OpenapiDocument): String = {
+    val classes = doc.components.schemas.map {
+      case (name, OpenapiSchemaObject(fields, required, _)) =>
+        val fs = fields.map {
+          case (k, st: OpenapiSchemaSimpleType) =>
+            val t = mapSchemaSimpleTypeToType(st)
+            innerTypePrinter(k, t._1, t._2)
+          case _ => throw new NotImplementedError("Only nonnested simple types supported!")
+        }
+        s"""|case class $name (
+            |${indent(2)(fs.mkString(",\n"))}
+            |)""".stripMargin
+      case _ => throw new NotImplementedError("Only objects supported!")
+    }
+    classes.mkString("\n")
+  }
+
+  private def innerTypePrinter(key: String, tp: String, optional: Boolean) = {
+    val fixedType = if (optional) s"Option[$tp]" else tp
+    s"$key: $fixedType"
+  }
+}

--- a/sbt/sbt-openapi-codegen/src/main/scala/codegen/ClassDefinitionGenerator.scala
+++ b/sbt/sbt-openapi-codegen/src/main/scala/codegen/ClassDefinitionGenerator.scala
@@ -2,28 +2,61 @@ package codegen
 
 import codegen.BasicGenerator.{indent, mapSchemaSimpleTypeToType}
 import codegen.openapi.models.OpenapiModels.OpenapiDocument
-import codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaObject, OpenapiSchemaSimpleType}
+import codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaObject, OpenapiSchemaSimpleType}
 
 class ClassDefinitionGenerator {
+
   def classDefs(doc: OpenapiDocument): String = {
-    val classes = doc.components.schemas.map {
-      case (name, OpenapiSchemaObject(fields, required, _)) =>
-        val fs = fields.map {
-          case (k, st: OpenapiSchemaSimpleType) =>
-            val t = mapSchemaSimpleTypeToType(st)
-            innerTypePrinter(k, t._1, t._2)
-          case _ => throw new NotImplementedError("Only nonnested simple types supported!")
-        }
-        s"""|case class $name (
-            |${indent(2)(fs.mkString(",\n"))}
-            |)""".stripMargin
+    val classes = doc.components.schemas.flatMap {
+      case (name, obj: OpenapiSchemaObject) =>
+        generateClass(name, obj)
       case _ => throw new NotImplementedError("Only objects supported!")
     }
     classes.mkString("\n")
   }
 
+  private[codegen] def generateClass(name: String, obj: OpenapiSchemaObject): Seq[String] = {
+    def addName(parentName: String, key: String) = parentName + key.replace('_', ' ').replace('-', ' ').capitalize.replace(" ", "")
+    def rec(name: String, obj: OpenapiSchemaObject, acc: List[String]): Seq[String] = {
+      val innerClasses = obj.properties
+        .collect { case (propName, st: OpenapiSchemaObject) =>
+          val newName = addName(name, propName)
+          rec(newName, st, Nil)
+        }
+        .flatten
+        .toList
+      val fs = obj.properties.collect {
+        case (k, st: OpenapiSchemaSimpleType) =>
+          val t = mapSchemaSimpleTypeToType(st)
+          innerTypePrinter(k, t._1, t._2 || !obj.required.contains(k))
+        case (k, st: OpenapiSchemaObject) =>
+          val t = addName(name, k)
+          innerTypePrinter(k, t, st.nullable || !obj.required.contains(k))
+        case (k, OpenapiSchemaArray(inner: OpenapiSchemaSimpleType, nullable)) =>
+          val innerT = mapSchemaSimpleTypeToType(inner)._1
+          innerTypePrinter(k, s"Seq[$innerT]", nullable || !obj.required.contains(k))
+      }
+      require(fs.size == obj.properties.size, s"We can't serialize some of the properties yet! $name $obj")
+      s"""|case class $name (
+          |${indent(2)(fs.mkString(",\n"))}
+          |)""".stripMargin :: innerClasses ::: acc
+    }
+
+    rec(addName("", name), obj, Nil)
+  }
+
+  private val reservedKeys = scala.reflect.runtime.universe.asInstanceOf[scala.reflect.internal.SymbolTable].nme.keywords.map(_.toString)
+
+  private def fixKey(key: String) = {
+    if (reservedKeys.contains(key))
+      s"`$key`"
+    else
+      key
+  }
+
   private def innerTypePrinter(key: String, tp: String, optional: Boolean) = {
     val fixedType = if (optional) s"Option[$tp]" else tp
-    s"$key: $fixedType"
+    val fixedKey = fixKey(key)
+    s"$fixedKey: $fixedType"
   }
 }

--- a/sbt/sbt-openapi-codegen/src/main/scala/codegen/EndpointGenerator.scala
+++ b/sbt/sbt-openapi-codegen/src/main/scala/codegen/EndpointGenerator.scala
@@ -1,0 +1,130 @@
+package codegen
+
+import codegen.BasicGenerator.{indent, mapSchemaSimpleTypeToType}
+import codegen.openapi.models.OpenapiModels.{OpenapiDocument, OpenapiParameter, OpenapiPath, OpenapiRequestBody, OpenapiResponse}
+import codegen.openapi.models.OpenapiSchemaType
+import codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaSimpleType}
+
+class EndpointGenerator {
+
+  private[codegen] def allEndpoints: String = "generatedEndpoints"
+
+  def endpointDefs(doc: OpenapiDocument): String = {
+    val ge = doc.paths.flatMap(generatedEndpoints)
+    val definitions = ge
+      .map { case (name, definition) =>
+        s"""|val $name =
+            |${indent(2)(definition)}
+            |""".stripMargin
+      }
+      .mkString("\n")
+    val allEP = s"val $allEndpoints = List(${ge.map(_._1).mkString(", ")})"
+
+    s"""|$definitions
+        |
+        |$allEP
+        |""".stripMargin
+  }
+
+  private[codegen] def generatedEndpoints(p: OpenapiPath): Seq[(String, String)] = {
+    p.methods.map { m =>
+      val definition =
+        s"""|endpoint
+            |  .${m.methodType}
+            |  ${urlMapper(p.url, m.parameters)}
+            |${indent(2)(ins(m.parameters, m.requestBody))}
+            |${indent(2)(outs(m.responses))}
+            |""".stripMargin
+
+      val name = m.methodType + p.url.split('/').map(_.replace("{", "").replace("}", "").toLowerCase.capitalize).mkString
+      (name, definition)
+    }
+  }
+
+  private def urlMapper(url: String, parameters: Seq[OpenapiParameter]): String = {
+    //.in(("books" / path[String]("genre") / path[Int]("year")).mapTo(BooksFromYear))
+    val inPath = url.split('/').filter(_.nonEmpty) map { segment =>
+      if (segment.startsWith("{")) {
+        val name = segment.drop(1).dropRight(1)
+        val param = parameters.find(_.name == name)
+        param.fold(throw new Error("URLParam not found!")) { p =>
+          p.schema match {
+            case st: OpenapiSchemaSimpleType =>
+              val (t, _) = mapSchemaSimpleTypeToType(st)
+              val desc = p.description.fold("")(d => s""".description("$d")""")
+              s"""path[$t]("$name")$desc"""
+            case _ => throw new NotImplementedError("Can't create non-simple params to url yet")
+          }
+        }
+      } else {
+        '"' + segment + '"'
+      }
+    }
+    ".in((" + inPath.mkString(" / ") + "))"
+  }
+
+  private def ins(parameters: Seq[OpenapiParameter], requestBody: Option[OpenapiRequestBody]): String = {
+    //.in(query[Limit]("limit").description("Maximum number of books to retrieve"))
+    //.in(header[AuthToken]("X-Auth-Token"))
+    val params = parameters
+      .filter(_.in != "path")
+      .map { param =>
+        param.schema match {
+          case st: OpenapiSchemaSimpleType =>
+            val (t, _) = mapSchemaSimpleTypeToType(st)
+            val desc = param.description.fold("")(d => s""".description("$d")""")
+            s""".in(${param.in}[$t]("${param.name}")$desc)"""
+          case _ => throw new NotImplementedError("Can't create non-simple params to input")
+        }
+      }
+      .mkString("\n")
+
+    val rqBody = requestBody.fold("") { b =>
+      s"\n.in(${contentTypeMapper(b.contentType, b.schema, b.required)})"
+    }
+
+    params + rqBody
+  }
+
+  private def outs(responses: Seq[OpenapiResponse]) = {
+    //.errorOut(stringBody)
+    //.out(jsonBody[List[Book]])
+    responses
+      .map { resp =>
+        if (resp.content.size != 1) throw new NotImplementedError("We can handle only one return content!")
+        resp.code match {
+          case "200" =>
+            val content = resp.content.head
+            s".out(${contentTypeMapper(content.contentType, content.schema)})"
+          case "default" =>
+            val content = resp.content.head
+            s".errorOut(${contentTypeMapper(content.contentType, content.schema)})"
+          case _ =>
+            throw new NotImplementedError("Statuscode mapping is incomplete!")
+        }
+      }
+      .sorted
+      .mkString("\n")
+  }
+
+  private def contentTypeMapper(contentType: String, schema: OpenapiSchemaType, required: Boolean = true) = {
+    contentType match {
+      case "text/plain" =>
+        "stringBody"
+      case "application/json" =>
+        val outT = schema match {
+          case st: OpenapiSchemaSimpleType =>
+            val (t, _) = mapSchemaSimpleTypeToType(st)
+            t
+          case OpenapiSchemaArray(st: OpenapiSchemaSimpleType, _) =>
+            val (t, _) = mapSchemaSimpleTypeToType(st)
+            s"List[$t]"
+          case _ => throw new NotImplementedError("Can't create non-simple or array params as output")
+        }
+        val req = if (required) outT else s"Option[$outT]"
+        s"jsonBody[$req]"
+      case _ => throw new NotImplementedError("We only handle json and text!")
+    }
+  }
+
+}

--- a/sbt/sbt-openapi-codegen/src/main/scala/codegen/openapi/models/OpenapiModels.scala
+++ b/sbt/sbt-openapi-codegen/src/main/scala/codegen/openapi/models/OpenapiModels.scala
@@ -61,7 +61,6 @@ object OpenapiModels {
 
   import io.circe._
   import io.circe.generic.semiauto._
-  import cats.implicits._
 
   implicit val OpenapiResponseContentDecoder: Decoder[Seq[OpenapiResponseContent]] = { (c: HCursor) =>
     case class Holder(d: OpenapiSchemaType)

--- a/sbt/sbt-openapi-codegen/src/main/scala/codegen/openapi/models/OpenapiSchemaType.scala
+++ b/sbt/sbt-openapi-codegen/src/main/scala/codegen/openapi/models/OpenapiSchemaType.scala
@@ -230,7 +230,7 @@ object OpenapiSchemaType {
 
   implicit val OpenapiSchemaArrayDecoder: Decoder[OpenapiSchemaArray] = { (c: HCursor) =>
     for {
-      t <- c.downField("type").as[String].ensure(DecodingFailure("Given type is not array!", c.history))(v => v == "array")
+      _ <- c.downField("type").as[String].ensure(DecodingFailure("Given type is not array!", c.history))(v => v == "array")
       f <- c.downField("items").as[OpenapiSchemaType]
       nb <- c.downField("nullable").as[Option[Boolean]]
     } yield {

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/BasicGeneratorSpec.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/BasicGeneratorSpec.scala
@@ -1,13 +1,11 @@
 package codegen
 
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
-import org.scalatestplus.scalacheck.Checkers
+import codegen.testutils.CompileCheckTestBase
 
-class BasicGeneratorSpec extends AnyFlatSpec with Matchers with Checkers {
+class BasicGeneratorSpec extends CompileCheckTestBase {
 
   it should "generate the bookshop example" in {
-    BasicGenerator.generateObjects(TestHelpers.myBookshopDoc)
+    BasicGenerator.generateObjects(TestHelpers.myBookshopDoc) shouldCompile ()
   }
 
 }

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/ClassDefinitionGeneratorSpec.scala
@@ -1,0 +1,11 @@
+package codegen
+
+import codegen.testutils.CompileCheckTestBase
+
+class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
+
+  it should "generate the class defs" in {
+    new ClassDefinitionGenerator().classDefs(TestHelpers.myBookshopDoc) shouldCompile ()
+  }
+
+}

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/ClassDefinitionGeneratorSpec.scala
@@ -1,11 +1,135 @@
 package codegen
 
+import codegen.openapi.models.OpenapiComponent
+import codegen.openapi.models.OpenapiModels.OpenapiDocument
+import codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaObject, OpenapiSchemaString}
 import codegen.testutils.CompileCheckTestBase
 
 class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
 
-  it should "generate the class defs" in {
+  it should "generate the example class defs" in {
     new ClassDefinitionGenerator().classDefs(TestHelpers.myBookshopDoc) shouldCompile ()
+  }
+
+  it should "generate simple class" in {
+    val doc = OpenapiDocument(
+      "",
+      null,
+      null,
+      OpenapiComponent(
+        Map(
+          "Test" -> OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(false)), Seq("text"), false)
+        )
+      )
+    )
+
+    new ClassDefinitionGenerator().classDefs(doc) shouldCompile ()
+  }
+
+  it should "generate simple class with reserved propName" in {
+    val doc = OpenapiDocument(
+      "",
+      null,
+      null,
+      OpenapiComponent(
+        Map(
+          "Test" -> OpenapiSchemaObject(Map("type" -> OpenapiSchemaString(false)), Seq("type"), false)
+        )
+      )
+    )
+
+    new ClassDefinitionGenerator().classDefs(doc) shouldCompile ()
+  }
+
+  it should "generate class with array" in {
+    val doc = OpenapiDocument(
+      "",
+      null,
+      null,
+      OpenapiComponent(
+        Map(
+          "Test" -> OpenapiSchemaObject(Map("texts" -> OpenapiSchemaArray(OpenapiSchemaString(false), false)), Seq("texts"), false)
+        )
+      )
+    )
+
+    new ClassDefinitionGenerator().classDefs(doc) shouldCompile ()
+  }
+
+  it should "generate class with inner class" in {
+    val doc = OpenapiDocument(
+      "",
+      null,
+      null,
+      OpenapiComponent(
+        Map(
+          "Test" -> OpenapiSchemaObject(
+            Map(
+              "inner" -> OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(false)), Seq("text"), false)
+            ),
+            Seq("inner"),
+            false
+          )
+        )
+      )
+    )
+
+    new ClassDefinitionGenerator().classDefs(doc) shouldCompile ()
+  }
+
+  it should "nonrequired and required are not the same" in {
+    val doc1 = OpenapiDocument(
+      "",
+      null,
+      null,
+      OpenapiComponent(
+        Map(
+          "Test" -> OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(false)), Seq.empty, false)
+        )
+      )
+    )
+    val doc2 = OpenapiDocument(
+      "",
+      null,
+      null,
+      OpenapiComponent(
+        Map(
+          "Test" -> OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(false)), Seq("text"), false)
+        )
+      )
+    )
+    val gen = new ClassDefinitionGenerator()
+    val res1 = gen.classDefs(doc1)
+    val res2 = gen.classDefs(doc2)
+    res1 shouldNot be(res2)
+    res1 shouldCompile ()
+    res2 shouldCompile ()
+  }
+  it should "nonrequired and nullable are the same" in {
+    val doc1 = OpenapiDocument(
+      "",
+      null,
+      null,
+      OpenapiComponent(
+        Map(
+          "Test" -> OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(false)), Seq.empty, false)
+        )
+      )
+    )
+    val doc2 = OpenapiDocument(
+      "",
+      null,
+      null,
+      OpenapiComponent(
+        Map(
+          "Test" -> OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(true)), Seq("text"), false)
+        )
+      )
+    )
+    val gen = new ClassDefinitionGenerator()
+    val res1 = gen.classDefs(doc1)
+    val res2 = gen.classDefs(doc2)
+    res1 shouldBe res2
   }
 
 }

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/EndpointGeneratorSpec.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/EndpointGeneratorSpec.scala
@@ -1,0 +1,46 @@
+package codegen
+
+import codegen.openapi.models.OpenapiModels.{
+  OpenapiDocument,
+  OpenapiParameter,
+  OpenapiPath,
+  OpenapiPathMethod,
+  OpenapiResponse,
+  OpenapiResponseContent
+}
+import codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaRef, OpenapiSchemaString}
+import codegen.testutils.CompileCheckTestBase
+
+class EndpointGeneratorSpec extends CompileCheckTestBase {
+
+  it should "generate the endpoint defs" in {
+    val doc = OpenapiDocument(
+      "",
+      null,
+      Seq(
+        OpenapiPath(
+          "test/{asd}",
+          Seq(
+            OpenapiPathMethod(
+              "get",
+              Seq(OpenapiParameter("asd", "path", true, None, OpenapiSchemaString(false))),
+              Seq(
+                OpenapiResponse(
+                  "200",
+                  "",
+                  Seq(OpenapiResponseContent("application/json", OpenapiSchemaArray(OpenapiSchemaString(false), false)))
+                ),
+                OpenapiResponse("default", "", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false))))
+              ),
+              None
+            )
+          )
+        )
+      ),
+      null
+    )
+    BasicGenerator.imports ++
+      new EndpointGenerator().endpointDefs(doc) shouldCompile ()
+  }
+
+}

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/EndpointGeneratorSpec.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/EndpointGeneratorSpec.scala
@@ -8,7 +8,7 @@ import codegen.openapi.models.OpenapiModels.{
   OpenapiResponse,
   OpenapiResponseContent
 }
-import codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaRef, OpenapiSchemaString}
+import codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaString}
 import codegen.testutils.CompileCheckTestBase
 
 class EndpointGeneratorSpec extends CompileCheckTestBase {

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/TestHelpers.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/TestHelpers.scala
@@ -13,7 +13,6 @@ import codegen.openapi.models.OpenapiModels.{
 import codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaArray,
   OpenapiSchemaInt,
-  OpenapiSchemaLong,
   OpenapiSchemaObject,
   OpenapiSchemaRef,
   OpenapiSchemaString

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/openapi/models/ModelParserSpec.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/openapi/models/ModelParserSpec.scala
@@ -1,22 +1,8 @@
 package codegen.openapi.models
 
 import codegen.TestHelpers
-import codegen.openapi.models.OpenapiModels.{
-  OpenapiDocument,
-  OpenapiInfo,
-  OpenapiParameter,
-  OpenapiPath,
-  OpenapiPathMethod,
-  OpenapiResponse,
-  OpenapiResponseContent
-}
-import codegen.openapi.models.OpenapiSchemaType.{
-  OpenapiSchemaArray,
-  OpenapiSchemaLong,
-  OpenapiSchemaObject,
-  OpenapiSchemaRef,
-  OpenapiSchemaString
-}
+import codegen.openapi.models.OpenapiModels.{OpenapiDocument, OpenapiResponse, OpenapiResponseContent}
+import codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaRef, OpenapiSchemaString}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/openapi/models/SchemaParserSpec.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/openapi/models/SchemaParserSpec.scala
@@ -1,13 +1,7 @@
 package codegen.openapi.models
 
 import codegen.openapi.models.OpenapiModels.OpenapiResponseContent
-import codegen.openapi.models.OpenapiSchemaType.{
-  OpenapiSchemaArray,
-  OpenapiSchemaInt,
-  OpenapiSchemaLong,
-  OpenapiSchemaObject,
-  OpenapiSchemaString
-}
+import codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaInt, OpenapiSchemaObject, OpenapiSchemaString}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/testutils/CompileCheckTestBase.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/testutils/CompileCheckTestBase.scala
@@ -1,0 +1,44 @@
+package codegen.testutils
+
+import org.scalactic.source
+import org.scalatest.Succeeded
+import org.scalatest.exceptions.{StackDepthException, TestFailedException}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.Checkers
+
+import scala.util.Try
+
+trait CompileCheckTestBase extends AnyFlatSpec with Matchers with Checkers {
+
+  def compile(code: String): Try[Unit] = {
+    import scala.reflect.runtime.universe._
+    import scala.tools.reflect.ToolBox
+    util
+      .Try {
+        val tb = runtimeMirror(this.getClass.getClassLoader).mkToolBox()
+        val tree = tb.parse(code)
+        tb.compile(tree)
+      }
+      .map(_ => ())
+  }
+
+  def compileWithoutHeader(code: String): Try[Unit] = {
+    compile(code.linesIterator.filter(!_.trim.startsWith("package")).mkString("\n"))
+  }
+
+  implicit class StringShouldCompileHelper(code: String)(implicit pos: source.Position) {
+    def shouldCompile(): Unit = {
+      compileWithoutHeader(code) match {
+        case util.Success(_) =>
+          Succeeded
+        case util.Failure(ex) =>
+          throw new TestFailedException(
+            (sde: StackDepthException) => Some(s"The input strings not compiles; ${ex.getMessage}"),
+            Some(ex),
+            pos
+          )
+      }
+    }
+  }
+}

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/testutils/CompileCheckTestBase.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/testutils/CompileCheckTestBase.scala
@@ -1,7 +1,6 @@
 package codegen.testutils
 
 import org.scalactic.source
-import org.scalatest.Succeeded
 import org.scalatest.exceptions.{StackDepthException, TestFailedException}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -31,10 +30,10 @@ trait CompileCheckTestBase extends AnyFlatSpec with Matchers with Checkers {
     def shouldCompile(): Unit = {
       compileWithoutHeader(code) match {
         case util.Success(_) =>
-          Succeeded
+          ()
         case util.Failure(ex) =>
           throw new TestFailedException(
-            (sde: StackDepthException) => Some(s"The input strings not compiles; ${ex.getMessage}"),
+            (_: StackDepthException) => Some(s"The input strings not compiles; ${ex.getMessage}"),
             Some(ex),
             pos
           )

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/testutils/CompileCheckTestBaseSpec.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/testutils/CompileCheckTestBaseSpec.scala
@@ -1,0 +1,57 @@
+package codegen.testutils
+
+import scala.tools.reflect.ToolBoxError
+
+class CompileCheckTestBaseSpec extends CompileCheckTestBase {
+  //Sure why not test the test :D
+
+  it should "compile valid code" in {
+    compile("object MyObj {}") shouldBe util.Success({})
+  }
+
+  it should "not compile invalid code" in {
+    compile("asdf") shouldBe a[util.Failure[_]]
+  }
+
+  it should "work with an extender too" in {
+    "object MyObj {}" shouldCompile ()
+  }
+
+  it should "compile full files" in {
+    """package test
+      |object Asd{}
+      |object Bsd{
+      |}""".stripMargin shouldCompile ()
+  }
+
+  it should "compile with imports" in {
+    """object Asd{
+      |  import scala.util._
+      |  Try(1/0)
+      |}""".stripMargin shouldCompile ()
+  }
+
+  it should "compile with implicit imports" in {
+    """object Asd{
+      |  import scala.concurrent.Future
+      |  import scala.concurrent.ExecutionContext.Implicits._
+      |  Future(1/0)
+      |}""".stripMargin shouldCompile ()
+  }
+
+  it should "compile code with tapir imports" in {
+    """object Asd{
+      |  import sttp.tapir._
+      |  import sttp.tapir.json.circe._
+      |  import io.circe.generic.auto._
+      |  case class Book(title: String)
+      |  endpoint.get.in("books" / "my").out(jsonBody[List[Book]])
+      |}""".stripMargin shouldCompile ()
+  }
+
+  it should "compile code with pure defs/vals" in {
+    """val x = 5
+      |def q = 4/2
+      |""".stripMargin shouldCompile ()
+  }
+}

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/testutils/CompileCheckTestBaseSpec.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/testutils/CompileCheckTestBaseSpec.scala
@@ -1,7 +1,5 @@
 package codegen.testutils
 
-import scala.tools.reflect.ToolBoxError
-
 class CompileCheckTestBaseSpec extends CompileCheckTestBase {
   //Sure why not test the test :D
 


### PR DESCRIPTION
Added a new `shouldCompile ()` test helper, split the generator into three classes, and made the class generator a bit smarter.

I think my next candidates are;
 - support tags to endpoints
 - changeable package name and generated object name
 - changeable json lib

Do you have a list of public projects with tapir interfaces to create a larger e2e test set?

Its a follow up to #810

> if you think it's worthy, you can add a hacktoberfest-accepted label to this PR ;)