### PR TITLE
Fixes #807: Introduce semi automatic derivation for Schemas and Validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ interpreted as:
 
 ```scala
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
 

--- a/client/sttp-client/src/test/scala/sttp/tapir/client/sttp/SttpClientRequestTests.scala
+++ b/client/sttp-client/src/test/scala/sttp/tapir/client/sttp/SttpClientRequestTests.scala
@@ -4,6 +4,7 @@ import java.io.File
 
 import sttp.tapir._
 import sttp.client3._
+import sttp.tapir.generic.auto._
 import sttp.model.{Header, HeaderNames, MediaType, Part}
 import sttp.tapir.tests.FruitData
 import org.scalatest.funsuite.AnyFunSuite

--- a/client/tests/src/main/scala/sttp/tapir/client/tests/ClientWebSocketTests.scala
+++ b/client/tests/src/main/scala/sttp/tapir/client/tests/ClientWebSocketTests.scala
@@ -5,6 +5,7 @@ import sttp.capabilities.{Streams, WebSockets}
 import sttp.tapir._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
+import sttp.tapir.generic.auto._
 import sttp.tapir.tests.Fruit
 
 trait ClientWebSocketTests[S] { this: ClientTests[S with WebSockets] =>

--- a/core/src/main/scala/sttp/tapir/Schema.scala
+++ b/core/src/main/scala/sttp/tapir/Schema.scala
@@ -9,11 +9,13 @@ import java.util.{Date, UUID}
 import sttp.model.Part
 import sttp.tapir.SchemaType._
 import sttp.tapir.generic.internal.OneOfMacro.oneOfMacro
-import sttp.tapir.generic.internal.{SchemaMagnoliaDerivation, SchemaMapMacro}
-import sttp.tapir.generic.Derived
+import sttp.tapir.generic.internal.SchemaMapMacro
 import sttp.tapir.internal.ModifySchemaMacro
 
 import scala.annotation.StaticAnnotation
+import sttp.tapir.generic.Derived
+import sttp.tapir.generic.internal.SchemaMagnoliaDerivation
+import magnolia.Magnolia
 
 /** Describes the shape of the low-level, "raw" representation of type `T`.
   * @param format The name of the format of the low-level representation of `T`.
@@ -123,6 +125,9 @@ object Schema extends SchemaExtensions with SchemaMagnoliaDerivation with LowPri
   implicit def schemaForMap[V: Schema]: Schema[Map[String, V]] = macro SchemaMapMacro.schemaForMap[Map[String, V], V]
 
   def oneOfUsingField[E, V](extractor: E => V, asString: V => String)(mapping: (V, Schema[_])*): Schema[E] = macro oneOfMacro[E, V]
+
+  def derive[T]: Schema[T] = macro Magnolia.gen[T]
+
 }
 
 trait LowPrioritySchema {

--- a/core/src/main/scala/sttp/tapir/TapirAliases.scala
+++ b/core/src/main/scala/sttp/tapir/TapirAliases.scala
@@ -51,7 +51,7 @@ trait TapirAliases {
 
   /** Schema.scala */
   type Schema[T] = sttp.tapir.Schema[T]
-  val Schema: sttp.tapir.Schema.type with SchemaMagnoliaDerivation = sttp.tapir.Schema
+  val Schema: sttp.tapir.Schema.type = sttp.tapir.Schema
 
   /** Tapir.scala */
   type Tapir = sttp.tapir.Tapir

--- a/core/src/main/scala/sttp/tapir/generic/auto/package.scala
+++ b/core/src/main/scala/sttp/tapir/generic/auto/package.scala
@@ -1,0 +1,3 @@
+package sttp.tapir.generic
+
+package object auto extends ValidatorDerivation with SchemaDerivation 

--- a/core/src/main/scala/sttp/tapir/generic/auto/schema/package.scala
+++ b/core/src/main/scala/sttp/tapir/generic/auto/schema/package.scala
@@ -1,0 +1,12 @@
+package sttp.tapir.generic.auto
+
+import sttp.tapir.generic.internal.SchemaMagnoliaDerivation
+import sttp.tapir.generic.Derived
+import sttp.tapir.generic.internal.MagnoliaDerivedMacro
+import sttp.tapir.Schema
+
+package object schema extends SchemaDerivation
+
+trait SchemaDerivation extends SchemaMagnoliaDerivation {
+    implicit def schemaForCaseClass[T]: Derived[Schema[T]] = macro MagnoliaDerivedMacro.derivedGen[T]
+}

--- a/core/src/main/scala/sttp/tapir/generic/auto/validator/package.scala
+++ b/core/src/main/scala/sttp/tapir/generic/auto/validator/package.scala
@@ -1,0 +1,7 @@
+package sttp.tapir.generic.auto
+
+import sttp.tapir.LowPriorityValidator
+
+package object validator extends ValidatorDerivation
+
+trait ValidatorDerivation extends LowPriorityValidator

--- a/core/src/main/scala/sttp/tapir/generic/internal/Refute.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/Refute.scala
@@ -1,0 +1,25 @@
+package sttp.tapir.generic.internal
+
+/** Evidence that no implicit instance of type `T` is available
+  *
+  *  @author Zainab Ali
+  *  @see https://github.com/milessabin/shapeless/blob/e9cf7454cf02c5af3bb0723afe0325872fe452a4/core/src/main/scala/shapeless/refute.scala
+  */
+@annotation.implicitNotFound(msg = "Implicit instance for ${T} in scope.")
+trait Refute[T]
+
+object Refute {
+
+  trait Impl[A]
+  object Impl {
+    /** This results in  ambigous implicits if there is implicit evidence of `T` */
+    implicit def amb1[T](implicit ev: T): Impl[T] = null
+    implicit def amb2[T]: Impl[T] = null
+  }
+
+  /** This always declares an instance of `Refute`
+    *
+    * This instance will only be found when there is no evidence of `T`
+    * */
+  implicit def refute[T](implicit dummy: Impl[T]): Refute[T] = new Refute[T] {}
+}

--- a/core/src/main/scala/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
@@ -3,13 +3,15 @@ package sttp.tapir.generic.internal
 import com.github.ghik.silencer.silent
 import magnolia._
 import sttp.tapir.SchemaType._
-import sttp.tapir.generic.{Configuration, Derived}
+import sttp.tapir.generic.Configuration
 import sttp.tapir.{deprecated, description, format, encodedName, FieldName, Schema, SchemaType}
 import SchemaMagnoliaDerivation.deriveInProgress
 
 import scala.collection.mutable
+import sttp.tapir.generic.Derived
 
 trait SchemaMagnoliaDerivation {
+
   type Typeclass[T] = Schema[T]
 
   @silent("discarded")
@@ -96,7 +98,6 @@ trait SchemaMagnoliaDerivation {
     Schema(coproduct)
   }
 
-  implicit def schemaForCaseClass[T]: Derived[Schema[T]] = macro MagnoliaDerivedMacro.derivedGen[T]
 }
 
 object SchemaMagnoliaDerivation {

--- a/core/src/test/scala/sttp/tapir/SchemaModifyTest.scala
+++ b/core/src/test/scala/sttp/tapir/SchemaModifyTest.scala
@@ -3,6 +3,7 @@ package sttp.tapir
 import sttp.tapir.SchemaType._
 import sttp.tapir.generic.{Configuration, D}
 import org.scalatest.flatspec.AnyFlatSpec
+import sttp.tapir.generic.auto._
 import org.scalatest.matchers.should.Matchers
 
 class SchemaMacroTest extends AnyFlatSpec with Matchers {

--- a/core/src/test/scala/sttp/tapir/ValidatorTest.scala
+++ b/core/src/test/scala/sttp/tapir/ValidatorTest.scala
@@ -141,7 +141,7 @@ class ValidatorTest extends AnyFlatSpec with Matchers {
     case class Person(name: String, age: Int)
     implicit val nameValidator: Validator[String] = Validator.pattern("^[A-Z].*")
     implicit val ageValidator: Validator[Int] = Validator.min(18)
-    val validator = Validator.validatorForCaseClass[Person]
+    val validator = Validator.derive[Person]
     validator.validate(Person("notImportantButOld", 21)).map(noPath(_)) shouldBe List(
       ValidationError.Primitive(Validator.pattern("^[A-Z].*"), "notImportantButOld")
     )
@@ -232,6 +232,7 @@ class ValidatorTest extends AnyFlatSpec with Matchers {
   }
 
   it should "show recursive validators" in {
+    import sttp.tapir.generic.auto.validator._
     val v: Validator[RecursiveName] = implicitly[Validator[RecursiveName]]
     v.show shouldBe Some("subNames->(elements(elements(recursive)))")
   }

--- a/core/src/test/scala/sttp/tapir/generic/FormCodecDerivationTest.scala
+++ b/core/src/test/scala/sttp/tapir/generic/FormCodecDerivationTest.scala
@@ -4,6 +4,7 @@ import java.math.{BigDecimal => JBigDecimal}
 
 import com.github.ghik.silencer.silent
 import sttp.tapir.SchemaType.{SObjectInfo, SProduct}
+import sttp.tapir.generic.auto._
 import sttp.tapir.{Codec, CodecFormat, DecodeResult, FieldName, Schema, Validator, encodedName}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/core/src/test/scala/sttp/tapir/generic/MultipartCodecDerivationTest.scala
+++ b/core/src/test/scala/sttp/tapir/generic/MultipartCodecDerivationTest.scala
@@ -2,6 +2,7 @@ package sttp.tapir.generic
 
 import com.github.ghik.silencer.silent
 import sttp.model.{Header, MediaType, Part}
+import sttp.tapir.generic.auto._
 import sttp.tapir.SchemaType._
 import sttp.tapir.{DecodeResult, FieldName, MultipartCodec, RawPart, Schema, Validator, TapirFile, encodedName}
 import org.scalatest.flatspec.AnyFlatSpec

--- a/core/src/test/scala/sttp/tapir/generic/SchemaGenericAutoTest.scala
+++ b/core/src/test/scala/sttp/tapir/generic/SchemaGenericAutoTest.scala
@@ -4,6 +4,7 @@ import java.math.{BigDecimal => JBigDecimal}
 
 import com.github.ghik.silencer.silent
 import sttp.tapir.SchemaType._
+import sttp.tapir.generic.auto._
 import sttp.tapir.{FieldName, Schema, SchemaType, deprecated, description, format, encodedName}
 
 import scala.concurrent.Future
@@ -11,12 +12,12 @@ import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 @silent("never used")
-class SchemaGenericTest extends AsyncFlatSpec with Matchers {
+class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
   private val stringSchema = implicitly[Schema[String]]
   private val intSchema = implicitly[Schema[Int]]
   private val longSchema = implicitly[Schema[Long]]
 
-  "Schema" should "find schema for simple types" in {
+  "Schema auto derivation" should "find schema for simple types" in {
     stringSchema.schemaType shouldBe SString
     stringSchema.isOptional shouldBe false
 
@@ -283,7 +284,7 @@ class SchemaGenericTest extends AsyncFlatSpec with Matchers {
 
     // when
     schema.schemaType shouldBe SProduct(
-      SObjectInfo("sttp.tapir.generic.SchemaGenericTest.<local SchemaGenericTest>.Test1"),
+      SObjectInfo("sttp.tapir.generic.SchemaGenericAutoTest.<local SchemaGenericAutoTest>.Test1"),
       List(
         (FieldName("f1"), implicitly[Schema[String]]),
         (FieldName("f2"), implicitly[Schema[Byte]]),
@@ -358,6 +359,7 @@ class SchemaGenericTest extends AsyncFlatSpec with Matchers {
       Some(Discriminator("who_am_i", Map.empty))
     )
   }
+  
 }
 
 case class StringValueClass(value: String) extends AnyVal

--- a/core/src/test/scala/sttp/tapir/server/ServerDefaultsTest.scala
+++ b/core/src/test/scala/sttp/tapir/server/ServerDefaultsTest.scala
@@ -2,6 +2,7 @@ package sttp.tapir.server
 
 import com.github.ghik.silencer.silent
 import sttp.tapir.Validator
+import sttp.tapir.generic.auto._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -10,11 +11,9 @@ class ServerDefaultsTest extends AnyFlatSpec with Matchers {
     // given
     @silent("never used")
     implicit val addressNumberValidator: Validator[Int] = Validator.min(1)
-    @silent("fallback derivation")
-    val personValidator = Validator.validatorForCaseClass[Person]
 
     // when
-    val validationErrors = personValidator.validate(Person("John", Address("Lane", 0)))
+    val validationErrors = implicitly[Validator[Person]].validate(Person("John", Address("Lane", 0)))
 
     // then
     ServerDefaults.ValidationMessages.validationErrorsMessage(

--- a/core/src/test/scalajvm/sttp/tapir/generic/SchemaGenericSemiautoTest.scala
+++ b/core/src/test/scalajvm/sttp/tapir/generic/SchemaGenericSemiautoTest.scala
@@ -1,0 +1,23 @@
+package sttp.tapir.generic
+
+import com.github.ghik.silencer.silent
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AsyncFlatSpec
+import sttp.tapir.util.CompileUtil
+
+@silent("never used")
+class SchemaGenericSemiautoTest extends AsyncFlatSpec with Matchers {
+
+    "Schema semiauto derivation" should "fail and hint if an implicit instance is missing" in {
+        val error = CompileUtil.interceptEval("""
+        |import sttp.tapir._
+        |case class Unknown(str: String)
+        |case class Example(str: String, unknown: Unknown)
+        |Schema.derive[Example]
+        |""".stripMargin)
+
+        error.message should include ("magnolia: could not find Schema.Typeclass for type Unknown")
+        error.message should include ("in parameter 'unknown' of product type Example")
+    }
+
+}

--- a/doc/docs/asyncapi.md
+++ b/doc/docs/asyncapi.md
@@ -18,6 +18,7 @@ import sttp.capabilities.akka.AkkaStreams
 import sttp.tapir._
 import sttp.tapir.asyncapi.AsyncAPI
 import sttp.tapir.docs.asyncapi._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
 

--- a/doc/endpoint/forms.md
+++ b/doc/endpoint/forms.md
@@ -17,6 +17,7 @@ compile-time. The fields of the case class should have types, for which there is
 
 ```scala mdoc:compile-only
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 
 case class RegistrationForm(name: String, age: Int, news: Boolean, city: Option[String])
 
@@ -58,6 +59,7 @@ For example:
 import sttp.tapir._
 import sttp.model.Part
 import java.io.File
+import sttp.tapir.generic.auto._
 
 case class RegistrationForm(userData: User, photo: Part[File], news: Boolean)
 case class User(email: String)

--- a/doc/endpoint/ios.md
+++ b/doc/endpoint/ios.md
@@ -50,6 +50,7 @@ parameters, `start` (mandatory) and `limit` (optional) can be written down as:
 
 ```scala mdoc:compile-only
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
 import java.util.UUID
@@ -71,6 +72,7 @@ base endpoint for our API, where all paths always start with `/api/v1.0`, and er
 
 ```scala mdoc:silent
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
 

--- a/doc/endpoint/json.md
+++ b/doc/endpoint/json.md
@@ -42,6 +42,7 @@ For example, to automatically generate a JSON codec for a case class:
 ```scala mdoc:compile-only
 import sttp.tapir._
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import io.circe.generic.auto._
 
 case class Book(author: String, title: String, year: Int)
@@ -105,6 +106,7 @@ import sttp.tapir.json.upickle._
 
 ```scala mdoc:compile-only
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import upickle.default._
 import sttp.tapir.json.upickle._
 

--- a/doc/endpoint/statuscodes.md
+++ b/doc/endpoint/statuscodes.md
@@ -57,6 +57,7 @@ Type erasure may prevent a status mapping from working properly. The following e
 ```scala mdoc:fail
 import sttp.tapir._
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import sttp.model.StatusCode
 import io.circe.generic.auto._
 
@@ -80,6 +81,7 @@ The solution is therefore to handwrite a function checking that a `val` (of type
 ```scala mdoc:invisible
 import sttp.tapir._
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import sttp.model.StatusCode
 import io.circe.generic.auto._
 

--- a/doc/endpoint/streaming.md
+++ b/doc/endpoint/streaming.md
@@ -23,6 +23,7 @@ which is a (presumably large) serialised list of json objects mapping to the `Pe
 
 ```scala mdoc:silent:reset
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import sttp.capabilities.akka.AkkaStreams
 import akka.stream.scaladsl._
 import akka.util.ByteString

--- a/doc/endpoint/websockets.md
+++ b/doc/endpoint/websockets.md
@@ -17,6 +17,7 @@ are parsed/formatted as json:
 import sttp.tapir._
 import sttp.capabilities.akka.AkkaStreams
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import io.circe.generic.auto._
 
 case class Response(msg: String, count: Int)

--- a/doc/index.md
+++ b/doc/index.md
@@ -27,6 +27,7 @@ for a more detailed description of how tapir works!
 
 ```scala mdoc:compile-only
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
 

--- a/doc/mytapir.md
+++ b/doc/mytapir.md
@@ -11,6 +11,8 @@ a single-import whenever you want to use tapir. For example:
 object MyTapir extends Tapir
   with TapirAkkaHttpServer
   with TapirSttpClient
+  with ValidatorDerivation
+  with SchemaDerivation
   with TapirJsonCirce
   with TapirOpenAPICirceYaml
   with TapirAliases

--- a/doc/server/errors.md
+++ b/doc/server/errors.md
@@ -79,6 +79,7 @@ a different format (other than textual):
 import sttp.tapir._
 import sttp.tapir.server._
 import sttp.tapir.server.akkahttp._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import sttp.model.StatusCode
 import io.circe.generic.auto._

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -26,6 +26,7 @@ Given the following endpoint:
 
 ```scala mdoc:silent
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
 

--- a/docs/asyncapi-docs/src/test/scala/sttp/tapir/docs/asyncapi/VerifyAsyncAPIYamlTest.scala
+++ b/docs/asyncapi-docs/src/test/scala/sttp/tapir/docs/asyncapi/VerifyAsyncAPIYamlTest.scala
@@ -3,6 +3,7 @@ package sttp.tapir.docs.asyncapi
 import io.circe.generic.auto._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import sttp.tapir.generic.auto._
 import sttp.capabilities.akka.AkkaStreams
 import sttp.model.HeaderNames
 import sttp.tapir.asyncapi.Server

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -8,6 +8,7 @@ import io.circe.generic.auto._
 import sttp.model.{Method, StatusCode}
 import sttp.tapir.EndpointIO.Example
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import sttp.tapir.docs.openapi.dtos.Book
 import sttp.tapir.docs.openapi.dtos.a.{Pet => APet}
 import sttp.tapir.docs.openapi.dtos.b.{Pet => BPet}

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
@@ -1,18 +1,28 @@
 package sttp.tapir.examples
 
 import com.typesafe.scalalogging.StrictLogging
+import sttp.tapir.{Schema, Validator}
 import sttp.tapir.swagger.akkahttp.SwaggerAkka
-import sttp.tapir.generic.auto._
 
-object BooksExample extends App with StrictLogging {
+object BooksExampleSemiauto extends App with StrictLogging {
   type Limit = Option[Int]
   type AuthToken = String
 
   case class Country(name: String)
   case class Author(name: String, country: Country)
   case class Genre(name: String, description: String)
+
   case class Book(title: String, genre: Genre, year: Int, author: Author)
   case class BooksQuery(genre: Option[String], limit: Limit)
+
+  implicit val sCountry: Schema[Country] = Schema.derive
+  implicit val validateCountry: Validator[Country] = Validator.derive
+  implicit val sAuthor: Schema[Author] = Schema.derive
+  implicit val validateAuthor: Validator[Author] = Validator.derive
+  implicit val sGenre: Schema[Genre] = Schema.derive
+  implicit val validateGenre: Validator[Genre] = Validator.derive
+  implicit val sBook: Schema[Book] = Schema.derive
+  implicit val validateBook: Validator[Book] = Validator.derive
 
   /** Descriptions of endpoints used in the example.
     */

--- a/examples/src/main/scala/sttp/tapir/examples/EndpointWithCustomTypes.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/EndpointWithCustomTypes.scala
@@ -3,6 +3,7 @@ package sttp.tapir.examples
 import io.circe.{Decoder, Encoder}
 import sttp.tapir._
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import io.circe.generic.auto._
 
 object EndpointWithCustomTypes {

--- a/examples/src/main/scala/sttp/tapir/examples/ErrorOutputsAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ErrorOutputsAkkaServer.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Route
 import sttp.client3._
+import sttp.tapir.generic.auto._
 import sttp.tapir._
 import sttp.tapir.server.akkahttp._
 import sttp.tapir.json.circe._

--- a/examples/src/main/scala/sttp/tapir/examples/MultipartFormUploadAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipartFormUploadAkkaServer.scala
@@ -6,6 +6,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Route
 import sttp.client3._
+import sttp.tapir.generic.auto._
 import sttp.model.Part
 import sttp.tapir._
 import sttp.tapir.server.akkahttp._

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
@@ -6,6 +6,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import com.github.ghik.silencer.silent
 import io.circe.generic.auto._
+import sttp.tapir.generic.auto._
 import sttp.tapir._
 import sttp.tapir.docs.openapi._
 import sttp.tapir.json.circe._

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationHttp4sServer.scala
@@ -13,6 +13,7 @@ import org.http4s.syntax.kleisli._
 import sttp.tapir._
 import sttp.tapir.docs.openapi._
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import sttp.tapir.openapi.OpenAPI
 import sttp.tapir.openapi.circe.yaml._
 import sttp.tapir.server.http4s._

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaClient.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaClient.scala
@@ -10,6 +10,7 @@ import sttp.client3.akkahttp.AkkaHttpBackend
 import sttp.tapir._
 import sttp.tapir.client.sttp._
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import sttp.tapir.client.sttp.ws.akkahttp._
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaServer.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Route
 import akka.stream.scaladsl.Flow
 import io.circe.generic.auto._
+import sttp.tapir.generic.auto._
 import sttp.capabilities.WebSockets
 import sttp.capabilities.akka.AkkaStreams
 import sttp.client3._

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketHttp4sServer.scala
@@ -9,6 +9,7 @@ import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
 import sttp.capabilities.WebSockets
 import sttp.capabilities.fs2.Fs2Streams
+import sttp.tapir.generic.auto._
 import sttp.client3._
 import sttp.client3.asynchttpclient.fs2.AsyncHttpClientFs2Backend
 import sttp.tapir._

--- a/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
@@ -6,6 +6,7 @@ import org.http4s._
 import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import sttp.tapir.server.http4s.ztapir._
 import sttp.tapir.swagger.http4s.SwaggerHttp4s

--- a/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
@@ -7,6 +7,7 @@ import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import sttp.tapir.server.http4s.ztapir._
 import sttp.tapir.swagger.http4s.SwaggerHttp4s
 import sttp.tapir.ztapir._

--- a/generated-doc/out/docs/asyncapi.md
+++ b/generated-doc/out/docs/asyncapi.md
@@ -18,6 +18,7 @@ import sttp.capabilities.akka.AkkaStreams
 import sttp.tapir._
 import sttp.tapir.asyncapi.AsyncAPI
 import sttp.tapir.docs.asyncapi._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
 

--- a/generated-doc/out/endpoint/customtypes.md
+++ b/generated-doc/out/endpoint/customtypes.md
@@ -93,8 +93,58 @@ hence configured separately.
 
 ## Schema derivation
 
-For case classes types, `Schema[_]` values are derived automatically using [Magnolia](https://propensive.com/opensource/magnolia/), given
-that schemas are defined for all the case class's fields. It is possible to configure the automatic derivation to use
+For case classes types, `Schema[_]` values can be derived automatically using [Magnolia](https://propensive.com/opensource/magnolia/), given
+that schemas are defined for all the case class's fields. 
+
+Two policies enable to choose the way custom types are derived : 
+- Automatic derivation
+- Semi automatic derivation 
+
+
+### Automatic mode
+
+Cases classes, traits and their children are recursively derived by Magnolia.   
+ 
+Importing `sttp.tapir.generic.auto._` enables fully automatic derivation for `Schema` and `Validator`.
+
+```scala
+import sttp.tapir.Schema
+import sttp.tapir.generic.auto._
+
+case class Parent(child: Child)
+case class Child(value: String)
+
+// implicit schema used by codecs
+implicitly[Schema[Parent]]
+
+```
+
+If you have a case class which contains some non-standard types (other than strings, number, other case classes, 
+collections), you only need to provide schemas for them. Using these, the rest will be derived automatically.
+
+### Semi-automatic mode
+
+Semi-automatic derivation can be done using `Schema.derive[T]` or `Validator.derive[T]`. 
+
+It only derives selected type `T`. However derivation is not recursive : 
+schemas and validators must be explicitly defined for every child type.
+
+This mode is easier to debug and helps to avoid issues encountered by automatic mode (wrong schemas for value classes or custom types).   
+
+```scala
+import sttp.tapir.Schema
+
+case class Parent(child: Child)
+case class Child(value: String)
+
+implicit def sChild: Schema[Child] = Schema.derive
+implicit def sParent: Schema[Parent] = Schema.derive
+
+```
+
+### Configuring derivation
+
+It is possible to configure Magnolia's automatic derivation to use
 snake_case, kebab-case or a custom field naming policy, by providing an implicit `sttp.tapir.generic.Configuration` value:
 
 ```scala
@@ -113,10 +163,6 @@ import sttp.tapir._
 case class MyCustomType()
 implicit val schemaForMyCustomType: Schema[MyCustomType] = Schema(SchemaType.SString)
 ```
-
-If you have a case class which contains some non-standard types (other than strings, number, other case classes, 
-collections), you only need to provide the schema for the non-standard types. Using these schemas, the rest will
-be derived automatically.
 
 ### Sealed traits / coproducts
 
@@ -153,8 +199,8 @@ case class Organization(name: String) extends Entity {
 
 import sttp.tapir._
 
-val sPerson = implicitly[Schema[Person]]
-val sOrganization = implicitly[Schema[Organization]]
+val sPerson = Schema.derive[Person]
+val sOrganization = Schema.derive[Organization]
 implicit val sEntity: Schema[Entity] = 
     Schema.oneOfUsingField[Entity, String](_.kind, _.toString)("person" -> sPerson, "org" -> sOrganization)
 ```
@@ -182,6 +228,7 @@ For example:
 
 ```scala
 import sttp.tapir._
+import sttp.tapir.generic.auto.schema._
 import sttp.tapir.generic.Derived
 
 case class Basket(fruits: List[FruitAmount])

--- a/generated-doc/out/endpoint/forms.md
+++ b/generated-doc/out/endpoint/forms.md
@@ -17,6 +17,7 @@ compile-time. The fields of the case class should have types, for which there is
 
 ```scala
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 
 case class RegistrationForm(name: String, age: Int, news: Boolean, city: Option[String])
 
@@ -58,6 +59,7 @@ For example:
 import sttp.tapir._
 import sttp.model.Part
 import java.io.File
+import sttp.tapir.generic.auto._
 
 case class RegistrationForm(userData: User, photo: Part[File], news: Boolean)
 case class User(email: String)

--- a/generated-doc/out/endpoint/ios.md
+++ b/generated-doc/out/endpoint/ios.md
@@ -50,6 +50,7 @@ parameters, `start` (mandatory) and `limit` (optional) can be written down as:
 
 ```scala
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
 import java.util.UUID
@@ -71,6 +72,7 @@ base endpoint for our API, where all paths always start with `/api/v1.0`, and er
 
 ```scala
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
 

--- a/generated-doc/out/endpoint/json.md
+++ b/generated-doc/out/endpoint/json.md
@@ -42,6 +42,7 @@ For example, to automatically generate a JSON codec for a case class:
 ```scala
 import sttp.tapir._
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import io.circe.generic.auto._
 
 case class Book(author: String, title: String, year: Int)
@@ -105,6 +106,7 @@ import sttp.tapir.json.upickle._
 
 ```scala
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import upickle.default._
 import sttp.tapir.json.upickle._
 

--- a/generated-doc/out/endpoint/statuscodes.md
+++ b/generated-doc/out/endpoint/statuscodes.md
@@ -57,6 +57,7 @@ Type erasure may prevent a status mapping from working properly. The following e
 ```scala
 import sttp.tapir._
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import sttp.model.StatusCode
 import io.circe.generic.auto._
 

--- a/generated-doc/out/endpoint/streaming.md
+++ b/generated-doc/out/endpoint/streaming.md
@@ -23,6 +23,7 @@ which is a (presumably large) serialised list of json objects mapping to the `Pe
 
 ```scala
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import sttp.capabilities.akka.AkkaStreams
 import akka.stream.scaladsl._
 import akka.util.ByteString

--- a/generated-doc/out/endpoint/validation.md
+++ b/generated-doc/out/endpoint/validation.md
@@ -35,8 +35,13 @@ Validation rules added using the built-in validators are translated to [OpenAPI]
 
 ### Validation rules and automatic codec derivation
 
-When a codec is automatically derived for a type (see [custom types](customtypes.md)), validators for all types 
-(for json this is a recursive process) are looked up through implicit `Validator[T]` values.
+Validator instances are looked up through implicit `Validator[T]` values. 
+
+While they can be manually defined, Tapir provides tools to derive automatically validators for custom types (traits and case classes).
+ 
+Like in `Schema`s ([custom types](customtypes.md)), two policies enable schema derivation : 
+- Automatic derivation 
+- Semi-automatic derivation
 
 ```eval_rst
 .. note::
@@ -44,6 +49,40 @@ When a codec is automatically derived for a type (see [custom types](customtypes
   Implicit ``Validator[T]`` values are used *only* when automatically deriving codecs. They are not used
   when the codec is defined by hand.
 ```
+
+### Automatic derivation
+
+When importing `sttp.tapir.generic.auto._`, validators are automatically derived for all types (for json this is a recursive process).  
+By default a leaf type without an already existing `Validator` is always considered as valid (`Validator.pass`). 
+
+```scala
+import sttp.tapir.generic.auto._
+import sttp.tapir.Validator
+
+case class Parent(child: Child)
+case class Child(value: String)
+
+// implicit validator used in tapir codecs
+implicitly[Validator[Parent]]
+```
+
+If you need to automatically derive validators while using semi-automatic derivation for schemas, you can import only `sttp.tapir.generic.validator._` and use `Schema.derive[T]`. 
+
+### Semi-automatic derivation
+
+In semi-automatic derivation, Tapir only helps to derive the selected `case class` or `trait` (no recursion involved).
+  
+```scala
+import sttp.tapir.Validator
+
+case class Parent(child: Child)
+case class Child(value: String)
+
+implicit val schemaForChild = Validator.derive[Child]
+implicit val schemaForParent = Validator.derive[Parent]
+```
+
+## Specific type validation
 
 Note that to validate a nested member of a case class, it needs to have a unique type (that is, not an `Int`, as 
 providing an implicit `Validator[Int]` would validate all ints in the hierarchy), as validator lookup is type-driven.
@@ -55,6 +94,8 @@ decoders (if that's the json library that we are using), schema information and 
  
 ```scala
 import sttp.tapir._
+import sttp.tapir.generic.auto.schema._
+import sttp.tapir.generic.auto.validator._
 import sttp.tapir.json.circe._
 import io.circe.{ Encoder, Decoder }
 import io.circe.generic.semiauto._

--- a/generated-doc/out/endpoint/websockets.md
+++ b/generated-doc/out/endpoint/websockets.md
@@ -17,6 +17,7 @@ are parsed/formatted as json:
 import sttp.tapir._
 import sttp.capabilities.akka.AkkaStreams
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import io.circe.generic.auto._
 
 case class Response(msg: String, count: Int)

--- a/generated-doc/out/index.md
+++ b/generated-doc/out/index.md
@@ -27,6 +27,7 @@ for a more detailed description of how tapir works!
 
 ```scala
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
 

--- a/generated-doc/out/mytapir.md
+++ b/generated-doc/out/mytapir.md
@@ -11,6 +11,8 @@ a single-import whenever you want to use tapir. For example:
 object MyTapir extends Tapir
   with TapirAkkaHttpServer
   with TapirSttpClient
+  with ValidatorDerivation
+  with SchemaDerivation
   with TapirJsonCirce
   with TapirOpenAPICirceYaml
   with TapirAliases

--- a/generated-doc/out/server/errors.md
+++ b/generated-doc/out/server/errors.md
@@ -79,6 +79,7 @@ a different format (other than textual):
 import sttp.tapir._
 import sttp.tapir.server._
 import sttp.tapir.server.akkahttp._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import sttp.model.StatusCode
 import io.circe.generic.auto._

--- a/generated-doc/out/server/play.md
+++ b/generated-doc/out/server/play.md
@@ -9,13 +9,13 @@ To expose endpoint as a [play-server](https://www.playframework.com/) first add 
 and (if you don't already depend on Play) 
 
 ```scala
-"com.typesafe.play" %% "play-akka-http-server" % "2.8.3"
+"com.typesafe.play" %% "play-akka-http-server" % "2.8.4"
 ```
 
 or
 
 ```scala
-"com.typesafe.play" %% "play-netty-server" % "2.8.3"
+"com.typesafe.play" %% "play-netty-server" % "2.8.4"
 ```
 
 depending on whether you want to use netty or akka based http-server under the hood.

--- a/generated-doc/out/testing.md
+++ b/generated-doc/out/testing.md
@@ -26,6 +26,7 @@ Given the following endpoint:
 
 ```scala
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
 

--- a/integrations/cats/src/test/scala/sttp/tapir/integ/cats/TapirCodecCatsTest.scala
+++ b/integrations/cats/src/test/scala/sttp/tapir/integ/cats/TapirCodecCatsTest.scala
@@ -6,6 +6,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck.Arbitrary.arbString
+import sttp.tapir.generic.auto._
 import sttp.tapir.SchemaType.{SArray, SString}
 import sttp.tapir.{Codec, CodecFormat, DecodeResult, Schema, Validator}
 import sttp.tapir.internal._

--- a/integrations/refined/src/test/scala/sttp/tapir/codec/refined/TapirCodecRefinedTest.scala
+++ b/integrations/refined/src/test/scala/sttp/tapir/codec/refined/TapirCodecRefinedTest.scala
@@ -7,6 +7,7 @@ import eu.timepit.refined.string.{IPv4, MatchesRegex}
 import eu.timepit.refined.types.string.NonEmptyString
 import eu.timepit.refined.{W, refineMV, refineV}
 import sttp.tapir.Codec.PlainCodec
+import sttp.tapir.generic.auto._
 import sttp.tapir.{DecodeResult, ValidationError, Validator}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/json/playjson/src/test/scala/sttp/tapir/json/play/TapirJsonPlayTests.scala
+++ b/json/playjson/src/test/scala/sttp/tapir/json/play/TapirJsonPlayTests.scala
@@ -4,6 +4,7 @@ import org.scalatest.Assertion
 import play.api.libs.json._
 import sttp.tapir._
 import sttp.tapir.DecodeResult._
+import sttp.tapir.generic.auto._
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/json/sprayjson/src/test/scala/sttp/tapir/json/spray/TapirJsonSprayTests.scala
+++ b/json/sprayjson/src/test/scala/sttp/tapir/json/spray/TapirJsonSprayTests.scala
@@ -3,6 +3,7 @@ package sttp.tapir.json.spray
 import org.scalatest.Assertion
 import sttp.tapir._
 import sttp.tapir.DecodeResult._
+import sttp.tapir.generic.auto._
 import spray.json._
 import sttp.tapir.Codec.JsonCodec
 import org.scalatest.flatspec.AnyFlatSpec

--- a/json/upickle/src/test/scala/sttp/tapir/json/upickle/TapirJsonuPickleTests.scala
+++ b/json/upickle/src/test/scala/sttp/tapir/json/upickle/TapirJsonuPickleTests.scala
@@ -2,6 +2,8 @@ package sttp.tapir.json.upickle
 
 import upickle.default._
 import org.scalatest.Assertion
+import sttp.tapir.generic.auto._
+import java.util.Date
 
 import sttp.tapir.Codec.JsonCodec
 import sttp.tapir._

--- a/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
+++ b/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
@@ -2,6 +2,7 @@ package sttp.tapir.example
 
 import com.typesafe.scalalogging.StrictLogging
 import sttp.tapir.example.Endpoints.Limit
+import sttp.tapir.generic.auto._
 import sttp.tapir.swagger.akkahttp.SwaggerAkka
 
 case class Country(name: String)

--- a/sbt/sbt-openapi-codegen/src/main/scala/codegen/BasicGenerator.scala
+++ b/sbt/sbt-openapi-codegen/src/main/scala/codegen/BasicGenerator.scala
@@ -40,6 +40,7 @@ object BasicGenerator {
   private[codegen] def imports: String =
     """import sttp.tapir._
       |import sttp.tapir.json.circe._
+      |import sttp.tapir.generic.auto._
       |import io.circe.generic.auto._
       |""".stripMargin
 

--- a/sbt/sbt-openapi-codegen/src/test/scala/codegen/testutils/CompileCheckTestBaseSpec.scala
+++ b/sbt/sbt-openapi-codegen/src/test/scala/codegen/testutils/CompileCheckTestBaseSpec.scala
@@ -41,6 +41,7 @@ class CompileCheckTestBaseSpec extends CompileCheckTestBase {
     """object Asd{
       |  import sttp.tapir._
       |  import sttp.tapir.json.circe._
+      |  import sttp.tapir.generic.auto._
       |  import io.circe.generic.auto._
       |  case class Book(title: String)
       |  endpoint.get.in("books" / "my").out(jsonBody[List[Book]])

--- a/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/SttpStubServerTest.scala
+++ b/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/SttpStubServerTest.scala
@@ -7,6 +7,7 @@ import sttp.client3.testing.SttpBackendStub
 import sttp.model.StatusCode
 import sttp.tapir._
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.monad.MonadError

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.implicits._
+import sttp.tapir.generic.auto._
 import io.circe.generic.auto._
 import sttp.client3._
 import sttp.model._

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerWebSocketTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerWebSocketTests.scala
@@ -7,6 +7,7 @@ import sttp.client3._
 import sttp.tapir._
 import sttp.ws.{WebSocket, WebSocketFrame}
 import sttp.tapir.json.circe._
+import sttp.tapir.generic.auto._
 import io.circe.generic.auto._
 import sttp.monad.MonadError
 import sttp.tapir.tests.{Fruit, Test}

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets
 
 import com.github.ghik.silencer.silent
 import io.circe.generic.auto._
+import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import com.softwaremill.macwire._
 import com.softwaremill.tagging.{@@, Tagger}


### PR DESCRIPTION
Semi automatic derivation enables to ensure that every `Schema` and `Instance` have explicitly been defined.
It helps avoiding unwanted Magnolia derivations (e.g. on value classes and custom types). 
It closes https://github.com/softwaremill/tapir/issues/807. 

I finally managed to bring both `Validator` and `Schema` derivations in scope by defining private `Typeclass` types. 