### PR TITLE
Allow swagger-ui to run on a non-root context-path. Solves #694.

### DIFF
--- a/docs/swagger-ui-akka-http/src/main/scala/sttp/tapir/swagger/akkahttp/SwaggerAkka.scala
+++ b/docs/swagger-ui-akka-http/src/main/scala/sttp/tapir/swagger/akkahttp/SwaggerAkka.scala
@@ -2,18 +2,21 @@ package sttp.tapir.swagger.akkahttp
 
 import java.util.Properties
 
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{PathMatcher, Route}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.Uri.Path
 
 /** Usage: add `new SwaggerAkka(yaml).routes` to your akka-http routes. Docs will be available using the `/docs` path.
   *
   * @param yaml        The yaml with the OpenAPI documentation.
   * @param contextPath The context in which the documentation will be served. Defaults to `docs`, so the address
-  *                    of the docs will be `/docs`.
+  *                    of the docs will be `/docs`. Should not start, nor end with a '/'.
   * @param yamlName    The name of the file, through which the yaml documentation will be served. Defaults to `docs.yaml`.
   */
 class SwaggerAkka(yaml: String, contextPath: String = "docs", yamlName: String = "docs.yaml") {
+  require(!contextPath.startsWith("/") && !contextPath.endsWith("/"))
+
   private val redirectToIndex: Route =
     redirect(s"/$contextPath/index.html?url=/$contextPath/$yamlName", StatusCodes.PermanentRedirect)
 
@@ -29,9 +32,14 @@ class SwaggerAkka(yaml: String, contextPath: String = "docs", yamlName: String =
     p.getProperty("version")
   }
 
+  private val contextPathMatcher = {
+    def toPathMatcher(segment: String) = PathMatcher(segment :: Path.Empty, ())
+    contextPath.split('/').map(toPathMatcher).reduceLeft(_ / _)
+  }
+
   val routes: Route =
     concat(
-      pathPrefix(contextPath) {
+      pathPrefix(contextPathMatcher) {
         concat(
           pathEndOrSingleSlash { redirectToIndex },
           path(yamlName) { complete(yaml) },


### PR DESCRIPTION
This solves #694 without an API change. No deprecations are necessary.