### PR TITLE
improve handling of missing authorization

### DIFF
--- a/core/src/main/scala/sttp/tapir/server/AuthenticationFailureHandler.scala
+++ b/core/src/main/scala/sttp/tapir/server/AuthenticationFailureHandler.scala
@@ -3,7 +3,7 @@ package sttp.tapir.server
 import sttp.model.StatusCode
 import sttp.tapir._
 
-class AuthorizationFailureHandler(handle: AuthorizationFailureHandler.Handle, next: DecodeFailureHandler) extends DecodeFailureHandler {
+class AuthenticationFailureHandler(handle: AuthenticationFailureHandler.Handle, next: DecodeFailureHandler) extends DecodeFailureHandler {
   override def apply(ctx: DecodeFailureContext): DecodeFailureHandling = handle(ctx) match {
     case DecodeFailureHandling.NoMatch => next(ctx)
     case handled                       => handled
@@ -14,9 +14,9 @@ sealed trait AuthChallenge extends Product with Serializable {
   def output: EndpointOutput[Unit]
 }
 final case class WWWAuthenticate(authType: String, realm: String, charset: Option[String] = None) extends AuthChallenge {
- override def output: EndpointOutput[Unit] = {
-    val cs = charset.fold("")(", " + _)
-    header("WWW-Authenticate", s"$authType realm=$realm$cs")
+  override def output: EndpointOutput[Unit] = {
+    val cs = charset.fold("")(cs => s""",  charset="$cs"""") // TODO szczygi test it too
+    header("WWW-Authenticate", s"""$authType realm="$realm"$cs""") // TODO szczygi escape "?
   }
 }
 case object NoChallenge extends AuthChallenge {
@@ -24,12 +24,12 @@ case object NoChallenge extends AuthChallenge {
 }
 
 object AuthChallenge {
-  def basic(realm: String, charset: Option[String]): AuthChallenge = WWWAuthenticate("Basic", realm, charset)
-  def bearer(realm: String, charset: Option[String]): AuthChallenge = WWWAuthenticate("Bearer", realm, charset)
+  def basic(realm: String, charset: Option[String] = None): AuthChallenge = WWWAuthenticate("Basic", realm, charset)
+  def bearer(realm: String, charset: Option[String] = None): AuthChallenge = WWWAuthenticate("Bearer", realm, charset)
   def none: AuthChallenge = NoChallenge
 }
 
-object AuthorizationFailureHandler {
+object AuthenticationFailureHandler {
   private val headerName = "Authorization"
   type Handle = DecodeFailureContext => DecodeFailureHandling
 

--- a/core/src/main/scala/sttp/tapir/server/AuthorizationFailureHandler.scala
+++ b/core/src/main/scala/sttp/tapir/server/AuthorizationFailureHandler.scala
@@ -1,0 +1,45 @@
+package sttp.tapir.server
+
+import sttp.model.StatusCode
+import sttp.tapir._
+
+class AuthorizationFailureHandler(handle: AuthorizationFailureHandler.Handle, next: DecodeFailureHandler) extends DecodeFailureHandler {
+  override def apply(ctx: DecodeFailureContext): DecodeFailureHandling = handle(ctx) match {
+    case DecodeFailureHandling.NoMatch => next(ctx)
+    case handled                       => handled
+  }
+}
+
+sealed trait AuthChallenge extends Product with Serializable {
+  def output: EndpointOutput[Unit]
+}
+final case class WWWAuthenticate(authType: String, realm: String, charset: Option[String] = None) extends AuthChallenge {
+ override def output: EndpointOutput[Unit] = {
+    val cs = charset.fold("")(", " + _)
+    header("WWW-Authenticate", s"$authType realm=$realm$cs")
+  }
+}
+case object NoChallenge extends AuthChallenge {
+  override def output: EndpointOutput[Unit] = emptyOutput
+}
+
+object AuthChallenge {
+  def basic(realm: String, charset: Option[String]): AuthChallenge = WWWAuthenticate("Basic", realm, charset)
+  def bearer(realm: String, charset: Option[String]): AuthChallenge = WWWAuthenticate("Bearer", realm, charset)
+  def none: AuthChallenge = NoChallenge
+}
+
+object AuthorizationFailureHandler {
+  private val headerName = "Authorization"
+  type Handle = DecodeFailureContext => DecodeFailureHandling
+
+  def handleMissingAuthorizationHeader(authChallenge: AuthChallenge): Handle = {
+    case DecodeFailureContext(h: EndpointIO.Header[_], _) if h.name == headerName =>
+      response(authChallenge)
+    case _ => DecodeFailureHandling.NoMatch
+  }
+
+  private def response(challenge: AuthChallenge) = {
+    DecodeFailureHandling.response(statusCode(StatusCode.Unauthorized).and(challenge.output))(())
+  }
+}

--- a/core/src/main/scala/sttp/tapir/server/ServerDefaults.scala
+++ b/core/src/main/scala/sttp/tapir/server/ServerDefaults.scala
@@ -30,6 +30,14 @@ object ServerDefaults {
       FailureMessages.failureMessage
     )
 
+  // TODO szczygi docs
+  def decodeFailureHandlerWithAuthentication(// TODO szczygi better name
+      handler: AuthenticationFailureHandler.Handle
+  ): DecodeFailureHandler =
+    {
+      new AuthenticationFailureHandler(handler, decodeFailureHandler)
+    }
+
   object FailureHandling {
     val failureOutput: EndpointOutput[(StatusCode, String)] = statusCode.and(stringBody)
 

--- a/examples/src/main/scala/sttp/tapir/examples/BasicAuthenticationServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BasicAuthenticationServer.scala
@@ -1,0 +1,43 @@
+package sttp.tapir.examples
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Route
+import sttp.client3._
+import sttp.model.StatusCode
+import sttp.tapir._
+import sttp.tapir.model._
+import sttp.tapir.server.{AuthChallenge, AuthenticationFailureHandler}
+import sttp.tapir.server.akkahttp._
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+object BasicAuthenticationServer extends App {
+  private val failureHandler = AuthenticationFailureHandler.handleMissingAuthorizationHeader(AuthChallenge.basic("secret"))
+  private implicit val serverOptions: AkkaHttpServerOptions = AkkaHttpServerOptions.default.copy(decodeFailureHandler = failureHandler)
+  val secret: Endpoint[UsernamePassword, Unit, String, Any] =
+    endpoint.get.in("secret").in(auth.basic[UsernamePassword]).out(stringBody)
+
+  val secretRoute: Route = secret.toRoute(credentials => Future.successful(Right(s"Hello, ${credentials.username}!")))
+
+  // starting the server
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
+  val bindAndCheck = Http().newServerAt("localhost", 8080).bindFlow(secretRoute).map { _ =>
+    // testing
+    val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
+    val unauthorized = basicRequest.get(uri"http://localhost:8080/secret").send(backend)
+    println("Got result: " + unauthorized)
+    assert(unauthorized.code == StatusCode.Unauthorized)
+    assert(unauthorized.header("WWW-Authenticate").contains("""Basic realm="secret""""))
+
+    val result = basicRequest.get(uri"http://localhost:8080/secret").header("Authorization", "Basic dXNlcjpzZWNyZXQ=").send(backend)
+    println("Got result: " + result)
+    assert(result.code == StatusCode.Ok)
+    assert(result.body == Right("Hello, user!"))
+  }
+
+  Await.result(bindAndCheck.transformWith { r => actorSystem.terminate().transform(_ => r) }, 1.minute)
+}

--- a/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerTests.scala
+++ b/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerTests.scala
@@ -12,7 +12,14 @@ import sttp.client3._
 import sttp.monad.FutureMonad
 import sttp.monad.syntax._
 import sttp.tapir._
-import sttp.tapir.server.tests.{ServerBasicTests, ServerStreamingTests, ServerTests, ServerWebSocketTests, backendResource}
+import sttp.tapir.server.tests.{
+  ServerAuthenticationTests,
+  ServerBasicTests,
+  ServerStreamingTests,
+  ServerTests,
+  ServerWebSocketTests,
+  backendResource
+}
 import sttp.tapir.tests.{Test, TestSuite}
 
 class AkkaHttpServerTests extends TestSuite {
@@ -44,6 +51,7 @@ class AkkaHttpServerTests extends TestSuite {
         new ServerWebSocketTests(backend, serverTests, AkkaStreams) {
           override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = Flow.fromFunction(f)
         }.tests() ++
+        new ServerAuthenticationTests(backend, serverTests).tests() ++
         additionalTests()
     }
   }

--- a/server/finatra-server/finatra-server-cats/src/test/scala/sttp/tapir/server/finatra/cats/FinatraServerCatsTests.scala
+++ b/server/finatra-server/finatra-server-cats/src/test/scala/sttp/tapir/server/finatra/cats/FinatraServerCatsTests.scala
@@ -2,7 +2,7 @@ package sttp.tapir.server.finatra.cats
 
 import cats.effect.{IO, Resource}
 import sttp.client3.impl.cats.CatsMonadAsyncError
-import sttp.tapir.server.tests.{ServerBasicTests, ServerTests, backendResource}
+import sttp.tapir.server.tests.{ServerAuthenticationTests, ServerBasicTests, ServerTests, backendResource}
 import sttp.tapir.tests.{Test, TestSuite}
 
 class FinatraServerCatsTests extends TestSuite {
@@ -11,6 +11,6 @@ class FinatraServerCatsTests extends TestSuite {
     val interpreter = new FinatraServerCatsInterpreter()
     val serverTests = new ServerTests(interpreter)
 
-    new ServerBasicTests(backend, serverTests, interpreter).tests()
+    new ServerBasicTests(backend, serverTests, interpreter).tests() ++ new ServerAuthenticationTests(backend, serverTests).tests()
   }
 }

--- a/server/finatra-server/src/test/scala/sttp/tapir/server/finatra/FinatraServerTests.scala
+++ b/server/finatra-server/src/test/scala/sttp/tapir/server/finatra/FinatraServerTests.scala
@@ -2,7 +2,7 @@ package sttp.tapir.server.finatra
 
 import cats.effect.{IO, Resource}
 import sttp.tapir.server.finatra
-import sttp.tapir.server.tests.{ServerBasicTests, ServerTests, backendResource}
+import sttp.tapir.server.tests.{ServerAuthenticationTests, ServerBasicTests, ServerTests, backendResource}
 import sttp.tapir.tests.{Test, TestSuite}
 
 class FinatraServerTests extends TestSuite {
@@ -12,6 +12,6 @@ class FinatraServerTests extends TestSuite {
     val interpreter = new FinatraServerInterpreter()
     val serverTests = new ServerTests(interpreter)
 
-    new ServerBasicTests(backend, serverTests, interpreter).tests()
+    new ServerBasicTests(backend, serverTests, interpreter).tests() ++ new ServerAuthenticationTests(backend, serverTests).tests()
   }
 }

--- a/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerTests.scala
+++ b/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerTests.scala
@@ -10,7 +10,7 @@ import sttp.capabilities.WebSockets
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3._
 import sttp.tapir._
-import sttp.tapir.server.tests.{ServerBasicTests, ServerStreamingTests, ServerTests, ServerWebSocketTests, backendResource}
+import sttp.tapir.server.tests.{ServerAuthenticationTests, ServerBasicTests, ServerStreamingTests, ServerTests, ServerWebSocketTests, backendResource}
 import sttp.tapir.tests.{Test, TestSuite}
 import sttp.ws.{WebSocket, WebSocketFrame}
 
@@ -64,6 +64,7 @@ class Http4sServerTests[R >: Fs2Streams[IO] with WebSockets] extends TestSuite {
       new ServerWebSocketTests(backend, serverTests, Fs2Streams[IO]) {
         override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = in => in.map(f)
       }.tests() ++
+      new ServerAuthenticationTests(backend, serverTests).tests() ++
       additionalTests()
   }
 }

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTests.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTests.scala
@@ -3,7 +3,7 @@ package sttp.tapir.server.play
 import akka.actor.ActorSystem
 import cats.effect.{IO, Resource}
 import sttp.monad.FutureMonad
-import sttp.tapir.server.tests.{ServerBasicTests, ServerTests, backendResource}
+import sttp.tapir.server.tests.{ServerAuthenticationTests, ServerBasicTests, ServerTests, backendResource}
 import sttp.tapir.tests.{Test, TestSuite}
 
 class PlayServerTests extends TestSuite {
@@ -24,7 +24,7 @@ class PlayServerTests extends TestSuite {
         multipleValueHeaderSupport = false,
         multipartInlineHeaderSupport = false,
         inputStreamSupport = false
-      ).tests()
+      ).tests() ++ new ServerAuthenticationTests(backend, serverTests).tests()
     }
   }
 }

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerAuthenticationTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerAuthenticationTests.scala
@@ -1,0 +1,45 @@
+package sttp.tapir.server.tests
+
+import cats.effect.IO
+import org.scalatest.matchers.should.Matchers
+import sttp.client3._
+import sttp.model.StatusCode
+import sttp.monad.MonadError
+import sttp.tapir._
+import sttp.tapir.server.{AuthChallenge, AuthenticationFailureHandler, ServerDefaults}
+import sttp.tapir.tests.{Test}
+import cats.implicits._
+
+class ServerAuthenticationTests[F[_], S, ROUTE](backend: SttpBackend[IO, Any], serverTests: ServerTests[F, S, ROUTE])(implicit
+    m: MonadError[F]
+) extends Matchers {
+  import serverTests._
+  import AuthenticationFailureHandler._
+
+  private val authedEndpoint: Endpoint[String, Unit, Unit, Any] = endpoint.in(header[String]("Authorization"))
+  private val realm = "access to the secret place"
+
+  private val challengeBasic =
+    ServerDefaults.decodeFailureHandlerWithAuthentication(handleMissingAuthorizationHeader(AuthChallenge.basic(realm)))
+  private val challengeBearer =
+    ServerDefaults.decodeFailureHandlerWithAuthentication(handleMissingAuthorizationHeader(AuthChallenge.bearer(realm)))
+  private val noChallenge = ServerDefaults.decodeFailureHandlerWithAuthentication(handleMissingAuthorizationHeader(AuthChallenge.none))
+
+  private val result = m.unit(().asRight[Unit])
+
+  private val wwwAuth = List(
+    ("unauthorized with basic challenge", challengeBasic, Some("""Basic realm="access to the secret place"""")),
+    ("unauthorized with bearer challenge", challengeBearer, Some("""Bearer realm="access to the secret place"""")),
+    ("unauthorized without challenge", noChallenge, None)
+  ).map { case (suffix, failureHandler, wwwAuth) =>
+    testServer(authedEndpoint, suffix, Some(failureHandler))((_: String) => result) { baseUri =>
+      basicRequest.get(baseUri).send(backend).map { r =>
+        r.code shouldBe StatusCode.Unauthorized
+        r.header("WWW-Authenticate") shouldBe wwwAuth
+      }
+    }
+  }
+
+  def tests(): List[Test] = wwwAuth
+
+}

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -2,7 +2,6 @@ package sttp.tapir.server.tests
 
 import java.io.{ByteArrayInputStream, File, InputStream}
 import java.nio.ByteBuffer
-
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.implicits._
@@ -14,7 +13,7 @@ import sttp.monad.MonadError
 import sttp.tapir._
 import sttp.tapir.json.circe._
 import sttp.tapir.model.UsernamePassword
-import sttp.tapir.server.{DecodeFailureHandler, ServerDefaults}
+import sttp.tapir.server.{AuthenticationFailureHandler, DecodeFailureHandler, DefaultDecodeFailureHandler, ServerDefaults}
 import sttp.tapir.tests.TestUtil._
 import sttp.tapir.tests._
 import org.scalatest.matchers.should.Matchers._

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxBlockingServerTests.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxBlockingServerTests.scala
@@ -3,7 +3,7 @@ package sttp.tapir.server.vertx
 import cats.effect.{IO, Resource}
 import io.vertx.scala.core.Vertx
 import sttp.monad.FutureMonad
-import sttp.tapir.server.tests.{ServerBasicTests, ServerTests, backendResource}
+import sttp.tapir.server.tests.{ServerAuthenticationTests, ServerBasicTests, ServerTests, backendResource}
 import sttp.tapir.tests.{Test, TestSuite}
 
 import scala.concurrent.ExecutionContext
@@ -23,7 +23,7 @@ class VertxBlockingServerTests extends TestSuite {
         serverTests,
         interpreter,
         multipartInlineHeaderSupport = false // README: doesn't seem supported but I may be wrong
-      ).tests()
+      ).tests() ++ new ServerAuthenticationTests(backend, serverTests).tests()
     }
   }
 }

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxServerTests.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxServerTests.scala
@@ -3,7 +3,7 @@ package sttp.tapir.server.vertx
 import cats.effect.{IO, Resource}
 import io.vertx.scala.core.Vertx
 import sttp.monad.FutureMonad
-import sttp.tapir.server.tests.{ServerBasicTests, ServerTests, backendResource}
+import sttp.tapir.server.tests.{ServerAuthenticationTests, ServerBasicTests, ServerTests, backendResource}
 import sttp.tapir.tests.{Test, TestSuite}
 
 import scala.concurrent.ExecutionContext
@@ -23,7 +23,7 @@ class VertxServerTests extends TestSuite {
         serverTests,
         interpreter,
         multipartInlineHeaderSupport = false // README: doesn't seem supported but I may be wrong
-      ).tests()
+      ).tests() ++ new ServerAuthenticationTests(backend, serverTests).tests()
     }
   }
 }


### PR DESCRIPTION
this is some initial take on https://github.com/softwaremill/tapir/issues/864
Unfortunately currently it's not possible (at least without many breaking changes) to distinguish at the `DecodeFailureHandler` level if we are dealing with authorization error or not, as what we would get in `DecodeFailureContext.input` [here](https://github.com/softwaremill/tapir/blob/master/core/src/main/scala/sttp/tapir/server/ServerDefaults.scala#L53) is underlying input of the `EndpointInput.Auth` (for example `Authorization` header). However I think this case is common enough so maybe we could include some middle ground solution and introduce `DecodeFailureHandling` that would handle commonly used authentication schemas?

This is an early stage work in progress just to know if this direction is fine
