### PR TITLE
JSON specific decode errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ project/plugins/project/
 .bloop
 .metals
 
+.bsp
 .idea*
 
 file-uploads

--- a/build.sbt
+++ b/build.sbt
@@ -303,7 +303,8 @@ lazy val circeJson: ProjectMatrix = (projectMatrix in file("json/circe"))
     name := "tapir-json-circe",
     libraryDependencies ++= Seq(
       "io.circe" %%% "circe-core" % Versions.circe,
-      "io.circe" %%% "circe-parser" % Versions.circe
+      "io.circe" %%% "circe-parser" % Versions.circe,
+      scalaTest.value % Test
     )
   )
   .jvmPlatform(scalaVersions = allScalaVersions)
@@ -371,7 +372,8 @@ lazy val tethysJson: ProjectMatrix = (projectMatrix in file("json/tethys"))
     name := "tapir-json-tethys",
     libraryDependencies ++= Seq(
       "com.tethys-json" %% "tethys-core" % Versions.tethys,
-      "com.tethys-json" %% "tethys-jackson" % Versions.tethys
+      "com.tethys-json" %% "tethys-jackson" % Versions.tethys,
+      scalaTest.value % Test
     )
   )
   .jvmPlatform(scalaVersions = allScalaVersions)
@@ -383,6 +385,7 @@ lazy val jsoniterScala: ProjectMatrix = (projectMatrix in file("json/jsoniter"))
     name := "tapir-jsoniter-scala",
     libraryDependencies ++= Seq(
       "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-core" % "2.6.2",
+      "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-macros" % "2.6.2" % Test,
       scalaTest.value % Test
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -304,7 +304,8 @@ lazy val circeJson: ProjectMatrix = (projectMatrix in file("json/circe"))
     libraryDependencies ++= Seq(
       "io.circe" %%% "circe-core" % Versions.circe,
       "io.circe" %%% "circe-parser" % Versions.circe,
-      scalaTest.value % Test
+      scalaTest.value % Test,
+      "io.circe" %%% "circe-generic" % Versions.circe % Test
     )
   )
   .jvmPlatform(scalaVersions = allScalaVersions)
@@ -373,7 +374,8 @@ lazy val tethysJson: ProjectMatrix = (projectMatrix in file("json/tethys"))
     libraryDependencies ++= Seq(
       "com.tethys-json" %% "tethys-core" % Versions.tethys,
       "com.tethys-json" %% "tethys-jackson" % Versions.tethys,
-      scalaTest.value % Test
+      scalaTest.value % Test,
+      "com.tethys-json" %% "tethys-derivation" % Versions.tethys % Test
     )
   )
   .jvmPlatform(scalaVersions = allScalaVersions)

--- a/core/src/main/scala/sttp/tapir/DecodeResult.scala
+++ b/core/src/main/scala/sttp/tapir/DecodeResult.scala
@@ -23,8 +23,11 @@ object DecodeResult {
           if (errors.isEmpty) underlying.getMessage else errors.map(_.message).mkString(", "),
           underlying
         )
-    case class JsonError(msg: String, atPath: Option[String]) {
-      def message: String = msg + atPath.map(path => s" at '$path'")
+    case class JsonError(msg: String, path: List[FieldName]) {
+      def message: String = {
+        val at = if (path.nonEmpty) s" at '${path.mkString(".")}'" else ""
+        msg + at
+      }
     }
   }
   case class Mismatch(expected: String, actual: String) extends Failure

--- a/core/src/main/scala/sttp/tapir/DecodeResult.scala
+++ b/core/src/main/scala/sttp/tapir/DecodeResult.scala
@@ -17,21 +17,18 @@ object DecodeResult {
   case object Missing extends Failure
   case class Multiple[R](vs: Seq[R]) extends Failure
   case class Error(original: String, error: Throwable) extends Failure
-  case class Mismatch(expected: String, actual: String) extends Failure
-  case class InvalidValue(errors: List[ValidationError[_]]) extends Failure
-  case class InvalidJson(
-      json: String,
-      errors: List[InvalidJson.Error],
-      underlying: Throwable
-  ) extends Failure {
-    def message: String =
-      if (errors.isEmpty) underlying.getMessage else errors.map(_.message).mkString(", ")
-  }
-  object InvalidJson {
-    case class Error(msg: String, atPath: Option[String]) {
+  object Error {
+    case class JsonDecodeException(errors: List[JsonError], underlying: Throwable)
+        extends Exception(
+          if (errors.isEmpty) underlying.getMessage else errors.map(_.message).mkString(", "),
+          underlying
+        )
+    case class JsonError(msg: String, atPath: Option[String]) {
       def message: String = msg + atPath.map(path => s" at '$path'")
     }
   }
+  case class Mismatch(expected: String, actual: String) extends Failure
+  case class InvalidValue(errors: List[ValidationError[_]]) extends Failure
 
   def sequence[T](results: Seq[DecodeResult[T]]): DecodeResult[Seq[T]] = {
     results.foldRight(Value(List.empty[T]): DecodeResult[Seq[T]]) { case (result, acc) =>

--- a/core/src/main/scala/sttp/tapir/DecodeResult.scala
+++ b/core/src/main/scala/sttp/tapir/DecodeResult.scala
@@ -19,6 +19,7 @@ object DecodeResult {
   case class Error(original: String, error: Throwable) extends Failure
   case class Mismatch(expected: String, actual: String) extends Failure
   case class InvalidValue(errors: List[ValidationError[_]]) extends Failure
+  case class InvalidJson(json: String, error: Throwable) extends Failure
 
   def sequence[T](results: Seq[DecodeResult[T]]): DecodeResult[Seq[T]] = {
     results.foldRight(Value(List.empty[T]): DecodeResult[Seq[T]]) { case (result, acc) =>

--- a/core/src/main/scala/sttp/tapir/DecodeResult.scala
+++ b/core/src/main/scala/sttp/tapir/DecodeResult.scala
@@ -25,7 +25,7 @@ object DecodeResult {
         )
     case class JsonError(msg: String, path: List[FieldName]) {
       def message: String = {
-        val at = if (path.nonEmpty) s" at '${path.mkString(".")}'" else ""
+        val at = if (path.nonEmpty) s" at '${path.map(_.encodedName).mkString(".")}'" else ""
         msg + at
       }
     }

--- a/core/src/main/scala/sttp/tapir/server/ServerDefaults.scala
+++ b/core/src/main/scala/sttp/tapir/server/ServerDefaults.scala
@@ -1,7 +1,8 @@
 package sttp.tapir.server
 
 import sttp.model.StatusCode
-import sttp.tapir.DecodeResult.InvalidValue
+import sttp.tapir.DecodeResult.Error.JsonDecodeException
+import sttp.tapir.DecodeResult.{Error, InvalidValue}
 import sttp.tapir._
 
 import scala.annotation.tailrec
@@ -124,6 +125,7 @@ object ServerDefaults {
 
       val detail = ctx.failure match {
         case InvalidValue(errors) if errors.nonEmpty => Some(ValidationMessages.validationErrorsMessage(errors))
+        case Error(_, error: JsonDecodeException)    => Some(error.getMessage)
         case _                                       => None
       }
 

--- a/core/src/test/scala/sttp/tapir/JsonDecodeExceptionTests.scala
+++ b/core/src/test/scala/sttp/tapir/JsonDecodeExceptionTests.scala
@@ -1,0 +1,26 @@
+package sttp.tapir
+
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
+
+class JsonDecodeExceptionTests extends AnyFlatSpecLike with Matchers {
+
+  it should "print failed paths" in {
+    val error = JsonDecodeException(
+      List(
+        JsonError("error.path.missing", List(FieldName("obj"), FieldName("customer"), FieldName("yearOfBirth"))),
+        JsonError("error.path.missing", List(FieldName("obj"), FieldName("items[0]"), FieldName("price")))
+      ),
+      new Exception("JsResultException")
+    )
+    error.getMessage shouldEqual
+      "error.path.missing at 'obj.customer.yearOfBirth', error.path.missing at 'obj.items[0].price'"
+  }
+
+  it should "print underlying exception message when there is no failed paths" in {
+    val error = JsonDecodeException(errors = List.empty, new Exception("ParseException"))
+    error.getMessage shouldEqual "ParseException"
+  }
+
+}

--- a/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
+++ b/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
@@ -3,7 +3,8 @@ package sttp.tapir.json.circe
 import io.circe._
 import io.circe.syntax._
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.{InvalidJson, Value}
+import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
+import sttp.tapir.DecodeResult.{Error, Value}
 import sttp.tapir.SchemaType._
 import sttp.tapir._
 
@@ -14,10 +15,10 @@ trait TapirJsonCirce {
     sttp.tapir.Codec.json[T] { s =>
       io.circe.parser.decode[T](s) match {
         case Left(failure @ ParsingFailure(msg, _)) =>
-          InvalidJson(s, List(InvalidJson.Error(msg, atPath = None)), failure)
+          Error(s, JsonDecodeException(List(JsonError(msg, atPath = None)), failure))
         case Left(failure: DecodingFailure) =>
           val path = CursorOp.opsToPath(failure.history)
-          InvalidJson(s, List(InvalidJson.Error(failure.message, Some(path))), failure)
+          Error(s, JsonDecodeException(List(JsonError(failure.message, Some(path))), failure))
         case Right(v) => Value(v)
       }
     } { t => jsonPrinter.print(t.asJson) }

--- a/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
+++ b/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
@@ -15,10 +15,11 @@ trait TapirJsonCirce {
     sttp.tapir.Codec.json[T] { s =>
       io.circe.parser.decode[T](s) match {
         case Left(failure @ ParsingFailure(msg, _)) =>
-          Error(s, JsonDecodeException(List(JsonError(msg, atPath = None)), failure))
+          Error(s, JsonDecodeException(List(JsonError(msg, path = List.empty)), failure))
         case Left(failure: DecodingFailure) =>
           val path = CursorOp.opsToPath(failure.history)
-          Error(s, JsonDecodeException(List(JsonError(failure.message, Some(path))), failure))
+          val fields = path.split("\\.").toList.filter(_.nonEmpty).map(FieldName.apply)
+          Error(s, JsonDecodeException(List(JsonError(failure.message, fields)), failure))
         case Right(v) => Value(v)
       }
     } { t => jsonPrinter.print(t.asJson) }

--- a/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
+++ b/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
@@ -3,7 +3,7 @@ package sttp.tapir.json.circe
 import io.circe._
 import io.circe.syntax._
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.{Error, Value}
+import sttp.tapir.DecodeResult.{InvalidJson, Value}
 import sttp.tapir.SchemaType._
 import sttp.tapir._
 
@@ -11,9 +11,9 @@ trait TapirJsonCirce {
   def jsonBody[T: Encoder: Decoder: Schema]: EndpointIO.Body[String, T] = anyFromUtf8StringBody(circeCodec[T])
 
   implicit def circeCodec[T: Encoder: Decoder: Schema]: JsonCodec[T] =
-    sttp.tapir.Codec.json { s =>
+    sttp.tapir.Codec.json[T] { s =>
       io.circe.parser.decode[T](s) match {
-        case Left(error) => Error(s, error)
+        case Left(error) => InvalidJson(s, error)
         case Right(v)    => Value(v)
       }
     } { t => jsonPrinter.print(t.asJson) }

--- a/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
+++ b/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
@@ -1,15 +1,29 @@
 package sttp.tapir.json.circe
 
+import io.circe.DecodingFailure
+import io.circe.generic.auto._
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import sttp.tapir.DecodeResult
+import sttp.tapir.generic.auto._
 
 class TapirJsonCirceTests extends AnyFlatSpecLike with Matchers {
 
+  case class Customer(name: String, yearOfBirth: Int, lastPurchase: Option[Long])
+
   it should "return a JSON specific decode error on failure" in {
-    val codec = circeCodec[String]
-    val actual = codec.decode("[]")
+    val codec = circeCodec[Customer]
+    val actual = codec.decode("{}")
     actual shouldBe a[DecodeResult.InvalidJson]
-    actual.asInstanceOf[DecodeResult.InvalidJson].json shouldEqual "[]"
+    val invalidJsonFailure = actual.asInstanceOf[DecodeResult.InvalidJson]
+    invalidJsonFailure.json shouldEqual "{}"
+    invalidJsonFailure.errors shouldEqual List(
+      DecodeResult.InvalidJson.Error(
+        "Attempt to decode value on failed cursor",
+        Some(".name")
+      )
+    )
+    invalidJsonFailure.underlying shouldBe a[DecodingFailure]
   }
+
 }

--- a/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
+++ b/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
@@ -4,24 +4,43 @@ import io.circe.DecodingFailure
 import io.circe.generic.auto._
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
-import sttp.tapir.DecodeResult
+import sttp.tapir.{DecodeResult, FieldName}
 import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
 import sttp.tapir.generic.auto._
 
 class TapirJsonCirceTests extends AnyFlatSpecLike with Matchers {
 
   case class Customer(name: String, yearOfBirth: Int, lastPurchase: Option[Long])
+  case class Item(serialNumber: Long, price: Int)
+  case class Order(items: Seq[Item], customer: Customer)
 
-  it should "return a JSON specific decode error on failure" in {
-    val codec = circeCodec[Customer]
-    val actual = codec.decode("{}")
+  val orderCodec = circeCodec[Customer]
+
+  it should "return a JSON specific error on object decode failure" in {
+    val input = """{"items":[]}"""
+    val actual = orderCodec.decode(input)
+
     actual shouldBe a[DecodeResult.Error]
     val failure = actual.asInstanceOf[DecodeResult.Error]
-    failure.original shouldEqual "{}"
+    failure.original shouldEqual input
     failure.error shouldBe a[JsonDecodeException]
     val error = failure.error.asInstanceOf[JsonDecodeException]
     error.errors shouldEqual
-      List(JsonError("Attempt to decode value on failed cursor", Some(".name")))
+      List(JsonError("Attempt to decode value on failed cursor", List(FieldName("name"))))
+    error.underlying shouldBe a[DecodingFailure]
+  }
+
+  it should "return a JSON specific error on array decode failure" in {
+    val input = """[{}]"""
+    val actual = circeCodec[Seq[Item]].decode(input)
+
+    actual shouldBe a[DecodeResult.Error]
+    val failure = actual.asInstanceOf[DecodeResult.Error]
+    failure.original shouldEqual input
+    failure.error shouldBe a[JsonDecodeException]
+    val error = failure.error.asInstanceOf[JsonDecodeException]
+    error.errors shouldEqual
+      List(JsonError("Attempt to decode value on failed cursor", List(FieldName("[0]"), FieldName("serialNumber"))))
     error.underlying shouldBe a[DecodingFailure]
   }
 

--- a/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
+++ b/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
@@ -1,0 +1,15 @@
+package sttp.tapir.json.circe
+
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import sttp.tapir.DecodeResult
+
+class TapirJsonCirceTests extends AnyFlatSpecLike with Matchers {
+
+  it should "return a JSON specific decode error on failure" in {
+    val codec = circeCodec[String]
+    val actual = codec.decode("[]")
+    actual shouldBe a[DecodeResult.InvalidJson]
+    actual.asInstanceOf[DecodeResult.InvalidJson].json shouldEqual "[]"
+  }
+}

--- a/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
+++ b/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
@@ -5,6 +5,7 @@ import io.circe.generic.auto._
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import sttp.tapir.DecodeResult
+import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
 import sttp.tapir.generic.auto._
 
 class TapirJsonCirceTests extends AnyFlatSpecLike with Matchers {
@@ -14,16 +15,14 @@ class TapirJsonCirceTests extends AnyFlatSpecLike with Matchers {
   it should "return a JSON specific decode error on failure" in {
     val codec = circeCodec[Customer]
     val actual = codec.decode("{}")
-    actual shouldBe a[DecodeResult.InvalidJson]
-    val invalidJsonFailure = actual.asInstanceOf[DecodeResult.InvalidJson]
-    invalidJsonFailure.json shouldEqual "{}"
-    invalidJsonFailure.errors shouldEqual List(
-      DecodeResult.InvalidJson.Error(
-        "Attempt to decode value on failed cursor",
-        Some(".name")
-      )
-    )
-    invalidJsonFailure.underlying shouldBe a[DecodingFailure]
+    actual shouldBe a[DecodeResult.Error]
+    val failure = actual.asInstanceOf[DecodeResult.Error]
+    failure.original shouldEqual "{}"
+    failure.error shouldBe a[JsonDecodeException]
+    val error = failure.error.asInstanceOf[JsonDecodeException]
+    error.errors shouldEqual
+      List(JsonError("Attempt to decode value on failed cursor", Some(".name")))
+    error.underlying shouldBe a[DecodingFailure]
   }
 
 }

--- a/json/jsoniter/src/main/scala/sttp/tapir/json/jsoniter/TapirJsonJsoniter.scala
+++ b/json/jsoniter/src/main/scala/sttp/tapir/json/jsoniter/TapirJsonJsoniter.scala
@@ -14,7 +14,7 @@ trait TapirJsonJsoniter {
   implicit def jsoniterCodec[T: JsonValueCodec: Schema]: JsonCodec[T] =
     sttp.tapir.Codec.json { s =>
       Try(readFromString[T](s)) match {
-        case Failure(error) => InvalidJson(s, error)
+        case Failure(error) => InvalidJson(s, List.empty, error)
         case Success(v)     => Value(v)
       }
     } { t => writeToString[T](t) }

--- a/json/jsoniter/src/main/scala/sttp/tapir/json/jsoniter/TapirJsonJsoniter.scala
+++ b/json/jsoniter/src/main/scala/sttp/tapir/json/jsoniter/TapirJsonJsoniter.scala
@@ -2,9 +2,10 @@ package sttp.tapir.json.jsoniter
 
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.{InvalidJson, Value}
+import sttp.tapir.DecodeResult.{Error, Value}
 import sttp.tapir.{EndpointIO, Schema, Validator, anyFromUtf8StringBody}
 import com.github.plokhotnyuk.jsoniter_scala.core._
+import sttp.tapir.DecodeResult.Error.JsonDecodeException
 
 import scala.util.{Failure, Success, Try}
 
@@ -14,7 +15,7 @@ trait TapirJsonJsoniter {
   implicit def jsoniterCodec[T: JsonValueCodec: Schema]: JsonCodec[T] =
     sttp.tapir.Codec.json { s =>
       Try(readFromString[T](s)) match {
-        case Failure(error) => InvalidJson(s, List.empty, error)
+        case Failure(error) => Error(s, JsonDecodeException(errors = List.empty, error))
         case Success(v)     => Value(v)
       }
     } { t => writeToString[T](t) }

--- a/json/jsoniter/src/main/scala/sttp/tapir/json/jsoniter/TapirJsonJsoniter.scala
+++ b/json/jsoniter/src/main/scala/sttp/tapir/json/jsoniter/TapirJsonJsoniter.scala
@@ -2,7 +2,7 @@ package sttp.tapir.json.jsoniter
 
 import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.{Error, Value}
+import sttp.tapir.DecodeResult.{InvalidJson, Value}
 import sttp.tapir.{EndpointIO, Schema, Validator, anyFromUtf8StringBody}
 import com.github.plokhotnyuk.jsoniter_scala.core._
 
@@ -14,7 +14,7 @@ trait TapirJsonJsoniter {
   implicit def jsoniterCodec[T: JsonValueCodec: Schema]: JsonCodec[T] =
     sttp.tapir.Codec.json { s =>
       Try(readFromString[T](s)) match {
-        case Failure(error) => Error(s, error)
+        case Failure(error) => InvalidJson(s, error)
         case Success(v)     => Value(v)
       }
     } { t => writeToString[T](t) }

--- a/json/jsoniter/src/test/scala/sttp/tapir/json/jsoniter/TapirJsonJsoniterTests.scala
+++ b/json/jsoniter/src/test/scala/sttp/tapir/json/jsoniter/TapirJsonJsoniterTests.scala
@@ -5,6 +5,7 @@ import com.github.plokhotnyuk.jsoniter_scala.macros._
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import sttp.tapir.DecodeResult
+import sttp.tapir.DecodeResult.Error.JsonDecodeException
 import sttp.tapir.generic.auto._
 
 object TapirJsoniterCodec extends TapirJsonJsoniter
@@ -17,11 +18,13 @@ class TapirJsonJsoniterTests extends AnyFlatSpecLike with Matchers {
     implicit val codec: JsonValueCodec[Customer] = JsonCodecMaker.make
     val tapirCodec = TapirJsoniterCodec.jsoniterCodec[Customer]
     val actual = tapirCodec.decode("{}")
-    actual shouldBe a[DecodeResult.InvalidJson]
-    val invalidJsonFailure = actual.asInstanceOf[DecodeResult.InvalidJson]
-    invalidJsonFailure.json shouldEqual "{}"
-    invalidJsonFailure.errors shouldEqual List.empty
-    invalidJsonFailure.underlying shouldBe a[JsonReaderException]
+    actual shouldBe a[DecodeResult.Error]
+    val failure = actual.asInstanceOf[DecodeResult.Error]
+    failure.original shouldEqual "{}"
+    failure.error shouldBe a[JsonDecodeException]
+    val error = failure.error.asInstanceOf[JsonDecodeException]
+    error.errors shouldEqual List.empty
+    error.underlying shouldBe a[JsonReaderException]
   }
 
 }

--- a/json/jsoniter/src/test/scala/sttp/tapir/json/jsoniter/TapirJsonJsoniterTests.scala
+++ b/json/jsoniter/src/test/scala/sttp/tapir/json/jsoniter/TapirJsonJsoniterTests.scala
@@ -5,16 +5,23 @@ import com.github.plokhotnyuk.jsoniter_scala.macros._
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import sttp.tapir.DecodeResult
+import sttp.tapir.generic.auto._
 
 object TapirJsoniterCodec extends TapirJsonJsoniter
 
 class TapirJsonJsoniterTests extends AnyFlatSpecLike with Matchers {
 
+  case class Customer(name: String, yearOfBirth: Int, lastPurchase: Option[Long])
+
   it should "return a JSON specific decode error on failure" in {
-    implicit val codec: JsonValueCodec[String] = JsonCodecMaker.make
-    val tapirCodec = TapirJsoniterCodec.jsoniterCodec[String]
-    val actual = tapirCodec.decode("[]")
+    implicit val codec: JsonValueCodec[Customer] = JsonCodecMaker.make
+    val tapirCodec = TapirJsoniterCodec.jsoniterCodec[Customer]
+    val actual = tapirCodec.decode("{}")
     actual shouldBe a[DecodeResult.InvalidJson]
-    actual.asInstanceOf[DecodeResult.InvalidJson].json shouldEqual "[]"
+    val invalidJsonFailure = actual.asInstanceOf[DecodeResult.InvalidJson]
+    invalidJsonFailure.json shouldEqual "{}"
+    invalidJsonFailure.errors shouldEqual List.empty
+    invalidJsonFailure.underlying shouldBe a[JsonReaderException]
   }
+
 }

--- a/json/jsoniter/src/test/scala/sttp/tapir/json/jsoniter/TapirJsonJsoniterTests.scala
+++ b/json/jsoniter/src/test/scala/sttp/tapir/json/jsoniter/TapirJsonJsoniterTests.scala
@@ -1,0 +1,20 @@
+package sttp.tapir.json.jsoniter
+
+import com.github.plokhotnyuk.jsoniter_scala.core._
+import com.github.plokhotnyuk.jsoniter_scala.macros._
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import sttp.tapir.DecodeResult
+
+object TapirJsoniterCodec extends TapirJsonJsoniter
+
+class TapirJsonJsoniterTests extends AnyFlatSpecLike with Matchers {
+
+  it should "return a JSON specific decode error on failure" in {
+    implicit val codec: JsonValueCodec[String] = JsonCodecMaker.make
+    val tapirCodec = TapirJsoniterCodec.jsoniterCodec[String]
+    val actual = tapirCodec.decode("[]")
+    actual shouldBe a[DecodeResult.InvalidJson]
+    actual.asInstanceOf[DecodeResult.InvalidJson].json shouldEqual "[]"
+  }
+}

--- a/json/playjson/src/main/scala/sttp/tapir/json/play/TapirJsonPlay.scala
+++ b/json/playjson/src/main/scala/sttp/tapir/json/play/TapirJsonPlay.scala
@@ -16,10 +16,11 @@ trait TapirJsonPlay {
         case JsError(errors) =>
           val jsonErrors = errors
             .flatMap { case (path, validationErrors) =>
-              validationErrors.map(error => path -> error)
+              val fields = path.toJsonString.split("\\.").toList.map(FieldName.apply)
+              validationErrors.map(error => fields -> error)
             }
-            .map { case (path, validationError) =>
-              JsonError(validationError.message, Some(path.toJsonString))
+            .map { case (fields, validationError) =>
+              JsonError(validationError.message, fields)
             }
             .toList
           Error(s, JsonDecodeException(jsonErrors, JsResultException(errors)))

--- a/json/playjson/src/main/scala/sttp/tapir/json/play/TapirJsonPlay.scala
+++ b/json/playjson/src/main/scala/sttp/tapir/json/play/TapirJsonPlay.scala
@@ -4,7 +4,8 @@ import play.api.libs.json._
 import sttp.tapir._
 import sttp.tapir.SchemaType._
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.{InvalidJson, Value}
+import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
+import sttp.tapir.DecodeResult.{Error, Value}
 
 trait TapirJsonPlay {
   def jsonBody[T: Reads: Writes: Schema]: EndpointIO.Body[String, T] = anyFromUtf8StringBody(readsWritesCodec[T])
@@ -18,10 +19,10 @@ trait TapirJsonPlay {
               validationErrors.map(error => path -> error)
             }
             .map { case (path, validationError) =>
-              InvalidJson.Error(validationError.message, Some(path.toJsonString))
+              JsonError(validationError.message, Some(path.toJsonString))
             }
             .toList
-          InvalidJson(s, jsonErrors, JsResultException(errors))
+          Error(s, JsonDecodeException(jsonErrors, JsResultException(errors)))
         case JsSuccess(value, _) => Value(value)
       }
     } { t => Json.stringify(Json.toJson(t)) }

--- a/json/playjson/src/main/scala/sttp/tapir/json/play/TapirJsonPlay.scala
+++ b/json/playjson/src/main/scala/sttp/tapir/json/play/TapirJsonPlay.scala
@@ -4,7 +4,7 @@ import play.api.libs.json._
 import sttp.tapir._
 import sttp.tapir.SchemaType._
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.{Error, Value}
+import sttp.tapir.DecodeResult.{InvalidJson, Value}
 
 trait TapirJsonPlay {
   def jsonBody[T: Reads: Writes: Schema]: EndpointIO.Body[String, T] = anyFromUtf8StringBody(readsWritesCodec[T])
@@ -12,7 +12,7 @@ trait TapirJsonPlay {
   implicit def readsWritesCodec[T: Reads: Writes: Schema]: JsonCodec[T] =
     Codec.json[T] { s =>
       implicitly[Reads[T]].reads(Json.parse(s)) match {
-        case JsError(errors)     => Error(s, JsResultException(errors))
+        case JsError(errors)     => InvalidJson(s, JsResultException(errors))
         case JsSuccess(value, _) => Value(value)
       }
     } { t => Json.stringify(Json.toJson(t)) }

--- a/json/playjson/src/test/scala/sttp/tapir/json/play/TapirJsonPlayTests.scala
+++ b/json/playjson/src/test/scala/sttp/tapir/json/play/TapirJsonPlayTests.scala
@@ -57,4 +57,11 @@ class TapirJsonPlayTests extends AnyFlatSpec with TapirJsonPlayTestExtensions wi
     val expected = """{"name":"Alita","yearOfBirth":1985}"""
     codec.encode(customer) shouldBe expected
   }
+
+  it should "return a JSON specific decode error on failure" in {
+    val codec = TapirJsonPlayCodec.readsWritesCodec[String]
+    val actual = codec.decode("[]")
+    actual shouldBe a[DecodeResult.InvalidJson]
+    actual.asInstanceOf[DecodeResult.InvalidJson].json shouldEqual "[]"
+  }
 }

--- a/json/playjson/src/test/scala/sttp/tapir/json/play/TapirJsonPlayTests.scala
+++ b/json/playjson/src/test/scala/sttp/tapir/json/play/TapirJsonPlayTests.scala
@@ -59,9 +59,15 @@ class TapirJsonPlayTests extends AnyFlatSpec with TapirJsonPlayTestExtensions wi
   }
 
   it should "return a JSON specific decode error on failure" in {
-    val codec = TapirJsonPlayCodec.readsWritesCodec[String]
-    val actual = codec.decode("[]")
+    val codec = TapirJsonPlayCodec.readsWritesCodec[Customer]
+    val actual = codec.decode("{}")
     actual shouldBe a[DecodeResult.InvalidJson]
-    actual.asInstanceOf[DecodeResult.InvalidJson].json shouldEqual "[]"
+    val failure = actual.asInstanceOf[InvalidJson]
+    failure.json shouldEqual "{}"
+    failure.errors shouldEqual List(
+      InvalidJson.Error("error.path.missing", Some("obj.yearOfBirth")),
+      InvalidJson.Error("error.path.missing", Some("obj.name"))
+    )
+    failure.underlying shouldBe a[JsResultException]
   }
 }

--- a/json/playjson/src/test/scala/sttp/tapir/json/play/TapirJsonPlayTests.scala
+++ b/json/playjson/src/test/scala/sttp/tapir/json/play/TapirJsonPlayTests.scala
@@ -18,7 +18,18 @@ class TapirJsonPlayTests extends AnyFlatSpec with TapirJsonPlayTestExtensions wi
     implicit val rw: Format[Customer] = Json.format
   }
 
+  case class Item(serialNumber: Long, price: Int)
+  object Item {
+    implicit val itemFmt: Format[Item] = Json.format
+  }
+
+  case class Order(items: Seq[Item], customer: Customer)
+  object Order {
+    implicit val orderFmt: Format[Order] = Json.format
+  }
+
   val customerDecoder = TapirJsonPlayCodec.readsWritesCodec[Customer]
+  val orderCodec = TapirJsonPlayCodec.readsWritesCodec[Order]
 
   // Helper to test encoding then decoding an object is the same as the original
   def testEncodeDecode[T: Format: Schema](original: T): Assertion = {
@@ -58,18 +69,37 @@ class TapirJsonPlayTests extends AnyFlatSpec with TapirJsonPlayTestExtensions wi
     codec.encode(customer) shouldBe expected
   }
 
-  it should "return a JSON specific decode error on failure" in {
-    val codec = TapirJsonPlayCodec.readsWritesCodec[Customer]
-    val actual = codec.decode("{}")
+  it should "return a JSON specific error on object decode failure" in {
+    val input = """{"items":[{"serialNumber":1}], "customer":{"name":"Alita"}}"""
+    val actual = orderCodec.decode(input)
+
     actual shouldBe a[DecodeResult.Error]
     val failure = actual.asInstanceOf[DecodeResult.Error]
-    failure.original shouldEqual "{}"
+    failure.original shouldEqual input
     failure.error shouldBe a[JsonDecodeException]
     val error = failure.error.asInstanceOf[JsonDecodeException]
-    error.errors shouldEqual List(
-      JsonError("error.path.missing", Some("obj.yearOfBirth")),
-      JsonError("error.path.missing", Some("obj.name"))
+    error.errors should contain theSameElementsAs List(
+      JsonError("error.path.missing", List(FieldName("obj"), FieldName("customer"), FieldName("yearOfBirth"))),
+      JsonError("error.path.missing", List(FieldName("obj"), FieldName("items[0]"), FieldName("price")))
     )
     error.underlying shouldBe a[JsResultException]
   }
+
+  it should "return a JSON specific error on array decode failure" in {
+    val itemsCodec = TapirJsonPlayCodec.readsWritesCodec[Seq[Item]]
+
+    val input = """[{"serialNumber":1}]"""
+    val actual = itemsCodec.decode(input)
+
+    actual shouldBe a[DecodeResult.Error]
+    val failure = actual.asInstanceOf[DecodeResult.Error]
+    failure.original shouldEqual input
+    failure.error shouldBe a[JsonDecodeException]
+    val error = failure.error.asInstanceOf[JsonDecodeException]
+    error.errors shouldEqual List(
+      JsonError("error.path.missing", List(FieldName("obj[0]"), FieldName("price")))
+    )
+    error.underlying shouldBe a[JsResultException]
+  }
+
 }

--- a/json/sprayjson/src/main/scala/sttp/tapir/json/spray/TapirJsonSpray.scala
+++ b/json/sprayjson/src/main/scala/sttp/tapir/json/spray/TapirJsonSpray.scala
@@ -15,7 +15,11 @@ trait TapirJsonSpray {
     Codec.json { s =>
       Try(s.parseJson.convertTo[T]) match {
         case Success(v) => Value(v)
-        case Failure(e) => InvalidJson(s, e)
+        case Failure(e @ DeserializationException(msg, _, fieldNames)) =>
+          val errors = fieldNames.map(field => InvalidJson.Error(msg, Some(field)))
+          InvalidJson(s, errors, e)
+        case Failure(e) =>
+          InvalidJson(s, errors = List.empty, e)
       }
     } { t => t.toJson.toString() }
 

--- a/json/sprayjson/src/main/scala/sttp/tapir/json/spray/TapirJsonSpray.scala
+++ b/json/sprayjson/src/main/scala/sttp/tapir/json/spray/TapirJsonSpray.scala
@@ -17,8 +17,8 @@ trait TapirJsonSpray {
       Try(s.parseJson.convertTo[T]) match {
         case Success(v) => Value(v)
         case Failure(e @ DeserializationException(msg, _, fieldNames)) =>
-          val errors = fieldNames.map(field => JsonError(msg, Some(field)))
-          Error(s, JsonDecodeException(errors, e))
+          val path = fieldNames.map(FieldName.apply)
+          Error(s, JsonDecodeException(List(JsonError(msg, path)), e))
         case Failure(e) =>
           Error(s, JsonDecodeException(errors = List.empty, e))
       }

--- a/json/sprayjson/src/main/scala/sttp/tapir/json/spray/TapirJsonSpray.scala
+++ b/json/sprayjson/src/main/scala/sttp/tapir/json/spray/TapirJsonSpray.scala
@@ -2,7 +2,7 @@ package sttp.tapir.json.spray
 
 import spray.json._
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.{Error, Value}
+import sttp.tapir.DecodeResult.{InvalidJson, Value}
 import sttp.tapir.SchemaType._
 import sttp.tapir._
 
@@ -15,7 +15,7 @@ trait TapirJsonSpray {
     Codec.json { s =>
       Try(s.parseJson.convertTo[T]) match {
         case Success(v) => Value(v)
-        case Failure(e) => Error("spray json decoder failed", e)
+        case Failure(e) => InvalidJson(s, e)
       }
     } { t => t.toJson.toString() }
 

--- a/json/sprayjson/src/main/scala/sttp/tapir/json/spray/TapirJsonSpray.scala
+++ b/json/sprayjson/src/main/scala/sttp/tapir/json/spray/TapirJsonSpray.scala
@@ -2,7 +2,8 @@ package sttp.tapir.json.spray
 
 import spray.json._
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.{InvalidJson, Value}
+import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
+import sttp.tapir.DecodeResult.{Error, Value}
 import sttp.tapir.SchemaType._
 import sttp.tapir._
 
@@ -16,10 +17,10 @@ trait TapirJsonSpray {
       Try(s.parseJson.convertTo[T]) match {
         case Success(v) => Value(v)
         case Failure(e @ DeserializationException(msg, _, fieldNames)) =>
-          val errors = fieldNames.map(field => InvalidJson.Error(msg, Some(field)))
-          InvalidJson(s, errors, e)
+          val errors = fieldNames.map(field => JsonError(msg, Some(field)))
+          Error(s, JsonDecodeException(errors, e))
         case Failure(e) =>
-          InvalidJson(s, errors = List.empty, e)
+          Error(s, JsonDecodeException(errors = List.empty, e))
       }
     } { t => t.toJson.toString() }
 

--- a/json/sprayjson/src/test/scala/sttp/tapir/json/spray/TapirJsonSprayTests.scala
+++ b/json/sprayjson/src/test/scala/sttp/tapir/json/spray/TapirJsonSprayTests.scala
@@ -52,9 +52,14 @@ class TapirJsonSprayTests extends AnyFlatSpec with Matchers with DefaultJsonProt
   }
 
   it should "return a JSON specific decode error on failure" in {
-    val codec = TapirJsonSprayCodec.jsonFormatCodec[String]
-    val actual = codec.decode("[]")
+    val codec = TapirJsonSprayCodec.jsonFormatCodec[Customer]
+    val actual = codec.decode("{}")
     actual shouldBe a[DecodeResult.InvalidJson]
-    actual.asInstanceOf[DecodeResult.InvalidJson].json shouldEqual "[]"
+    val invalidJsonFailure = actual.asInstanceOf[InvalidJson]
+    invalidJsonFailure.json shouldEqual "{}"
+    invalidJsonFailure.errors shouldEqual List(
+      InvalidJson.Error("Object is missing required member 'name'", Some("name"))
+    )
+    invalidJsonFailure.underlying shouldBe a[DeserializationException]
   }
 }

--- a/json/sprayjson/src/test/scala/sttp/tapir/json/spray/TapirJsonSprayTests.scala
+++ b/json/sprayjson/src/test/scala/sttp/tapir/json/spray/TapirJsonSprayTests.scala
@@ -50,4 +50,11 @@ class TapirJsonSprayTests extends AnyFlatSpec with Matchers with DefaultJsonProt
   it should "encode and decode Long type" in {
     testEncodeDecode(1566150331L)
   }
+
+  it should "return a JSON specific decode error on failure" in {
+    val codec = TapirJsonSprayCodec.jsonFormatCodec[String]
+    val actual = codec.decode("[]")
+    actual shouldBe a[DecodeResult.InvalidJson]
+    actual.asInstanceOf[DecodeResult.InvalidJson].json shouldEqual "[]"
+  }
 }

--- a/json/sprayjson/src/test/scala/sttp/tapir/json/spray/TapirJsonSprayTests.scala
+++ b/json/sprayjson/src/test/scala/sttp/tapir/json/spray/TapirJsonSprayTests.scala
@@ -19,7 +19,18 @@ class TapirJsonSprayTests extends AnyFlatSpec with Matchers with DefaultJsonProt
     implicit val rw: JsonFormat[Customer] = jsonFormat3(Customer.apply)
   }
 
+  case class Item(serialNumber: Long, price: Int)
+  object Item {
+    implicit val itemFmt: JsonFormat[Item] = jsonFormat2(Item.apply)
+  }
+
+  case class Order(items: Seq[Item], customer: Customer)
+  object Order {
+    implicit val orderFmt: JsonFormat[Order] = jsonFormat2(Order.apply)
+  }
+
   val customerDecoder: JsonCodec[Customer] = TapirJsonSprayCodec.jsonFormatCodec[Customer]
+  val orderCodec = TapirJsonSprayCodec.jsonFormatCodec[Order]
 
   // Helper to test encoding then decoding an object is the same as the original
   def testEncodeDecode[T: JsonFormat: Schema](original: T): Assertion = {
@@ -53,15 +64,38 @@ class TapirJsonSprayTests extends AnyFlatSpec with Matchers with DefaultJsonProt
   }
 
   it should "return a JSON specific decode error on failure" in {
-    val codec = TapirJsonSprayCodec.jsonFormatCodec[Customer]
-    val actual = codec.decode("{}")
+    val input = """{"items":[], "customer":{}}"""
+    val actual = orderCodec.decode(input)
+
     actual shouldBe a[DecodeResult.Error]
     val failure = actual.asInstanceOf[Error]
-    failure.original shouldEqual "{}"
+    failure.original shouldEqual input
     failure.error shouldBe a[JsonDecodeException]
     val error = failure.error.asInstanceOf[JsonDecodeException]
-    error.errors shouldEqual
-      List(JsonError("Object is missing required member 'name'", Some("name")))
+    error.errors shouldEqual List(
+      JsonError(
+        "Object is missing required member 'name'",
+        List(FieldName("customer"), FieldName("name"))
+      )
+    )
     error.underlying shouldBe a[DeserializationException]
   }
+
+  it should "return a JSON specific error on array decode failure" in {
+    val itemsCodec = TapirJsonSprayCodec.jsonFormatCodec[Seq[Item]]
+
+    val input = """[{"serialNumber":1}]"""
+    val actual = itemsCodec.decode(input)
+
+    actual shouldBe a[DecodeResult.Error]
+    val failure = actual.asInstanceOf[DecodeResult.Error]
+    failure.original shouldEqual input
+    failure.error shouldBe a[JsonDecodeException]
+    val error = failure.error.asInstanceOf[JsonDecodeException]
+    error.errors shouldEqual List(
+      JsonError("Object is missing required member 'price'", List(FieldName("price")))
+    )
+    error.underlying shouldBe a[DeserializationException]
+  }
+
 }

--- a/json/tethys/src/main/scala/sttp/tapir/json/circe/TapirJsonTethys.scala
+++ b/json/tethys/src/main/scala/sttp/tapir/json/circe/TapirJsonTethys.scala
@@ -1,7 +1,8 @@
 package sttp.tapir.json.circe
 
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.{InvalidJson, Value}
+import sttp.tapir.DecodeResult.Error.JsonDecodeException
+import sttp.tapir.DecodeResult.{Error, Value}
 import sttp.tapir._
 import tethys._
 import tethys.jackson._
@@ -12,7 +13,7 @@ trait TapirJsonTethys {
   implicit def tethysCodec[T: JsonReader: JsonWriter: Schema]: JsonCodec[T] =
     Codec.json(s =>
       s.jsonAs[T] match {
-        case Left(readerError) => InvalidJson(s, List.empty, readerError)
+        case Left(readerError) => Error(s, JsonDecodeException(errors = List.empty, readerError))
         case Right(value)      => Value(value)
       }
     )(_.asJson)

--- a/json/tethys/src/main/scala/sttp/tapir/json/circe/TapirJsonTethys.scala
+++ b/json/tethys/src/main/scala/sttp/tapir/json/circe/TapirJsonTethys.scala
@@ -12,7 +12,7 @@ trait TapirJsonTethys {
   implicit def tethysCodec[T: JsonReader: JsonWriter: Schema]: JsonCodec[T] =
     Codec.json(s =>
       s.jsonAs[T] match {
-        case Left(readerError) => InvalidJson(s, readerError)
+        case Left(readerError) => InvalidJson(s, List.empty, readerError)
         case Right(value)      => Value(value)
       }
     )(_.asJson)

--- a/json/tethys/src/main/scala/sttp/tapir/json/circe/TapirJsonTethys.scala
+++ b/json/tethys/src/main/scala/sttp/tapir/json/circe/TapirJsonTethys.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.json.circe
 
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.{Error, Value}
+import sttp.tapir.DecodeResult.{InvalidJson, Value}
 import sttp.tapir._
 import tethys._
 import tethys.jackson._
@@ -12,7 +12,7 @@ trait TapirJsonTethys {
   implicit def tethysCodec[T: JsonReader: JsonWriter: Schema]: JsonCodec[T] =
     Codec.json(s =>
       s.jsonAs[T] match {
-        case Left(readerError) => Error(s, readerError)
+        case Left(readerError) => InvalidJson(s, readerError)
         case Right(value)      => Value(value)
       }
     )(_.asJson)

--- a/json/tethys/src/test/scala/sttp/tapir/json/circe/TapirJsonTethysTests.scala
+++ b/json/tethys/src/test/scala/sttp/tapir/json/circe/TapirJsonTethysTests.scala
@@ -3,15 +3,24 @@ package sttp.tapir.json.circe
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import sttp.tapir.DecodeResult
+import sttp.tapir.generic.auto._
+import tethys.derivation.auto._
+import tethys.readers.ReaderError
 
 object TapirJsonTethysCodec extends TapirJsonTethys
 
 class TapirJsonTethysTests extends AnyFlatSpecLike with Matchers {
 
+  case class Customer(name: String, yearOfBirth: Int, lastPurchase: Option[Long])
+
   it should "return a JSON specific decode error on failure" in {
-    val codec = TapirJsonTethysCodec.tethysCodec[String]
-    val actual = codec.decode("[]")
+    val codec = TapirJsonTethysCodec.tethysCodec[Customer]
+    val actual = codec.decode("{}")
     actual shouldBe a[DecodeResult.InvalidJson]
-    actual.asInstanceOf[DecodeResult.InvalidJson].json shouldEqual "[]"
+    val failure = actual.asInstanceOf[DecodeResult.InvalidJson]
+    failure.json shouldEqual "{}"
+    failure.errors shouldEqual List.empty
+    failure.underlying shouldBe a[ReaderError]
   }
+
 }

--- a/json/tethys/src/test/scala/sttp/tapir/json/circe/TapirJsonTethysTests.scala
+++ b/json/tethys/src/test/scala/sttp/tapir/json/circe/TapirJsonTethysTests.scala
@@ -1,0 +1,17 @@
+package sttp.tapir.json.circe
+
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import sttp.tapir.DecodeResult
+
+object TapirJsonTethysCodec extends TapirJsonTethys
+
+class TapirJsonTethysTests extends AnyFlatSpecLike with Matchers {
+
+  it should "return a JSON specific decode error on failure" in {
+    val codec = TapirJsonTethysCodec.tethysCodec[String]
+    val actual = codec.decode("[]")
+    actual shouldBe a[DecodeResult.InvalidJson]
+    actual.asInstanceOf[DecodeResult.InvalidJson].json shouldEqual "[]"
+  }
+}

--- a/json/tethys/src/test/scala/sttp/tapir/json/circe/TapirJsonTethysTests.scala
+++ b/json/tethys/src/test/scala/sttp/tapir/json/circe/TapirJsonTethysTests.scala
@@ -3,6 +3,7 @@ package sttp.tapir.json.circe
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import sttp.tapir.DecodeResult
+import sttp.tapir.DecodeResult.Error.JsonDecodeException
 import sttp.tapir.generic.auto._
 import tethys.derivation.auto._
 import tethys.readers.ReaderError
@@ -16,11 +17,13 @@ class TapirJsonTethysTests extends AnyFlatSpecLike with Matchers {
   it should "return a JSON specific decode error on failure" in {
     val codec = TapirJsonTethysCodec.tethysCodec[Customer]
     val actual = codec.decode("{}")
-    actual shouldBe a[DecodeResult.InvalidJson]
-    val failure = actual.asInstanceOf[DecodeResult.InvalidJson]
-    failure.json shouldEqual "{}"
-    failure.errors shouldEqual List.empty
-    failure.underlying shouldBe a[ReaderError]
+    actual shouldBe a[DecodeResult.Error]
+    val failure = actual.asInstanceOf[DecodeResult.Error]
+    failure.original shouldEqual "{}"
+    failure.error shouldBe a[JsonDecodeException]
+    val error = failure.error.asInstanceOf[JsonDecodeException]
+    error.errors shouldEqual List.empty
+    error.underlying shouldBe a[ReaderError]
   }
 
 }

--- a/json/upickle/src/main/scala/sttp/tapir/json/upickle/TapirJsonuPickle.scala
+++ b/json/upickle/src/main/scala/sttp/tapir/json/upickle/TapirJsonuPickle.scala
@@ -1,9 +1,10 @@
 package sttp.tapir.json.upickle
 
-import scala.util.{Try, Success, Failure}
+import scala.util.{Failure, Success, Try}
 import sttp.tapir._
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.{InvalidJson, Value}
+import sttp.tapir.DecodeResult.Error.JsonDecodeException
+import sttp.tapir.DecodeResult.{Error, Value}
 import upickle.default.{ReadWriter, read, write}
 
 trait TapirJsonuPickle {
@@ -14,7 +15,7 @@ trait TapirJsonuPickle {
     Codec.json[T] { s =>
       Try(read[T](s)) match {
         case Success(v) => Value(v)
-        case Failure(e) => InvalidJson(s, List.empty, e)
+        case Failure(e) => Error(s, JsonDecodeException(errors = List.empty, e))
       }
     } { t => write(t) }
 }

--- a/json/upickle/src/main/scala/sttp/tapir/json/upickle/TapirJsonuPickle.scala
+++ b/json/upickle/src/main/scala/sttp/tapir/json/upickle/TapirJsonuPickle.scala
@@ -3,7 +3,7 @@ package sttp.tapir.json.upickle
 import scala.util.{Try, Success, Failure}
 import sttp.tapir._
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.{Error, Value}
+import sttp.tapir.DecodeResult.{InvalidJson, Value}
 import upickle.default.{ReadWriter, read, write}
 
 trait TapirJsonuPickle {
@@ -14,7 +14,7 @@ trait TapirJsonuPickle {
     Codec.json[T] { s =>
       Try(read[T](s)) match {
         case Success(v) => Value(v)
-        case Failure(e) => Error("upickle decoder failed", e)
+        case Failure(e) => InvalidJson(s, e)
       }
     } { t => write(t) }
 }

--- a/json/upickle/src/main/scala/sttp/tapir/json/upickle/TapirJsonuPickle.scala
+++ b/json/upickle/src/main/scala/sttp/tapir/json/upickle/TapirJsonuPickle.scala
@@ -14,7 +14,7 @@ trait TapirJsonuPickle {
     Codec.json[T] { s =>
       Try(read[T](s)) match {
         case Success(v) => Value(v)
-        case Failure(e) => InvalidJson(s, e)
+        case Failure(e) => InvalidJson(s, List.empty, e)
       }
     } { t => write(t) }
 }

--- a/json/upickle/src/test/scala/sttp/tapir/json/upickle/TapirJsonuPickleTests.scala
+++ b/json/upickle/src/test/scala/sttp/tapir/json/upickle/TapirJsonuPickleTests.scala
@@ -53,4 +53,10 @@ class TapirJsonuPickleTests extends AnyFlatSpec with TapirJsonuPickleTestExtensi
     testEncodeDecode(1566150331L)
   }
 
+  it should "return a JSON specific decode error on failure" in {
+    val codec = TapirJsonuPickleCodec.readWriterCodec[String]
+    val actual = codec.decode("[]")
+    actual shouldBe a[DecodeResult.InvalidJson]
+    actual.asInstanceOf[DecodeResult.InvalidJson].json shouldEqual "[]"
+  }
 }

--- a/json/upickle/src/test/scala/sttp/tapir/json/upickle/TapirJsonuPickleTests.scala
+++ b/json/upickle/src/test/scala/sttp/tapir/json/upickle/TapirJsonuPickleTests.scala
@@ -10,6 +10,7 @@ import sttp.tapir._
 import sttp.tapir.DecodeResult._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import upickle.core.AbortException
 
 object TapirJsonuPickleCodec extends TapirJsonuPickle
 
@@ -54,9 +55,12 @@ class TapirJsonuPickleTests extends AnyFlatSpec with TapirJsonuPickleTestExtensi
   }
 
   it should "return a JSON specific decode error on failure" in {
-    val codec = TapirJsonuPickleCodec.readWriterCodec[String]
-    val actual = codec.decode("[]")
+    val codec = TapirJsonuPickleCodec.readWriterCodec[Customer]
+    val actual = codec.decode("{}")
     actual shouldBe a[DecodeResult.InvalidJson]
-    actual.asInstanceOf[DecodeResult.InvalidJson].json shouldEqual "[]"
+    val failure = actual.asInstanceOf[InvalidJson]
+    failure.json shouldEqual "{}"
+    failure.errors shouldEqual List.empty
+    failure.underlying shouldBe an[AbortException]
   }
 }

--- a/json/upickle/src/test/scala/sttp/tapir/json/upickle/TapirJsonuPickleTests.scala
+++ b/json/upickle/src/test/scala/sttp/tapir/json/upickle/TapirJsonuPickleTests.scala
@@ -10,6 +10,7 @@ import sttp.tapir._
 import sttp.tapir.DecodeResult._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.tapir.DecodeResult.Error.JsonDecodeException
 import upickle.core.AbortException
 
 object TapirJsonuPickleCodec extends TapirJsonuPickle
@@ -57,10 +58,12 @@ class TapirJsonuPickleTests extends AnyFlatSpec with TapirJsonuPickleTestExtensi
   it should "return a JSON specific decode error on failure" in {
     val codec = TapirJsonuPickleCodec.readWriterCodec[Customer]
     val actual = codec.decode("{}")
-    actual shouldBe a[DecodeResult.InvalidJson]
-    val failure = actual.asInstanceOf[InvalidJson]
-    failure.json shouldEqual "{}"
-    failure.errors shouldEqual List.empty
-    failure.underlying shouldBe an[AbortException]
+    actual shouldBe a[DecodeResult.Error]
+    val failure = actual.asInstanceOf[DecodeResult.Error]
+    failure.original shouldEqual "{}"
+    failure.error shouldBe a[JsonDecodeException]
+    val error = failure.error.asInstanceOf[JsonDecodeException]
+    error.errors shouldEqual List.empty
+    error.underlying shouldBe an[AbortException]
   }
 }


### PR DESCRIPTION
This PR introduces a `JsonDecodeException`, it aims to improve JSON-specific decode errors handling. 

In its current implementation, this PR allows to output JSON decode errors in responses when wrongly formatted JSONs bodies are submitted. 
For example, using Play-JSON and given an endpoint expecting a
```scala
case class User(name: String)
```
in request body, sending 
```json
{}
``` 
will output `error.path.missing at 'obj.name'` in the response body alongside with the 404 status code.

Errors and failed paths are populated according to what JSON-libraries provide. 

Default behavior of decode errors handling was changed to output detailed JSON decode errors, when available.

Closes https://github.com/softwaremill/tapir/issues/872.