### PR TITLE
Fix for ClassCastException when using default multipart codec

### DIFF
--- a/core/src/main/scala/sttp/tapir/Codec.scala
+++ b/core/src/main/scala/sttp/tapir/Codec.scala
@@ -502,7 +502,7 @@ case class MultipartCodec[T](rawBodyType: RawBodyType.MultipartBody, codec: Code
 object MultipartCodec extends MultipartCodecDerivation {
   val Default: MultipartCodec[Seq[Part[Array[Byte]]]] = {
     Codec
-      .multipartCodec(Map.empty, Some(PartCodec(RawBodyType.ByteArrayBody, Codec.list(Codec.byteArray))))
+      .multipartCodec(Map.empty, Some(PartCodec(RawBodyType.ByteArrayBody, Codec.listHead(Codec.byteArray))))
       .asInstanceOf[MultipartCodec[Seq[Part[Array[Byte]]]]] // we know that all parts will end up as byte arrays
   }
 }

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -239,6 +239,26 @@ class ServerBasicTests[F[_], ROUTE](
           r.body should include regex "name=\"data\"[\\s\\S]*oiram hcaep"
         }
     },
+    testServer(in_raw_multipart_out_string)((parts: Seq[Part[Array[Byte]]]) =>
+      pureResult(
+        parts.map(part => s"${part.name}:${new String(part.body)}").mkString("\n").asRight[Unit]
+      )
+    ) { baseUri =>
+      val file1 = writeToFile("peach mario")
+      val file2 = writeToFile("daisy luigi")
+      basicStringRequest
+        .post(uri"$baseUri/api/echo/multipart")
+        .multipartBody(
+          multipartFile("file1", file1).fileName("file1.txt"),
+          multipartFile("file2", file2).fileName("file2.txt")
+        )
+        .send(backend)
+        .map { r =>
+          r.code shouldBe StatusCode.Ok
+          r.body should include("file1:peach mario")
+          r.body should include("file2:daisy luigi")
+        }
+    },
     testServer(in_query_out_string, "invalid query parameter")((fruit: String) => pureResult(s"fruit: $fruit".asRight[Unit])) { baseUri =>
       basicRequest.get(uri"$baseUri?fruit2=orange").send(backend).map(_.code shouldBe StatusCode.BadRequest)
     },

--- a/tests/src/main/scala/sttp/tapir/tests/package.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/package.scala
@@ -11,7 +11,7 @@ import com.softwaremill.macwire._
 import com.softwaremill.tagging.{@@, Tagger}
 import io.circe.{Decoder, Encoder}
 import sttp.capabilities.Streams
-import sttp.model.{Cookie, CookieValueWithMeta, CookieWithMeta, Header, HeaderNames, QueryParams, StatusCode}
+import sttp.model.{Cookie, CookieValueWithMeta, CookieWithMeta, Header, HeaderNames, Part, QueryParams, StatusCode}
 import sttp.tapir.Codec.PlainCodec
 import sttp.tapir.model._
 
@@ -148,6 +148,9 @@ package object tests {
 
   val in_file_multipart_out_multipart: Endpoint[FruitData, Unit, FruitData, Any] =
     endpoint.post.in("api" / "echo" / "multipart").in(multipartBody[FruitData]).out(multipartBody[FruitData]).name("echo file")
+
+  val in_raw_multipart_out_string: Endpoint[Seq[Part[Array[Byte]]], Unit, String, Any] =
+    endpoint.post.in("api" / "echo" / "multipart").in(multipartBody).out(stringBody).name("echo raw parts")
 
   val in_cookie_cookie_out_header: Endpoint[(Int, String), Unit, List[String], Any] =
     endpoint.get


### PR DESCRIPTION
This is fix for https://github.com/softwaremill/tapir/issues/875
While fixing codec itself it turned out that Vertx server interpreter skipped fields that were not part of `MultipartBody.partTypes`