### PR TITLE
Closes #889: explicit interpreters instead of extension methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ val booksListing: Endpoint[(BooksFromYear, Limit, AuthToken), String, List[Book]
 
 // Generate OpenAPI documentation
 
-import sttp.tapir.docs.openapi.OpenAPIInterpreter
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import sttp.tapir.openapi.circe.yaml._
 
-val docs = OpenAPIInterpreter.toOpenAPI(booksListing)("My Bookshop", "1.0")
+val docs = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
 println(docs.toYaml)
 
 
 // Convert to akka-http Route
 
-import sttp.tapir.server.akkahttp.AkkaHttpInterpreter
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import akka.http.scaladsl.server.Route
 import scala.concurrent.Future
 
@@ -67,7 +67,8 @@ def bookListingLogic(bfy: BooksFromYear,
                      limit: Limit,
                      at: AuthToken): Future[Either[String, List[Book]]] =
   Future.successful(Right(List(Book("The Sorrows of Young Werther"))))
-val booksListingRoute: Route = AkkaHttpInterpreter.toRoute(booksListing)((bookListingLogic _).tupled)
+val booksListingRoute: Route = AkkaHttpServerInterpreter
+  .toRoute(booksListing)((bookListingLogic _).tupled)
 
 
 // Convert to sttp Request
@@ -76,7 +77,7 @@ import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.client3._
 
 val booksListingRequest: Request[DecodeResult[Either[String, List[Book]]], Any] = SttpClientInterpreter
-  .toRequest(booksListing)(uri"http://localhost:8080")
+  .toRequest(booksListing, uri"http://localhost:8080")
   .apply((BooksFromYear("SF", 2016), 20, "xyz-abc-123"))
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ interpreted as:
 
 ## Teaser
 
-```scala
+```scala mdoc:compile-only
 import sttp.tapir._
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
@@ -38,7 +38,7 @@ case class Book(title: String)
 
 // Define an endpoint
 
-val booksListing: Endpoint[(BooksFromYear, Limit, AuthToken), String, List[Book], Nothing] =
+val booksListing: Endpoint[(BooksFromYear, Limit, AuthToken), String, List[Book], Any] = 
   endpoint
     .get
     .in(("books" / path[String]("genre") / path[Int]("year")).mapTo(BooksFromYear))
@@ -50,16 +50,16 @@ val booksListing: Endpoint[(BooksFromYear, Limit, AuthToken), String, List[Book]
 
 // Generate OpenAPI documentation
 
-import sttp.tapir.docs.openapi._
+import sttp.tapir.docs.openapi.OpenAPIInterpreter
 import sttp.tapir.openapi.circe.yaml._
 
-val docs = booksListing.toOpenAPI("My Bookshop", "1.0")
+val docs = OpenAPIInterpreter.toOpenAPI(booksListing)("My Bookshop", "1.0")
 println(docs.toYaml)
 
 
 // Convert to akka-http Route
 
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpInterpreter
 import akka.http.scaladsl.server.Route
 import scala.concurrent.Future
 
@@ -67,16 +67,16 @@ def bookListingLogic(bfy: BooksFromYear,
                      limit: Limit,
                      at: AuthToken): Future[Either[String, List[Book]]] =
   Future.successful(Right(List(Book("The Sorrows of Young Werther"))))
-val booksListingRoute: Route = booksListing.toRoute((bookListingLogic _).tupled)
+val booksListingRoute: Route = AkkaHttpInterpreter.toRoute(booksListing)((bookListingLogic _).tupled)
 
 
 // Convert to sttp Request
 
-import sttp.tapir.client.sttp._
+import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.client3._
 
-val booksListingRequest: Request[DecodeResult[Either[String, List[Book]]], Nothing] = booksListing
-  .toSttpRequest(uri"http://localhost:8080")
+val booksListingRequest: Request[DecodeResult[Either[String, List[Book]]], Any] = SttpClientInterpreter
+  .toRequest(booksListing)(uri"http://localhost:8080")
   .apply((BooksFromYear("SF", 2016), 20, "xyz-abc-123"))
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ val booksListing: Endpoint[(BooksFromYear, Limit, AuthToken), String, List[Book]
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import sttp.tapir.openapi.circe.yaml._
 
-val docs = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
+val docs = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "My Bookshop", "1.0")
 println(docs.toYaml)
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -743,6 +743,7 @@ lazy val sttpClient: ProjectMatrix = (projectMatrix in file("client/sttp-client"
   .dependsOn(core, clientTests % Test)
 
 lazy val playClient: ProjectMatrix = (projectMatrix in file("client/play-client"))
+  .settings(clientTestServerSettings)
   .settings(commonSettings)
   .settings(
     name := "tapir-play-client",

--- a/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
+++ b/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
@@ -28,7 +28,7 @@ import sttp.tapir.{
 
 import scala.collection.Seq
 
-class EndpointToPlayClient(clientOptions: PlayClientOptions, ws: StandaloneWSClient) {
+private[play] class EndpointToPlayClient(clientOptions: PlayClientOptions, ws: StandaloneWSClient) {
 
   def toPlayRequest[I, E, O, R](
       e: Endpoint[I, E, O, R],

--- a/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
+++ b/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
@@ -59,18 +59,17 @@ class EndpointToPlayClient(clientOptions: PlayClientOptions, ws: StandaloneWSCli
     (req, unsafeResponseParser)
   }
 
-  private def parsePlayResponse[I, E, O, Nothing](e: Endpoint[I, E, O, Nothing]): StandaloneWSResponse => DecodeResult[Either[E, O]] = {
-    response =>
-      val code = sttp.model.StatusCode(response.status)
+  private def parsePlayResponse[I, E, O, R](e: Endpoint[I, E, O, R]): StandaloneWSResponse => DecodeResult[Either[E, O]] = { response =>
+    val code = sttp.model.StatusCode(response.status)
 
-      val parser = if (code.isSuccess) responseFromOutput(e.output) else responseFromOutput(e.errorOutput)
-      val output = if (code.isSuccess) e.output else e.errorOutput
+    val parser = if (code.isSuccess) responseFromOutput(e.output) else responseFromOutput(e.errorOutput)
+    val output = if (code.isSuccess) e.output else e.errorOutput
 
-      val headers = cookiesAsHeaders(response.cookies) ++ response.headers
+    val headers = cookiesAsHeaders(response.cookies) ++ response.headers
 
-      val params = getOutputParams(output, parser(response), headers, code, response.statusText)
+    val params = getOutputParams(output, parser(response), headers, code, response.statusText)
 
-      params.map(_.asAny).map(p => if (code.isSuccess) Right(p.asInstanceOf[O]) else Left(p.asInstanceOf[E]))
+    params.map(_.asAny).map(p => if (code.isSuccess) Right(p.asInstanceOf[O]) else Left(p.asInstanceOf[E]))
   }
 
   private def getOutputParams(

--- a/client/play-client/src/main/scala/sttp/tapir/client/play/PlayClientInterpreter.scala
+++ b/client/play-client/src/main/scala/sttp/tapir/client/play/PlayClientInterpreter.scala
@@ -1,0 +1,41 @@
+package sttp.tapir.client.play
+
+import play.api.libs.ws.{StandaloneWSClient, StandaloneWSRequest, StandaloneWSResponse}
+import sttp.tapir.{DecodeResult, Endpoint}
+
+trait PlayClientInterpreter {
+
+  /** Interprets the endpoint as a client call, using the given `baseUri` as the starting point to create the target
+    * uri.
+    *
+    * Returns:
+    * - a function which, when applied to the endpoint's input parameters (given as a tuple), will encode them
+    * to appropriate request parameters: path, query, headers and body. The result is a `StandaloneWSRequest`,
+    * which can be sent using the `execute()` method.
+    * - a response parser to use on the `StandaloneWSResponse` obtained after executing the request.
+    */
+  def toPlayRequest[I, E, O, R](e: Endpoint[I, E, O, R])(baseUri: String)(implicit
+      clientOptions: PlayClientOptions,
+      ws: StandaloneWSClient
+  ): I => (StandaloneWSRequest, StandaloneWSResponse => DecodeResult[Either[E, O]]) =
+    new EndpointToPlayClient(clientOptions, ws).toPlayRequest(e, baseUri)
+
+  /** Interprets the endpoint as a client call, using the given `baseUri` as the starting point to create the target
+    * uri.
+    *
+    * Returns:
+    * - a function which, when applied to the endpoint's input parameters (given as a tuple), will encode them
+    * to appropriate request parameters: path, query, headers and body. The result is a `StandaloneWSRequest`,
+    * which can be sent using the `execute()` method.
+    * - a response parser to use on the `StandaloneWSResponse` obtained after executing the request.
+    *
+    * @throws IllegalArgumentException when response parsing fails
+    */
+  def toPlayRequestUnsafe[I, E, O, R](e: Endpoint[I, E, O, R])(
+      baseUri: String
+  )(implicit clientOptions: PlayClientOptions, ws: StandaloneWSClient): I => (StandaloneWSRequest, StandaloneWSResponse => Either[E, O]) =
+    new EndpointToPlayClient(clientOptions, ws).toPlayRequestUnsafe(e, baseUri)
+
+}
+
+object PlayClientInterpreter extends PlayClientInterpreter

--- a/client/play-client/src/main/scala/sttp/tapir/client/play/PlayClientInterpreter.scala
+++ b/client/play-client/src/main/scala/sttp/tapir/client/play/PlayClientInterpreter.scala
@@ -14,7 +14,7 @@ trait PlayClientInterpreter {
     * which can be sent using the `execute()` method.
     * - a response parser to use on the `StandaloneWSResponse` obtained after executing the request.
     */
-  def toPlayRequest[I, E, O, R](e: Endpoint[I, E, O, R])(baseUri: String)(implicit
+  def toRequest[I, E, O, R](e: Endpoint[I, E, O, R], baseUri: String)(implicit
       clientOptions: PlayClientOptions,
       ws: StandaloneWSClient
   ): I => (StandaloneWSRequest, StandaloneWSResponse => DecodeResult[Either[E, O]]) =
@@ -31,9 +31,10 @@ trait PlayClientInterpreter {
     *
     * @throws IllegalArgumentException when response parsing fails
     */
-  def toPlayRequestUnsafe[I, E, O, R](e: Endpoint[I, E, O, R])(
-      baseUri: String
-  )(implicit clientOptions: PlayClientOptions, ws: StandaloneWSClient): I => (StandaloneWSRequest, StandaloneWSResponse => Either[E, O]) =
+  def toRequestUnsafe[I, E, O, R](e: Endpoint[I, E, O, R], baseUri: String)(implicit
+      clientOptions: PlayClientOptions,
+      ws: StandaloneWSClient
+  ): I => (StandaloneWSRequest, StandaloneWSResponse => Either[E, O]) =
     new EndpointToPlayClient(clientOptions, ws).toPlayRequestUnsafe(e, baseUri)
 
 }

--- a/client/play-client/src/main/scala/sttp/tapir/client/play/TapirPlayClient.scala
+++ b/client/play-client/src/main/scala/sttp/tapir/client/play/TapirPlayClient.scala
@@ -17,7 +17,7 @@ trait TapirPlayClient {
       * which can be sent using the `execute()` method.
       * - a response parser to use on the `StandaloneWSResponse` obtained after executing the request.
       */
-    @deprecated("Use PlayClientInterpreter.toPlayRequest", since = "0.17.1")
+    @deprecated("Use PlayClientInterpreter.toRequest", since = "0.17.1")
     def toPlayRequest(baseUri: String)(implicit
         clientOptions: PlayClientOptions,
         ws: StandaloneWSClient
@@ -35,7 +35,7 @@ trait TapirPlayClient {
       *
       * @throws IllegalArgumentException when response parsing fails
       */
-    @deprecated("Use PlayClientInterpreter.toPlayRequestUnsafe", since = "0.17.1")
+    @deprecated("Use PlayClientInterpreter.toRequestUnsafe", since = "0.17.1")
     def toPlayRequestUnsafe(
         baseUri: String
     )(implicit clientOptions: PlayClientOptions, ws: StandaloneWSClient): I => (StandaloneWSRequest, StandaloneWSResponse => Either[E, O]) =

--- a/client/play-client/src/main/scala/sttp/tapir/client/play/TapirPlayClient.scala
+++ b/client/play-client/src/main/scala/sttp/tapir/client/play/TapirPlayClient.scala
@@ -3,6 +3,7 @@ package sttp.tapir.client.play
 import play.api.libs.ws.{StandaloneWSClient, StandaloneWSRequest, StandaloneWSResponse}
 import sttp.tapir.{DecodeResult, Endpoint}
 
+@deprecated("Use PlayClientInterpreter", since = "0.17.1")
 trait TapirPlayClient {
 
   implicit class RichPlayClientEndpoint[I, E, O, R](e: Endpoint[I, E, O, R]) {
@@ -16,6 +17,7 @@ trait TapirPlayClient {
       * which can be sent using the `execute()` method.
       * - a response parser to use on the `StandaloneWSResponse` obtained after executing the request.
       */
+    @deprecated("Use PlayClientInterpreter.toPlayRequest", since = "0.17.1")
     def toPlayRequest(baseUri: String)(implicit
         clientOptions: PlayClientOptions,
         ws: StandaloneWSClient
@@ -33,6 +35,7 @@ trait TapirPlayClient {
       *
       * @throws IllegalArgumentException when response parsing fails
       */
+    @deprecated("Use PlayClientInterpreter.toPlayRequestUnsafe", since = "0.17.1")
     def toPlayRequestUnsafe(
         baseUri: String
     )(implicit clientOptions: PlayClientOptions, ws: StandaloneWSClient): I => (StandaloneWSRequest, StandaloneWSResponse => Either[E, O]) =

--- a/client/play-client/src/test/scala/sttp/tapir/client/play/PlayClientTests.scala
+++ b/client/play-client/src/test/scala/sttp/tapir/client/play/PlayClientTests.scala
@@ -19,7 +19,7 @@ abstract class PlayClientTests[R] extends ClientTests[R] {
 
   override def send[I, E, O, FN[_]](e: Endpoint[I, E, O, R], port: Port, args: I, scheme: String = "http"): IO[Either[E, O]] = {
     def response: Future[Either[E, O]] = {
-      val (req, responseParser) = PlayClientInterpreter.toPlayRequestUnsafe(e)(s"http://localhost:$port").apply(args)
+      val (req, responseParser) = PlayClientInterpreter.toRequestUnsafe(e, s"http://localhost:$port").apply(args)
       req.execute().map(responseParser)
     }
     IO.fromFuture(IO(response))
@@ -31,7 +31,7 @@ abstract class PlayClientTests[R] extends ClientTests[R] {
       args: I
   ): IO[DecodeResult[Either[E, O]]] = {
     def response: Future[DecodeResult[Either[E, O]]] = {
-      val (req, responseParser) = PlayClientInterpreter.toPlayRequest(e)(s"http://localhost:$port").apply(args)
+      val (req, responseParser) = PlayClientInterpreter.toRequest(e, s"http://localhost:$port").apply(args)
       req.execute().map(responseParser)
     }
     IO.fromFuture(IO(response))

--- a/client/play-client/src/test/scala/sttp/tapir/client/play/PlayClientTests.scala
+++ b/client/play-client/src/test/scala/sttp/tapir/client/play/PlayClientTests.scala
@@ -19,7 +19,7 @@ abstract class PlayClientTests[R] extends ClientTests[R] {
 
   override def send[I, E, O, FN[_]](e: Endpoint[I, E, O, R], port: Port, args: I, scheme: String = "http"): IO[Either[E, O]] = {
     def response: Future[Either[E, O]] = {
-      val (req, responseParser) = e.toPlayRequestUnsafe(s"http://localhost:$port").apply(args)
+      val (req, responseParser) = PlayClientInterpreter.toPlayRequestUnsafe(e)(s"http://localhost:$port").apply(args)
       req.execute().map(responseParser)
     }
     IO.fromFuture(IO(response))
@@ -31,7 +31,7 @@ abstract class PlayClientTests[R] extends ClientTests[R] {
       args: I
   ): IO[DecodeResult[Either[E, O]]] = {
     def response: Future[DecodeResult[Either[E, O]]] = {
-      val (req, responseParser) = e.toPlayRequest(s"http://localhost:$port").apply(args)
+      val (req, responseParser) = PlayClientInterpreter.toPlayRequest(e)(s"http://localhost:$port").apply(args)
       req.execute().map(responseParser)
     }
     IO.fromFuture(IO(response))

--- a/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
+++ b/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
@@ -122,14 +122,14 @@ class EndpointToSttpClient[R](clientOptions: SttpClientOptions, wsToPipe: WebSoc
         val ps = codec.encode(value)
         (uri.copy(pathSegments = uri.pathSegments ++ ps.map(PathSegment(_))), req)
       case EndpointInput.Query(name, codec, _) =>
-        val uri2 = codec.encode(value).foldLeft(uri) { case (u, v) => u.param(name, v) }
+        val uri2 = codec.encode(value).foldLeft(uri) { case (u, v) => u.addParam(name, v) }
         (uri2, req)
       case EndpointInput.Cookie(name, codec, _) =>
         val req2 = codec.encode(value).foldLeft(req) { case (r, v) => r.cookie(name, v) }
         (uri, req2)
       case EndpointInput.QueryParams(codec, _) =>
         val mqp = codec.encode(value)
-        val uri2 = uri.params(mqp.toSeq: _*)
+        val uri2 = uri.addParams(mqp.toSeq: _*)
         (uri2, req)
       case EndpointIO.Empty(_, _) => (uri, req)
       case EndpointIO.Body(bodyType, codec, _) =>

--- a/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
+++ b/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
@@ -12,7 +12,7 @@ import sttp.tapir._
 import sttp.tapir.internal._
 import sttp.ws.WebSocket
 
-class EndpointToSttpClient[R](clientOptions: SttpClientOptions, wsToPipe: WebSocketToPipe[R]) {
+private[sttp] class EndpointToSttpClient[R](clientOptions: SttpClientOptions, wsToPipe: WebSocketToPipe[R]) {
   def toSttpRequestUnsafe[I, E, O](e: Endpoint[I, E, O, R], baseUri: Uri): I => Request[Either[E, O], R] = { params =>
     toSttpRequest(e, baseUri)(params).mapResponse(getOrThrow)
   }

--- a/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/SttpClientInterpreter.scala
+++ b/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/SttpClientInterpreter.scala
@@ -1,0 +1,38 @@
+package sttp.tapir.client.sttp
+
+import sttp.client3.Request
+import sttp.model.Uri
+import sttp.tapir.{DecodeResult, Endpoint}
+
+trait SttpClientInterpreter {
+
+  /** Interprets the endpoint as a client call, using the given `baseUri` as the starting point to create the target
+    * uri.
+    *
+    * Returns a function which, when applied to the endpoint's input parameters (given as a tuple), will encode them
+    * to appropriate request parameters: path, query, headers and body. The result is a description of a request,
+    * which can be sent using any sttp backend. The response will then contain the decoded error or success values
+    * (note that this can be the body enriched with data from headers/status code).
+    *
+    * @throws IllegalArgumentException when response parsing fails
+    */
+  def toRequestUnsafe[I, E, O, R](e: Endpoint[I, E, O, R])(
+      baseUri: Uri
+  )(implicit clientOptions: SttpClientOptions, wsToPipe: WebSocketToPipe[R]): I => Request[Either[E, O], R] =
+    new EndpointToSttpClient(clientOptions, wsToPipe).toSttpRequestUnsafe(e, baseUri)
+
+  /** Interprets the endpoint as a client call, using the given `baseUri` as the starting point to create the target
+    * uri.
+    *
+    * Returns a function which, when applied to the endpoint's input parameters (given as a tuple), will encode them
+    * to appropriate request parameters: path, query, headers and body. The result is a description of a request,
+    * which can be sent using any sttp backend. The response will then contain the decoded error or success values
+    * (note that this can be the body enriched with data from headers/status code).
+    */
+  def toRequest[I, E, O, R](e: Endpoint[I, E, O, R])(
+      baseUri: Uri
+  )(implicit clientOptions: SttpClientOptions, wsToPipe: WebSocketToPipe[R]): I => Request[DecodeResult[Either[E, O]], R] =
+    new EndpointToSttpClient(clientOptions, wsToPipe).toSttpRequest(e, baseUri)
+}
+
+object SttpClientInterpreter extends SttpClientInterpreter

--- a/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/SttpClientInterpreter.scala
+++ b/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/SttpClientInterpreter.scala
@@ -16,9 +16,10 @@ trait SttpClientInterpreter {
     *
     * @throws IllegalArgumentException when response parsing fails
     */
-  def toRequestUnsafe[I, E, O, R](e: Endpoint[I, E, O, R])(
-      baseUri: Uri
-  )(implicit clientOptions: SttpClientOptions, wsToPipe: WebSocketToPipe[R]): I => Request[Either[E, O], R] =
+  def toRequestUnsafe[I, E, O, R](e: Endpoint[I, E, O, R], baseUri: Uri)(implicit
+      clientOptions: SttpClientOptions,
+      wsToPipe: WebSocketToPipe[R]
+  ): I => Request[Either[E, O], R] =
     new EndpointToSttpClient(clientOptions, wsToPipe).toSttpRequestUnsafe(e, baseUri)
 
   /** Interprets the endpoint as a client call, using the given `baseUri` as the starting point to create the target
@@ -29,9 +30,10 @@ trait SttpClientInterpreter {
     * which can be sent using any sttp backend. The response will then contain the decoded error or success values
     * (note that this can be the body enriched with data from headers/status code).
     */
-  def toRequest[I, E, O, R](e: Endpoint[I, E, O, R])(
-      baseUri: Uri
-  )(implicit clientOptions: SttpClientOptions, wsToPipe: WebSocketToPipe[R]): I => Request[DecodeResult[Either[E, O]], R] =
+  def toRequest[I, E, O, R](e: Endpoint[I, E, O, R], baseUri: Uri)(implicit
+      clientOptions: SttpClientOptions,
+      wsToPipe: WebSocketToPipe[R]
+  ): I => Request[DecodeResult[Either[E, O]], R] =
     new EndpointToSttpClient(clientOptions, wsToPipe).toSttpRequest(e, baseUri)
 }
 

--- a/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/TapirSttpClient.scala
+++ b/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/TapirSttpClient.scala
@@ -22,7 +22,7 @@ trait TapirSttpClient {
     def toSttpRequestUnsafe(
         baseUri: Uri
     )(implicit clientOptions: SttpClientOptions, wsToPipe: WebSocketToPipe[R]): I => Request[Either[E, O], R] =
-      SttpClientInterpreter.toRequestUnsafe(e)(baseUri)
+      SttpClientInterpreter.toRequestUnsafe(e, baseUri)
 
     /** Interprets the endpoint as a client call, using the given `baseUri` as the starting point to create the target
       * uri.
@@ -36,6 +36,6 @@ trait TapirSttpClient {
     def toSttpRequest(
         baseUri: Uri
     )(implicit clientOptions: SttpClientOptions, wsToPipe: WebSocketToPipe[R]): I => Request[DecodeResult[Either[E, O]], R] =
-      SttpClientInterpreter.toRequest(e)(baseUri)
+      SttpClientInterpreter.toRequest(e, baseUri)
   }
 }

--- a/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/TapirSttpClient.scala
+++ b/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/TapirSttpClient.scala
@@ -4,6 +4,7 @@ import sttp.client3.Request
 import sttp.model.Uri
 import sttp.tapir.{DecodeResult, Endpoint}
 
+@deprecated("Use SttpClientInterpreter", since = "0.17.1")
 trait TapirSttpClient {
   implicit class RichEndpoint[I, E, O, R](e: Endpoint[I, E, O, R]) {
 
@@ -17,10 +18,11 @@ trait TapirSttpClient {
       *
       * @throws IllegalArgumentException when response parsing fails
       */
+    @deprecated("Use SttpClientInterpreter.toRequestUnsafe", since = "0.17.1")
     def toSttpRequestUnsafe(
         baseUri: Uri
     )(implicit clientOptions: SttpClientOptions, wsToPipe: WebSocketToPipe[R]): I => Request[Either[E, O], R] =
-      new EndpointToSttpClient(clientOptions, wsToPipe).toSttpRequestUnsafe(e, baseUri)
+      SttpClientInterpreter.toRequestUnsafe(e)(baseUri)
 
     /** Interprets the endpoint as a client call, using the given `baseUri` as the starting point to create the target
       * uri.
@@ -30,9 +32,10 @@ trait TapirSttpClient {
       * which can be sent using any sttp backend. The response will then contain the decoded error or success values
       * (note that this can be the body enriched with data from headers/status code).
       */
+    @deprecated("Use SttpClientInterpreter.toRequest", since = "0.17.1")
     def toSttpRequest(
         baseUri: Uri
     )(implicit clientOptions: SttpClientOptions, wsToPipe: WebSocketToPipe[R]): I => Request[DecodeResult[Either[E, O]], R] =
-      new EndpointToSttpClient(clientOptions, wsToPipe).toSttpRequest(e, baseUri)
+      SttpClientInterpreter.toRequest(e)(baseUri)
   }
 }

--- a/client/sttp-client/src/test/scala/sttp/tapir/client/sttp/SttpClientRequestTests.scala
+++ b/client/sttp-client/src/test/scala/sttp/tapir/client/sttp/SttpClientRequestTests.scala
@@ -16,8 +16,8 @@ class SttpClientRequestTests extends AnyFunSuite with Matchers {
     val testFile = createTempFile()
 
     // when
-    val sttpClientRequest = testEndpoint
-      .toSttpRequest(uri"http://localhost")
+    val sttpClientRequest = SttpClientInterpreter
+      .toRequest(testEndpoint)(uri"http://localhost")
       .apply(FruitData(Part("image", testFile, contentType = Some(MediaType.ImageJpeg))))
 
     // then

--- a/client/sttp-client/src/test/scala/sttp/tapir/client/sttp/SttpClientRequestTests.scala
+++ b/client/sttp-client/src/test/scala/sttp/tapir/client/sttp/SttpClientRequestTests.scala
@@ -17,7 +17,7 @@ class SttpClientRequestTests extends AnyFunSuite with Matchers {
 
     // when
     val sttpClientRequest = SttpClientInterpreter
-      .toRequest(testEndpoint)(uri"http://localhost")
+      .toRequest(testEndpoint, uri"http://localhost")
       .apply(FruitData(Part("image", testFile, contentType = Some(MediaType.ImageJpeg))))
 
     // then

--- a/client/sttp-client/src/test/scalajs/sttp/tapir/client/sttp/SttpClientTests.scala
+++ b/client/sttp-client/src/test/scalajs/sttp/tapir/client/sttp/SttpClientTests.scala
@@ -15,7 +15,7 @@ abstract class SttpClientTests[R >: Any] extends ClientTests[R] {
   override def send[I, E, O, FN[_]](e: Endpoint[I, E, O, R], port: Port, args: I, scheme: String = "http"): IO[Either[E, O]] = {
     implicit val wst: WebSocketToPipe[R] = wsToPipe
     val response: Future[Either[E, O]] =
-      e.toSttpRequestUnsafe(uri"$scheme://localhost:$port").apply(args).send(backend).map(_.body)
+      SttpClientInterpreter.toRequestUnsafe(e)(uri"$scheme://localhost:$port").apply(args).send(backend).map(_.body)
     IO.fromFuture(IO(response))
   }
 
@@ -26,7 +26,7 @@ abstract class SttpClientTests[R >: Any] extends ClientTests[R] {
   ): IO[DecodeResult[Either[E, O]]] = {
     implicit val wst: WebSocketToPipe[R] = wsToPipe
     def response: Future[DecodeResult[Either[E, O]]] =
-      e.toSttpRequest(uri"http://localhost:$port").apply(args).send(backend).map(_.body)
+      SttpClientInterpreter.toRequest(e)(uri"http://localhost:$port").apply(args).send(backend).map(_.body)
     IO.fromFuture(IO(response))
   }
 

--- a/client/sttp-client/src/test/scalajs/sttp/tapir/client/sttp/SttpClientTests.scala
+++ b/client/sttp-client/src/test/scalajs/sttp/tapir/client/sttp/SttpClientTests.scala
@@ -15,7 +15,7 @@ abstract class SttpClientTests[R >: Any] extends ClientTests[R] {
   override def send[I, E, O, FN[_]](e: Endpoint[I, E, O, R], port: Port, args: I, scheme: String = "http"): IO[Either[E, O]] = {
     implicit val wst: WebSocketToPipe[R] = wsToPipe
     val response: Future[Either[E, O]] =
-      SttpClientInterpreter.toRequestUnsafe(e)(uri"$scheme://localhost:$port").apply(args).send(backend).map(_.body)
+      SttpClientInterpreter.toRequestUnsafe(e, uri"$scheme://localhost:$port").apply(args).send(backend).map(_.body)
     IO.fromFuture(IO(response))
   }
 
@@ -26,7 +26,7 @@ abstract class SttpClientTests[R >: Any] extends ClientTests[R] {
   ): IO[DecodeResult[Either[E, O]]] = {
     implicit val wst: WebSocketToPipe[R] = wsToPipe
     def response: Future[DecodeResult[Either[E, O]]] =
-      SttpClientInterpreter.toRequest(e)(uri"http://localhost:$port").apply(args).send(backend).map(_.body)
+      SttpClientInterpreter.toRequest(e, uri"http://localhost:$port").apply(args).send(backend).map(_.body)
     IO.fromFuture(IO(response))
   }
 

--- a/client/sttp-client/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientTests.scala
+++ b/client/sttp-client/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientTests.scala
@@ -18,7 +18,7 @@ abstract class SttpClientTests[R >: WebSockets with Fs2Streams[IO]] extends Clie
 
   override def send[I, E, O, FN[_]](e: Endpoint[I, E, O, R], port: Port, args: I, scheme: String = "http"): IO[Either[E, O]] = {
     implicit val wst: WebSocketToPipe[R] = wsToPipe
-    e.toSttpRequestUnsafe(uri"$scheme://localhost:$port").apply(args).send(backend).map(_.body)
+    SttpClientInterpreter.toRequestUnsafe(e)(uri"$scheme://localhost:$port").apply(args).send(backend).map(_.body)
   }
 
   override def safeSend[I, E, O, FN[_]](
@@ -27,7 +27,7 @@ abstract class SttpClientTests[R >: WebSockets with Fs2Streams[IO]] extends Clie
       args: I
   ): IO[DecodeResult[Either[E, O]]] = {
     implicit val wst: WebSocketToPipe[R] = wsToPipe
-    e.toSttpRequest(uri"http://localhost:$port").apply(args).send(backend).map(_.body)
+    SttpClientInterpreter.toRequest(e)(uri"http://localhost:$port").apply(args).send(backend).map(_.body)
   }
 
   override protected def afterAll(): Unit = {

--- a/client/sttp-client/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientTests.scala
+++ b/client/sttp-client/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientTests.scala
@@ -18,7 +18,7 @@ abstract class SttpClientTests[R >: WebSockets with Fs2Streams[IO]] extends Clie
 
   override def send[I, E, O, FN[_]](e: Endpoint[I, E, O, R], port: Port, args: I, scheme: String = "http"): IO[Either[E, O]] = {
     implicit val wst: WebSocketToPipe[R] = wsToPipe
-    SttpClientInterpreter.toRequestUnsafe(e)(uri"$scheme://localhost:$port").apply(args).send(backend).map(_.body)
+    SttpClientInterpreter.toRequestUnsafe(e, uri"$scheme://localhost:$port").apply(args).send(backend).map(_.body)
   }
 
   override def safeSend[I, E, O, FN[_]](
@@ -27,7 +27,7 @@ abstract class SttpClientTests[R >: WebSockets with Fs2Streams[IO]] extends Clie
       args: I
   ): IO[DecodeResult[Either[E, O]]] = {
     implicit val wst: WebSocketToPipe[R] = wsToPipe
-    SttpClientInterpreter.toRequest(e)(uri"http://localhost:$port").apply(args).send(backend).map(_.body)
+    SttpClientInterpreter.toRequest(e, uri"http://localhost:$port").apply(args).send(backend).map(_.body)
   }
 
   override protected def afterAll(): Unit = {

--- a/doc/client/play.md
+++ b/doc/client/play.md
@@ -9,24 +9,24 @@ Add the dependency:
 To make requests using an endpoint definition using the [play client](https://github.com/playframework/play-ws), import:
 
 ```scala mdoc:compile-only
-import sttp.tapir.client.play._
+import sttp.tapir.client.play.PlayClientInterpreter
 ```
 
-This adds the two extension methods to any `Endpoint`:
- - `toPlayRequestUnsafe(String)`: given the base URI returns a function,
+This objects contains two methods:
+ - `toRequestUnsafe(Endpoint, String)`: given the base URI returns a function,
    which will generate a request and a response parser which might throw
    an exception when decoding of the result fails
    ```scala
    I => (StandaloneWSRequest, StandaloneWSResponse => Either[E, O])
    ```
- - `toPlayRequest(String)`: given the base URI returns a function,
+ - `toRequest(Endpoint, String)`: given the base URI returns a function,
    which will generate a request and a response parser which represents
    decoding errors as the `DecodeResult` class
    ```scala
    I => (StandaloneWSRequest, StandaloneWSResponse => DecodeResult[Either[E, O]])
    ```
 
-Note that these are a one-argument functions, where the single argument is the input of end endpoint. This might be a 
+Note that the returned functions have one-argument: the input values of end endpoint. This might be a 
 single type, a tuple, or a case class, depending on the endpoint description. 
 
 After providing the input parameters, the two following are returned:
@@ -41,7 +41,7 @@ Example:
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.client.play._
+import sttp.tapir.client.play.PlayClientInterpreter
 import sttp.capabilities.akka.AkkaStreams
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -53,8 +53,8 @@ def example[I, E, O, R >: AkkaStreams](implicit wsClient: StandaloneWSClient) {
   val e: Endpoint[I, E, O, R] = ???
   val inputArgs: I = ???
   
-  val (req, responseParser) = e
-      .toPlayRequestUnsafe(s"http://localhost:9000")
+  val (req, responseParser) = PlayClientInterpreter
+      .toRequestUnsafe(e, s"http://localhost:9000")
       .apply(inputArgs)
   
   val result: Future[Either[E, O]] = req

--- a/doc/client/sttp.md
+++ b/doc/client/sttp.md
@@ -13,6 +13,7 @@ import sttp.tapir.client.sttp.SttpClientInterpreter
 ```
 
 This objects contains two methods:
+
  - `toRequestUnsafe(Endpoint, Uri)`: given the base URI returns a function, which might throw an exception if 
    decoding of the result fails
    ```scala

--- a/doc/client/sttp.md
+++ b/doc/client/sttp.md
@@ -9,23 +9,23 @@ Add the dependency:
 To make requests using an endpoint definition using the [sttp client](https://github.com/softwaremill/sttp), import:
 
 ```scala mdoc:compile-only
-import sttp.tapir.client.sttp._
+import sttp.tapir.client.sttp.SttpClientInterpreter
 ```
 
-This adds the two extension methods to any `Endpoint`:
- - `toSttpRequestUnsafe(Uri)`: given the base URI returns a function, which might throw an exception if 
+This objects contains two methods:
+ - `toRequestUnsafe(Endpoint, Uri)`: given the base URI returns a function, which might throw an exception if 
    decoding of the result fails
    ```scala
    I => Request[Either[E, O], Any]
    ```
- - `toSttpRequest(Uri)`: given the base URI returns a function, which represents decoding errors as the `DecodeResult` 
+ - `toRequest(Endpoint, Uri)`: given the base URI returns a function, which represents decoding errors as the `DecodeResult` 
    class
    ```scala
    I => Request[DecodeResult[Either[E, O]], Any]
    ```
 
-Note that these are a one-argument functions, where the single argument is the input of end endpoint. This might be a 
-single type, a tuple, or a case class, depending on the endpoint description. 
+Note that the returned functions have one-argument: the input values of end endpoint. This might be a
+single type, a tuple, or a case class, depending on the endpoint description.
 
 After providing the input parameters, a description of the request to be made is returned, with the input value
 encoded as appropriate request parameters: path, query, headers and body. This can be further 

--- a/doc/docs/asyncapi.md
+++ b/doc/docs/asyncapi.md
@@ -10,14 +10,14 @@ To use, add the following dependencies:
 Tapir contains a case class-based model of the asyncapi data structures in the `asyncapi/asyncapi-model` subproject (the
 model is independent from all other tapir modules and can be used stand-alone).
  
-An endpoint can be converted to an instance of the model by importing the `sttp.tapir.docs.asyncapi._` package and calling
-the provided extension method:
+An endpoint can be converted to an instance of the model by importing the `sttp.tapir.docs.asyncapi.AsyncAPIInterpreter` 
+object and calling the provided extension method:
 
 ```scala mdoc:silent
 import sttp.capabilities.akka.AkkaStreams
 import sttp.tapir._
 import sttp.tapir.asyncapi.AsyncAPI
-import sttp.tapir.docs.asyncapi._
+import sttp.tapir.docs.asyncapi.AsyncAPIInterpreter
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
@@ -26,7 +26,7 @@ case class Response(msg: String, count: Int)
 val echoWS = endpoint.out(
   webSocketBody[String, CodecFormat.TextPlain, Response, CodecFormat.Json](AkkaStreams))
 
-val docs: AsyncAPI = echoWS.toAsyncAPI("Echo web socket", "1.0")
+val docs: AsyncAPI = AsyncAPIInterpreter.fromEndpoint(echoWS, "Echo web socket", "1.0")
 ```
 
 Such a model can then be refined, by adding details which are not auto-generated. Working with a deeply nested case 
@@ -41,7 +41,8 @@ Quite often, you'll need to define the servers, through which the API can be rea
 ```scala mdoc:silent
 import sttp.tapir.asyncapi.Server
 
-val docsWithServers: AsyncAPI = echoWS.toAsyncAPI(
+val docsWithServers: AsyncAPI = AsyncAPIInterpreter.fromEndpoint(
+  echoWS, 
   "Echo web socket", 
   "1.0",
   List("production" -> Server("api.example.com", "wss"))

--- a/doc/docs/asyncapi.md
+++ b/doc/docs/asyncapi.md
@@ -26,7 +26,7 @@ case class Response(msg: String, count: Int)
 val echoWS = endpoint.out(
   webSocketBody[String, CodecFormat.TextPlain, Response, CodecFormat.Json](AkkaStreams))
 
-val docs: AsyncAPI = AsyncAPIInterpreter.fromEndpoint(echoWS, "Echo web socket", "1.0")
+val docs: AsyncAPI = AsyncAPIInterpreter.toAsyncAPI(echoWS, "Echo web socket", "1.0")
 ```
 
 Such a model can then be refined, by adding details which are not auto-generated. Working with a deeply nested case 
@@ -41,7 +41,7 @@ Quite often, you'll need to define the servers, through which the API can be rea
 ```scala mdoc:silent
 import sttp.tapir.asyncapi.Server
 
-val docsWithServers: AsyncAPI = AsyncAPIInterpreter.fromEndpoint(
+val docsWithServers: AsyncAPI = AsyncAPIInterpreter.toAsyncAPI(
   echoWS, 
   "Echo web socket", 
   "1.0",

--- a/doc/docs/asyncapi.md
+++ b/doc/docs/asyncapi.md
@@ -10,8 +10,8 @@ To use, add the following dependencies:
 Tapir contains a case class-based model of the asyncapi data structures in the `asyncapi/asyncapi-model` subproject (the
 model is independent from all other tapir modules and can be used stand-alone).
  
-An endpoint can be converted to an instance of the model by importing the `sttp.tapir.docs.asyncapi.AsyncAPIInterpreter` 
-object and calling the provided extension method:
+An endpoint can be converted to an instance of the model by using the `sttp.tapir.docs.asyncapi.AsyncAPIInterpreter` 
+object:
 
 ```scala mdoc:silent
 import sttp.capabilities.akka.AkkaStreams
@@ -51,7 +51,7 @@ val docsWithServers: AsyncAPI = AsyncAPIInterpreter.toAsyncAPI(
 
 Servers can also be later added through methods on the `AsyncAPI` object.
 
-Multiple endpoints can be converted to an `AsyncAPI` instance by calling the extension method on a list of endpoints/
+Multiple endpoints can be converted to an `AsyncAPI` instance by calling the method using a list of endpoints.
 
 The asyncapi case classes can then be serialised, either to JSON or YAML using [Circe](https://circe.github.io/circe/):
 

--- a/doc/docs/openapi.md
+++ b/doc/docs/openapi.md
@@ -39,7 +39,7 @@ val docsWithServers: OpenAPI = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "M
   .servers(List(Server("https://api.example.com/v1").description("Production server")))
 ```
 
-Multiple endpoints can be converted to an `OpenAPI` instance by calling the extension method on a list of endpoints:
+Multiple endpoints can be converted to an `OpenAPI` instance by calling the method on a list of endpoints:
 
 ```scala mdoc:invisible
 val addBook = endpoint.in(path[String]("bookId"))

--- a/doc/docs/openapi.md
+++ b/doc/docs/openapi.md
@@ -20,7 +20,7 @@ import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 val booksListing = endpoint.in(path[String]("bookId"))
 
-val docs: OpenAPI = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
+val docs: OpenAPI = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "My Bookshop", "1.0")
 ```
 
 Such a model can then be refined, by adding details which are not auto-generated. Working with a deeply nested case 
@@ -35,7 +35,7 @@ returned `OpenAPI` case class either directly or by using a helper method:
 ```scala mdoc:silent
 import sttp.tapir.openapi.Server
 
-val docsWithServers: OpenAPI = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
+val docsWithServers: OpenAPI = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "My Bookshop", "1.0")
   .servers(List(Server("https://api.example.com/v1").description("Production server")))
 ```
 
@@ -47,7 +47,7 @@ val booksListingByGenre = endpoint.in(path[String]("genre"))
 ```
 
 ```scala mdoc:silent
-OpenAPIDocsInterpreter.fromEndpoints(List(addBook, booksListing, booksListingByGenre), "My Bookshop", "1.0")
+OpenAPIDocsInterpreter.toOpenAPI(List(addBook, booksListing, booksListingByGenre), "My Bookshop", "1.0")
 ```
 
 The openapi case classes can then be serialised, either to JSON or YAML using [Circe](https://circe.github.io/circe/):
@@ -105,7 +105,7 @@ import sttp.tapir.openapi.circe.yaml._
 import sttp.tapir.swagger.akkahttp.SwaggerAkka
 
 val myEndpoints: Seq[Endpoint[_, _, _, _]] = ???
-val docsAsYaml: String = OpenAPIDocsInterpreter.fromEndpoints(myEndpoints, "My App", "1.0").toYaml
+val docsAsYaml: String = OpenAPIDocsInterpreter.toOpenAPI(myEndpoints, "My App", "1.0").toYaml
 // add to your akka routes
 new SwaggerAkka(docsAsYaml).routes
 ```

--- a/doc/docs/openapi.md
+++ b/doc/docs/openapi.md
@@ -10,8 +10,8 @@ To use, add the following dependencies:
 Tapir contains a case class-based model of the openapi data structures in the `openapi/openapi-model` subproject (the
 model is independent from all other tapir modules and can be used stand-alone).
  
-An endpoint can be converted to an instance of the model by importing the `sttp.tapir.docs.openapi._` package and calling
-the provided extension method:
+An endpoint can be converted to an instance of the model by importing the `sttp.tapir.docs.openapi.OpenAPIDocsInterpreter` 
+object:
 
 ```scala mdoc:silent
 import sttp.tapir._
@@ -20,7 +20,7 @@ import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 val booksListing = endpoint.in(path[String]("bookId"))
 
-val docs: OpenAPI = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "My Bookshop", "1.0")
+val docs: OpenAPI = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
 ```
 
 Such a model can then be refined, by adding details which are not auto-generated. Working with a deeply nested case 
@@ -35,7 +35,7 @@ returned `OpenAPI` case class either directly or by using a helper method:
 ```scala mdoc:silent
 import sttp.tapir.openapi.Server
 
-val docsWithServers: OpenAPI = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "My Bookshop", "1.0")
+val docsWithServers: OpenAPI = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
   .servers(List(Server("https://api.example.com/v1").description("Production server")))
 ```
 
@@ -47,7 +47,7 @@ val booksListingByGenre = endpoint.in(path[String]("genre"))
 ```
 
 ```scala mdoc:silent
-OpenAPIDocsInterpreter.toOpenAPI(List(addBook, booksListing, booksListingByGenre), "My Bookshop", "1.0")
+OpenAPIDocsInterpreter.fromEndpoints(List(addBook, booksListing, booksListingByGenre), "My Bookshop", "1.0")
 ```
 
 The openapi case classes can then be serialised, either to JSON or YAML using [Circe](https://circe.github.io/circe/):
@@ -105,7 +105,7 @@ import sttp.tapir.openapi.circe.yaml._
 import sttp.tapir.swagger.akkahttp.SwaggerAkka
 
 val myEndpoints: Seq[Endpoint[_, _, _, _]] = ???
-val docsAsYaml: String = OpenAPIDocsInterpreter.toOpenAPI(myEndpoints, "My App", "1.0").toYaml
+val docsAsYaml: String = OpenAPIDocsInterpreter.fromEndpoints(myEndpoints, "My App", "1.0").toYaml
 // add to your akka routes
 new SwaggerAkka(docsAsYaml).routes
 ```

--- a/doc/docs/openapi.md
+++ b/doc/docs/openapi.md
@@ -16,11 +16,11 @@ the provided extension method:
 ```scala mdoc:silent
 import sttp.tapir._
 import sttp.tapir.openapi.OpenAPI
-import sttp.tapir.docs.openapi._
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 val booksListing = endpoint.in(path[String]("bookId"))
 
-val docs: OpenAPI = booksListing.toOpenAPI("My Bookshop", "1.0")
+val docs: OpenAPI = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "My Bookshop", "1.0")
 ```
 
 Such a model can then be refined, by adding details which are not auto-generated. Working with a deeply nested case 
@@ -35,7 +35,7 @@ returned `OpenAPI` case class either directly or by using a helper method:
 ```scala mdoc:silent
 import sttp.tapir.openapi.Server
 
-val docsWithServers: OpenAPI = booksListing.toOpenAPI("My Bookshop", "1.0")
+val docsWithServers: OpenAPI = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "My Bookshop", "1.0")
   .servers(List(Server("https://api.example.com/v1").description("Production server")))
 ```
 
@@ -47,7 +47,7 @@ val booksListingByGenre = endpoint.in(path[String]("genre"))
 ```
 
 ```scala mdoc:silent
-List(addBook, booksListing, booksListingByGenre).toOpenAPI("My Bookshop", "1.0")
+OpenAPIDocsInterpreter.toOpenAPI(List(addBook, booksListing, booksListingByGenre), "My Bookshop", "1.0")
 ```
 
 The openapi case classes can then be serialised, either to JSON or YAML using [Circe](https://circe.github.io/circe/):
@@ -100,12 +100,12 @@ Usage example for akka-http:
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.docs.openapi._
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import sttp.tapir.openapi.circe.yaml._
 import sttp.tapir.swagger.akkahttp.SwaggerAkka
 
 val myEndpoints: Seq[Endpoint[_, _, _, _]] = ???
-val docsAsYaml: String = myEndpoints.toOpenAPI("My App", "1.0").toYaml
+val docsAsYaml: String = OpenAPIDocsInterpreter.toOpenAPI(myEndpoints, "My App", "1.0").toYaml
 // add to your akka routes
 new SwaggerAkka(docsAsYaml).routes
 ```

--- a/doc/endpoint/auth.md
+++ b/doc/endpoint/auth.md
@@ -26,7 +26,6 @@ details.
 
 For each `auth` scheme, one can define `WWW-Authenticate` headers that should be returned by the server in case input is not provided. Default behavior is to return `401` status with the headers needed for authentication.
 
-
 For example if you define `endpoint.get.in("path").in(auth.basic[UsernamePassword]())` then your browser will show you a password prompt.
 
 ## Next

--- a/doc/endpoint/zio.md
+++ b/doc/endpoint/zio.md
@@ -1,7 +1,7 @@
 # ZIO integration
 
 The `tapir-zio` module defines type aliases and extension methods which make it more ergonomic to work with 
-[ZIO](https://zio.dev) and tapir. Moreover, the `tapir-zio-http4s-server` contains similar extensions useful when
+[ZIO](https://zio.dev) and tapir. Moreover, the `tapir-zio-http4s-server` contains an interpreter useful when
 exposing the endpoints using the [http4s](https://http4s.org) server.
 
 You'll need the following dependencies:
@@ -40,11 +40,10 @@ The first defines complete server logic, while the second and third allow defini
 
 ## Exposing endpoints using the http4s server
 
-To bring into scope the extension methods used to interpret a `ZServerEndpoint` as a http4s server, add the following
-import:
+To interpret a `ZServerEndpoint` as a http4s server, add the following  import:
 
 ```scala mdoc:compile-only
-import sttp.tapir.server.http4s.ztapir._
+import sttp.tapir.server.http4s.ztapir.ZHttp4sServerInterpreter
 ```
 
 This adds the following method on `ZEndpoint`:
@@ -63,7 +62,7 @@ so that it is uniform across all endpoints, using the `.widen` method:
 ```scala mdoc:compile-only
 import org.http4s.HttpRoutes
 import sttp.tapir.ztapir._
-import sttp.tapir.server.http4s.ztapir._
+import sttp.tapir.server.http4s.ztapir.ZHttp4sServerInterpreter
 import zio.{Has, RIO, ZIO}
 import zio.clock.Clock
 import zio.interop.catz._

--- a/doc/endpoint/zio.md
+++ b/doc/endpoint/zio.md
@@ -78,10 +78,10 @@ val serverEndpoint2: ZServerEndpoint[Service2, Unit, Unit, Unit] = ???
 
 type Env = Service1 with Service2
 val routes: HttpRoutes[RIO[Env with Clock, *]] = 
-  ZHttp4sServerInterpreter.toRoutes(List(
+  ZHttp4sServerInterpreter.from(List(
     serverEndpoint1.widen[Env], 
     serverEndpoint2.widen[Env]
-  )) // this is where zio-cats interop is needed
+  )).toRoutes // this is where zio-cats interop is needed
 ```
 
 ## Example

--- a/doc/endpoint/zio.md
+++ b/doc/endpoint/zio.md
@@ -78,11 +78,10 @@ val serverEndpoint2: ZServerEndpoint[Service2, Unit, Unit, Unit] = ???
 
 type Env = Service1 with Service2
 val routes: HttpRoutes[RIO[Env with Clock, *]] = 
-  List(
+  ZHttp4sServerInterpreter.toRoutes(List(
     serverEndpoint1.widen[Env], 
     serverEndpoint2.widen[Env]
-  )
-  .toRoutes // this is where zio-cats interop is needed
+  )) // this is where zio-cats interop is needed
 ```
 
 ## Example

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -37,6 +37,7 @@ A new project can be created using: `sbt new https://codeberg.org/wegtam/http4s-
 * [Three easy endpoints](https://blog.softwaremill.com/three-easy-endpoints-a6cbd52b0a6e)
 * [tAPIr’s Endpoint meets ZIO’s IO](https://blog.softwaremill.com/tapirs-endpoint-meets-zio-s-io-3278099c5e10)
 * [Describe, then interpret: HTTP endpoints using tapir](https://blog.softwaremill.com/describe-then-interpret-http-endpoints-using-tapir-ac139ba565b0)
+* [Functional pancakes](https://blog.softwaremill.com/functional-pancakes-cf70023f0dcb)
 
 ## Videos
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -53,16 +53,16 @@ val booksListing: Endpoint[(BooksFromYear, Limit, AuthToken), String, List[Book]
 
 // Generate OpenAPI documentation
 
-import sttp.tapir.docs.openapi.OpenAPIInterpreter
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import sttp.tapir.openapi.circe.yaml._
 
-val docs = OpenAPIInterpreter.toOpenAPI(booksListing)("My Bookshop", "1.0")
+val docs = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
 println(docs.toYaml)
 
 
 // Convert to akka-http Route
 
-import sttp.tapir.server.akkahttp.AkkaHttpInterpreter
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import akka.http.scaladsl.server.Route
 import scala.concurrent.Future
 
@@ -70,7 +70,8 @@ def bookListingLogic(bfy: BooksFromYear,
                      limit: Limit,
                      at: AuthToken): Future[Either[String, List[Book]]] =
   Future.successful(Right(List(Book("The Sorrows of Young Werther"))))
-val booksListingRoute: Route = AkkaHttpInterpreter.toRoute(booksListing)((bookListingLogic _).tupled)
+val booksListingRoute: Route = AkkaHttpServerInterpreter
+  .toRoute(booksListing)((bookListingLogic _).tupled)
 
 
 // Convert to sttp Request
@@ -79,7 +80,7 @@ import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.client3._
 
 val booksListingRequest: Request[DecodeResult[Either[String, List[Book]]], Any] = SttpClientInterpreter
-  .toRequest(booksListing)(uri"http://localhost:8080")
+  .toRequest(booksListing, uri"http://localhost:8080")
   .apply((BooksFromYear("SF", 2016), 20, "xyz-abc-123"))
 ```
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -56,7 +56,7 @@ val booksListing: Endpoint[(BooksFromYear, Limit, AuthToken), String, List[Book]
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import sttp.tapir.openapi.circe.yaml._
 
-val docs = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
+val docs = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "My Bookshop", "1.0")
 println(docs.toYaml)
 
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -53,16 +53,16 @@ val booksListing: Endpoint[(BooksFromYear, Limit, AuthToken), String, List[Book]
 
 // Generate OpenAPI documentation
 
-import sttp.tapir.docs.openapi._
+import sttp.tapir.docs.openapi.OpenAPIInterpreter
 import sttp.tapir.openapi.circe.yaml._
 
-val docs = booksListing.toOpenAPI("My Bookshop", "1.0")
+val docs = OpenAPIInterpreter.toOpenAPI(booksListing)("My Bookshop", "1.0")
 println(docs.toYaml)
 
 
 // Convert to akka-http Route
 
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpInterpreter
 import akka.http.scaladsl.server.Route
 import scala.concurrent.Future
 
@@ -70,16 +70,16 @@ def bookListingLogic(bfy: BooksFromYear,
                      limit: Limit,
                      at: AuthToken): Future[Either[String, List[Book]]] =
   Future.successful(Right(List(Book("The Sorrows of Young Werther"))))
-val booksListingRoute: Route = booksListing.toRoute((bookListingLogic _).tupled)
+val booksListingRoute: Route = AkkaHttpInterpreter.toRoute(booksListing)((bookListingLogic _).tupled)
 
 
 // Convert to sttp Request
 
-import sttp.tapir.client.sttp._
+import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.client3._
 
-val booksListingRequest: Request[DecodeResult[Either[String, List[Book]]], Any] = booksListing
-  .toSttpRequest(uri"http://localhost:8080")
+val booksListingRequest: Request[DecodeResult[Either[String, List[Book]]], Any] = SttpClientInterpreter
+  .toRequest(booksListing)(uri"http://localhost:8080")
   .apply((BooksFromYear("SF", 2016), 20, "xyz-abc-123"))
 ```
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,6 +1,6 @@
 # tapir, or Typed API descRiptions
 
-With tapir you can describe HTTP API endpoints as immutable Scala values. Each endpoint can contain a number of 
+With tapir, you can describe HTTP API endpoints as immutable Scala values. Each endpoint can contain a number of 
 input parameters, error-output parameters, and normal-output parameters. An endpoint specification can be 
 interpreted as:
 

--- a/doc/mytapir.md
+++ b/doc/mytapir.md
@@ -12,11 +12,10 @@ object MyTapir extends Tapir
   with AkkaHttpServerInterpreter
   with SttpClientInterpreter
   with OpenAPIDocsInterpreter
-  with ValidatorDerivation
   with SchemaDerivation
   with TapirJsonCirce
   with TapirOpenAPICirceYaml
   with TapirAliases
 ```
 
-Then, a single `import MyTapir._` and all Tapir data types and extensions methods will be in scope!
+Then, a single `import MyTapir._` and all Tapir data types and interpreter methods will be in scope!

--- a/doc/mytapir.md
+++ b/doc/mytapir.md
@@ -9,8 +9,9 @@ a single-import whenever you want to use tapir. For example:
 
 ```scala
 object MyTapir extends Tapir
-  with TapirAkkaHttpServer
-  with TapirSttpClient
+  with AkkaHttpServerInterpreter
+  with SttpClientInterpreter
+  with OpenAPIDocsInterpreter
   with ValidatorDerivation
   with SchemaDerivation
   with TapirJsonCirce

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -9,8 +9,8 @@ To use tapir, add the following dependency to your project:
 This will import only the core classes needed to create endpoint descriptions. To generate a server or a client, you
 will need to add further dependencies.
 
-Most of tapir functionalities are grouped into package objects which provide builder and extensions methods, hence it's
-easiest to work with tapir if you import whole packages, e.g.:
+Many of tapir functionalities come as builder methods in the main package, hence it's easiest to work with tapir if 
+you import the main package entirely, i.e.:
 
 ```scala
 import sttp.tapir._

--- a/doc/server/akkahttp.md
+++ b/doc/server/akkahttp.md
@@ -47,7 +47,7 @@ def countCharacters(s: String): Future[Either[Unit, Int]] =
 val countCharactersEndpoint: Endpoint[String, Unit, Int, Any] = 
   endpoint.in(stringBody).out(plainBody[Int])
   
-val countCharactersRoute: Route = countCharactersEndpoint.toRoute(countCharacters)
+val countCharactersRoute: Route = AkkaHttpServerInterpreter.toRoute(countCharactersEndpoint)(countCharacters)
 ```
 
 Note that these functions take one argument, which is a tuple of type `I`. This means that functions which take multiple 
@@ -61,7 +61,7 @@ import akka.http.scaladsl.server.Route
 
 def logic(s: String, i: Int): Future[Either[Unit, String]] = ???
 val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ??? 
-val aRoute: Route = anEndpoint.toRoute((logic _).tupled)
+val aRoute: Route = AkkaHttpServerInterpreter.toRoute(anEndpoint)((logic _).tupled)
 ```
 
 ## Using `toDirective`
@@ -111,7 +111,7 @@ val tapirEndpoint: Endpoint[String, Unit, Unit, Any] = endpoint.in(path[String](
 
 val myRoute: Route = metricsDirective {
   securityDirective { user =>
-    tapirEndpoint.toRoute(input => ??? /* here we can use both `user` and `input` values */)
+    AkkaHttpServerInterpreter.toRoute(tapirEndpoint)(input => ??? /* here we can use both `user` and `input` values */)
   }
 }
 ```

--- a/doc/server/akkahttp.md
+++ b/doc/server/akkahttp.md
@@ -8,7 +8,7 @@ dependency:
 ```
 
 This will transitively pull some Akka modules in version 2.6. If you want to force
-your own Akka version (for example 2.5), use sbt exclusion.  Mind the Scala version in artifact name:
+your own Akka version (for example 2.5), use sbt exclusion. Mind the Scala version in artifact name:
 
 ```scala
 "com.softwaremill.sttp.tapir" %% "tapir-akka-http-server" % "@VERSION@" exclude("com.typesafe.akka", "akka-stream_2.12")
@@ -16,7 +16,7 @@ your own Akka version (for example 2.5), use sbt exclusion.  Mind the Scala vers
 
 Now import the object:
 
-```scala
+```scala mdoc:compile-only
 import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 ```
 

--- a/doc/server/errors.md
+++ b/doc/server/errors.md
@@ -12,7 +12,7 @@ However, any exceptions can be recovered from and mapped to an error value. For 
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import scala.concurrent.Future
 import scala.util._
 
@@ -28,11 +28,13 @@ def handleErrors[T](f: Future[T]): Future[Either[ErrorInfo, T]] =
       Success(Left(e.getMessage))
   }
 
-endpoint
-  .errorOut(plainBody[ErrorInfo])
-  .out(plainBody[Int])
-  .in(query[String]("name"))
-  .toRoute((logic _).andThen(handleErrors))
+AkkaHttpServerInterpreter.toRoute(
+  endpoint
+    .errorOut(plainBody[ErrorInfo])
+    .out(plainBody[Int])
+    .in(query[String]("name"))) {
+  (logic _).andThen(handleErrors)
+}
 ```
 
 In the above example, errors are represented as `String`s (aliased to `ErrorInfo` for readability). When the
@@ -78,7 +80,7 @@ a different format (other than textual):
 ```scala mdoc:compile-only
 import sttp.tapir._
 import sttp.tapir.server._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.{ AkkaHttpServerInterpreter, AkkaHttpServerOptions }
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import sttp.model.StatusCode

--- a/doc/server/finatra.md
+++ b/doc/server/finatra.md
@@ -47,7 +47,7 @@ For example:
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.finatra._
+import sttp.tapir.server.finatra.FinatraServerInterpreter
 import com.twitter.util.Future
 
 def countCharacters(s: String): Future[Either[Unit, Int]] =
@@ -56,7 +56,7 @@ def countCharacters(s: String): Future[Either[Unit, Int]] =
 val countCharactersEndpoint: Endpoint[String, Unit, Int, Any] =
   endpoint.in(stringBody).out(plainBody[Int])
   
-val countCharactersRoute: FinatraRoute = countCharactersEndpoint.toRoute(countCharacters)
+val countCharactersRoute: FinatraRoute = FinatraServerInterpreter.toRoute(countCharactersEndpoint)(countCharacters)
 ```
 
 or a cats-effect's example:
@@ -65,7 +65,7 @@ or a cats-effect's example:
 import cats.effect.IO
 import sttp.tapir._
 import sttp.tapir.server.finatra.FinatraRoute
-import sttp.tapir.server.finatra.cats._
+import sttp.tapir.server.finatra.cats.FinatraCatsServerInterpreter
 
 def countCharacters(s: String): IO[Either[Unit, Int]] =
   IO.pure(Right[Unit, Int](s.length))
@@ -73,7 +73,7 @@ def countCharacters(s: String): IO[Either[Unit, Int]] =
 val countCharactersEndpoint: Endpoint[String, Unit, Int, Any] =
   endpoint.in(stringBody).out(plainBody[Int])
   
-val countCharactersRoute: FinatraRoute = countCharactersEndpoint.toRoute(countCharacters)
+val countCharactersRoute: FinatraRoute = FinatraCatsServerInterpreter.toRoute(countCharactersEndpoint)(countCharacters)
 ```
 
 Note that these functions take one argument, which is a tuple of type `I`. This means that functions which take multiple 
@@ -81,12 +81,12 @@ arguments need to be converted to a function using a single argument using `.tup
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.finatra._
+import sttp.tapir.server.finatra.FinatraServerInterpreter
 import com.twitter.util.Future
 
 def logic(s: String, i: Int): Future[Either[Unit, String]] = ???
 val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ???
-val aRoute: FinatraRoute = anEndpoint.toRoute((logic _).tupled)
+val aRoute: FinatraRoute = FinatraServerInterpreter.toRoute(anEndpoint)((logic _).tupled)
 ```
 
 Now that you've created the `FinatraRoute`, add `TapirController` as a trait to your `Controller`. You can then

--- a/doc/server/finatra.md
+++ b/doc/server/finatra.md
@@ -7,10 +7,10 @@ dependency:
 "com.softwaremill.sttp.tapir" %% "tapir-finatra-server" % "@VERSION@"
 ```
 
-and import the package:
+and import the object:
 
 ```scala mdoc:compile-only
-import sttp.tapir.server.finatra._
+import sttp.tapir.server.finatra.FinatraServerInterpreter
 ```
 
 or if you would like to use cats-effect project, you can add the following dependency:
@@ -19,22 +19,21 @@ or if you would like to use cats-effect project, you can add the following depen
 "com.softwaremill.sttp.tapir" %% "tapir-finatra-server-cats" % "@VERSION@"
 ```
 
-and import the packate:
+and import the object:
 
 ```scala mdoc:compile-only
-import sttp.tapir.server.finatra.cats._
+import sttp.tapir.server.finatra.cats.FinatraCatsServerInterpreter
 ```
 
-This adds extension methods to the `Endpoint` type: `toRoute` and `toRouteRecoverErrors`. The first one
+The interpreter objects contain the `toRoute` and `toRouteRecoverErrors` method. The first one
 requires the logic of the endpoint to be given as a function of type (note this is a Twitter `Future` or a cats-effect project's `Effect` type):
 
 ```scala
 I => Future[Either[E, O]]
 ```
 
-or
-
-An effect type that supports cats-effect's `Effect[F]` type, for example, project [Catbird's](https://github.com/travisbrown/catbird) `Rerunnbale`.
+or giben an effect type that supports cats-effect's `Effect[F]` type, for example, project 
+[Catbird's](https://github.com/travisbrown/catbird) `Rerunnbale`:
 
 ```scala
 I => Rerunnable[Either[E, O]]
@@ -47,7 +46,7 @@ For example:
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.finatra.FinatraServerInterpreter
+import sttp.tapir.server.finatra.{ FinatraServerInterpreter, FinatraRoute }
 import com.twitter.util.Future
 
 def countCharacters(s: String): Future[Either[Unit, Int]] =
@@ -76,12 +75,12 @@ val countCharactersEndpoint: Endpoint[String, Unit, Int, Any] =
 val countCharactersRoute: FinatraRoute = FinatraCatsServerInterpreter.toRoute(countCharactersEndpoint)(countCharacters)
 ```
 
-Note that these functions take one argument, which is a tuple of type `I`. This means that functions which take multiple 
-arguments need to be converted to a function using a single argument using `.tupled`:
+Note that the second argument to `toRoute` is a function with one argument, a tuple of type `I`.  This means that 
+functions which take multiple arguments need to be converted to a function using a single argument using `.tupled`:
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.finatra.FinatraServerInterpreter
+import sttp.tapir.server.finatra.{ FinatraServerInterpreter, FinatraRoute }
 import com.twitter.util.Future
 
 def logic(s: String, i: Int): Future[Either[Unit, String]] = ???

--- a/doc/server/http4s.md
+++ b/doc/server/http4s.md
@@ -7,13 +7,13 @@ dependency:
 "com.softwaremill.sttp.tapir" %% "tapir-http4s-server" % "@VERSION@"
 ```
 
-and import the package:
+and import the object:
 
 ```scala mdoc:compile-only
-import sttp.tapir.server.http4s._
+import sttp.tapir.server.http4s.Http4sServerInterpreter
 ```
 
-This adds two extension methods to the `Endpoint` type: `toRoutes` and `toRoutesRecoverErrors`. This first requires the 
+This objects contains the `toRoutes` and `toRoutesRecoverErrors` methods. This first requires the 
 logic of the endpoint to be given as a function of type:
 
 ```scala
@@ -25,7 +25,7 @@ a subclass of `Throwable` (an exception); it expects a function of type `I => F[
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.http4s._
+import sttp.tapir.server.http4s.Http4sServerInterpreter
 import cats.effect.IO
 import org.http4s.HttpRoutes
 import cats.effect.{ContextShift, Timer}
@@ -45,12 +45,12 @@ val countCharactersRoutes: HttpRoutes[IO] =
   Http4sServerInterpreter.toRoutes(countCharactersEndpoint)(countCharacters _)
 ```
 
-Note that these functions take one argument, which is a tuple of type `I`. This means that functions which take multiple 
-arguments need to be converted to a function using a single argument using `.tupled`:
+Note that the second argument to `toRoute` is a function with one argument, a tuple of type `I`. This means that 
+functions which take multiple arguments need to be converted to a function using a single argument using `.tupled`:
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.http4s._
+import sttp.tapir.server.http4s.Http4sServerInterpreter
 import cats.effect.IO
 import org.http4s.HttpRoutes
 import cats.effect.{ContextShift, Timer}

--- a/doc/server/http4s.md
+++ b/doc/server/http4s.md
@@ -42,7 +42,7 @@ def countCharacters(s: String): IO[Either[Unit, Int]] =
 val countCharactersEndpoint: Endpoint[String, Unit, Int, Any] = 
   endpoint.in(stringBody).out(plainBody[Int])
 val countCharactersRoutes: HttpRoutes[IO] = 
-  countCharactersEndpoint.toRoutes(countCharacters _)
+  Http4sServerInterpreter.toRoutes(countCharactersEndpoint)(countCharacters _)
 ```
 
 Note that these functions take one argument, which is a tuple of type `I`. This means that functions which take multiple 
@@ -63,7 +63,7 @@ implicit val t: Timer[IO] =
 
 def logic(s: String, i: Int): IO[Either[Unit, String]] = ???
 val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ??? 
-val routes: HttpRoutes[IO] = anEndpoint.toRoutes((logic _).tupled)
+val routes: HttpRoutes[IO] = Http4sServerInterpreter.toRoutes(anEndpoint)((logic _).tupled)
 ```
 
 The created `HttpRoutes` are the usual http4s `Kleisli`-based transformation of a `Request` to a `Response`, and can 

--- a/doc/server/logic.md
+++ b/doc/server/logic.md
@@ -16,7 +16,7 @@ The book example can be more concisely written as follows:
 ```scala mdoc:compile-only
 import sttp.tapir._
 import sttp.tapir.server._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import scala.concurrent.Future
 import akka.http.scaladsl.server.Route
 
@@ -25,7 +25,7 @@ val countCharactersServerEndpoint: ServerEndpoint[String, Unit, Int, Any, Future
     Future.successful[Either[Unit, Int]](Right(s.length))
   }
 
-val countCharactersRoute: Route = countCharactersServerEndpoint.toRoute
+val countCharactersRoute: Route = AkkaHttpServerInterpreter.toRoute(countCharactersServerEndpoint)
 ```
 
 A `ServerEndpoint` can then be converted to a route using `.toRoute`/`.toRoutes` methods (without any additional
@@ -35,7 +35,7 @@ Moreover, a list of server endpoints can be converted to routes or documentation
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import scala.concurrent.Future
 import akka.http.scaladsl.server.Route
 
@@ -45,7 +45,7 @@ val endpoint1 = endpoint.in("hello").out(stringBody)
 val endpoint2 = endpoint.in("ping").out(stringBody)
   .serverLogic { _ => Future.successful[Either[Unit, String]](Right("pong")) }
 
-val route: Route = List(endpoint1, endpoint2).toRoute
+val route: Route = AkkaHttpServerInterpreter.toRoute(List(endpoint1, endpoint2))
 ```
 
 Note that when dealing with endpoints which have multiple input parameters, the server logic function is a function

--- a/doc/server/play.md
+++ b/doc/server/play.md
@@ -20,13 +20,13 @@ or
 
 depending on whether you want to use netty or akka based http-server under the hood.
 
-Then import the package:
+Then import the object:
 
 ```scala mdoc:compile-only
-import sttp.tapir.server.play._
+import sttp.tapir.server.play.PlayServerInterpreter
 ```
 
-This adds two extension methods to the `Endpoint` type: `toRoute` and `toRoutesRecoverError`. This first requires the
+This object contains the `toRoute` and `toRoutesRecoverError` methods. This first requires the
 logic of the endpoint to be given as a function of type:
 
 ```scala
@@ -55,8 +55,8 @@ val countCharactersRoutes: Routes =
   PlayServerInterpreter.toRoute(countCharactersEndpoint)(countCharacters _)
 ```
 
-Note that these functions take one argument, which is a tuple of type `I`. This means that functions which take multiple 
-arguments need to be converted to a function using a single argument using `.tupled`:
+Note that the second argument to `toRoute` is a function with one argument, a tuple of type `I`. This means that 
+functions which take multiple arguments need to be converted to a function using a single argument using `.tupled`:
 
 ```scala mdoc:compile-only
 import sttp.tapir._

--- a/doc/server/play.md
+++ b/doc/server/play.md
@@ -38,7 +38,7 @@ a subclass of `Throwable` (an exception); it expects a function of type `I => Fu
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.play._
+import sttp.tapir.server.play.PlayServerInterpreter
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import akka.stream.Materializer
@@ -52,7 +52,7 @@ def countCharacters(s: String): Future[Either[Unit, Int]] =
 val countCharactersEndpoint: Endpoint[String, Unit, Int, Any] = 
   endpoint.in(stringBody).out(plainBody[Int])
 val countCharactersRoutes: Routes = 
-  countCharactersEndpoint.toRoute(countCharacters _)
+  PlayServerInterpreter.toRoute(countCharactersEndpoint)(countCharacters _)
 ```
 
 Note that these functions take one argument, which is a tuple of type `I`. This means that functions which take multiple 
@@ -70,7 +70,7 @@ implicit val materializer: Materializer = ???
 
 def logic(s: String, i: Int): Future[Either[Unit, String]] = ???
 val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ??? 
-val aRoute: Routes = anEndpoint.toRoute((logic _).tupled)
+val aRoute: Routes = PlayServerInterpreter.toRoute(anEndpoint)((logic _).tupled)
 ```
 
 ## Bind the routes

--- a/doc/server/vertx.md
+++ b/doc/server/vertx.md
@@ -10,7 +10,7 @@ Use the following dependency
 Then import the package:
 
 ```scala mdoc:compile-only
-import sttp.tapir.server.vertx._
+import sttp.tapir.server.vertx.VertxServerInterpreter
 ```
 
 This adds extension methods to the `Endpoint` type: 
@@ -26,14 +26,14 @@ arguments need to be converted to a function using a single argument using `.tup
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.vertx._
+import sttp.tapir.server.vertx.VertxServerInterpreter
 import io.vertx.scala.ext.web._
 import scala.concurrent.Future
 
 implicit val options: VertxEndpointOptions = ???
 def logic(s: String, i: Int): Future[Either[Unit, String]] = ???
 val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ??? 
-val aRoute: Router => Route = anEndpoint.route((logic _).tupled)
+val aRoute: Router => Route = VertxServerInterpreter.route(anEndpoint)((logic _).tupled)
 ```
 
 In practice, routes will be mounted on a router, this router can then be used as a request handler for your http server. 
@@ -41,7 +41,7 @@ An HTTP server can then be started as in the following example:
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.vertx._
+import sttp.tapir.server.vertx.VertxServerInterpreter
 import io.vertx.scala.core.Vertx
 import io.vertx.scala.ext.web._
 import scala.concurrent.Future
@@ -55,7 +55,7 @@ object Main {
     val router = Router.router(vertx)
     val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ??? // your definition here
     def logic(s: String, i: Int): Future[Either[Unit, String]] = ??? // your logic here 
-    val attach = anEndpoint.route((logic _).tupled)
+    val attach = VertxServerInterpreter.route(anEndpoint)((logic _).tupled)
     attach(router) // your endpoint is now attached to the router, and the route has been created
     server.requestHandler(router).listenFuture(9000)
   }

--- a/doc/server/vertx.md
+++ b/doc/server/vertx.md
@@ -7,26 +7,27 @@ Use the following dependency
 "com.softwaremill.sttp.tapir" %% "tapir-vertx-server" % "@VERSION@"
 ```
 
-Then import the package:
+Then import the object:
 
 ```scala mdoc:compile-only
 import sttp.tapir.server.vertx.VertxServerInterpreter
 ```
 
-This adds extension methods to the `Endpoint` type: 
-* `route(logic: I => Future[Either[E, O]])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. Errors will be recovered automatically (but generically)
-* `routeRecoverErrors(logic: I => Future[O])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. You're providing your own way to deal with errors happening in the `logic` function.
-* `blockingRoute(logic: I => Future[Either[E, O]])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an blocking handler. Errors will be recovered automatically (but generically)
-* `blockingRouteRecoverErrors(logic: I => Future[O])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as a blocking handler. You're providing your own way to deal with errors happening in the `logic` function.
+This object contains the following methods: 
+
+* `route(e: Endpoint[I, E, O, Any], logic: I => Future[Either[E, O]])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. Errors will be recovered automatically (but generically)
+* `routeRecoverErrors(e: Endpoint[I, E, O, Any], logic: I => Future[O])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. You're providing your own way to deal with errors happening in the `logic` function.
+* `blockingRoute(e: Endpoint[I, E, O, Any], logic: I => Future[Either[E, O]])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an blocking handler. Errors will be recovered automatically (but generically)
+* `blockingRouteRecoverErrors(e: Endpoint[I, E, O, Any], logic: I => Future[O])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as a blocking handler. You're providing your own way to deal with errors happening in the `logic` function.
 
 The methods recovering errors from failed effects, require `E` to be a subclass of `Throwable` (an exception); and expect a function of type `I => Future[O]`. For example:
 
-Note that these functions take one argument, which is a tuple of type `I`. This means that functions which take multiple 
-arguments need to be converted to a function using a single argument using `.tupled`:
+Note that the second argument to `route` etc. is a function with one argument, a tuple of type `I`. This means that 
+functions which take multiple arguments need to be converted to a function using a single argument using `.tupled`:
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.vertx.VertxServerInterpreter
+import sttp.tapir.server.vertx.{ VertxServerInterpreter, VertxEndpointOptions }
 import io.vertx.scala.ext.web._
 import scala.concurrent.Future
 
@@ -41,7 +42,7 @@ An HTTP server can then be started as in the following example:
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.vertx.VertxServerInterpreter
+import sttp.tapir.server.vertx.{ VertxServerInterpreter, VertxEndpointOptions }
 import io.vertx.scala.core.Vertx
 import io.vertx.scala.ext.web._
 import scala.concurrent.Future

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/AsyncAPIInterpreter.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/AsyncAPIInterpreter.scala
@@ -1,0 +1,72 @@
+package sttp.tapir.docs.asyncapi
+
+import sttp.tapir.Endpoint
+import sttp.tapir.asyncapi.{AsyncAPI, Info, Server}
+import sttp.tapir.server.ServerEndpoint
+
+trait AsyncAPIInterpreter {
+  def fromEndpoint[I, E, O, S](e: Endpoint[I, E, O, S], title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+    fromEndpoint(e, Info(title, version), Nil)
+  def fromEndpoint[I, E, O, S](e: Endpoint[I, E, O, S], title: String, version: String, servers: Iterable[(String, Server)])(implicit
+      options: AsyncAPIDocsOptions
+  ): AsyncAPI =
+    fromEndpoint(e, Info(title, version), servers)
+  def fromEndpoint[I, E, O, S](e: Endpoint[I, E, O, S], info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+    fromEndpoint(e, info, Nil)
+  def fromEndpoint[I, E, O, S](e: Endpoint[I, E, O, S], info: Info, servers: Iterable[(String, Server)])(implicit
+      options: AsyncAPIDocsOptions
+  ): AsyncAPI =
+    EndpointToAsyncAPIDocs.toAsyncAPI(info, servers, Seq(e), options)
+
+  def fromServerEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], title: String, version: String)(implicit
+      options: AsyncAPIDocsOptions
+  ): AsyncAPI =
+    fromServerEndpoint(se, Info(title, version), Nil)
+  def fromServerEndpoint[I, E, O, S, F[_]](
+      se: ServerEndpoint[I, E, O, S, F],
+      title: String,
+      version: String,
+      servers: Iterable[(String, Server)]
+  )(implicit
+      options: AsyncAPIDocsOptions
+  ): AsyncAPI =
+    fromServerEndpoint(se, Info(title, version), servers)
+  def fromServerEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+    fromServerEndpoint(se, info, Nil)
+  def fromServerEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], info: Info, servers: Iterable[(String, Server)])(implicit
+      options: AsyncAPIDocsOptions
+  ): AsyncAPI =
+    EndpointToAsyncAPIDocs.toAsyncAPI(info, servers, Seq(se.endpoint), options)
+
+  def fromEndpoints(es: Iterable[Endpoint[_, _, _, _]], title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+    fromEndpoints(es, Info(title, version), Nil)
+  def fromEndpoints(es: Iterable[Endpoint[_, _, _, _]], title: String, version: String, servers: Iterable[(String, Server)])(implicit
+      options: AsyncAPIDocsOptions
+  ): AsyncAPI =
+    fromEndpoints(es, Info(title, version), servers)
+  def fromEndpoints(es: Iterable[Endpoint[_, _, _, _]], info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+    fromEndpoints(es, info, Nil)
+  def fromEndpoints(es: Iterable[Endpoint[_, _, _, _]], info: Info, servers: Iterable[(String, Server)])(implicit
+      options: AsyncAPIDocsOptions
+  ): AsyncAPI =
+    EndpointToAsyncAPIDocs.toAsyncAPI(info, servers, es, options)
+
+  def fromServerEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], title: String, version: String)(implicit
+      options: AsyncAPIDocsOptions
+  ): AsyncAPI = fromServerEndpoints(ses, Info(title, version), Nil)
+  def fromServerEndpoints[F[_]](
+      ses: Iterable[ServerEndpoint[_, _, _, _, F]],
+      title: String,
+      version: String,
+      servers: Iterable[(String, Server)]
+  )(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+    fromServerEndpoints(ses, Info(title, version), servers)
+  def fromServerEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+    fromServerEndpoints(ses, info, Nil)
+  def fromServerEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], info: Info, servers: Iterable[(String, Server)])(implicit
+      options: AsyncAPIDocsOptions
+  ): AsyncAPI =
+    EndpointToAsyncAPIDocs.toAsyncAPI(info, servers, ses.map(_.endpoint), options)
+}
+
+object AsyncAPIInterpreter extends AsyncAPIInterpreter

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/AsyncAPIInterpreter.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/AsyncAPIInterpreter.scala
@@ -5,24 +5,24 @@ import sttp.tapir.asyncapi.{AsyncAPI, Info, Server}
 import sttp.tapir.server.ServerEndpoint
 
 trait AsyncAPIInterpreter {
-  def fromEndpoint[I, E, O, S](e: Endpoint[I, E, O, S], title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-    fromEndpoint(e, Info(title, version), Nil)
-  def fromEndpoint[I, E, O, S](e: Endpoint[I, E, O, S], title: String, version: String, servers: Iterable[(String, Server)])(implicit
+  def toAsyncAPI[I, E, O, S](e: Endpoint[I, E, O, S], title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+    toAsyncAPI(e, Info(title, version), Nil)
+  def toAsyncAPI[I, E, O, S](e: Endpoint[I, E, O, S], title: String, version: String, servers: Iterable[(String, Server)])(implicit
       options: AsyncAPIDocsOptions
   ): AsyncAPI =
-    fromEndpoint(e, Info(title, version), servers)
-  def fromEndpoint[I, E, O, S](e: Endpoint[I, E, O, S], info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-    fromEndpoint(e, info, Nil)
-  def fromEndpoint[I, E, O, S](e: Endpoint[I, E, O, S], info: Info, servers: Iterable[(String, Server)])(implicit
+    toAsyncAPI(e, Info(title, version), servers)
+  def toAsyncAPI[I, E, O, S](e: Endpoint[I, E, O, S], info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+    toAsyncAPI(e, info, Nil)
+  def toAsyncAPI[I, E, O, S](e: Endpoint[I, E, O, S], info: Info, servers: Iterable[(String, Server)])(implicit
       options: AsyncAPIDocsOptions
   ): AsyncAPI =
     EndpointToAsyncAPIDocs.toAsyncAPI(info, servers, Seq(e), options)
 
-  def fromServerEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], title: String, version: String)(implicit
+  def toAsyncAPI[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], title: String, version: String)(implicit
       options: AsyncAPIDocsOptions
   ): AsyncAPI =
-    fromServerEndpoint(se, Info(title, version), Nil)
-  def fromServerEndpoint[I, E, O, S, F[_]](
+    toAsyncAPI(se, Info(title, version), Nil)
+  def toAsyncAPI[I, E, O, S, F[_]](
       se: ServerEndpoint[I, E, O, S, F],
       title: String,
       version: String,
@@ -30,41 +30,43 @@ trait AsyncAPIInterpreter {
   )(implicit
       options: AsyncAPIDocsOptions
   ): AsyncAPI =
-    fromServerEndpoint(se, Info(title, version), servers)
-  def fromServerEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-    fromServerEndpoint(se, info, Nil)
-  def fromServerEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], info: Info, servers: Iterable[(String, Server)])(implicit
+    toAsyncAPI(se, Info(title, version), servers)
+  def toAsyncAPI[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+    toAsyncAPI(se, info, Nil)
+  def toAsyncAPI[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], info: Info, servers: Iterable[(String, Server)])(implicit
       options: AsyncAPIDocsOptions
   ): AsyncAPI =
     EndpointToAsyncAPIDocs.toAsyncAPI(info, servers, Seq(se.endpoint), options)
 
-  def fromEndpoints(es: Iterable[Endpoint[_, _, _, _]], title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-    fromEndpoints(es, Info(title, version), Nil)
-  def fromEndpoints(es: Iterable[Endpoint[_, _, _, _]], title: String, version: String, servers: Iterable[(String, Server)])(implicit
+  def toAsyncAPI(es: Iterable[Endpoint[_, _, _, _]], title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+    toAsyncAPI(es, Info(title, version), Nil)
+  def toAsyncAPI(es: Iterable[Endpoint[_, _, _, _]], title: String, version: String, servers: Iterable[(String, Server)])(implicit
       options: AsyncAPIDocsOptions
   ): AsyncAPI =
-    fromEndpoints(es, Info(title, version), servers)
-  def fromEndpoints(es: Iterable[Endpoint[_, _, _, _]], info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-    fromEndpoints(es, info, Nil)
-  def fromEndpoints(es: Iterable[Endpoint[_, _, _, _]], info: Info, servers: Iterable[(String, Server)])(implicit
+    toAsyncAPI(es, Info(title, version), servers)
+  def toAsyncAPI(es: Iterable[Endpoint[_, _, _, _]], info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+    toAsyncAPI(es, info, Nil)
+  def toAsyncAPI(es: Iterable[Endpoint[_, _, _, _]], info: Info, servers: Iterable[(String, Server)])(implicit
       options: AsyncAPIDocsOptions
   ): AsyncAPI =
     EndpointToAsyncAPIDocs.toAsyncAPI(info, servers, es, options)
 
-  def fromServerEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], title: String, version: String)(implicit
+  def serverEndpointsToAsyncAPI[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], title: String, version: String)(implicit
       options: AsyncAPIDocsOptions
-  ): AsyncAPI = fromServerEndpoints(ses, Info(title, version), Nil)
-  def fromServerEndpoints[F[_]](
+  ): AsyncAPI = serverEndpointsToAsyncAPI(ses, Info(title, version), Nil)
+  def serverEndpointsToAsyncAPI[F[_]](
       ses: Iterable[ServerEndpoint[_, _, _, _, F]],
       title: String,
       version: String,
       servers: Iterable[(String, Server)]
   )(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-    fromServerEndpoints(ses, Info(title, version), servers)
-  def fromServerEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-    fromServerEndpoints(ses, info, Nil)
-  def fromServerEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], info: Info, servers: Iterable[(String, Server)])(implicit
+    serverEndpointsToAsyncAPI(ses, Info(title, version), servers)
+  def serverEndpointsToAsyncAPI[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], info: Info)(implicit
       options: AsyncAPIDocsOptions
+  ): AsyncAPI =
+    serverEndpointsToAsyncAPI(ses, info, Nil)
+  def serverEndpointsToAsyncAPI[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], info: Info, servers: Iterable[(String, Server)])(
+      implicit options: AsyncAPIDocsOptions
   ): AsyncAPI =
     EndpointToAsyncAPIDocs.toAsyncAPI(info, servers, ses.map(_.endpoint), options)
 }

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIDocs.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIDocs.scala
@@ -9,7 +9,7 @@ import sttp.tapir.{EndpointInput, _}
 
 import scala.collection.immutable.{ListMap, ListSet}
 
-object EndpointToAsyncAPIDocs {
+private[asyncapi] object EndpointToAsyncAPIDocs {
   def toAsyncAPI(
       info: Info,
       servers: Iterable[(String, Server)],

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIWebSocketChannel.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIWebSocketChannel.scala
@@ -11,7 +11,7 @@ import sttp.tapir.{Codec, CodecFormat, Endpoint, EndpointIO, EndpointInput}
 
 import scala.collection.immutable.ListMap
 
-class EndpointToAsyncAPIWebSocketChannel(
+private[asyncapi] class EndpointToAsyncAPIWebSocketChannel(
     schemas: Schemas,
     codecToMessageKey: Map[Codec[_, _, _ <: CodecFormat], MessageKey],
     options: AsyncAPIDocsOptions

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/TapirAsyncAPIDocs.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/TapirAsyncAPIDocs.scala
@@ -7,44 +7,45 @@ import sttp.tapir.server.ServerEndpoint
 @deprecated("Use AsyncAPIInterpreter", since = "0.17.1")
 trait TapirAsyncAPIDocs {
   implicit class RichOpenAPIEndpoint[I, E, O, S](e: Endpoint[I, E, O, S]) {
-    @deprecated("Use AsyncAPIInterpreter.fromEndpoint", since = "0.17.1")
+    @deprecated("Use AsyncAPIInterpreter.toAsyncAPI", since = "0.17.1")
     def toAsyncAPI(title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      AsyncAPIInterpreter.fromEndpoint(e, Info(title, version), Nil)
-    @deprecated("Use AsyncAPIInterpreter.fromEndpoint", since = "0.17.1")
+      AsyncAPIInterpreter.toAsyncAPI(e, Info(title, version), Nil)
+    @deprecated("Use AsyncAPIInterpreter.toAsyncAPI", since = "0.17.1")
     def toAsyncAPI(title: String, version: String, servers: Iterable[(String, Server)])(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      AsyncAPIInterpreter.fromEndpoint(e, Info(title, version), servers)
-    @deprecated("Use AsyncAPIInterpreter.fromEndpoint", since = "0.17.1")
-    def toAsyncAPI(info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI = AsyncAPIInterpreter.fromEndpoint(e, info, Nil)
-    @deprecated("Use AsyncAPIInterpreter.fromEndpoint", since = "0.17.1")
+      AsyncAPIInterpreter.toAsyncAPI(e, Info(title, version), servers)
+    @deprecated("Use AsyncAPIInterpreter.toAsyncAPI", since = "0.17.1")
+    def toAsyncAPI(info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI = AsyncAPIInterpreter.toAsyncAPI(e, info, Nil)
+    @deprecated("Use AsyncAPIInterpreter.toAsyncAPI", since = "0.17.1")
     def toAsyncAPI(info: Info, servers: Iterable[(String, Server)])(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      AsyncAPIInterpreter.fromEndpoint(e, info, servers)
+      AsyncAPIInterpreter.toAsyncAPI(e, info, servers)
   }
 
   implicit class RichOpenAPIEndpoints(es: Iterable[Endpoint[_, _, _, _]]) {
-    @deprecated("Use AsyncAPIInterpreter.fromEndpoints", since = "0.17.1")
+    @deprecated("Use AsyncAPIInterpreter.toAsyncAPI", since = "0.17.1")
     def toAsyncAPI(title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      AsyncAPIInterpreter.fromEndpoints(es, Info(title, version), Nil)
-    @deprecated("Use AsyncAPIInterpreter.fromEndpoints", since = "0.17.1")
+      AsyncAPIInterpreter.toAsyncAPI(es, Info(title, version), Nil)
+    @deprecated("Use AsyncAPIInterpreter.toAsyncAPI", since = "0.17.1")
     def toAsyncAPI(title: String, version: String, servers: Iterable[(String, Server)])(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      AsyncAPIInterpreter.fromEndpoints(es, Info(title, version), servers)
-    @deprecated("Use AsyncAPIInterpreter.fromEndpoints", since = "0.17.1")
-    def toAsyncAPI(info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI = AsyncAPIInterpreter.fromEndpoints(es, info, Nil)
-    @deprecated("Use AsyncAPIInterpreter.fromEndpoints", since = "0.17.1")
+      AsyncAPIInterpreter.toAsyncAPI(es, Info(title, version), servers)
+    @deprecated("Use AsyncAPIInterpreter.toAsyncAPI", since = "0.17.1")
+    def toAsyncAPI(info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI = AsyncAPIInterpreter.toAsyncAPI(es, info, Nil)
+    @deprecated("Use AsyncAPIInterpreter.toAsyncAPI", since = "0.17.1")
     def toAsyncAPI(info: Info, servers: Iterable[(String, Server)])(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      AsyncAPIInterpreter.fromEndpoints(es, info, servers)
+      AsyncAPIInterpreter.toAsyncAPI(es, info, servers)
   }
 
   implicit class RichOpenAPIServerEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]]) {
-    @deprecated("Use AsyncAPIInterpreter.fromServerEndpoints", since = "0.17.1")
+    @deprecated("Use AsyncAPIInterpreter.serverEndpointsToAsyncAPI", since = "0.17.1")
     def toAsyncAPI(title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      AsyncAPIInterpreter.fromServerEndpoints(ses, Info(title, version), Nil)
-    @deprecated("Use AsyncAPIInterpreter.fromServerEndpoints", since = "0.17.1")
+      AsyncAPIInterpreter.serverEndpointsToAsyncAPI(ses, Info(title, version), Nil)
+    @deprecated("Use AsyncAPIInterpreter.serverEndpointsToAsyncAPI", since = "0.17.1")
     def toAsyncAPI(title: String, version: String, servers: Iterable[(String, Server)])(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      AsyncAPIInterpreter.fromServerEndpoints(ses, Info(title, version), servers)
-    @deprecated("Use AsyncAPIInterpreter.fromServerEndpoints", since = "0.17.1")
-    def toAsyncAPI(info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI = AsyncAPIInterpreter.fromServerEndpoints(ses, info, Nil)
-    @deprecated("Use AsyncAPIInterpreter.fromServerEndpoints", since = "0.17.1")
+      AsyncAPIInterpreter.serverEndpointsToAsyncAPI(ses, Info(title, version), servers)
+    @deprecated("Use AsyncAPIInterpreter.serverEndpointsToAsyncAPI", since = "0.17.1")
+    def toAsyncAPI(info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+      AsyncAPIInterpreter.serverEndpointsToAsyncAPI(ses, info, Nil)
+    @deprecated("Use AsyncAPIInterpreter.serverEndpointsToAsyncAPI", since = "0.17.1")
     def toAsyncAPI(info: Info, servers: Iterable[(String, Server)])(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      AsyncAPIInterpreter.fromServerEndpoints(ses, info, servers)
+      AsyncAPIInterpreter.serverEndpointsToAsyncAPI(ses, info, servers)
   }
 }

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/TapirAsyncAPIDocs.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/TapirAsyncAPIDocs.scala
@@ -4,31 +4,47 @@ import sttp.tapir.Endpoint
 import sttp.tapir.asyncapi.{AsyncAPI, Info, Server}
 import sttp.tapir.server.ServerEndpoint
 
+@deprecated("Use AsyncAPIInterpreter", since = "0.17.1")
 trait TapirAsyncAPIDocs {
   implicit class RichOpenAPIEndpoint[I, E, O, S](e: Endpoint[I, E, O, S]) {
-    def toAsyncAPI(title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI = toAsyncAPI(Info(title, version), Nil)
+    @deprecated("Use AsyncAPIInterpreter.fromEndpoint", since = "0.17.1")
+    def toAsyncAPI(title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+      AsyncAPIInterpreter.fromEndpoint(e, Info(title, version), Nil)
+    @deprecated("Use AsyncAPIInterpreter.fromEndpoint", since = "0.17.1")
     def toAsyncAPI(title: String, version: String, servers: Iterable[(String, Server)])(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      toAsyncAPI(Info(title, version), servers)
-    def toAsyncAPI(info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI = toAsyncAPI(info, Nil)
+      AsyncAPIInterpreter.fromEndpoint(e, Info(title, version), servers)
+    @deprecated("Use AsyncAPIInterpreter.fromEndpoint", since = "0.17.1")
+    def toAsyncAPI(info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI = AsyncAPIInterpreter.fromEndpoint(e, info, Nil)
+    @deprecated("Use AsyncAPIInterpreter.fromEndpoint", since = "0.17.1")
     def toAsyncAPI(info: Info, servers: Iterable[(String, Server)])(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      EndpointToAsyncAPIDocs.toAsyncAPI(info, servers, Seq(e), options)
+      AsyncAPIInterpreter.fromEndpoint(e, info, servers)
   }
 
   implicit class RichOpenAPIEndpoints(es: Iterable[Endpoint[_, _, _, _]]) {
-    def toAsyncAPI(title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI = toAsyncAPI(Info(title, version), Nil)
+    @deprecated("Use AsyncAPIInterpreter.fromEndpoints", since = "0.17.1")
+    def toAsyncAPI(title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+      AsyncAPIInterpreter.fromEndpoints(es, Info(title, version), Nil)
+    @deprecated("Use AsyncAPIInterpreter.fromEndpoints", since = "0.17.1")
     def toAsyncAPI(title: String, version: String, servers: Iterable[(String, Server)])(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      toAsyncAPI(Info(title, version), servers)
-    def toAsyncAPI(info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI = toAsyncAPI(info, Nil)
+      AsyncAPIInterpreter.fromEndpoints(es, Info(title, version), servers)
+    @deprecated("Use AsyncAPIInterpreter.fromEndpoints", since = "0.17.1")
+    def toAsyncAPI(info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI = AsyncAPIInterpreter.fromEndpoints(es, info, Nil)
+    @deprecated("Use AsyncAPIInterpreter.fromEndpoints", since = "0.17.1")
     def toAsyncAPI(info: Info, servers: Iterable[(String, Server)])(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      EndpointToAsyncAPIDocs.toAsyncAPI(info, servers, es, options)
+      AsyncAPIInterpreter.fromEndpoints(es, info, servers)
   }
 
-  implicit class RichOpenAPIServerEndpoints[F[_]](serverEndpoints: Iterable[ServerEndpoint[_, _, _, _, F]]) {
-    def toAsyncAPI(title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI = toAsyncAPI(Info(title, version), Nil)
+  implicit class RichOpenAPIServerEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]]) {
+    @deprecated("Use AsyncAPIInterpreter.fromServerEndpoints", since = "0.17.1")
+    def toAsyncAPI(title: String, version: String)(implicit options: AsyncAPIDocsOptions): AsyncAPI =
+      AsyncAPIInterpreter.fromServerEndpoints(ses, Info(title, version), Nil)
+    @deprecated("Use AsyncAPIInterpreter.fromServerEndpoints", since = "0.17.1")
     def toAsyncAPI(title: String, version: String, servers: Iterable[(String, Server)])(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      toAsyncAPI(Info(title, version), servers)
-    def toAsyncAPI(info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI = toAsyncAPI(info, Nil)
+      AsyncAPIInterpreter.fromServerEndpoints(ses, Info(title, version), servers)
+    @deprecated("Use AsyncAPIInterpreter.fromServerEndpoints", since = "0.17.1")
+    def toAsyncAPI(info: Info)(implicit options: AsyncAPIDocsOptions): AsyncAPI = AsyncAPIInterpreter.fromServerEndpoints(ses, info, Nil)
+    @deprecated("Use AsyncAPIInterpreter.fromServerEndpoints", since = "0.17.1")
     def toAsyncAPI(info: Info, servers: Iterable[(String, Server)])(implicit options: AsyncAPIDocsOptions): AsyncAPI =
-      EndpointToAsyncAPIDocs.toAsyncAPI(info, servers, serverEndpoints.map(_.endpoint), options)
+      AsyncAPIInterpreter.fromServerEndpoints(ses, info, servers)
   }
 }

--- a/docs/asyncapi-docs/src/test/scala/sttp/tapir/docs/asyncapi/VerifyAsyncAPIYamlTest.scala
+++ b/docs/asyncapi-docs/src/test/scala/sttp/tapir/docs/asyncapi/VerifyAsyncAPIYamlTest.scala
@@ -21,7 +21,7 @@ class VerifyAsyncAPIYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_json_json.yml")
 
-    val actualYaml = AsyncAPIInterpreter.fromEndpoint(e, "The fruit basket", "0.1").toYaml
+    val actualYaml = AsyncAPIInterpreter.toAsyncAPI(e, "The fruit basket", "0.1").toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -32,7 +32,7 @@ class VerifyAsyncAPIYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_string_json.yml")
 
-    val actualYaml = AsyncAPIInterpreter.fromEndpoint(e, "The fruit basket", "0.1").toYaml
+    val actualYaml = AsyncAPIInterpreter.toAsyncAPI(e, "The fruit basket", "0.1").toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -44,7 +44,7 @@ class VerifyAsyncAPIYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_two_endpoints.yml")
 
-    val actualYaml = AsyncAPIInterpreter.fromEndpoints(List(e1, e2), "The fruit basket", "0.1").toYaml
+    val actualYaml = AsyncAPIInterpreter.toAsyncAPI(List(e1, e2), "The fruit basket", "0.1").toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -59,7 +59,7 @@ class VerifyAsyncAPIYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_binding.yml")
 
-    val actualYaml = AsyncAPIInterpreter.fromEndpoint(e, "The fruit basket", "0.1").toYaml
+    val actualYaml = AsyncAPIInterpreter.toAsyncAPI(e, "The fruit basket", "0.1").toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -74,7 +74,7 @@ class VerifyAsyncAPIYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_security.yml")
 
     val actualYaml =
-      AsyncAPIInterpreter.fromEndpoint(e, "The fruit basket", "0.1", List("production" -> Server("example.org", "ws"))).toYaml
+      AsyncAPIInterpreter.toAsyncAPI(e, "The fruit basket", "0.1", List("production" -> Server("example.org", "ws"))).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml

--- a/docs/asyncapi-docs/src/test/scala/sttp/tapir/docs/asyncapi/VerifyAsyncAPIYamlTest.scala
+++ b/docs/asyncapi-docs/src/test/scala/sttp/tapir/docs/asyncapi/VerifyAsyncAPIYamlTest.scala
@@ -21,7 +21,7 @@ class VerifyAsyncAPIYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_json_json.yml")
 
-    val actualYaml = e.toAsyncAPI("The fruit basket", "0.1").toYaml
+    val actualYaml = AsyncAPIInterpreter.fromEndpoint(e, "The fruit basket", "0.1").toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -32,7 +32,7 @@ class VerifyAsyncAPIYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_string_json.yml")
 
-    val actualYaml = e.toAsyncAPI("The fruit basket", "0.1").toYaml
+    val actualYaml = AsyncAPIInterpreter.fromEndpoint(e, "The fruit basket", "0.1").toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -44,7 +44,7 @@ class VerifyAsyncAPIYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_two_endpoints.yml")
 
-    val actualYaml = List(e1, e2).toAsyncAPI("The fruit basket", "0.1").toYaml
+    val actualYaml = AsyncAPIInterpreter.fromEndpoints(List(e1, e2), "The fruit basket", "0.1").toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -59,7 +59,7 @@ class VerifyAsyncAPIYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_binding.yml")
 
-    val actualYaml = e.toAsyncAPI("The fruit basket", "0.1").toYaml
+    val actualYaml = AsyncAPIInterpreter.fromEndpoint(e, "The fruit basket", "0.1").toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -73,7 +73,8 @@ class VerifyAsyncAPIYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_security.yml")
 
-    val actualYaml = e.toAsyncAPI("The fruit basket", "0.1", List("production" -> Server("example.org", "ws"))).toYaml
+    val actualYaml =
+      AsyncAPIInterpreter.fromEndpoint(e, "The fruit basket", "0.1", List("production" -> Server("example.org", "ws"))).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIDocs.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIDocs.scala
@@ -8,7 +8,7 @@ import sttp.tapir.openapi._
 
 import scala.collection.immutable.ListMap
 
-object EndpointToOpenAPIDocs {
+private[openapi] object EndpointToOpenAPIDocs {
   def toOpenAPI(api: Info, es: Iterable[Endpoint[_, _, _, _]], options: OpenAPIDocsOptions): OpenAPI = {
     val es2 = es.filter(e => findWebSocket(e).isEmpty).map(nameAllPathCapturesInEndpoint)
     val (keyToSchema, schemas) = SchemasForEndpoints(es2)

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/OpenAPIDocsInterpreter.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/OpenAPIDocsInterpreter.scala
@@ -1,0 +1,36 @@
+package sttp.tapir.docs.openapi
+
+import sttp.tapir.Endpoint
+import sttp.tapir.openapi.{Info, OpenAPI}
+import sttp.tapir.server.ServerEndpoint
+
+trait OpenAPIDocsInterpreter {
+  def endpoint[I, E, O, S](e: Endpoint[I, E, O, S], title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
+    endpoint(e, Info(title, version))
+
+  def endpoint[I, E, O, S](e: Endpoint[I, E, O, S], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
+    EndpointToOpenAPIDocs.toOpenAPI(info, Seq(e), options)
+
+  def serverEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], title: String, version: String)(implicit
+      options: OpenAPIDocsOptions
+  ): OpenAPI =
+    endpoint(se.endpoint, Info(title, version))
+
+  def serverEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
+    EndpointToOpenAPIDocs.toOpenAPI(info, Seq(se.endpoint), options)
+
+  def endpoints(es: Iterable[Endpoint[_, _, _, _]], title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
+    endpoints(es, Info(title, version))
+
+  def endpoints(es: Iterable[Endpoint[_, _, _, _]], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
+    EndpointToOpenAPIDocs.toOpenAPI(info, es, options)
+
+  def serverEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], title: String, version: String)(implicit
+      options: OpenAPIDocsOptions
+  ): OpenAPI = serverEndpoints(ses, Info(title, version))
+
+  def serverEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
+    EndpointToOpenAPIDocs.toOpenAPI(info, ses.map(_.endpoint), options)
+}
+
+object OpenAPIDocsInterpreter extends OpenAPIDocsInterpreter

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/OpenAPIDocsInterpreter.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/OpenAPIDocsInterpreter.scala
@@ -5,31 +5,33 @@ import sttp.tapir.openapi.{Info, OpenAPI}
 import sttp.tapir.server.ServerEndpoint
 
 trait OpenAPIDocsInterpreter {
-  def fromEndpoint[I, E, O, S](e: Endpoint[I, E, O, S], title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
-    fromEndpoint(e, Info(title, version))
+  def toOpenAPI[I, E, O, S](e: Endpoint[I, E, O, S], title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
+    toOpenAPI(e, Info(title, version))
 
-  def fromEndpoint[I, E, O, S](e: Endpoint[I, E, O, S], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
+  def toOpenAPI[I, E, O, S](e: Endpoint[I, E, O, S], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
     EndpointToOpenAPIDocs.toOpenAPI(info, Seq(e), options)
 
-  def fromServerEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], title: String, version: String)(implicit
+  def toOpenAPI[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], title: String, version: String)(implicit
       options: OpenAPIDocsOptions
   ): OpenAPI =
-    fromEndpoint(se.endpoint, Info(title, version))
+    toOpenAPI(se.endpoint, Info(title, version))
 
-  def fromServerEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
+  def toOpenAPI[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
     EndpointToOpenAPIDocs.toOpenAPI(info, Seq(se.endpoint), options)
 
-  def fromEndpoints(es: Iterable[Endpoint[_, _, _, _]], title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
-    fromEndpoints(es, Info(title, version))
+  def toOpenAPI(es: Iterable[Endpoint[_, _, _, _]], title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
+    toOpenAPI(es, Info(title, version))
 
-  def fromEndpoints(es: Iterable[Endpoint[_, _, _, _]], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
+  def toOpenAPI(es: Iterable[Endpoint[_, _, _, _]], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
     EndpointToOpenAPIDocs.toOpenAPI(info, es, options)
 
-  def fromServerEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], title: String, version: String)(implicit
+  def serverEndpointsToOpenAPI[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], title: String, version: String)(implicit
       options: OpenAPIDocsOptions
-  ): OpenAPI = fromServerEndpoints(ses, Info(title, version))
+  ): OpenAPI = serverEndpointsToOpenAPI(ses, Info(title, version))
 
-  def fromServerEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
+  def serverEndpointsToOpenAPI[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], info: Info)(implicit
+      options: OpenAPIDocsOptions
+  ): OpenAPI =
     EndpointToOpenAPIDocs.toOpenAPI(info, ses.map(_.endpoint), options)
 }
 

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/OpenAPIDocsInterpreter.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/OpenAPIDocsInterpreter.scala
@@ -5,31 +5,31 @@ import sttp.tapir.openapi.{Info, OpenAPI}
 import sttp.tapir.server.ServerEndpoint
 
 trait OpenAPIDocsInterpreter {
-  def endpoint[I, E, O, S](e: Endpoint[I, E, O, S], title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
-    endpoint(e, Info(title, version))
+  def fromEndpoint[I, E, O, S](e: Endpoint[I, E, O, S], title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
+    fromEndpoint(e, Info(title, version))
 
-  def endpoint[I, E, O, S](e: Endpoint[I, E, O, S], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
+  def fromEndpoint[I, E, O, S](e: Endpoint[I, E, O, S], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
     EndpointToOpenAPIDocs.toOpenAPI(info, Seq(e), options)
 
-  def serverEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], title: String, version: String)(implicit
+  def fromServerEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], title: String, version: String)(implicit
       options: OpenAPIDocsOptions
   ): OpenAPI =
-    endpoint(se.endpoint, Info(title, version))
+    fromEndpoint(se.endpoint, Info(title, version))
 
-  def serverEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
+  def fromServerEndpoint[I, E, O, S, F[_]](se: ServerEndpoint[I, E, O, S, F], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
     EndpointToOpenAPIDocs.toOpenAPI(info, Seq(se.endpoint), options)
 
-  def endpoints(es: Iterable[Endpoint[_, _, _, _]], title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
-    endpoints(es, Info(title, version))
+  def fromEndpoints(es: Iterable[Endpoint[_, _, _, _]], title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
+    fromEndpoints(es, Info(title, version))
 
-  def endpoints(es: Iterable[Endpoint[_, _, _, _]], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
+  def fromEndpoints(es: Iterable[Endpoint[_, _, _, _]], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
     EndpointToOpenAPIDocs.toOpenAPI(info, es, options)
 
-  def serverEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], title: String, version: String)(implicit
+  def fromServerEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], title: String, version: String)(implicit
       options: OpenAPIDocsOptions
-  ): OpenAPI = serverEndpoints(ses, Info(title, version))
+  ): OpenAPI = fromServerEndpoints(ses, Info(title, version))
 
-  def serverEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
+  def fromServerEndpoints[F[_]](ses: Iterable[ServerEndpoint[_, _, _, _, F]], info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
     EndpointToOpenAPIDocs.toOpenAPI(info, ses.map(_.endpoint), options)
 }
 

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/TapirOpenAPIDocs.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/TapirOpenAPIDocs.scala
@@ -4,25 +4,35 @@ import sttp.tapir.Endpoint
 import sttp.tapir.openapi.{Info, OpenAPI}
 import sttp.tapir.server.ServerEndpoint
 
+@deprecated("Use OpenAPIDocsInterpreter", since = "0.17.1")
 trait TapirOpenAPIDocs {
   implicit class RichOpenAPIEndpoint[I, E, O, S](e: Endpoint[I, E, O, S]) {
-    def toOpenAPI(title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI = toOpenAPI(Info(title, version))
+    @deprecated("Use OpenAPIDocsInterpreter.endpoint", since = "0.17.1")
+    def toOpenAPI(title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
+      OpenAPIDocsInterpreter.endpoint(e, Info(title, version))
 
+    @deprecated("Use OpenAPIDocsInterpreter.endpoint", since = "0.17.1")
     def toOpenAPI(info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      EndpointToOpenAPIDocs.toOpenAPI(info, Seq(e), options)
+      OpenAPIDocsInterpreter.endpoint(e, info)
   }
 
   implicit class RichOpenAPIEndpoints(es: Iterable[Endpoint[_, _, _, _]]) {
-    def toOpenAPI(title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI = toOpenAPI(Info(title, version))
+    @deprecated("Use OpenAPIDocsInterpreter.endpoints", since = "0.17.1")
+    def toOpenAPI(title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
+      OpenAPIDocsInterpreter.endpoints(es, Info(title, version))
 
+    @deprecated("Use OpenAPIDocsInterpreter.endpoints", since = "0.17.1")
     def toOpenAPI(info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      EndpointToOpenAPIDocs.toOpenAPI(info, es, options)
+      OpenAPIDocsInterpreter.endpoints(es, info)
   }
 
   implicit class RichOpenAPIServerEndpoints[F[_]](serverEndpoints: Iterable[ServerEndpoint[_, _, _, _, F]]) {
-    def toOpenAPI(title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI = toOpenAPI(Info(title, version))
+    @deprecated("Use OpenAPIDocsInterpreter.serverEndpoints", since = "0.17.1")
+    def toOpenAPI(title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
+      OpenAPIDocsInterpreter.serverEndpoints(serverEndpoints, Info(title, version))
 
+    @deprecated("Use OpenAPIDocsInterpreter.serverEndpoints", since = "0.17.1")
     def toOpenAPI(info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      EndpointToOpenAPIDocs.toOpenAPI(info, serverEndpoints.map(_.endpoint), options)
+      OpenAPIDocsInterpreter.serverEndpoints(serverEndpoints, info)
   }
 }

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/TapirOpenAPIDocs.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/TapirOpenAPIDocs.scala
@@ -7,32 +7,32 @@ import sttp.tapir.server.ServerEndpoint
 @deprecated("Use OpenAPIDocsInterpreter", since = "0.17.1")
 trait TapirOpenAPIDocs {
   implicit class RichOpenAPIEndpoint[I, E, O, S](e: Endpoint[I, E, O, S]) {
-    @deprecated("Use OpenAPIDocsInterpreter.fromEndpoint", since = "0.17.1")
+    @deprecated("Use OpenAPIDocsInterpreter.toOpenAPI", since = "0.17.1")
     def toOpenAPI(title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      OpenAPIDocsInterpreter.fromEndpoint(e, Info(title, version))
+      OpenAPIDocsInterpreter.toOpenAPI(e, Info(title, version))
 
-    @deprecated("Use OpenAPIDocsInterpreter.fromEndpoint", since = "0.17.1")
+    @deprecated("Use OpenAPIDocsInterpreter.toOpenAPI", since = "0.17.1")
     def toOpenAPI(info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      OpenAPIDocsInterpreter.fromEndpoint(e, info)
+      OpenAPIDocsInterpreter.toOpenAPI(e, info)
   }
 
   implicit class RichOpenAPIEndpoints(es: Iterable[Endpoint[_, _, _, _]]) {
-    @deprecated("Use OpenAPIDocsInterpreter.fromEndpoints", since = "0.17.1")
+    @deprecated("Use OpenAPIDocsInterpreter.toOpenAPI", since = "0.17.1")
     def toOpenAPI(title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      OpenAPIDocsInterpreter.fromEndpoints(es, Info(title, version))
+      OpenAPIDocsInterpreter.toOpenAPI(es, Info(title, version))
 
-    @deprecated("Use OpenAPIDocsInterpreter.fromEndpoints", since = "0.17.1")
+    @deprecated("Use OpenAPIDocsInterpreter.toOpenAPI", since = "0.17.1")
     def toOpenAPI(info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      OpenAPIDocsInterpreter.fromEndpoints(es, info)
+      OpenAPIDocsInterpreter.toOpenAPI(es, info)
   }
 
   implicit class RichOpenAPIServerEndpoints[F[_]](serverEndpoints: Iterable[ServerEndpoint[_, _, _, _, F]]) {
-    @deprecated("Use OpenAPIDocsInterpreter.fromServerEndpoints", since = "0.17.1")
+    @deprecated("Use OpenAPIDocsInterpreter.serverEndpointsToOpenAPI", since = "0.17.1")
     def toOpenAPI(title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      OpenAPIDocsInterpreter.fromServerEndpoints(serverEndpoints, Info(title, version))
+      OpenAPIDocsInterpreter.serverEndpointsToOpenAPI(serverEndpoints, Info(title, version))
 
-    @deprecated("Use OpenAPIDocsInterpreter.fromServerEndpoints", since = "0.17.1")
+    @deprecated("Use OpenAPIDocsInterpreter.serverEndpointsToOpenAPI", since = "0.17.1")
     def toOpenAPI(info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      OpenAPIDocsInterpreter.fromServerEndpoints(serverEndpoints, info)
+      OpenAPIDocsInterpreter.serverEndpointsToOpenAPI(serverEndpoints, info)
   }
 }

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/TapirOpenAPIDocs.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/TapirOpenAPIDocs.scala
@@ -7,32 +7,32 @@ import sttp.tapir.server.ServerEndpoint
 @deprecated("Use OpenAPIDocsInterpreter", since = "0.17.1")
 trait TapirOpenAPIDocs {
   implicit class RichOpenAPIEndpoint[I, E, O, S](e: Endpoint[I, E, O, S]) {
-    @deprecated("Use OpenAPIDocsInterpreter.endpoint", since = "0.17.1")
+    @deprecated("Use OpenAPIDocsInterpreter.fromEndpoint", since = "0.17.1")
     def toOpenAPI(title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      OpenAPIDocsInterpreter.endpoint(e, Info(title, version))
+      OpenAPIDocsInterpreter.fromEndpoint(e, Info(title, version))
 
-    @deprecated("Use OpenAPIDocsInterpreter.endpoint", since = "0.17.1")
+    @deprecated("Use OpenAPIDocsInterpreter.fromEndpoint", since = "0.17.1")
     def toOpenAPI(info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      OpenAPIDocsInterpreter.endpoint(e, info)
+      OpenAPIDocsInterpreter.fromEndpoint(e, info)
   }
 
   implicit class RichOpenAPIEndpoints(es: Iterable[Endpoint[_, _, _, _]]) {
-    @deprecated("Use OpenAPIDocsInterpreter.endpoints", since = "0.17.1")
+    @deprecated("Use OpenAPIDocsInterpreter.fromEndpoints", since = "0.17.1")
     def toOpenAPI(title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      OpenAPIDocsInterpreter.endpoints(es, Info(title, version))
+      OpenAPIDocsInterpreter.fromEndpoints(es, Info(title, version))
 
-    @deprecated("Use OpenAPIDocsInterpreter.endpoints", since = "0.17.1")
+    @deprecated("Use OpenAPIDocsInterpreter.fromEndpoints", since = "0.17.1")
     def toOpenAPI(info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      OpenAPIDocsInterpreter.endpoints(es, info)
+      OpenAPIDocsInterpreter.fromEndpoints(es, info)
   }
 
   implicit class RichOpenAPIServerEndpoints[F[_]](serverEndpoints: Iterable[ServerEndpoint[_, _, _, _, F]]) {
-    @deprecated("Use OpenAPIDocsInterpreter.serverEndpoints", since = "0.17.1")
+    @deprecated("Use OpenAPIDocsInterpreter.fromServerEndpoints", since = "0.17.1")
     def toOpenAPI(title: String, version: String)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      OpenAPIDocsInterpreter.serverEndpoints(serverEndpoints, Info(title, version))
+      OpenAPIDocsInterpreter.fromServerEndpoints(serverEndpoints, Info(title, version))
 
-    @deprecated("Use OpenAPIDocsInterpreter.serverEndpoints", since = "0.17.1")
+    @deprecated("Use OpenAPIDocsInterpreter.fromServerEndpoints", since = "0.17.1")
     def toOpenAPI(info: Info)(implicit options: OpenAPIDocsOptions): OpenAPI =
-      OpenAPIDocsInterpreter.serverEndpoints(serverEndpoints, info)
+      OpenAPIDocsInterpreter.fromServerEndpoints(serverEndpoints, info)
   }
 }

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIDocsTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIDocsTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 class EndpointToOpenAPIDocsTest extends AnyFunSuite with Matchers {
   for (e <- allTestEndpoints) {
     test(s"${e.showDetail} should convert to open api") {
-      e.toOpenAPI(Info("title", "19.2-beta-RC1"))
+      OpenAPIDocsInterpreter.endpoint(e, Info("title", "19.2-beta-RC1"))
     }
   }
 }

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIDocsTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIDocsTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 class EndpointToOpenAPIDocsTest extends AnyFunSuite with Matchers {
   for (e <- allTestEndpoints) {
     test(s"${e.showDetail} should convert to open api") {
-      OpenAPIDocsInterpreter.endpoint(e, Info("title", "19.2-beta-RC1"))
+      OpenAPIDocsInterpreter.fromEndpoint(e, Info("title", "19.2-beta-RC1"))
     }
   }
 }

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIDocsTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIDocsTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.matchers.should.Matchers
 class EndpointToOpenAPIDocsTest extends AnyFunSuite with Matchers {
   for (e <- allTestEndpoints) {
     test(s"${e.showDetail} should convert to open api") {
-      OpenAPIDocsInterpreter.fromEndpoint(e, Info("title", "19.2-beta-RC1"))
+      OpenAPIDocsInterpreter.toOpenAPI(e, Info("title", "19.2-beta-RC1"))
     }
   }
 }

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -34,7 +34,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected.yml")
 
     val actualYaml =
-      OpenAPIDocsInterpreter.endpoints(List(in_query_query_out_string, all_the_way, delete_endpoint), Info("Fruits", "1.0")).toYaml
+      OpenAPIDocsInterpreter.fromEndpoints(List(in_query_query_out_string, all_the_way, delete_endpoint), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -46,7 +46,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should match the expected yaml when schema is recursive") {
     val expectedYaml = loadYaml("expected_recursive.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint_wit_recursive_structure, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint_wit_recursive_structure, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -57,7 +57,8 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val options = OpenAPIDocsOptions.default.copy(customOperationIdGenerator)
     val expectedYaml = loadYaml("expected_custom_operation_id.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(in_query_query_out_string.in("add").in("path"), Info("Fruits", "1.0"))(options).toYaml
+    val actualYaml =
+      OpenAPIDocsInterpreter.fromEndpoint(in_query_query_out_string.in("add").in("path"), Info("Fruits", "1.0"))(options).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
@@ -74,7 +75,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should match the expected yaml for streaming endpoints") {
     val expectedYaml = loadYaml("expected_streaming.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(streaming_endpoint, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(streaming_endpoint, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -88,7 +89,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_tags.yml")
 
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoints(List(userTaggedEndpointShow, userTaggedEdnpointSearch, adminTaggedEndpointAdd), Info("Fruits", "1.0"))
+      .fromEndpoints(List(userTaggedEndpointShow, userTaggedEdnpointSearch, adminTaggedEndpointAdd), Info("Fruits", "1.0"))
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -107,7 +108,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       license = Some(License("MIT", Some("mit.license")))
     )
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(in_query_query_out_string, api).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(in_query_query_out_string, api).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -116,7 +117,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should support multipart") {
     val expectedYaml = loadYaml("expected_multipart.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(in_file_multipart_out_multipart, "Fruits", "1.0").toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(in_file_multipart_out_multipart, "Fruits", "1.0").toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -129,7 +130,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val e2 = endpoint.in(auth.bearer[String]()).in("api2" / path[String]).out(stringBody)
     val e3 = endpoint.in(auth.apiKey(header[String]("apikey"))).in("api3" / path[String]).out(stringBody)
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -142,7 +143,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val e2 = endpoint.in(auth.bearer[Option[String]]()).in("api2" / path[String]).out(stringBody)
     val e3 = endpoint.in(auth.apiKey(header[Option[String]]("apikey"))).in("api3" / path[String]).out(stringBody)
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -157,7 +158,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val e3 =
       endpoint.in(auth.apiKey(header[String]("apikey")).securitySchemeName("secApiKeyHeader")).in("secure" / "apiKeyHeader").out(stringBody)
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -189,7 +190,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
         .in("api3" / path[String])
         .out(stringBody)
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -197,7 +198,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should support empty bodies") {
     val expectedYaml = loadYaml("expected_empty.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -219,7 +220,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     )
 
     // when
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(e, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(e, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     // then
@@ -230,7 +231,10 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_multiple.yml")
 
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoints(List(endpoint.in("p1"), endpoint.in("p3"), endpoint.in("p2"), endpoint.in("p5"), endpoint.in("p4")), Info("Fruits", "1.0"))
+      .fromEndpoints(
+        List(endpoint.in("p1"), endpoint.in("p3"), endpoint.in("p2"), endpoint.in("p5"), endpoint.in("p4")),
+        Info("Fruits", "1.0")
+      )
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -243,7 +247,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, Entity, Any] = endpoint
       .out(jsonBody[Entity])
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -258,7 +262,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_coproduct_discriminator.yml")
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, Entity, Any] = endpoint
       .out(jsonBody[Entity])
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -270,7 +274,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, NestedEntity, Any] = endpoint
       .out(jsonBody[NestedEntity])
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -285,7 +289,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_coproduct_discriminator_nested.yml")
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, NestedEntity, Any] = endpoint
       .out(jsonBody[NestedEntity])
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -297,7 +301,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       .out(jsonBody[BPet])
     val expectedYaml = loadYaml("expected_same_fullnames.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(e, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(e, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -309,7 +313,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       .out(stringBody)
     val expectedYaml = loadYaml("expected_unfolded_hierarchy.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(e, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(e, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -319,7 +323,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val e = endpoint.in(jsonBody[List[FruitAmount]]).out(stringBody)
     val expectedYaml = loadYaml("expected_unfolded_array.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(e, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(e, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -329,7 +333,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_generic.yml")
 
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoints(List(endpoint.in("p1" and jsonBody[G[String]]), endpoint.in("p2" and jsonBody[G[Int]])), Info("Fruits", "1.0"))
+      .fromEndpoints(List(endpoint.in("p1" and jsonBody[G[String]]), endpoint.in("p2" and jsonBody[G[Int]])), Info("Fruits", "1.0"))
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -339,7 +343,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should unfold objects from unfolded arrays") {
     val expectedYaml = loadYaml("expected_unfolded_object_unfolded_array.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -356,7 +360,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       )
     ).description("Amount of fruits")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.post.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.post.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -369,7 +373,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       .description("Amount of fruits")
       .modifyUnsafe[Nothing]("amount")(_.format("int32"))
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.post.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.post.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -378,7 +382,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should unfold coproducts from unfolded arrays") {
     val expectedYaml = loadYaml("expected_unfolded_coproduct_unfolded_array.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(jsonBody[List[Entity]]), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(jsonBody[List[Entity]]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -387,7 +391,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_generic_coproduct.yml")
 
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoints(
+      .fromEndpoints(
         List(endpoint.in("p1" and jsonBody[GenericEntity[String]]), endpoint.in("p2" and jsonBody[GenericEntity[Int]])),
         Info("Fruits", "1.0")
       )
@@ -400,7 +404,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should unfold arrays from object") {
     val expectedYaml = loadYaml("expected_unfolded_array_unfolded_object.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(jsonBody[ObjectWithList]), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(jsonBody[ObjectWithList]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -410,7 +414,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_fixed_status_code.yml")
 
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(endpoint.out(statusCode(StatusCode.PermanentRedirect)).out(header[String]("Location")), Info("Entities", "1.0"))
+      .fromEndpoint(endpoint.out(statusCode(StatusCode.PermanentRedirect)).out(header[String]("Location")), Info("Entities", "1.0"))
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -421,7 +425,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_one_of_status_codes.yml")
 
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(
+      .fromEndpoint(
         endpoint
           .out(header[String]("Location"))
           .errorOut(statusCode.description(StatusCode.NotFound, "entity not found").description(StatusCode.BadRequest, "")),
@@ -436,7 +440,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render additional properties for map") {
     val expectedYaml = loadYaml("expected_additional_properties.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(jsonBody[Map[String, Person]]), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(jsonBody[Map[String, Person]]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -445,7 +449,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render map with plain values") {
     val expectedYaml = loadYaml("expected_map_with_plain_values.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(jsonBody[Map[String, String]]), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(jsonBody[Map[String, String]]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -454,7 +458,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("use fixed status code output in response if it's the only output") {
     val expectedYaml = loadYaml("expected_fixed_status_code_2.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(statusCode(StatusCode.NoContent)), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(statusCode(StatusCode.NoContent)), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -463,14 +467,15 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should support prepending inputs") {
     val expectedYaml = loadYaml("expected_prepended_input.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(in_query_query_out_string.in("add").prependIn("path"), Info("Fruits", "1.0")).toYaml
+    val actualYaml =
+      OpenAPIDocsInterpreter.fromEndpoint(in_query_query_out_string.in("add").prependIn("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("use fixed header output in response") {
     val expectedYaml = loadYaml("expected_fixed_header_output_response.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(header("Location", "Poland")), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(header("Location", "Poland")), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -479,7 +484,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("use fixed header input in request") {
     val expectedYaml = loadYaml("expected_fixed_header_input_request.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.in(header("Location", "Poland")), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.in(header("Location", "Poland")), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -488,28 +493,29 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("validator with tagged type in query") {
     val expectedYaml = loadYaml("expected_valid_query_tagged.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_query_tagged.in("add").in("path"), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_query_tagged.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("validator with wrapper type in body") {
     val expectedYaml = loadYaml("expected_valid_body_wrapped.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_valid_json.in("add").in("path"), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_valid_json.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("validator with optional wrapper type in body") {
     val expectedYaml = loadYaml("expected_valid_optional_body_wrapped.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_valid_optional_json.in("add").in("path"), Info("Fruits", "1.0")).toYaml
+    val actualYaml =
+      OpenAPIDocsInterpreter.fromEndpoint(Validation.in_valid_optional_json.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("validator with enum type in body") {
     val expectedYaml = loadYaml("expected_valid_body_enum.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_json_wrapper_enum.in("add").in("path"), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_json_wrapper_enum.in("add").in("path"), Info("Fruits", "1.0")).toYaml
 
     noIndentation(actualYaml) shouldBe expectedYaml
   }
@@ -517,7 +523,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("validator with wrappers type in query") {
     val expectedYaml = loadYaml("expected_valid_query_wrapped.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_valid_query.in("add").in("path"), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_valid_query.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
@@ -525,14 +531,14 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_valid_body_collection.yml")
 
     val actualYaml =
-      OpenAPIDocsInterpreter.endpoint(Validation.in_valid_json_collection.in("add").in("path"), Info("Fruits", "1.0")).toYaml
+      OpenAPIDocsInterpreter.fromEndpoint(Validation.in_valid_json_collection.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("render validator for additional properties of map") {
     val expectedYaml = loadYaml("expected_valid_additional_properties.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_valid_map, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_valid_map, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -540,7 +546,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render validator for additional properties of array elements") {
     val expectedYaml = loadYaml("expected_valid_int_array.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_valid_int_array, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_valid_int_array, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -548,7 +554,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render enum validator for classes") {
     val expectedYaml = loadYaml("expected_valid_enum_class.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_enum_class, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_enum_class, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -556,7 +562,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render enum validator for classes wrapped in option") {
     val expectedYaml = loadYaml("expected_valid_enum_class_wrapped_in_option.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_optional_enum_class, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_optional_enum_class, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -564,7 +570,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render enum validator for values") {
     val expectedYaml = loadYaml("expected_valid_enum_values.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_enum_values, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_enum_values, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -572,7 +578,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("use enum in object in output response") {
     val expectedYaml = loadYaml("expected_valid_enum_object.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.out_enum_object, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.out_enum_object, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -583,7 +589,9 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_valid_enumeratum.yml")
 
     val actualYaml =
-      OpenAPIDocsInterpreter.endpoints(List(endpoint.in("enum-test").out(jsonBody[Enumeratum.FruitWithEnum])), Info("Fruits", "1.0")).toYaml
+      OpenAPIDocsInterpreter
+        .fromEndpoints(List(endpoint.in("enum-test").out(jsonBody[Enumeratum.FruitWithEnum])), Info("Fruits", "1.0"))
+        .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -597,7 +605,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_valid_enum_cats_nel.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.in(jsonBody[NonEmptyList[Color]]), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.in(jsonBody[NonEmptyList[Color]]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -605,7 +613,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support example of list and not-list types") {
     val expectedYaml = loadYaml("expected_examples_of_list_and_not_list_types.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(
+      .fromEndpoint(
         endpoint.post
           .in(query[List[String]]("friends").example(List("bob", "alice")))
           .in(query[String]("current-person").example("alan"))
@@ -621,7 +629,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support multiple examples with explicit names") {
     val expectedYaml = loadYaml("expected_multiple_examples_with_names.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(
+      .fromEndpoint(
         endpoint.post
           .out(
             jsonBody[Entity].examples(
@@ -642,7 +650,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support multiple examples with default names") {
     val expectedYaml = loadYaml("expected_multiple_examples_with_default_names.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(
+      .fromEndpoint(
         endpoint.post
           .in(jsonBody[Person].example(Person("bob", 23)).example(Person("matt", 30))),
         Info("Entities", "1.0")
@@ -656,7 +664,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support example name even if there is a single example") {
     val expectedYaml = loadYaml("expected_single_example_with_name.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(
+      .fromEndpoint(
         endpoint.post
           .out(
             jsonBody[Entity].example(
@@ -674,7 +682,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support multiple examples with both explicit and default names ") {
     val expectedYaml = loadYaml("expected_multiple_examples_with_explicit_and_default_names.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(
+      .fromEndpoint(
         endpoint.post
           .in(jsonBody[Person].examples(List(Example.of(Person("bob", 23), name = Some("Bob")), Example.of(Person("matt", 30))))),
         Info("Entities", "1.0")
@@ -688,7 +696,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support examples in different IO params") {
     val expectedYaml = loadYaml("expected_multiple_examples.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(
+      .fromEndpoint(
         endpoint.post
           .in(path[String]("country").example("Poland").example("UK"))
           .in(query[String]("current-person").example("alan").example("bob"))
@@ -707,7 +715,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support recursive coproducts") {
     val expectedYaml = loadYaml("expected_recursive_coproducts.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(
+      .fromEndpoint(
         endpoint.post.in(jsonBody[Clause]),
         Info("Entities", "1.0")
       )
@@ -721,7 +729,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     implicit val ageSchema: Schema[Int] = Schema.schemaForInt.validate(Validator.min(11))
     val expectedYaml = loadYaml("expected_valid_coproduct.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(
+      .fromEndpoint(
         endpoint.get.out(jsonBody[Entity]),
         Info("Entities", "1.0")
       )
@@ -734,7 +742,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render field validator when used inside of optional coproduct") {
     implicit val ageSchema: Schema[Int] = Schema.schemaForInt.validate(Validator.min(11))
     val expectedYaml = loadYaml("expected_valid_optional_coproduct.yml")
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.get.in(jsonBody[Option[Entity]]), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.get.in(jsonBody[Option[Entity]]), Info("Entities", "1.0")).toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
@@ -743,7 +751,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("arbitrary json output") {
     val expectedYaml = loadYaml("expected_arbitrary_json_output.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(
+      .fromEndpoint(
         endpoint
           .out(jsonBody[Json]),
         Info("Entities", "1.0")
@@ -757,7 +765,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("deprecated endpoint") {
     val expectedYaml = loadYaml("expected_deprecated.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(
+      .fromEndpoint(
         endpoint.in("api").deprecated(),
         Info("Entities", "1.0")
       )
@@ -770,7 +778,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should not set format for array types ") {
     val expectedYaml = loadYaml("expected_array_no_format.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .endpoint(
+      .fromEndpoint(
         endpoint
           .in(query[List[String]]("foo"))
           .in(query[List[Long]]("bar")),
@@ -799,7 +807,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
         )
     )
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(in_query_query_out_string, api).servers(servers).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(in_query_query_out_string, api).servers(servers).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -818,7 +826,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       Server("https://api.example.com/v1", Some("Production server"), None)
     )
 
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(in_query_query_out_string, api).servers(servers).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(in_query_query_out_string, api).servers(servers).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -829,7 +837,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
     implicit val customConfiguration: Configuration = Configuration.default.withSnakeCaseMemberNames
     val baseEndpoint = endpoint.post.in(jsonBody[MyClass])
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(baseEndpoint, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(baseEndpoint, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -839,7 +847,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_fixed_header_example.yml")
 
     val e = endpoint.in(header("Content-Type", "application/json"))
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(e, Info("Examples", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(e, Info("Examples", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -849,7 +857,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_date_time.yml")
 
     val e = endpoint.in(query[Instant]("instant"))
-    val actualYaml = OpenAPIDocsInterpreter.endpoint(e, Info("Examples", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(e, Info("Examples", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -34,7 +34,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected.yml")
 
     val actualYaml =
-      OpenAPIDocsInterpreter.fromEndpoints(List(in_query_query_out_string, all_the_way, delete_endpoint), Info("Fruits", "1.0")).toYaml
+      OpenAPIDocsInterpreter.toOpenAPI(List(in_query_query_out_string, all_the_way, delete_endpoint), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -46,7 +46,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should match the expected yaml when schema is recursive") {
     val expectedYaml = loadYaml("expected_recursive.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint_wit_recursive_structure, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint_wit_recursive_structure, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -58,7 +58,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_custom_operation_id.yml")
 
     val actualYaml =
-      OpenAPIDocsInterpreter.fromEndpoint(in_query_query_out_string.in("add").in("path"), Info("Fruits", "1.0"))(options).toYaml
+      OpenAPIDocsInterpreter.toOpenAPI(in_query_query_out_string.in("add").in("path"), Info("Fruits", "1.0"))(options).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
@@ -75,7 +75,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should match the expected yaml for streaming endpoints") {
     val expectedYaml = loadYaml("expected_streaming.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(streaming_endpoint, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(streaming_endpoint, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -89,7 +89,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_tags.yml")
 
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoints(List(userTaggedEndpointShow, userTaggedEdnpointSearch, adminTaggedEndpointAdd), Info("Fruits", "1.0"))
+      .toOpenAPI(List(userTaggedEndpointShow, userTaggedEdnpointSearch, adminTaggedEndpointAdd), Info("Fruits", "1.0"))
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -108,7 +108,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       license = Some(License("MIT", Some("mit.license")))
     )
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(in_query_query_out_string, api).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(in_query_query_out_string, api).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -117,7 +117,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should support multipart") {
     val expectedYaml = loadYaml("expected_multipart.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(in_file_multipart_out_multipart, "Fruits", "1.0").toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(in_file_multipart_out_multipart, "Fruits", "1.0").toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -130,7 +130,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val e2 = endpoint.in(auth.bearer[String]()).in("api2" / path[String]).out(stringBody)
     val e3 = endpoint.in(auth.apiKey(header[String]("apikey"))).in("api3" / path[String]).out(stringBody)
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -143,7 +143,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val e2 = endpoint.in(auth.bearer[Option[String]]()).in("api2" / path[String]).out(stringBody)
     val e3 = endpoint.in(auth.apiKey(header[Option[String]]("apikey"))).in("api3" / path[String]).out(stringBody)
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -158,7 +158,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val e3 =
       endpoint.in(auth.apiKey(header[String]("apikey")).securitySchemeName("secApiKeyHeader")).in("secure" / "apiKeyHeader").out(stringBody)
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -190,7 +190,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
         .in("api3" / path[String])
         .out(stringBody)
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -198,7 +198,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should support empty bodies") {
     val expectedYaml = loadYaml("expected_empty.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -220,7 +220,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     )
 
     // when
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(e, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(e, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     // then
@@ -231,7 +231,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_multiple.yml")
 
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoints(
+      .toOpenAPI(
         List(endpoint.in("p1"), endpoint.in("p3"), endpoint.in("p2"), endpoint.in("p5"), endpoint.in("p4")),
         Info("Fruits", "1.0")
       )
@@ -247,7 +247,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, Entity, Any] = endpoint
       .out(jsonBody[Entity])
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -262,7 +262,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_coproduct_discriminator.yml")
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, Entity, Any] = endpoint
       .out(jsonBody[Entity])
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -274,7 +274,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, NestedEntity, Any] = endpoint
       .out(jsonBody[NestedEntity])
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -289,7 +289,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_coproduct_discriminator_nested.yml")
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, NestedEntity, Any] = endpoint
       .out(jsonBody[NestedEntity])
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -301,7 +301,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       .out(jsonBody[BPet])
     val expectedYaml = loadYaml("expected_same_fullnames.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(e, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(e, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -313,7 +313,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       .out(stringBody)
     val expectedYaml = loadYaml("expected_unfolded_hierarchy.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(e, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(e, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -323,7 +323,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val e = endpoint.in(jsonBody[List[FruitAmount]]).out(stringBody)
     val expectedYaml = loadYaml("expected_unfolded_array.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(e, Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(e, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -333,7 +333,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_generic.yml")
 
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoints(List(endpoint.in("p1" and jsonBody[G[String]]), endpoint.in("p2" and jsonBody[G[Int]])), Info("Fruits", "1.0"))
+      .toOpenAPI(List(endpoint.in("p1" and jsonBody[G[String]]), endpoint.in("p2" and jsonBody[G[Int]])), Info("Fruits", "1.0"))
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -343,7 +343,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should unfold objects from unfolded arrays") {
     val expectedYaml = loadYaml("expected_unfolded_object_unfolded_array.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -360,7 +360,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       )
     ).description("Amount of fruits")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.post.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint.post.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -373,7 +373,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       .description("Amount of fruits")
       .modifyUnsafe[Nothing]("amount")(_.format("int32"))
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.post.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint.post.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -382,7 +382,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should unfold coproducts from unfolded arrays") {
     val expectedYaml = loadYaml("expected_unfolded_coproduct_unfolded_array.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(jsonBody[List[Entity]]), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint.out(jsonBody[List[Entity]]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -391,7 +391,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_generic_coproduct.yml")
 
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoints(
+      .toOpenAPI(
         List(endpoint.in("p1" and jsonBody[GenericEntity[String]]), endpoint.in("p2" and jsonBody[GenericEntity[Int]])),
         Info("Fruits", "1.0")
       )
@@ -404,7 +404,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should unfold arrays from object") {
     val expectedYaml = loadYaml("expected_unfolded_array_unfolded_object.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(jsonBody[ObjectWithList]), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint.out(jsonBody[ObjectWithList]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -414,7 +414,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_fixed_status_code.yml")
 
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(endpoint.out(statusCode(StatusCode.PermanentRedirect)).out(header[String]("Location")), Info("Entities", "1.0"))
+      .toOpenAPI(endpoint.out(statusCode(StatusCode.PermanentRedirect)).out(header[String]("Location")), Info("Entities", "1.0"))
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -425,7 +425,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_one_of_status_codes.yml")
 
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(
+      .toOpenAPI(
         endpoint
           .out(header[String]("Location"))
           .errorOut(statusCode.description(StatusCode.NotFound, "entity not found").description(StatusCode.BadRequest, "")),
@@ -440,7 +440,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render additional properties for map") {
     val expectedYaml = loadYaml("expected_additional_properties.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(jsonBody[Map[String, Person]]), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint.out(jsonBody[Map[String, Person]]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -449,7 +449,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render map with plain values") {
     val expectedYaml = loadYaml("expected_map_with_plain_values.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(jsonBody[Map[String, String]]), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint.out(jsonBody[Map[String, String]]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -458,7 +458,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("use fixed status code output in response if it's the only output") {
     val expectedYaml = loadYaml("expected_fixed_status_code_2.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(statusCode(StatusCode.NoContent)), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint.out(statusCode(StatusCode.NoContent)), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -468,14 +468,14 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_prepended_input.yml")
 
     val actualYaml =
-      OpenAPIDocsInterpreter.fromEndpoint(in_query_query_out_string.in("add").prependIn("path"), Info("Fruits", "1.0")).toYaml
+      OpenAPIDocsInterpreter.toOpenAPI(in_query_query_out_string.in("add").prependIn("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("use fixed header output in response") {
     val expectedYaml = loadYaml("expected_fixed_header_output_response.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.out(header("Location", "Poland")), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint.out(header("Location", "Poland")), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -484,7 +484,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("use fixed header input in request") {
     val expectedYaml = loadYaml("expected_fixed_header_input_request.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.in(header("Location", "Poland")), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint.in(header("Location", "Poland")), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -493,14 +493,14 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("validator with tagged type in query") {
     val expectedYaml = loadYaml("expected_valid_query_tagged.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_query_tagged.in("add").in("path"), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(Validation.in_query_tagged.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("validator with wrapper type in body") {
     val expectedYaml = loadYaml("expected_valid_body_wrapped.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_valid_json.in("add").in("path"), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(Validation.in_valid_json.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
@@ -508,14 +508,14 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_valid_optional_body_wrapped.yml")
 
     val actualYaml =
-      OpenAPIDocsInterpreter.fromEndpoint(Validation.in_valid_optional_json.in("add").in("path"), Info("Fruits", "1.0")).toYaml
+      OpenAPIDocsInterpreter.toOpenAPI(Validation.in_valid_optional_json.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("validator with enum type in body") {
     val expectedYaml = loadYaml("expected_valid_body_enum.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_json_wrapper_enum.in("add").in("path"), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(Validation.in_json_wrapper_enum.in("add").in("path"), Info("Fruits", "1.0")).toYaml
 
     noIndentation(actualYaml) shouldBe expectedYaml
   }
@@ -523,7 +523,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("validator with wrappers type in query") {
     val expectedYaml = loadYaml("expected_valid_query_wrapped.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_valid_query.in("add").in("path"), Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(Validation.in_valid_query.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
@@ -531,14 +531,14 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_valid_body_collection.yml")
 
     val actualYaml =
-      OpenAPIDocsInterpreter.fromEndpoint(Validation.in_valid_json_collection.in("add").in("path"), Info("Fruits", "1.0")).toYaml
+      OpenAPIDocsInterpreter.toOpenAPI(Validation.in_valid_json_collection.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("render validator for additional properties of map") {
     val expectedYaml = loadYaml("expected_valid_additional_properties.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_valid_map, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(Validation.in_valid_map, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -546,7 +546,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render validator for additional properties of array elements") {
     val expectedYaml = loadYaml("expected_valid_int_array.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_valid_int_array, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(Validation.in_valid_int_array, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -554,7 +554,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render enum validator for classes") {
     val expectedYaml = loadYaml("expected_valid_enum_class.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_enum_class, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(Validation.in_enum_class, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -562,7 +562,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render enum validator for classes wrapped in option") {
     val expectedYaml = loadYaml("expected_valid_enum_class_wrapped_in_option.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_optional_enum_class, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(Validation.in_optional_enum_class, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -570,7 +570,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render enum validator for values") {
     val expectedYaml = loadYaml("expected_valid_enum_values.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.in_enum_values, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(Validation.in_enum_values, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -578,7 +578,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("use enum in object in output response") {
     val expectedYaml = loadYaml("expected_valid_enum_object.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(Validation.out_enum_object, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(Validation.out_enum_object, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -590,7 +590,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
     val actualYaml =
       OpenAPIDocsInterpreter
-        .fromEndpoints(List(endpoint.in("enum-test").out(jsonBody[Enumeratum.FruitWithEnum])), Info("Fruits", "1.0"))
+        .toOpenAPI(List(endpoint.in("enum-test").out(jsonBody[Enumeratum.FruitWithEnum])), Info("Fruits", "1.0"))
         .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -605,7 +605,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_valid_enum_cats_nel.yml")
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.in(jsonBody[NonEmptyList[Color]]), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint.in(jsonBody[NonEmptyList[Color]]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -613,7 +613,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support example of list and not-list types") {
     val expectedYaml = loadYaml("expected_examples_of_list_and_not_list_types.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(
+      .toOpenAPI(
         endpoint.post
           .in(query[List[String]]("friends").example(List("bob", "alice")))
           .in(query[String]("current-person").example("alan"))
@@ -629,7 +629,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support multiple examples with explicit names") {
     val expectedYaml = loadYaml("expected_multiple_examples_with_names.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(
+      .toOpenAPI(
         endpoint.post
           .out(
             jsonBody[Entity].examples(
@@ -650,7 +650,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support multiple examples with default names") {
     val expectedYaml = loadYaml("expected_multiple_examples_with_default_names.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(
+      .toOpenAPI(
         endpoint.post
           .in(jsonBody[Person].example(Person("bob", 23)).example(Person("matt", 30))),
         Info("Entities", "1.0")
@@ -664,7 +664,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support example name even if there is a single example") {
     val expectedYaml = loadYaml("expected_single_example_with_name.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(
+      .toOpenAPI(
         endpoint.post
           .out(
             jsonBody[Entity].example(
@@ -682,7 +682,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support multiple examples with both explicit and default names ") {
     val expectedYaml = loadYaml("expected_multiple_examples_with_explicit_and_default_names.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(
+      .toOpenAPI(
         endpoint.post
           .in(jsonBody[Person].examples(List(Example.of(Person("bob", 23), name = Some("Bob")), Example.of(Person("matt", 30))))),
         Info("Entities", "1.0")
@@ -696,7 +696,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support examples in different IO params") {
     val expectedYaml = loadYaml("expected_multiple_examples.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(
+      .toOpenAPI(
         endpoint.post
           .in(path[String]("country").example("Poland").example("UK"))
           .in(query[String]("current-person").example("alan").example("bob"))
@@ -715,7 +715,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("support recursive coproducts") {
     val expectedYaml = loadYaml("expected_recursive_coproducts.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(
+      .toOpenAPI(
         endpoint.post.in(jsonBody[Clause]),
         Info("Entities", "1.0")
       )
@@ -729,7 +729,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     implicit val ageSchema: Schema[Int] = Schema.schemaForInt.validate(Validator.min(11))
     val expectedYaml = loadYaml("expected_valid_coproduct.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(
+      .toOpenAPI(
         endpoint.get.out(jsonBody[Entity]),
         Info("Entities", "1.0")
       )
@@ -742,7 +742,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render field validator when used inside of optional coproduct") {
     implicit val ageSchema: Schema[Int] = Schema.schemaForInt.validate(Validator.min(11))
     val expectedYaml = loadYaml("expected_valid_optional_coproduct.yml")
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(endpoint.get.in(jsonBody[Option[Entity]]), Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(endpoint.get.in(jsonBody[Option[Entity]]), Info("Entities", "1.0")).toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
@@ -751,7 +751,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("arbitrary json output") {
     val expectedYaml = loadYaml("expected_arbitrary_json_output.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(
+      .toOpenAPI(
         endpoint
           .out(jsonBody[Json]),
         Info("Entities", "1.0")
@@ -765,7 +765,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("deprecated endpoint") {
     val expectedYaml = loadYaml("expected_deprecated.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(
+      .toOpenAPI(
         endpoint.in("api").deprecated(),
         Info("Entities", "1.0")
       )
@@ -778,7 +778,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should not set format for array types ") {
     val expectedYaml = loadYaml("expected_array_no_format.yml")
     val actualYaml = OpenAPIDocsInterpreter
-      .fromEndpoint(
+      .toOpenAPI(
         endpoint
           .in(query[List[String]]("foo"))
           .in(query[List[Long]]("bar")),
@@ -807,7 +807,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
         )
     )
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(in_query_query_out_string, api).servers(servers).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(in_query_query_out_string, api).servers(servers).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -826,7 +826,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       Server("https://api.example.com/v1", Some("Production server"), None)
     )
 
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(in_query_query_out_string, api).servers(servers).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(in_query_query_out_string, api).servers(servers).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -837,7 +837,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
     implicit val customConfiguration: Configuration = Configuration.default.withSnakeCaseMemberNames
     val baseEndpoint = endpoint.post.in(jsonBody[MyClass])
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(baseEndpoint, Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(baseEndpoint, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -847,7 +847,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_fixed_header_example.yml")
 
     val e = endpoint.in(header("Content-Type", "application/json"))
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(e, Info("Examples", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(e, Info("Examples", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -857,7 +857,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_date_time.yml")
 
     val e = endpoint.in(query[Instant]("instant"))
-    val actualYaml = OpenAPIDocsInterpreter.fromEndpoint(e, Info("Examples", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.toOpenAPI(e, Info("Examples", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml

--- a/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
+++ b/docs/openapi-docs/src/test/scala/sttp/tapir/docs/openapi/VerifyYamlTest.scala
@@ -33,7 +33,8 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should match the expected yaml") {
     val expectedYaml = loadYaml("expected.yml")
 
-    val actualYaml = List(in_query_query_out_string, all_the_way, delete_endpoint).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml =
+      OpenAPIDocsInterpreter.endpoints(List(in_query_query_out_string, all_the_way, delete_endpoint), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -45,7 +46,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should match the expected yaml when schema is recursive") {
     val expectedYaml = loadYaml("expected_recursive.yml")
 
-    val actualYaml = endpoint_wit_recursive_structure.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint_wit_recursive_structure, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -56,11 +57,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val options = OpenAPIDocsOptions.default.copy(customOperationIdGenerator)
     val expectedYaml = loadYaml("expected_custom_operation_id.yml")
 
-    val actualYaml = in_query_query_out_string
-      .in("add")
-      .in("path")
-      .toOpenAPI(Info("Fruits", "1.0"))(options)
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(in_query_query_out_string.in("add").in("path"), Info("Fruits", "1.0"))(options).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
@@ -77,7 +74,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should match the expected yaml for streaming endpoints") {
     val expectedYaml = loadYaml("expected_streaming.yml")
 
-    val actualYaml = streaming_endpoint.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(streaming_endpoint, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -90,7 +87,9 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_tags.yml")
 
-    val actualYaml = List(userTaggedEndpointShow, userTaggedEdnpointSearch, adminTaggedEndpointAdd).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoints(List(userTaggedEndpointShow, userTaggedEdnpointSearch, adminTaggedEndpointAdd), Info("Fruits", "1.0"))
+      .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -108,7 +107,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       license = Some(License("MIT", Some("mit.license")))
     )
 
-    val actualYaml = in_query_query_out_string.toOpenAPI(api).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(in_query_query_out_string, api).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -117,7 +116,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should support multipart") {
     val expectedYaml = loadYaml("expected_multipart.yml")
 
-    val actualYaml = List(in_file_multipart_out_multipart).toOpenAPI("Fruits", "1.0").toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(in_file_multipart_out_multipart, "Fruits", "1.0").toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -130,7 +129,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val e2 = endpoint.in(auth.bearer[String]()).in("api2" / path[String]).out(stringBody)
     val e3 = endpoint.in(auth.apiKey(header[String]("apikey"))).in("api3" / path[String]).out(stringBody)
 
-    val actualYaml = List(e1, e2, e3).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -143,7 +142,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val e2 = endpoint.in(auth.bearer[Option[String]]()).in("api2" / path[String]).out(stringBody)
     val e3 = endpoint.in(auth.apiKey(header[Option[String]]("apikey"))).in("api3" / path[String]).out(stringBody)
 
-    val actualYaml = List(e1, e2, e3).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -158,7 +157,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val e3 =
       endpoint.in(auth.apiKey(header[String]("apikey")).securitySchemeName("secApiKeyHeader")).in("secure" / "apiKeyHeader").out(stringBody)
 
-    val actualYaml = List(e1, e2, e3).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -190,7 +189,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
         .in("api3" / path[String])
         .out(stringBody)
 
-    val actualYaml = List(e1, e2, e3).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoints(List(e1, e2, e3), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -198,7 +197,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should support empty bodies") {
     val expectedYaml = loadYaml("expected_empty.yml")
 
-    val actualYaml = List(endpoint).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -220,7 +219,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     )
 
     // when
-    val actualYaml = List(e).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(e, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     // then
@@ -230,8 +229,8 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should keep the order of multiple endpoints") {
     val expectedYaml = loadYaml("expected_multiple.yml")
 
-    val actualYaml = List(endpoint.in("p1"), endpoint.in("p3"), endpoint.in("p2"), endpoint.in("p5"), endpoint.in("p4"))
-      .toOpenAPI(Info("Fruits", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoints(List(endpoint.in("p1"), endpoint.in("p3"), endpoint.in("p2"), endpoint.in("p5"), endpoint.in("p4")), Info("Fruits", "1.0"))
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -244,7 +243,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, Entity, Any] = endpoint
       .out(jsonBody[Entity])
 
-    val actualYaml = endpoint_wit_sealed_trait.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -259,7 +258,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_coproduct_discriminator.yml")
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, Entity, Any] = endpoint
       .out(jsonBody[Entity])
-    val actualYaml = endpoint_wit_sealed_trait.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -271,7 +270,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, NestedEntity, Any] = endpoint
       .out(jsonBody[NestedEntity])
 
-    val actualYaml = endpoint_wit_sealed_trait.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -286,7 +285,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_coproduct_discriminator_nested.yml")
     val endpoint_wit_sealed_trait: Endpoint[Unit, Unit, NestedEntity, Any] = endpoint
       .out(jsonBody[NestedEntity])
-    val actualYaml = endpoint_wit_sealed_trait.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint_wit_sealed_trait, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -298,7 +297,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       .out(jsonBody[BPet])
     val expectedYaml = loadYaml("expected_same_fullnames.yml")
 
-    val actualYaml = e.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(e, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -310,7 +309,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       .out(stringBody)
     val expectedYaml = loadYaml("expected_unfolded_hierarchy.yml")
 
-    val actualYaml = e.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(e, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -320,7 +319,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val e = endpoint.in(jsonBody[List[FruitAmount]]).out(stringBody)
     val expectedYaml = loadYaml("expected_unfolded_array.yml")
 
-    val actualYaml = e.toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(e, Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -329,8 +328,8 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should differentiate when a generic type is used multiple times") {
     val expectedYaml = loadYaml("expected_generic.yml")
 
-    val actualYaml = List(endpoint.in("p1" and jsonBody[G[String]]), endpoint.in("p2" and jsonBody[G[Int]]))
-      .toOpenAPI(Info("Fruits", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoints(List(endpoint.in("p1" and jsonBody[G[String]]), endpoint.in("p2" and jsonBody[G[Int]])), Info("Fruits", "1.0"))
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -340,10 +339,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should unfold objects from unfolded arrays") {
     val expectedYaml = loadYaml("expected_unfolded_object_unfolded_array.yml")
 
-    val actualYaml = endpoint
-      .out(jsonBody[List[ObjectWrapper]])
-      .toOpenAPI(Info("Fruits", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -360,10 +356,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       )
     ).description("Amount of fruits")
 
-    val actualYaml = endpoint.post
-      .out(jsonBody[List[ObjectWrapper]])
-      .toOpenAPI(Info("Fruits", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.post.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -376,10 +369,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       .description("Amount of fruits")
       .modifyUnsafe[Nothing]("amount")(_.format("int32"))
 
-    val actualYaml = endpoint.post
-      .out(jsonBody[List[ObjectWrapper]])
-      .toOpenAPI(Info("Fruits", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.post.out(jsonBody[List[ObjectWrapper]]), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -388,10 +378,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should unfold coproducts from unfolded arrays") {
     val expectedYaml = loadYaml("expected_unfolded_coproduct_unfolded_array.yml")
 
-    val actualYaml = endpoint
-      .out(jsonBody[List[Entity]])
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(jsonBody[List[Entity]]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -399,8 +386,11 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should differentiate when a generic coproduct type is used multiple times") {
     val expectedYaml = loadYaml("expected_generic_coproduct.yml")
 
-    val actualYaml = List(endpoint.in("p1" and jsonBody[GenericEntity[String]]), endpoint.in("p2" and jsonBody[GenericEntity[Int]]))
-      .toOpenAPI(Info("Fruits", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoints(
+        List(endpoint.in("p1" and jsonBody[GenericEntity[String]]), endpoint.in("p2" and jsonBody[GenericEntity[Int]])),
+        Info("Fruits", "1.0")
+      )
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -410,10 +400,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should unfold arrays from object") {
     val expectedYaml = loadYaml("expected_unfolded_array_unfolded_object.yml")
 
-    val actualYaml = endpoint
-      .out(jsonBody[ObjectWithList])
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(jsonBody[ObjectWithList]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -422,10 +409,8 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("use fixed status code output in response") {
     val expectedYaml = loadYaml("expected_fixed_status_code.yml")
 
-    val actualYaml = endpoint
-      .out(statusCode(StatusCode.PermanentRedirect))
-      .out(header[String]("Location"))
-      .toOpenAPI(Info("Entities", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(endpoint.out(statusCode(StatusCode.PermanentRedirect)).out(header[String]("Location")), Info("Entities", "1.0"))
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -435,10 +420,13 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("use status codes declared with description") {
     val expectedYaml = loadYaml("expected_one_of_status_codes.yml")
 
-    val actualYaml = endpoint
-      .out(header[String]("Location"))
-      .errorOut(statusCode.description(StatusCode.NotFound, "entity not found").description(StatusCode.BadRequest, ""))
-      .toOpenAPI(Info("Entities", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(
+        endpoint
+          .out(header[String]("Location"))
+          .errorOut(statusCode.description(StatusCode.NotFound, "entity not found").description(StatusCode.BadRequest, "")),
+        Info("Entities", "1.0")
+      )
       .toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
@@ -448,10 +436,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render additional properties for map") {
     val expectedYaml = loadYaml("expected_additional_properties.yml")
 
-    val actualYaml = endpoint
-      .out(jsonBody[Map[String, Person]])
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(jsonBody[Map[String, Person]]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -460,10 +445,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render map with plain values") {
     val expectedYaml = loadYaml("expected_map_with_plain_values.yml")
 
-    val actualYaml = endpoint
-      .out(jsonBody[Map[String, String]])
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(jsonBody[Map[String, String]]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -472,10 +454,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("use fixed status code output in response if it's the only output") {
     val expectedYaml = loadYaml("expected_fixed_status_code_2.yml")
 
-    val actualYaml = endpoint
-      .out(statusCode(StatusCode.NoContent))
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(statusCode(StatusCode.NoContent)), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -484,21 +463,14 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("should support prepending inputs") {
     val expectedYaml = loadYaml("expected_prepended_input.yml")
 
-    val actualYaml = in_query_query_out_string
-      .in("add")
-      .prependIn("path")
-      .toOpenAPI(Info("Fruits", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(in_query_query_out_string.in("add").prependIn("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("use fixed header output in response") {
     val expectedYaml = loadYaml("expected_fixed_header_output_response.yml")
 
-    val actualYaml = endpoint
-      .out(header("Location", "Poland"))
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.out(header("Location", "Poland")), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -507,10 +479,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("use fixed header input in request") {
     val expectedYaml = loadYaml("expected_fixed_header_input_request.yml")
 
-    val actualYaml = endpoint
-      .in(header("Location", "Poland"))
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.in(header("Location", "Poland")), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -519,44 +488,28 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("validator with tagged type in query") {
     val expectedYaml = loadYaml("expected_valid_query_tagged.yml")
 
-    val actualYaml = Validation.in_query_tagged
-      .in("add")
-      .in("path")
-      .toOpenAPI(Info("Fruits", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_query_tagged.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("validator with wrapper type in body") {
     val expectedYaml = loadYaml("expected_valid_body_wrapped.yml")
 
-    val actualYaml = Validation.in_valid_json
-      .in("add")
-      .in("path")
-      .toOpenAPI(Info("Fruits", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_valid_json.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("validator with optional wrapper type in body") {
     val expectedYaml = loadYaml("expected_valid_optional_body_wrapped.yml")
 
-    val actualYaml = Validation.in_valid_optional_json
-      .in("add")
-      .in("path")
-      .toOpenAPI(Info("Fruits", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_valid_optional_json.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("validator with enum type in body") {
     val expectedYaml = loadYaml("expected_valid_body_enum.yml")
 
-    val actualYaml = Validation.in_json_wrapper_enum
-      .in("add")
-      .in("path")
-      .toOpenAPI(Info("Fruits", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_json_wrapper_enum.in("add").in("path"), Info("Fruits", "1.0")).toYaml
 
     noIndentation(actualYaml) shouldBe expectedYaml
   }
@@ -564,31 +517,22 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("validator with wrappers type in query") {
     val expectedYaml = loadYaml("expected_valid_query_wrapped.yml")
 
-    val actualYaml = Validation.in_valid_query
-      .in("add")
-      .in("path")
-      .toOpenAPI(Info("Fruits", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_valid_query.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("validator with list") {
     val expectedYaml = loadYaml("expected_valid_body_collection.yml")
 
-    val actualYaml = Validation.in_valid_json_collection
-      .in("add")
-      .in("path")
-      .toOpenAPI(Info("Fruits", "1.0"))
-      .toYaml
+    val actualYaml =
+      OpenAPIDocsInterpreter.endpoint(Validation.in_valid_json_collection.in("add").in("path"), Info("Fruits", "1.0")).toYaml
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
   test("render validator for additional properties of map") {
     val expectedYaml = loadYaml("expected_valid_additional_properties.yml")
 
-    val actualYaml = Validation.in_valid_map
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_valid_map, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -596,9 +540,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render validator for additional properties of array elements") {
     val expectedYaml = loadYaml("expected_valid_int_array.yml")
 
-    val actualYaml = Validation.in_valid_int_array
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_valid_int_array, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -606,9 +548,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render enum validator for classes") {
     val expectedYaml = loadYaml("expected_valid_enum_class.yml")
 
-    val actualYaml = Validation.in_enum_class
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_enum_class, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -616,9 +556,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render enum validator for classes wrapped in option") {
     val expectedYaml = loadYaml("expected_valid_enum_class_wrapped_in_option.yml")
 
-    val actualYaml = Validation.in_optional_enum_class
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_optional_enum_class, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -626,9 +564,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render enum validator for values") {
     val expectedYaml = loadYaml("expected_valid_enum_values.yml")
 
-    val actualYaml = Validation.in_enum_values
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.in_enum_values, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -636,9 +572,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("use enum in object in output response") {
     val expectedYaml = loadYaml("expected_valid_enum_object.yml")
 
-    val actualYaml = Validation.out_enum_object
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(Validation.out_enum_object, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
@@ -648,7 +582,8 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_valid_enumeratum.yml")
 
-    val actualYaml = List(endpoint.in("enum-test").out(jsonBody[Enumeratum.FruitWithEnum])).toOpenAPI(Info("Fruits", "1.0")).toYaml
+    val actualYaml =
+      OpenAPIDocsInterpreter.endpoints(List(endpoint.in("enum-test").out(jsonBody[Enumeratum.FruitWithEnum])), Info("Fruits", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -662,21 +597,21 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
     val expectedYaml = loadYaml("expected_valid_enum_cats_nel.yml")
 
-    val actualYaml = endpoint
-      .in(jsonBody[NonEmptyList[Color]])
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.in(jsonBody[NonEmptyList[Color]]), Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
   }
 
   test("support example of list and not-list types") {
     val expectedYaml = loadYaml("expected_examples_of_list_and_not_list_types.yml")
-    val actualYaml = endpoint.post
-      .in(query[List[String]]("friends").example(List("bob", "alice")))
-      .in(query[String]("current-person").example("alan"))
-      .in(jsonBody[Person].example(Person("bob", 23)))
-      .toOpenAPI(Info("Entities", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(
+        endpoint.post
+          .in(query[List[String]]("friends").example(List("bob", "alice")))
+          .in(query[String]("current-person").example("alan"))
+          .in(jsonBody[Person].example(Person("bob", 23))),
+        Info("Entities", "1.0")
+      )
       .toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
@@ -685,16 +620,19 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
   test("support multiple examples with explicit names") {
     val expectedYaml = loadYaml("expected_multiple_examples_with_names.yml")
-    val actualYaml = endpoint.post
-      .out(
-        jsonBody[Entity].examples(
-          List(
-            Example.of(Person("michal", 40), Some("Michal"), Some("Some summary")),
-            Example.of(Organization("acme"), Some("Acme"))
-          )
-        )
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(
+        endpoint.post
+          .out(
+            jsonBody[Entity].examples(
+              List(
+                Example.of(Person("michal", 40), Some("Michal"), Some("Some summary")),
+                Example.of(Organization("acme"), Some("Acme"))
+              )
+            )
+          ),
+        Info("Entities", "1.0")
       )
-      .toOpenAPI(Info("Entities", "1.0"))
       .toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
@@ -703,9 +641,12 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
   test("support multiple examples with default names") {
     val expectedYaml = loadYaml("expected_multiple_examples_with_default_names.yml")
-    val actualYaml = endpoint.post
-      .in(jsonBody[Person].example(Person("bob", 23)).example(Person("matt", 30)))
-      .toOpenAPI(Info("Entities", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(
+        endpoint.post
+          .in(jsonBody[Person].example(Person("bob", 23)).example(Person("matt", 30))),
+        Info("Entities", "1.0")
+      )
       .toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
@@ -714,13 +655,16 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
   test("support example name even if there is a single example") {
     val expectedYaml = loadYaml("expected_single_example_with_name.yml")
-    val actualYaml = endpoint.post
-      .out(
-        jsonBody[Entity].example(
-          Example(Person("michal", 40), Some("Michal"), Some("Some summary"))
-        )
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(
+        endpoint.post
+          .out(
+            jsonBody[Entity].example(
+              Example(Person("michal", 40), Some("Michal"), Some("Some summary"))
+            )
+          ),
+        Info("Entities", "1.0")
       )
-      .toOpenAPI(Info("Entities", "1.0"))
       .toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
@@ -729,9 +673,12 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
   test("support multiple examples with both explicit and default names ") {
     val expectedYaml = loadYaml("expected_multiple_examples_with_explicit_and_default_names.yml")
-    val actualYaml = endpoint.post
-      .in(jsonBody[Person].examples(List(Example.of(Person("bob", 23), name = Some("Bob")), Example.of(Person("matt", 30)))))
-      .toOpenAPI(Info("Entities", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(
+        endpoint.post
+          .in(jsonBody[Person].examples(List(Example.of(Person("bob", 23), name = Some("Bob")), Example.of(Person("matt", 30))))),
+        Info("Entities", "1.0")
+      )
       .toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
@@ -740,14 +687,17 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
   test("support examples in different IO params") {
     val expectedYaml = loadYaml("expected_multiple_examples.yml")
-    val actualYaml = endpoint.post
-      .in(path[String]("country").example("Poland").example("UK"))
-      .in(query[String]("current-person").example("alan").example("bob"))
-      .in(jsonBody[Person].example(Person("bob", 23)).example(Person("alan", 50)))
-      .in(header[String]("X-Forwarded-User").example("user1").example("user2"))
-      .in(cookie[String]("cookie-param").example("cookie1").example("cookie2"))
-      .out(jsonBody[Entity].example(Person("michal", 40)).example(Organization("acme")))
-      .toOpenAPI(Info("Entities", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(
+        endpoint.post
+          .in(path[String]("country").example("Poland").example("UK"))
+          .in(query[String]("current-person").example("alan").example("bob"))
+          .in(jsonBody[Person].example(Person("bob", 23)).example(Person("alan", 50)))
+          .in(header[String]("X-Forwarded-User").example("user1").example("user2"))
+          .in(cookie[String]("cookie-param").example("cookie1").example("cookie2"))
+          .out(jsonBody[Entity].example(Person("michal", 40)).example(Organization("acme"))),
+        Info("Entities", "1.0")
+      )
       .toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
@@ -756,9 +706,11 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
   test("support recursive coproducts") {
     val expectedYaml = loadYaml("expected_recursive_coproducts.yml")
-    val actualYaml = endpoint.post
-      .in(jsonBody[Clause])
-      .toOpenAPI(Info("Entities", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(
+        endpoint.post.in(jsonBody[Clause]),
+        Info("Entities", "1.0")
+      )
       .toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
@@ -768,9 +720,11 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render field validator when used inside of coproduct") {
     implicit val ageSchema: Schema[Int] = Schema.schemaForInt.validate(Validator.min(11))
     val expectedYaml = loadYaml("expected_valid_coproduct.yml")
-    val actualYaml = endpoint.get
-      .out(jsonBody[Entity])
-      .toOpenAPI(Info("Entities", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(
+        endpoint.get.out(jsonBody[Entity]),
+        Info("Entities", "1.0")
+      )
       .toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
@@ -780,10 +734,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
   test("render field validator when used inside of optional coproduct") {
     implicit val ageSchema: Schema[Int] = Schema.schemaForInt.validate(Validator.min(11))
     val expectedYaml = loadYaml("expected_valid_optional_coproduct.yml")
-    val actualYaml = endpoint.get
-      .in(jsonBody[Option[Entity]])
-      .toOpenAPI(Info("Entities", "1.0"))
-      .toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(endpoint.get.in(jsonBody[Option[Entity]]), Info("Entities", "1.0")).toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
     actualYamlNoIndent shouldBe expectedYaml
@@ -791,9 +742,12 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
   test("arbitrary json output") {
     val expectedYaml = loadYaml("expected_arbitrary_json_output.yml")
-    val actualYaml = endpoint
-      .out(jsonBody[Json])
-      .toOpenAPI(Info("Entities", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(
+        endpoint
+          .out(jsonBody[Json]),
+        Info("Entities", "1.0")
+      )
       .toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
@@ -802,10 +756,11 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
   test("deprecated endpoint") {
     val expectedYaml = loadYaml("expected_deprecated.yml")
-    val actualYaml = endpoint
-      .in("api")
-      .deprecated()
-      .toOpenAPI(Info("Entities", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(
+        endpoint.in("api").deprecated(),
+        Info("Entities", "1.0")
+      )
       .toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
@@ -814,10 +769,13 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
   test("should not set format for array types ") {
     val expectedYaml = loadYaml("expected_array_no_format.yml")
-    val actualYaml = endpoint
-      .in(query[List[String]]("foo"))
-      .in(query[List[Long]]("bar"))
-      .toOpenAPI(Info("Entities", "1.0"))
+    val actualYaml = OpenAPIDocsInterpreter
+      .endpoint(
+        endpoint
+          .in(query[List[String]]("foo"))
+          .in(query[List[Long]]("bar")),
+        Info("Entities", "1.0")
+      )
       .toYaml
 
     val actualYamlNoIndent = noIndentation(actualYaml)
@@ -841,7 +799,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
         )
     )
 
-    val actualYaml = in_query_query_out_string.toOpenAPI(api).servers(servers).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(in_query_query_out_string, api).servers(servers).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -860,7 +818,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
       Server("https://api.example.com/v1", Some("Production server"), None)
     )
 
-    val actualYaml = in_query_query_out_string.toOpenAPI(api).servers(servers).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(in_query_query_out_string, api).servers(servers).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -871,7 +829,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
 
     implicit val customConfiguration: Configuration = Configuration.default.withSnakeCaseMemberNames
     val baseEndpoint = endpoint.post.in(jsonBody[MyClass])
-    val actualYaml = baseEndpoint.toOpenAPI(Info("Entities", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(baseEndpoint, Info("Entities", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -881,7 +839,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_fixed_header_example.yml")
 
     val e = endpoint.in(header("Content-Type", "application/json"))
-    val actualYaml = e.toOpenAPI(Info("Examples", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(e, Info("Examples", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
@@ -891,7 +849,7 @@ class VerifyYamlTest extends AnyFunSuite with Matchers {
     val expectedYaml = loadYaml("expected_date_time.yml")
 
     val e = endpoint.in(query[Instant]("instant"))
-    val actualYaml = e.toOpenAPI(Info("Examples", "1.0")).toYaml
+    val actualYaml = OpenAPIDocsInterpreter.endpoint(e, Info("Examples", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml

--- a/examples/src/main/scala/sttp/tapir/examples/BasicAuthenticationAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BasicAuthenticationAkkaServer.scala
@@ -17,7 +17,8 @@ object BasicAuthenticationAkkaServer extends App {
   val secret: Endpoint[UsernamePassword, Unit, String, Any] =
     endpoint.get.in("secret").in(auth.basic[UsernamePassword](WWWAuthenticate.basic("example"))).out(stringBody)
 
-  val secretRoute: Route = secret.toRoute(credentials => Future.successful(Right(s"Hello, ${credentials.username}!")))
+  val secretRoute: Route =
+    AkkaHttpServerInterpreter.toRoute(secret)(credentials => Future.successful(Right(s"Hello, ${credentials.username}!")))
 
   // starting the server
   implicit val actorSystem: ActorSystem = ActorSystem()

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
@@ -88,7 +88,7 @@ object BooksExample extends App with StrictLogging {
   import akka.http.scaladsl.server.Route
 
   def openapiYamlDocumentation: String = {
-    import sttp.tapir.docs.openapi._
+    import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
     import sttp.tapir.openapi.circe.yaml._
 
     // interpreting the endpoint description to generate yaml openapi documentation
@@ -98,7 +98,7 @@ object BooksExample extends App with StrictLogging {
 
   def booksRoutes: Route = {
     import akka.http.scaladsl.server.Directives._
-    import sttp.tapir.server.akkahttp._
+    import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
     import scala.concurrent.ExecutionContext.Implicits.global
     import scala.concurrent.Future
@@ -150,7 +150,7 @@ object BooksExample extends App with StrictLogging {
 
   def makeClientRequest(): Unit = {
     import sttp.client3._
-    import sttp.tapir.client.sttp._
+    import sttp.tapir.client.sttp.SttpClientInterpreter
 
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
 

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
@@ -154,8 +154,8 @@ object BooksExample extends App with StrictLogging {
 
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
 
-    val booksListingRequest: Request[Either[String, Vector[Book]], Any] = booksListing
-      .toSttpRequestUnsafe(uri"http://localhost:8080")
+    val booksListingRequest: Request[Either[String, Vector[Book]], Any] = SttpClientInterpreter
+      .toRequestUnsafe(booksListing)(uri"http://localhost:8080")
       .apply(Option(3))
 
     val result: Either[String, Vector[Book]] = booksListingRequest.send(backend).body

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
@@ -92,7 +92,7 @@ object BooksExample extends App with StrictLogging {
     import sttp.tapir.openapi.circe.yaml._
 
     // interpreting the endpoint description to generate yaml openapi documentation
-    val docs = List(addBook, booksListing, booksListingByGenre).toOpenAPI("The Tapir Library", "1.0")
+    val docs = OpenAPIDocsInterpreter.endpoints(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
     docs.toYaml
   }
 

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
@@ -92,7 +92,7 @@ object BooksExample extends App with StrictLogging {
     import sttp.tapir.openapi.circe.yaml._
 
     // interpreting the endpoint description to generate yaml openapi documentation
-    val docs = OpenAPIDocsInterpreter.fromEndpoints(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
+    val docs = OpenAPIDocsInterpreter.toOpenAPI(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
     docs.toYaml
   }
 

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
@@ -155,7 +155,7 @@ object BooksExample extends App with StrictLogging {
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
 
     val booksListingRequest: Request[Either[String, Vector[Book]], Any] = SttpClientInterpreter
-      .toRequestUnsafe(booksListing)(uri"http://localhost:8080")
+      .toRequestUnsafe(booksListing, uri"http://localhost:8080")
       .apply(Option(3))
 
     val result: Either[String, Vector[Book]] = booksListingRequest.send(backend).body

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
@@ -92,7 +92,7 @@ object BooksExample extends App with StrictLogging {
     import sttp.tapir.openapi.circe.yaml._
 
     // interpreting the endpoint description to generate yaml openapi documentation
-    val docs = OpenAPIDocsInterpreter.endpoints(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
+    val docs = OpenAPIDocsInterpreter.fromEndpoints(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
     docs.toYaml
   }
 

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
@@ -128,9 +128,9 @@ object BooksExample extends App with StrictLogging {
     // interpreting the endpoint description and converting it to an akka-http route, providing the logic which
     // should be run when the endpoint is invoked.
     concat(
-      addBook.toRoute((bookAddLogic _).tupled),
-      booksListing.toRoute(bookListingLogic),
-      booksListingByGenre.toRoute(bookListingByGenreLogic)
+      AkkaHttpServerInterpreter.toRoute(addBook)((bookAddLogic _).tupled),
+      AkkaHttpServerInterpreter.toRoute(booksListing)(bookListingLogic),
+      AkkaHttpServerInterpreter.toRoute(booksListingByGenre)(bookListingByGenreLogic)
     )
   }
 

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
@@ -94,11 +94,11 @@ object BooksExampleSemiauto extends App with StrictLogging {
   import akka.http.scaladsl.server.Route
 
   def openapiYamlDocumentation: String = {
-    import sttp.tapir.docs.openapi._
+    import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
     import sttp.tapir.openapi.circe.yaml._
 
     // interpreting the endpoint description to generate yaml openapi documentation
-    val docs = List(addBook, booksListing, booksListingByGenre).toOpenAPI("The Tapir Library", "1.0")
+    val docs = OpenAPIDocsInterpreter.endpoints(List(addBook, booksListing, booksListingByGenre), ("The Tapir Library", "1.0"))
     docs.toYaml
   }
 

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
@@ -160,8 +160,8 @@ object BooksExampleSemiauto extends App with StrictLogging {
 
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
 
-    val booksListingRequest: Request[Either[String, Vector[Book]], Any] = booksListing
-      .toSttpRequestUnsafe(uri"http://localhost:8080")
+    val booksListingRequest: Request[Either[String, Vector[Book]], Any] = SttpClientInterpreter
+      .toRequestUnsafe(booksListing)(uri"http://localhost:8080")
       .apply(Option(3))
 
     val result: Either[String, Vector[Book]] = booksListingRequest.send(backend).body

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
@@ -98,7 +98,7 @@ object BooksExampleSemiauto extends App with StrictLogging {
     import sttp.tapir.openapi.circe.yaml._
 
     // interpreting the endpoint description to generate yaml openapi documentation
-    val docs = OpenAPIDocsInterpreter.fromEndpoints(List(addBook, booksListing, booksListingByGenre), ("The Tapir Library", "1.0"))
+    val docs = OpenAPIDocsInterpreter.fromEndpoints(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
     docs.toYaml
   }
 

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
@@ -134,9 +134,9 @@ object BooksExampleSemiauto extends App with StrictLogging {
     // interpreting the endpoint description and converting it to an akka-http route, providing the logic which
     // should be run when the endpoint is invoked.
     concat(
-      addBook.toRoute((bookAddLogic _).tupled),
-      booksListing.toRoute(bookListingLogic),
-      booksListingByGenre.toRoute(bookListingByGenreLogic)
+      AkkaHttpServerInterpreter.toRoute(addBook)((bookAddLogic _).tupled),
+      AkkaHttpServerInterpreter.toRoute(booksListing)(bookListingLogic),
+      AkkaHttpServerInterpreter.toRoute(booksListingByGenre)(bookListingByGenreLogic)
     )
   }
 

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
@@ -98,7 +98,7 @@ object BooksExampleSemiauto extends App with StrictLogging {
     import sttp.tapir.openapi.circe.yaml._
 
     // interpreting the endpoint description to generate yaml openapi documentation
-    val docs = OpenAPIDocsInterpreter.endpoints(List(addBook, booksListing, booksListingByGenre), ("The Tapir Library", "1.0"))
+    val docs = OpenAPIDocsInterpreter.fromEndpoints(List(addBook, booksListing, booksListingByGenre), ("The Tapir Library", "1.0"))
     docs.toYaml
   }
 

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
@@ -104,7 +104,7 @@ object BooksExampleSemiauto extends App with StrictLogging {
 
   def booksRoutes: Route = {
     import akka.http.scaladsl.server.Directives._
-    import sttp.tapir.server.akkahttp._
+    import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
     import scala.concurrent.ExecutionContext.Implicits.global
     import scala.concurrent.Future
@@ -156,7 +156,7 @@ object BooksExampleSemiauto extends App with StrictLogging {
 
   def makeClientRequest(): Unit = {
     import sttp.client3._
-    import sttp.tapir.client.sttp._
+    import sttp.tapir.client.sttp.SttpClientInterpreter
 
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
 

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
@@ -98,7 +98,7 @@ object BooksExampleSemiauto extends App with StrictLogging {
     import sttp.tapir.openapi.circe.yaml._
 
     // interpreting the endpoint description to generate yaml openapi documentation
-    val docs = OpenAPIDocsInterpreter.fromEndpoints(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
+    val docs = OpenAPIDocsInterpreter.toOpenAPI(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
     docs.toYaml
   }
 

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
@@ -161,7 +161,7 @@ object BooksExampleSemiauto extends App with StrictLogging {
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
 
     val booksListingRequest: Request[Either[String, Vector[Book]], Any] = SttpClientInterpreter
-      .toRequestUnsafe(booksListing)(uri"http://localhost:8080")
+      .toRequestUnsafe(booksListing, uri"http://localhost:8080")
       .apply(Option(3))
 
     val result: Either[String, Vector[Book]] = booksListingRequest.send(backend).body

--- a/examples/src/main/scala/sttp/tapir/examples/CustomErrorsOnDecodeFailureAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/CustomErrorsOnDecodeFailureAkkaServer.scala
@@ -30,7 +30,7 @@ object CustomErrorsOnDecodeFailureAkkaServer extends App {
     }
   )
 
-  val amountRoute: Route = amountEndpoint.toRoute(_ => Future.successful(Right(())))
+  val amountRoute: Route = AkkaHttpServerInterpreter.toRoute(amountEndpoint)(_ => Future.successful(Right(())))
 
   // starting the server
   implicit val actorSystem: ActorSystem = ActorSystem()

--- a/examples/src/main/scala/sttp/tapir/examples/CustomErrorsOnDecodeFailureAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/CustomErrorsOnDecodeFailureAkkaServer.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Route
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.{AkkaHttpServerInterpreter, AkkaHttpServerOptions}
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._

--- a/examples/src/main/scala/sttp/tapir/examples/ErrorOutputsAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ErrorOutputsAkkaServer.scala
@@ -24,7 +24,7 @@ object ErrorOutputsAkkaServer extends App {
       .errorOut(stringBody)
 
   // converting an endpoint to a route
-  val errorOrJsonRoute: Route = errorOrJson.toRoute {
+  val errorOrJsonRoute: Route = AkkaHttpServerInterpreter.toRoute(errorOrJson) {
     case x if x < 0 => Future.successful(Left("Invalid parameter, smaller than 0!"))
     case x          => Future.successful(Right(Result(x * 2)))
   }

--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldAkkaServer.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Route
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._

--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldAkkaServer.scala
@@ -17,7 +17,7 @@ object HelloWorldAkkaServer extends App {
     endpoint.get.in("hello").in(query[String]("name")).out(stringBody)
 
   // converting an endpoint to a route (providing server-side logic); extension method comes from imported packages
-  val helloWorldRoute: Route = helloWorld.toRoute(name => Future.successful(Right(s"Hello, $name!")))
+  val helloWorldRoute: Route = AkkaHttpServerInterpreter.toRoute(helloWorld)(name => Future.successful(Right(s"Hello, $name!")))
 
   // starting the server
   implicit val actorSystem: ActorSystem = ActorSystem()

--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldHttp4sServer.scala
@@ -24,7 +24,7 @@ object HelloWorldHttp4sServer extends App {
   implicit val timer: Timer[IO] = IO.timer(ec)
 
   // converting an endpoint to a route (providing server-side logic); extension method comes from imported packages
-  val helloWorldRoutes: HttpRoutes[IO] = helloWorld.toRoutes(name => IO(s"Hello, $name!".asRight[Unit]))
+  val helloWorldRoutes: HttpRoutes[IO] = Http4sServerInterpreter.toRoutes(helloWorld)(name => IO(s"Hello, $name!".asRight[Unit]))
 
   // starting the server
 

--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldHttp4sServer.scala
@@ -7,7 +7,7 @@ import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
 import sttp.tapir._
-import sttp.tapir.server.http4s._
+import sttp.tapir.server.http4s.Http4sServerInterpreter
 import cats.syntax.all._
 
 import scala.concurrent.ExecutionContext

--- a/examples/src/main/scala/sttp/tapir/examples/MultipartFormUploadAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipartFormUploadAkkaServer.scala
@@ -30,7 +30,7 @@ object MultipartFormUploadAkkaServer extends App {
     endpoint.post.in("user" / "profile").in(multipartBody[UserProfile]).out(stringBody)
 
   // converting an endpoint to a route (providing server-side logic); extension method comes from imported packages
-  val setProfileRoute: Route = setProfile.toRoute { data =>
+  val setProfileRoute: Route = AkkaHttpServerInterpreter.toRoute(setProfile) { data =>
     Future {
       val response = s"Received: ${data.name} / ${data.hobby} / ${data.age} / ${data.photo.fileName} (${data.photo.body.length()})"
       data.photo.body.delete()

--- a/examples/src/main/scala/sttp/tapir/examples/MultipartFormUploadAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipartFormUploadAkkaServer.scala
@@ -9,7 +9,7 @@ import sttp.client3._
 import sttp.tapir.generic.auto._
 import sttp.model.Part
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
@@ -53,7 +53,7 @@ object MultipleEndpointsDocumentationAkkaServer extends App {
     AkkaHttpServerInterpreter.toRoute(addBook)(book => Future.successful(Right(books.getAndUpdate(books => books :+ book))))
 
   // generating the documentation in yml; extension methods come from imported packages
-  val openApiDocs: OpenAPI = OpenAPIDocsInterpreter.fromEndpoints(List(booksListing, addBook), "The tapir library", "1.0.0")
+  val openApiDocs: OpenAPI = OpenAPIDocsInterpreter.toOpenAPI(List(booksListing, addBook), "The tapir library", "1.0.0")
   val openApiYml: String = openApiDocs.toYaml
 
   // starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
@@ -53,7 +53,7 @@ object MultipleEndpointsDocumentationAkkaServer extends App {
     AkkaHttpServerInterpreter.toRoute(addBook)(book => Future.successful(Right(books.getAndUpdate(books => books :+ book))))
 
   // generating the documentation in yml; extension methods come from imported packages
-  val openApiDocs: OpenAPI = OpenAPIDocsInterpreter.endpoints(List(booksListing, addBook), "The tapir library", "1.0.0")
+  val openApiDocs: OpenAPI = OpenAPIDocsInterpreter.fromEndpoints(List(booksListing, addBook), "The tapir library", "1.0.0")
   val openApiYml: String = openApiDocs.toYaml
 
   // starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
@@ -7,11 +7,11 @@ import akka.http.scaladsl.Http
 import io.circe.generic.auto._
 import sttp.tapir.generic.auto._
 import sttp.tapir._
-import sttp.tapir.docs.openapi._
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import sttp.tapir.json.circe._
 import sttp.tapir.openapi.OpenAPI
 import sttp.tapir.openapi.circe.yaml._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import sttp.tapir.swagger.akkahttp.SwaggerAkka
 
 import scala.concurrent.duration._

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
@@ -48,8 +48,9 @@ object MultipleEndpointsDocumentationAkkaServer extends App {
     )
   )
 
-  val booksListingRoute = booksListing.toRoute(_ => Future.successful(Right(books.get())))
-  val addBookRoute = addBook.toRoute(book => Future.successful(Right(books.getAndUpdate(books => books :+ book))))
+  val booksListingRoute = AkkaHttpServerInterpreter.toRoute(booksListing)(_ => Future.successful(Right(books.get())))
+  val addBookRoute =
+    AkkaHttpServerInterpreter.toRoute(addBook)(book => Future.successful(Right(books.getAndUpdate(books => books :+ book))))
 
   // generating the documentation in yml; extension methods come from imported packages
   val openApiDocs: OpenAPI = List(booksListing, addBook).toOpenAPI("The tapir library", "1.0.0")

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
@@ -53,7 +53,7 @@ object MultipleEndpointsDocumentationAkkaServer extends App {
     AkkaHttpServerInterpreter.toRoute(addBook)(book => Future.successful(Right(books.getAndUpdate(books => books :+ book))))
 
   // generating the documentation in yml; extension methods come from imported packages
-  val openApiDocs: OpenAPI = List(booksListing, addBook).toOpenAPI("The tapir library", "1.0.0")
+  val openApiDocs: OpenAPI = OpenAPIDocsInterpreter.endpoints(List(booksListing, addBook), "The tapir library", "1.0.0")
   val openApiYml: String = openApiDocs.toYaml
 
   // starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationHttp4sServer.scala
@@ -55,8 +55,9 @@ object MultipleEndpointsDocumentationHttp4sServer extends App {
     )
   )
 
-  val booksListingRoutes: HttpRoutes[IO] = booksListing.toRoutes(_ => IO(books.get().asRight[Unit]))
-  val addBookRoutes: HttpRoutes[IO] = addBook.toRoutes(book => IO((books.getAndUpdate(books => books :+ book): Unit).asRight[Unit]))
+  val booksListingRoutes: HttpRoutes[IO] = Http4sServerInterpreter.toRoutes(booksListing)(_ => IO(books.get().asRight[Unit]))
+  val addBookRoutes: HttpRoutes[IO] =
+    Http4sServerInterpreter.toRoutes(addBook)(book => IO((books.getAndUpdate(books => books :+ book): Unit).asRight[Unit]))
   val routes: HttpRoutes[IO] = booksListingRoutes <+> addBookRoutes
 
   // generating the documentation in yml; extension methods come from imported packages

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationHttp4sServer.scala
@@ -61,7 +61,7 @@ object MultipleEndpointsDocumentationHttp4sServer extends App {
   val routes: HttpRoutes[IO] = booksListingRoutes <+> addBookRoutes
 
   // generating the documentation in yml; extension methods come from imported packages
-  val openApiDocs: OpenAPI = OpenAPIDocsInterpreter.endpoints(List(booksListing, addBook), "The tapir library", "1.0.0")
+  val openApiDocs: OpenAPI = OpenAPIDocsInterpreter.fromEndpoints(List(booksListing, addBook), "The tapir library", "1.0.0")
   val openApiYml: String = openApiDocs.toYaml
 
   // starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationHttp4sServer.scala
@@ -61,7 +61,7 @@ object MultipleEndpointsDocumentationHttp4sServer extends App {
   val routes: HttpRoutes[IO] = booksListingRoutes <+> addBookRoutes
 
   // generating the documentation in yml; extension methods come from imported packages
-  val openApiDocs: OpenAPI = OpenAPIDocsInterpreter.fromEndpoints(List(booksListing, addBook), "The tapir library", "1.0.0")
+  val openApiDocs: OpenAPI = OpenAPIDocsInterpreter.toOpenAPI(List(booksListing, addBook), "The tapir library", "1.0.0")
   val openApiYml: String = openApiDocs.toYaml
 
   // starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationHttp4sServer.scala
@@ -61,7 +61,7 @@ object MultipleEndpointsDocumentationHttp4sServer extends App {
   val routes: HttpRoutes[IO] = booksListingRoutes <+> addBookRoutes
 
   // generating the documentation in yml; extension methods come from imported packages
-  val openApiDocs: OpenAPI = List(booksListing, addBook).toOpenAPI("The tapir library", "1.0.0")
+  val openApiDocs: OpenAPI = OpenAPIDocsInterpreter.endpoints(List(booksListing, addBook), "The tapir library", "1.0.0")
   val openApiYml: String = openApiDocs.toYaml
 
   // starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationHttp4sServer.scala
@@ -10,12 +10,12 @@ import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
 import sttp.tapir._
-import sttp.tapir.docs.openapi._
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import sttp.tapir.json.circe._
 import sttp.tapir.generic.auto._
 import sttp.tapir.openapi.OpenAPI
 import sttp.tapir.openapi.circe.yaml._
-import sttp.tapir.server.http4s._
+import sttp.tapir.server.http4s.Http4sServerInterpreter
 import sttp.tapir.swagger.http4s.SwaggerHttp4s
 
 import scala.concurrent.ExecutionContext

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleServerEndpointsAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleServerEndpointsAkkaServer.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Route
 import sttp.client3._
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleServerEndpointsAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleServerEndpointsAkkaServer.scala
@@ -17,7 +17,7 @@ object MultipleServerEndpointsAkkaServer extends App {
     endpoint.get.in("endpoint2").in(path[String]).out(stringBody).serverLogic[Future] { path => Future.successful(Right(s"ok2: $path")) }
 
   // converting the endpoints to a (single) route
-  val route: Route = List(endpoint1, endpoint2).toRoute
+  val route: Route = AkkaHttpServerInterpreter.toRoute(List(endpoint1, endpoint2))
 
   // starting the server
   implicit val actorSystem: ActorSystem = ActorSystem()

--- a/examples/src/main/scala/sttp/tapir/examples/PartialServerLogicAkka.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/PartialServerLogicAkka.scala
@@ -57,8 +57,8 @@ object PartialServerLogicAkka extends App {
   // ---
 
   // interpreting as routes
-  val helloWorld1Route: Route = secureHelloWorld1WithLogic.toRoute
-  val helloWorld2Route: Route = secureHelloWorld2WithLogic.toRoute
+  val helloWorld1Route: Route = AkkaHttpServerInterpreter.toRoute(secureHelloWorld1WithLogic)
+  val helloWorld2Route: Route = AkkaHttpServerInterpreter.toRoute(secureHelloWorld2WithLogic)
 
   // starting the server
   val bindAndCheck = Http().newServerAt("localhost", 8080).bind(concat(helloWorld1Route, helloWorld2Route)).map { _ =>

--- a/examples/src/main/scala/sttp/tapir/examples/PartialServerLogicAkka.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/PartialServerLogicAkka.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.server.Route
 import sttp.client3._
 import sttp.tapir._
 import sttp.tapir.server.PartialServerEndpoint
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}

--- a/examples/src/main/scala/sttp/tapir/examples/StreamingAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/StreamingAkkaServer.scala
@@ -22,7 +22,7 @@ object StreamingAkkaServer extends App {
 
   // converting an endpoint to a route (providing server-side logic); extension method comes from imported packages
   val testStream: Source[ByteString, Any] = Source.repeat("Hello!").take(10).map(s => ByteString(s))
-  val streamingRoute: Route = streamingEndpoint.toRoute(_ => Future.successful(Right(testStream)))
+  val streamingRoute: Route = AkkaHttpServerInterpreter.toRoute(streamingEndpoint)(_ => Future.successful(Right(testStream)))
 
   // starting the server
   implicit val actorSystem: ActorSystem = ActorSystem()

--- a/examples/src/main/scala/sttp/tapir/examples/StreamingAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/StreamingAkkaServer.scala
@@ -8,7 +8,7 @@ import akka.util.ByteString
 import sttp.capabilities.akka.AkkaStreams
 import sttp.client3._
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}

--- a/examples/src/main/scala/sttp/tapir/examples/StreamingHttp4sFs2Server.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/StreamingHttp4sFs2Server.scala
@@ -10,7 +10,7 @@ import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
 import sttp.client3._
 import sttp.tapir._
-import sttp.tapir.server.http4s._
+import sttp.tapir.server.http4s.Http4sServerInterpreter
 import fs2._
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.model.HeaderNames

--- a/examples/src/main/scala/sttp/tapir/examples/StreamingHttp4sFs2Server.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/StreamingHttp4sFs2Server.scala
@@ -34,7 +34,7 @@ object StreamingHttp4sFs2Server extends App {
   implicit val timer: Timer[IO] = IO.timer(ec)
 
   // converting an endpoint to a route (providing server-side logic); extension method comes from imported packages
-  val streamingRoutes: HttpRoutes[IO] = streamingEndpoint.toRoutes { _ =>
+  val streamingRoutes: HttpRoutes[IO] = Http4sServerInterpreter.toRoutes(streamingEndpoint) { _ =>
     val size = 100L
     Stream
       .emit(List[Char]('a', 'b', 'c', 'd'))

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaClient.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaClient.scala
@@ -8,7 +8,7 @@ import sttp.capabilities.akka.AkkaStreams
 import sttp.client3._
 import sttp.client3.akkahttp.AkkaHttpBackend
 import sttp.tapir._
-import sttp.tapir.client.sttp._
+import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.tapir.json.circe._
 import sttp.tapir.generic.auto._
 import sttp.tapir.client.sttp.ws.akkahttp._

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaClient.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaClient.scala
@@ -26,7 +26,7 @@ object WebSocketAkkaClient extends App {
   implicit val actorSystem: ActorSystem = ActorSystem()
   val backend = AkkaHttpBackend.usingActorSystem(actorSystem)
   val result = SttpClientInterpreter
-    .toRequestUnsafe(jsonEchoWsEndpoint)(uri"wss://echo.websocket.org")
+    .toRequestUnsafe(jsonEchoWsEndpoint, uri"wss://echo.websocket.org")
     .apply(())
     .send(backend)
     .map(_.body)

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaClient.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaClient.scala
@@ -25,8 +25,8 @@ object WebSocketAkkaClient extends App {
 
   implicit val actorSystem: ActorSystem = ActorSystem()
   val backend = AkkaHttpBackend.usingActorSystem(actorSystem)
-  val result = jsonEchoWsEndpoint
-    .toSttpRequestUnsafe(uri"wss://echo.websocket.org")
+  val result = SttpClientInterpreter
+    .toRequestUnsafe(jsonEchoWsEndpoint)(uri"wss://echo.websocket.org")
     .apply(())
     .send(backend)
     .map(_.body)

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaServer.scala
@@ -31,7 +31,8 @@ object WebSocketAkkaServer extends App {
     endpoint.get.in("ping").out(webSocketBody[String, CodecFormat.TextPlain, Response, CodecFormat.Json](AkkaStreams))
 
   // Implementation of the web socket: a flow which echoes incoming messages
-  val wsRoute: Route = wsEndpoint.toRoute(_ => Future.successful(Right(Flow.fromFunction((in: String) => Response(in)))))
+  val wsRoute: Route =
+    AkkaHttpServerInterpreter.toRoute(wsEndpoint)(_ => Future.successful(Right(Flow.fromFunction((in: String) => Response(in)))))
 
   // Documentation
   val apiDocs = wsEndpoint.toAsyncAPI("JSON echo", "1.0", List("dev" -> Server("localhost:8080", "ws"))).toYaml

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaServer.scala
@@ -35,7 +35,7 @@ object WebSocketAkkaServer extends App {
     AkkaHttpServerInterpreter.toRoute(wsEndpoint)(_ => Future.successful(Right(Flow.fromFunction((in: String) => Response(in)))))
 
   // Documentation
-  val apiDocs = AsyncAPIInterpreter.fromEndpoint(wsEndpoint, "JSON echo", "1.0", List("dev" -> Server("localhost:8080", "ws"))).toYaml
+  val apiDocs = AsyncAPIInterpreter.toAsyncAPI(wsEndpoint, "JSON echo", "1.0", List("dev" -> Server("localhost:8080", "ws"))).toYaml
   println(s"Paste into https://playground.asyncapi.io/ to see the docs for this endpoint:\n$apiDocs")
 
   // Starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaServer.scala
@@ -35,7 +35,7 @@ object WebSocketAkkaServer extends App {
     AkkaHttpServerInterpreter.toRoute(wsEndpoint)(_ => Future.successful(Right(Flow.fromFunction((in: String) => Response(in)))))
 
   // Documentation
-  val apiDocs = wsEndpoint.toAsyncAPI("JSON echo", "1.0", List("dev" -> Server("localhost:8080", "ws"))).toYaml
+  val apiDocs = AsyncAPIInterpreter.fromEndpoint(wsEndpoint, "JSON echo", "1.0", List("dev" -> Server("localhost:8080", "ws"))).toYaml
   println(s"Paste into https://playground.asyncapi.io/ to see the docs for this endpoint:\n$apiDocs")
 
   // Starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaServer.scala
@@ -11,11 +11,11 @@ import sttp.capabilities.akka.AkkaStreams
 import sttp.client3._
 import sttp.client3.akkahttp.AkkaHttpBackend
 import sttp.tapir._
-import sttp.tapir.docs.asyncapi._
+import sttp.tapir.docs.asyncapi.AsyncAPIInterpreter
 import sttp.tapir.asyncapi.Server
 import sttp.tapir.asyncapi.circe.yaml._
 import sttp.tapir.json.circe._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import sttp.ws.WebSocket
 
 import scala.concurrent.duration._

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketHttp4sServer.scala
@@ -70,7 +70,7 @@ object WebSocketHttp4sServer extends App {
   val wsRoutes: HttpRoutes[IO] = Http4sServerInterpreter.toRoutes(wsEndpoint)(_ => IO.pure(Right(countBytes)))
 
   // Documentation
-  val apiDocs = wsEndpoint.toAsyncAPI("Byte counter", "1.0", List("dev" -> Server("localhost:8080", "ws"))).toYaml
+  val apiDocs = AsyncAPIInterpreter.fromEndpoint(wsEndpoint, "Byte counter", "1.0", List("dev" -> Server("localhost:8080", "ws"))).toYaml
   println(s"Paste into https://playground.asyncapi.io/ to see the docs for this endpoint:\n$apiDocs")
 
   // Starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketHttp4sServer.scala
@@ -13,11 +13,11 @@ import sttp.tapir.generic.auto._
 import sttp.client3._
 import sttp.client3.asynchttpclient.fs2.AsyncHttpClientFs2Backend
 import sttp.tapir._
-import sttp.tapir.docs.asyncapi._
+import sttp.tapir.docs.asyncapi.AsyncAPIInterpreter
 import sttp.tapir.asyncapi.Server
 import sttp.tapir.asyncapi.circe.yaml._
 import sttp.tapir.json.circe._
-import sttp.tapir.server.http4s._
+import sttp.tapir.server.http4s.Http4sServerInterpreter
 import sttp.ws.WebSocket
 
 import scala.concurrent.ExecutionContext

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketHttp4sServer.scala
@@ -70,7 +70,7 @@ object WebSocketHttp4sServer extends App {
   val wsRoutes: HttpRoutes[IO] = Http4sServerInterpreter.toRoutes(wsEndpoint)(_ => IO.pure(Right(countBytes)))
 
   // Documentation
-  val apiDocs = AsyncAPIInterpreter.fromEndpoint(wsEndpoint, "Byte counter", "1.0", List("dev" -> Server("localhost:8080", "ws"))).toYaml
+  val apiDocs = AsyncAPIInterpreter.toAsyncAPI(wsEndpoint, "Byte counter", "1.0", List("dev" -> Server("localhost:8080", "ws"))).toYaml
   println(s"Paste into https://playground.asyncapi.io/ to see the docs for this endpoint:\n$apiDocs")
 
   // Starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketHttp4sServer.scala
@@ -67,7 +67,7 @@ object WebSocketHttp4sServer extends App {
   }
 
   // Implementing the endpoint's logic, by providing the web socket pipe
-  val wsRoutes: HttpRoutes[IO] = wsEndpoint.toRoutes(_ => IO.pure(Right(countBytes)))
+  val wsRoutes: HttpRoutes[IO] = Http4sServerInterpreter.toRoutes(wsEndpoint)(_ => IO.pure(Right(countBytes)))
 
   // Documentation
   val apiDocs = wsEndpoint.toAsyncAPI("Byte counter", "1.0", List("dev" -> Server("localhost:8080", "ws"))).toYaml

--- a/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
@@ -55,9 +55,9 @@ object ZioEnvExampleHttp4sServer extends App {
 
   // Documentation
   val yaml: String = {
-    import sttp.tapir.docs.openapi._
+    import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
     import sttp.tapir.openapi.circe.yaml._
-    List(petEndpoint).toOpenAPI("Our pets", "1.0").toYaml
+    OpenAPIDocsInterpreter.endpoints(List(petEndpoint), "Our pets", "1.0").toYaml
   }
 
   // Starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
@@ -57,7 +57,7 @@ object ZioEnvExampleHttp4sServer extends App {
   val yaml: String = {
     import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
     import sttp.tapir.openapi.circe.yaml._
-    OpenAPIDocsInterpreter.endpoints(List(petEndpoint), "Our pets", "1.0").toYaml
+    OpenAPIDocsInterpreter.fromEndpoints(List(petEndpoint), "Our pets", "1.0").toYaml
   }
 
   // Starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
@@ -8,7 +8,7 @@ import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
-import sttp.tapir.server.http4s.ztapir._
+import sttp.tapir.server.http4s.ztapir.ZHttp4sServerInterpreter
 import sttp.tapir.swagger.http4s.SwaggerHttp4s
 import sttp.tapir.ztapir._
 import zio.clock.Clock

--- a/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
@@ -58,7 +58,7 @@ object ZioEnvExampleHttp4sServer extends App {
   val yaml: String = {
     import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
     import sttp.tapir.openapi.circe.yaml._
-    OpenAPIDocsInterpreter.fromEndpoints(List(petEndpoint), "Our pets", "1.0").toYaml
+    OpenAPIDocsInterpreter.toOpenAPI(List(petEndpoint), "Our pets", "1.0").toYaml
   }
 
   // Starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
@@ -47,11 +47,12 @@ object ZioEnvExampleHttp4sServer extends App {
   val petEndpoint: ZEndpoint[Int, String, Pet] =
     endpoint.get.in("pet" / path[Int]("petId")).errorOut(stringBody).out(jsonBody[Pet])
 
-  val petRoutes: HttpRoutes[RIO[PetService with Clock, *]] = ZHttp4sServerInterpreter.toRoutes(petEndpoint)(petId => PetService.find(petId))
+  val petRoutes: HttpRoutes[RIO[PetService with Clock, *]] =
+    ZHttp4sServerInterpreter.from(petEndpoint)(petId => PetService.find(petId)).toRoutes
 
   // Same as above, but combining endpoint description with server logic:
   val petServerEndpoint: ZServerEndpoint[PetService, Int, String, Pet] = petEndpoint.zServerLogic(petId => PetService.find(petId))
-  val petServerRoutes: HttpRoutes[RIO[PetService with Clock, *]] = ZHttp4sServerInterpreter.toRoutes(petServerEndpoint)
+  val petServerRoutes: HttpRoutes[RIO[PetService with Clock, *]] = ZHttp4sServerInterpreter.from(List(petServerEndpoint)).toRoutes
 
   // Documentation
   val yaml: String = {

--- a/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioEnvExampleHttp4sServer.scala
@@ -47,11 +47,11 @@ object ZioEnvExampleHttp4sServer extends App {
   val petEndpoint: ZEndpoint[Int, String, Pet] =
     endpoint.get.in("pet" / path[Int]("petId")).errorOut(stringBody).out(jsonBody[Pet])
 
-  val petRoutes: HttpRoutes[RIO[PetService with Clock, *]] = petEndpoint.toRoutes(petId => PetService.find(petId))
+  val petRoutes: HttpRoutes[RIO[PetService with Clock, *]] = ZHttp4sServerInterpreter.toRoutes(petEndpoint)(petId => PetService.find(petId))
 
   // Same as above, but combining endpoint description with server logic:
   val petServerEndpoint: ZServerEndpoint[PetService, Int, String, Pet] = petEndpoint.zServerLogic(petId => PetService.find(petId))
-  val petServerRoutes: HttpRoutes[RIO[PetService with Clock, *]] = petServerEndpoint.toRoutes
+  val petServerRoutes: HttpRoutes[RIO[PetService with Clock, *]] = ZHttp4sServerInterpreter.toRoutes(petServerEndpoint)
 
   // Documentation
   val yaml: String = {

--- a/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
@@ -43,9 +43,9 @@ object ZioExampleHttp4sServer extends App {
   //
 
   val yaml: String = {
-    import sttp.tapir.docs.openapi._
+    import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
     import sttp.tapir.openapi.circe.yaml._
-    List(petEndpoint).toOpenAPI("Our pets", "1.0").toYaml
+    OpenAPIDocsInterpreter.endpoint(petEndpoint, "Our pets", "1.0").toYaml
   }
 
   // Starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
@@ -8,7 +8,7 @@ import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.syntax.kleisli._
 import sttp.tapir.json.circe._
 import sttp.tapir.generic.auto._
-import sttp.tapir.server.http4s.ztapir._
+import sttp.tapir.server.http4s.ztapir.ZHttp4sServerInterpreter
 import sttp.tapir.swagger.http4s.SwaggerHttp4s
 import sttp.tapir.ztapir._
 import zio.clock.Clock

--- a/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
@@ -22,7 +22,7 @@ object ZioExampleHttp4sServer extends App {
   val petEndpoint: ZEndpoint[Int, String, Pet] =
     endpoint.get.in("pet" / path[Int]("petId")).errorOut(stringBody).out(jsonBody[Pet])
 
-  val petRoutes: HttpRoutes[RIO[Clock, *]] = petEndpoint.toRoutes { petId =>
+  val petRoutes: HttpRoutes[RIO[Clock, *]] = ZHttp4sServerInterpreter.toRoutes(petEndpoint) { petId =>
     if (petId == 35) {
       UIO(Pet("Tapirus terrestris", "https://en.wikipedia.org/wiki/Tapir"))
     } else {
@@ -38,7 +38,7 @@ object ZioExampleHttp4sServer extends App {
       IO.fail("Unknown pet id")
     }
   }
-  val petServerRoutes: HttpRoutes[RIO[Clock, *]] = petServerEndpoint.toRoutes
+  val petServerRoutes: HttpRoutes[RIO[Clock, *]] = ZHttp4sServerInterpreter.toRoutes(petServerEndpoint)
 
   //
 

--- a/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
@@ -47,7 +47,7 @@ object ZioExampleHttp4sServer extends App {
   val yaml: String = {
     import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
     import sttp.tapir.openapi.circe.yaml._
-    OpenAPIDocsInterpreter.fromEndpoint(petEndpoint, "Our pets", "1.0").toYaml
+    OpenAPIDocsInterpreter.toOpenAPI(petEndpoint, "Our pets", "1.0").toYaml
   }
 
   // Starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
@@ -22,13 +22,15 @@ object ZioExampleHttp4sServer extends App {
   val petEndpoint: ZEndpoint[Int, String, Pet] =
     endpoint.get.in("pet" / path[Int]("petId")).errorOut(stringBody).out(jsonBody[Pet])
 
-  val petRoutes: HttpRoutes[RIO[Clock, *]] = ZHttp4sServerInterpreter.toRoutes(petEndpoint) { petId =>
-    if (petId == 35) {
-      UIO(Pet("Tapirus terrestris", "https://en.wikipedia.org/wiki/Tapir"))
-    } else {
-      IO.fail("Unknown pet id")
+  val petRoutes: HttpRoutes[RIO[Clock, *]] = ZHttp4sServerInterpreter
+    .from(petEndpoint) { petId =>
+      if (petId == 35) {
+        UIO(Pet("Tapirus terrestris", "https://en.wikipedia.org/wiki/Tapir"))
+      } else {
+        IO.fail("Unknown pet id")
+      }
     }
-  }
+    .toRoutes
 
   // Same as above, but combining endpoint description with server logic:
   val petServerEndpoint: ZServerEndpoint[Any, Int, String, Pet] = petEndpoint.zServerLogic { petId =>
@@ -38,7 +40,7 @@ object ZioExampleHttp4sServer extends App {
       IO.fail("Unknown pet id")
     }
   }
-  val petServerRoutes: HttpRoutes[RIO[Clock, *]] = ZHttp4sServerInterpreter.toRoutes(petServerEndpoint)
+  val petServerRoutes: HttpRoutes[RIO[Clock, *]] = ZHttp4sServerInterpreter.from(petServerEndpoint).toRoutes
 
   //
 

--- a/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioExampleHttp4sServer.scala
@@ -45,7 +45,7 @@ object ZioExampleHttp4sServer extends App {
   val yaml: String = {
     import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
     import sttp.tapir.openapi.circe.yaml._
-    OpenAPIDocsInterpreter.endpoint(petEndpoint, "Our pets", "1.0").toYaml
+    OpenAPIDocsInterpreter.fromEndpoint(petEndpoint, "Our pets", "1.0").toYaml
   }
 
   // Starting the server

--- a/examples/src/main/scala/sttp/tapir/examples/ZioPartialServerLogicHttp4s.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioPartialServerLogicHttp4s.scala
@@ -57,7 +57,7 @@ object ZioPartialServerLogicHttp4s extends App {
 
   // interpreting as routes
   val helloWorldRoutes: HttpRoutes[RIO[UserService with Console with Clock, *]] =
-    List(secureHelloWorld1WithLogic, secureHelloWorld2WithLogic).toRoutes
+    ZHttp4sServerInterpreter.toRoutes(List(secureHelloWorld1WithLogic, secureHelloWorld2WithLogic))
 
   // testing
   val test: Task[Unit] = AsyncHttpClientZioBackend.managed().use { backend =>

--- a/examples/src/main/scala/sttp/tapir/examples/ZioPartialServerLogicHttp4s.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioPartialServerLogicHttp4s.scala
@@ -57,7 +57,7 @@ object ZioPartialServerLogicHttp4s extends App {
 
   // interpreting as routes
   val helloWorldRoutes: HttpRoutes[RIO[UserService with Console with Clock, *]] =
-    ZHttp4sServerInterpreter.toRoutes(List(secureHelloWorld1WithLogic, secureHelloWorld2WithLogic))
+    ZHttp4sServerInterpreter.from(List(secureHelloWorld1WithLogic, secureHelloWorld2WithLogic)).toRoutes
 
   // testing
   val test: Task[Unit] = AsyncHttpClientZioBackend.managed().use { backend =>

--- a/generated-doc/out/client/play.md
+++ b/generated-doc/out/client/play.md
@@ -9,24 +9,24 @@ Add the dependency:
 To make requests using an endpoint definition using the [play client](https://github.com/playframework/play-ws), import:
 
 ```scala
-import sttp.tapir.client.play._
+import sttp.tapir.client.play.PlayClientInterpreter
 ```
 
-This adds the two extension methods to any `Endpoint`:
- - `toPlayRequestUnsafe(String)`: given the base URI returns a function,
+This objects contains two methods:
+ - `toRequestUnsafe(Endpoint, String)`: given the base URI returns a function,
    which will generate a request and a response parser which might throw
    an exception when decoding of the result fails
    ```scala
    I => (StandaloneWSRequest, StandaloneWSResponse => Either[E, O])
    ```
- - `toPlayRequest(String)`: given the base URI returns a function,
+ - `toRequest(Endpoint, String)`: given the base URI returns a function,
    which will generate a request and a response parser which represents
    decoding errors as the `DecodeResult` class
    ```scala
    I => (StandaloneWSRequest, StandaloneWSResponse => DecodeResult[Either[E, O]])
    ```
 
-Note that these are a one-argument functions, where the single argument is the input of end endpoint. This might be a 
+Note that the returned functions have one-argument: the input values of end endpoint. This might be a 
 single type, a tuple, or a case class, depending on the endpoint description. 
 
 After providing the input parameters, the two following are returned:
@@ -41,7 +41,7 @@ Example:
 
 ```scala
 import sttp.tapir._
-import sttp.tapir.client.play._
+import sttp.tapir.client.play.PlayClientInterpreter
 import sttp.capabilities.akka.AkkaStreams
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -53,8 +53,8 @@ def example[I, E, O, R >: AkkaStreams](implicit wsClient: StandaloneWSClient) {
   val e: Endpoint[I, E, O, R] = ???
   val inputArgs: I = ???
   
-  val (req, responseParser) = e
-      .toPlayRequestUnsafe(s"http://localhost:9000")
+  val (req, responseParser) = PlayClientInterpreter
+      .toRequestUnsafe(e, s"http://localhost:9000")
       .apply(inputArgs)
   
   val result: Future[Either[E, O]] = req

--- a/generated-doc/out/client/sttp.md
+++ b/generated-doc/out/client/sttp.md
@@ -9,23 +9,23 @@ Add the dependency:
 To make requests using an endpoint definition using the [sttp client](https://github.com/softwaremill/sttp), import:
 
 ```scala
-import sttp.tapir.client.sttp._
+import sttp.tapir.client.sttp.SttpClientInterpreter
 ```
 
-This adds the two extension methods to any `Endpoint`:
- - `toSttpRequestUnsafe(Uri)`: given the base URI returns a function, which might throw an exception if 
+This objects contains two methods:
+ - `toRequestUnsafe(Endpoint, Uri)`: given the base URI returns a function, which might throw an exception if 
    decoding of the result fails
    ```scala
    I => Request[Either[E, O], Any]
    ```
- - `toSttpRequest(Uri)`: given the base URI returns a function, which represents decoding errors as the `DecodeResult` 
+ - `toRequest(Endpoint, Uri)`: given the base URI returns a function, which represents decoding errors as the `DecodeResult` 
    class
    ```scala
    I => Request[DecodeResult[Either[E, O]], Any]
    ```
 
-Note that these are a one-argument functions, where the single argument is the input of end endpoint. This might be a 
-single type, a tuple, or a case class, depending on the endpoint description. 
+Note that the returned functions have one-argument: the input values of end endpoint. This might be a
+single type, a tuple, or a case class, depending on the endpoint description.
 
 After providing the input parameters, a description of the request to be made is returned, with the input value
 encoded as appropriate request parameters: path, query, headers and body. This can be further 

--- a/generated-doc/out/client/sttp.md
+++ b/generated-doc/out/client/sttp.md
@@ -13,6 +13,7 @@ import sttp.tapir.client.sttp.SttpClientInterpreter
 ```
 
 This objects contains two methods:
+
  - `toRequestUnsafe(Endpoint, Uri)`: given the base URI returns a function, which might throw an exception if 
    decoding of the result fails
    ```scala

--- a/generated-doc/out/docs/asyncapi.md
+++ b/generated-doc/out/docs/asyncapi.md
@@ -10,14 +10,14 @@ To use, add the following dependencies:
 Tapir contains a case class-based model of the asyncapi data structures in the `asyncapi/asyncapi-model` subproject (the
 model is independent from all other tapir modules and can be used stand-alone).
  
-An endpoint can be converted to an instance of the model by importing the `sttp.tapir.docs.asyncapi._` package and calling
-the provided extension method:
+An endpoint can be converted to an instance of the model by importing the `sttp.tapir.docs.asyncapi.AsyncAPIInterpreter` 
+object and calling the provided extension method:
 
 ```scala
 import sttp.capabilities.akka.AkkaStreams
 import sttp.tapir._
 import sttp.tapir.asyncapi.AsyncAPI
-import sttp.tapir.docs.asyncapi._
+import sttp.tapir.docs.asyncapi.AsyncAPIInterpreter
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
@@ -26,7 +26,7 @@ case class Response(msg: String, count: Int)
 val echoWS = endpoint.out(
   webSocketBody[String, CodecFormat.TextPlain, Response, CodecFormat.Json](AkkaStreams))
 
-val docs: AsyncAPI = echoWS.toAsyncAPI("Echo web socket", "1.0")
+val docs: AsyncAPI = AsyncAPIInterpreter.fromEndpoint(echoWS, "Echo web socket", "1.0")
 ```
 
 Such a model can then be refined, by adding details which are not auto-generated. Working with a deeply nested case 
@@ -41,7 +41,8 @@ Quite often, you'll need to define the servers, through which the API can be rea
 ```scala
 import sttp.tapir.asyncapi.Server
 
-val docsWithServers: AsyncAPI = echoWS.toAsyncAPI(
+val docsWithServers: AsyncAPI = AsyncAPIInterpreter.fromEndpoint(
+  echoWS, 
   "Echo web socket", 
   "1.0",
   List("production" -> Server("api.example.com", "wss"))

--- a/generated-doc/out/docs/asyncapi.md
+++ b/generated-doc/out/docs/asyncapi.md
@@ -10,8 +10,8 @@ To use, add the following dependencies:
 Tapir contains a case class-based model of the asyncapi data structures in the `asyncapi/asyncapi-model` subproject (the
 model is independent from all other tapir modules and can be used stand-alone).
  
-An endpoint can be converted to an instance of the model by importing the `sttp.tapir.docs.asyncapi.AsyncAPIInterpreter` 
-object and calling the provided extension method:
+An endpoint can be converted to an instance of the model by using the `sttp.tapir.docs.asyncapi.AsyncAPIInterpreter` 
+object:
 
 ```scala
 import sttp.capabilities.akka.AkkaStreams
@@ -51,7 +51,7 @@ val docsWithServers: AsyncAPI = AsyncAPIInterpreter.toAsyncAPI(
 
 Servers can also be later added through methods on the `AsyncAPI` object.
 
-Multiple endpoints can be converted to an `AsyncAPI` instance by calling the extension method on a list of endpoints/
+Multiple endpoints can be converted to an `AsyncAPI` instance by calling the method using a list of endpoints.
 
 The asyncapi case classes can then be serialised, either to JSON or YAML using [Circe](https://circe.github.io/circe/):
 

--- a/generated-doc/out/docs/asyncapi.md
+++ b/generated-doc/out/docs/asyncapi.md
@@ -26,7 +26,7 @@ case class Response(msg: String, count: Int)
 val echoWS = endpoint.out(
   webSocketBody[String, CodecFormat.TextPlain, Response, CodecFormat.Json](AkkaStreams))
 
-val docs: AsyncAPI = AsyncAPIInterpreter.fromEndpoint(echoWS, "Echo web socket", "1.0")
+val docs: AsyncAPI = AsyncAPIInterpreter.toAsyncAPI(echoWS, "Echo web socket", "1.0")
 ```
 
 Such a model can then be refined, by adding details which are not auto-generated. Working with a deeply nested case 
@@ -41,7 +41,7 @@ Quite often, you'll need to define the servers, through which the API can be rea
 ```scala
 import sttp.tapir.asyncapi.Server
 
-val docsWithServers: AsyncAPI = AsyncAPIInterpreter.fromEndpoint(
+val docsWithServers: AsyncAPI = AsyncAPIInterpreter.toAsyncAPI(
   echoWS, 
   "Echo web socket", 
   "1.0",

--- a/generated-doc/out/docs/openapi.md
+++ b/generated-doc/out/docs/openapi.md
@@ -10,17 +10,17 @@ To use, add the following dependencies:
 Tapir contains a case class-based model of the openapi data structures in the `openapi/openapi-model` subproject (the
 model is independent from all other tapir modules and can be used stand-alone).
  
-An endpoint can be converted to an instance of the model by importing the `sttp.tapir.docs.openapi._` package and calling
-the provided extension method:
+An endpoint can be converted to an instance of the model by importing the `sttp.tapir.docs.openapi.OpenAPIDocsInterpreter` 
+object:
 
 ```scala
 import sttp.tapir._
 import sttp.tapir.openapi.OpenAPI
-import sttp.tapir.docs.openapi._
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 val booksListing = endpoint.in(path[String]("bookId"))
 
-val docs: OpenAPI = booksListing.toOpenAPI("My Bookshop", "1.0")
+val docs: OpenAPI = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
 ```
 
 Such a model can then be refined, by adding details which are not auto-generated. Working with a deeply nested case 
@@ -35,7 +35,7 @@ returned `OpenAPI` case class either directly or by using a helper method:
 ```scala
 import sttp.tapir.openapi.Server
 
-val docsWithServers: OpenAPI = booksListing.toOpenAPI("My Bookshop", "1.0")
+val docsWithServers: OpenAPI = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
   .servers(List(Server("https://api.example.com/v1").description("Production server")))
 ```
 
@@ -43,7 +43,7 @@ Multiple endpoints can be converted to an `OpenAPI` instance by calling the exte
 
 
 ```scala
-List(addBook, booksListing, booksListingByGenre).toOpenAPI("My Bookshop", "1.0")
+OpenAPIDocsInterpreter.fromEndpoints(List(addBook, booksListing, booksListingByGenre), "My Bookshop", "1.0")
 ```
 
 The openapi case classes can then be serialised, either to JSON or YAML using [Circe](https://circe.github.io/circe/):
@@ -96,12 +96,12 @@ Usage example for akka-http:
 
 ```scala
 import sttp.tapir._
-import sttp.tapir.docs.openapi._
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import sttp.tapir.openapi.circe.yaml._
 import sttp.tapir.swagger.akkahttp.SwaggerAkka
 
 val myEndpoints: Seq[Endpoint[_, _, _, _]] = ???
-val docsAsYaml: String = myEndpoints.toOpenAPI("My App", "1.0").toYaml
+val docsAsYaml: String = OpenAPIDocsInterpreter.fromEndpoints(myEndpoints, "My App", "1.0").toYaml
 // add to your akka routes
 new SwaggerAkka(docsAsYaml).routes
 ```

--- a/generated-doc/out/docs/openapi.md
+++ b/generated-doc/out/docs/openapi.md
@@ -20,7 +20,7 @@ import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 val booksListing = endpoint.in(path[String]("bookId"))
 
-val docs: OpenAPI = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
+val docs: OpenAPI = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "My Bookshop", "1.0")
 ```
 
 Such a model can then be refined, by adding details which are not auto-generated. Working with a deeply nested case 
@@ -35,7 +35,7 @@ returned `OpenAPI` case class either directly or by using a helper method:
 ```scala
 import sttp.tapir.openapi.Server
 
-val docsWithServers: OpenAPI = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
+val docsWithServers: OpenAPI = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "My Bookshop", "1.0")
   .servers(List(Server("https://api.example.com/v1").description("Production server")))
 ```
 
@@ -43,7 +43,7 @@ Multiple endpoints can be converted to an `OpenAPI` instance by calling the exte
 
 
 ```scala
-OpenAPIDocsInterpreter.fromEndpoints(List(addBook, booksListing, booksListingByGenre), "My Bookshop", "1.0")
+OpenAPIDocsInterpreter.toOpenAPI(List(addBook, booksListing, booksListingByGenre), "My Bookshop", "1.0")
 ```
 
 The openapi case classes can then be serialised, either to JSON or YAML using [Circe](https://circe.github.io/circe/):
@@ -101,7 +101,7 @@ import sttp.tapir.openapi.circe.yaml._
 import sttp.tapir.swagger.akkahttp.SwaggerAkka
 
 val myEndpoints: Seq[Endpoint[_, _, _, _]] = ???
-val docsAsYaml: String = OpenAPIDocsInterpreter.fromEndpoints(myEndpoints, "My App", "1.0").toYaml
+val docsAsYaml: String = OpenAPIDocsInterpreter.toOpenAPI(myEndpoints, "My App", "1.0").toYaml
 // add to your akka routes
 new SwaggerAkka(docsAsYaml).routes
 ```

--- a/generated-doc/out/docs/openapi.md
+++ b/generated-doc/out/docs/openapi.md
@@ -39,7 +39,7 @@ val docsWithServers: OpenAPI = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "M
   .servers(List(Server("https://api.example.com/v1").description("Production server")))
 ```
 
-Multiple endpoints can be converted to an `OpenAPI` instance by calling the extension method on a list of endpoints:
+Multiple endpoints can be converted to an `OpenAPI` instance by calling the method on a list of endpoints:
 
 
 ```scala

--- a/generated-doc/out/endpoint/auth.md
+++ b/generated-doc/out/endpoint/auth.md
@@ -26,7 +26,6 @@ details.
 
 For each `auth` scheme, one can define `WWW-Authenticate` headers that should be returned by the server in case input is not provided. Default behavior is to return `401` status with the headers needed for authentication.
 
-
 For example if you define `endpoint.get.in("path").in(auth.basic[UsernamePassword]())` then your browser will show you a password prompt.
 
 ## Next

--- a/generated-doc/out/endpoint/zio.md
+++ b/generated-doc/out/endpoint/zio.md
@@ -1,7 +1,7 @@
 # ZIO integration
 
 The `tapir-zio` module defines type aliases and extension methods which make it more ergonomic to work with 
-[ZIO](https://zio.dev) and tapir. Moreover, the `tapir-zio-http4s-server` contains similar extensions useful when
+[ZIO](https://zio.dev) and tapir. Moreover, the `tapir-zio-http4s-server` contains an interpreter useful when
 exposing the endpoints using the [http4s](https://http4s.org) server.
 
 You'll need the following dependencies:
@@ -40,11 +40,10 @@ The first defines complete server logic, while the second and third allow defini
 
 ## Exposing endpoints using the http4s server
 
-To bring into scope the extension methods used to interpret a `ZServerEndpoint` as a http4s server, add the following
-import:
+To interpret a `ZServerEndpoint` as a http4s server, add the following  import:
 
 ```scala
-import sttp.tapir.server.http4s.ztapir._
+import sttp.tapir.server.http4s.ztapir.ZHttp4sServerInterpreter
 ```
 
 This adds the following method on `ZEndpoint`:
@@ -63,7 +62,7 @@ so that it is uniform across all endpoints, using the `.widen` method:
 ```scala
 import org.http4s.HttpRoutes
 import sttp.tapir.ztapir._
-import sttp.tapir.server.http4s.ztapir._
+import sttp.tapir.server.http4s.ztapir.ZHttp4sServerInterpreter
 import zio.{Has, RIO, ZIO}
 import zio.clock.Clock
 import zio.interop.catz._

--- a/generated-doc/out/endpoint/zio.md
+++ b/generated-doc/out/endpoint/zio.md
@@ -78,11 +78,10 @@ val serverEndpoint2: ZServerEndpoint[Service2, Unit, Unit, Unit] = ???
 
 type Env = Service1 with Service2
 val routes: HttpRoutes[RIO[Env with Clock, *]] = 
-  List(
+  ZHttp4sServerInterpreter.from(List(
     serverEndpoint1.widen[Env], 
     serverEndpoint2.widen[Env]
-  )
-  .toRoutes // this is where zio-cats interop is needed
+  )).toRoutes // this is where zio-cats interop is needed
 ```
 
 ## Example

--- a/generated-doc/out/examples.md
+++ b/generated-doc/out/examples.md
@@ -37,6 +37,7 @@ A new project can be created using: `sbt new https://codeberg.org/wegtam/http4s-
 * [Three easy endpoints](https://blog.softwaremill.com/three-easy-endpoints-a6cbd52b0a6e)
 * [tAPIr’s Endpoint meets ZIO’s IO](https://blog.softwaremill.com/tapirs-endpoint-meets-zio-s-io-3278099c5e10)
 * [Describe, then interpret: HTTP endpoints using tapir](https://blog.softwaremill.com/describe-then-interpret-http-endpoints-using-tapir-ac139ba565b0)
+* [Functional pancakes](https://blog.softwaremill.com/functional-pancakes-cf70023f0dcb)
 
 ## Videos
 

--- a/generated-doc/out/index.md
+++ b/generated-doc/out/index.md
@@ -75,11 +75,11 @@ val booksListingRoute: Route = booksListing.toRoute((bookListingLogic _).tupled)
 
 // Convert to sttp Request
 
-import sttp.tapir.client.sttp._
+import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.client3._
 
-val booksListingRequest: Request[DecodeResult[Either[String, List[Book]]], Any] = booksListing
-  .toSttpRequest(uri"http://localhost:8080")
+val booksListingRequest: Request[DecodeResult[Either[String, List[Book]]], Any] = SttpClientInterpreter
+  .toRequest(booksListing)(uri"http://localhost:8080")
   .apply((BooksFromYear("SF", 2016), 20, "xyz-abc-123"))
 ```
 

--- a/generated-doc/out/index.md
+++ b/generated-doc/out/index.md
@@ -56,7 +56,7 @@ val booksListing: Endpoint[(BooksFromYear, Limit, AuthToken), String, List[Book]
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import sttp.tapir.openapi.circe.yaml._
 
-val docs = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
+val docs = OpenAPIDocsInterpreter.toOpenAPI(booksListing, "My Bookshop", "1.0")
 println(docs.toYaml)
 
 

--- a/generated-doc/out/index.md
+++ b/generated-doc/out/index.md
@@ -53,16 +53,16 @@ val booksListing: Endpoint[(BooksFromYear, Limit, AuthToken), String, List[Book]
 
 // Generate OpenAPI documentation
 
-import sttp.tapir.docs.openapi._
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import sttp.tapir.openapi.circe.yaml._
 
-val docs = booksListing.toOpenAPI("My Bookshop", "1.0")
+val docs = OpenAPIDocsInterpreter.fromEndpoint(booksListing, "My Bookshop", "1.0")
 println(docs.toYaml)
 
 
 // Convert to akka-http Route
 
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import akka.http.scaladsl.server.Route
 import scala.concurrent.Future
 
@@ -70,7 +70,8 @@ def bookListingLogic(bfy: BooksFromYear,
                      limit: Limit,
                      at: AuthToken): Future[Either[String, List[Book]]] =
   Future.successful(Right(List(Book("The Sorrows of Young Werther"))))
-val booksListingRoute: Route = booksListing.toRoute((bookListingLogic _).tupled)
+val booksListingRoute: Route = AkkaHttpServerInterpreter
+  .toRoute(booksListing)((bookListingLogic _).tupled)
 
 
 // Convert to sttp Request
@@ -79,7 +80,7 @@ import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.client3._
 
 val booksListingRequest: Request[DecodeResult[Either[String, List[Book]]], Any] = SttpClientInterpreter
-  .toRequest(booksListing)(uri"http://localhost:8080")
+  .toRequest(booksListing, uri"http://localhost:8080")
   .apply((BooksFromYear("SF", 2016), 20, "xyz-abc-123"))
 ```
 

--- a/generated-doc/out/index.md
+++ b/generated-doc/out/index.md
@@ -1,6 +1,6 @@
 # tapir, or Typed API descRiptions
 
-With tapir you can describe HTTP API endpoints as immutable Scala values. Each endpoint can contain a number of 
+With tapir, you can describe HTTP API endpoints as immutable Scala values. Each endpoint can contain a number of 
 input parameters, error-output parameters, and normal-output parameters. An endpoint specification can be 
 interpreted as:
 

--- a/generated-doc/out/mytapir.md
+++ b/generated-doc/out/mytapir.md
@@ -19,4 +19,4 @@ object MyTapir extends Tapir
   with TapirAliases
 ```
 
-Then, a single `import MyTapir._` and all Tapir data types and extensions methods will be in scope!
+Then, a single `import MyTapir._` and all Tapir data types and interpreter methods will be in scope!

--- a/generated-doc/out/mytapir.md
+++ b/generated-doc/out/mytapir.md
@@ -9,8 +9,9 @@ a single-import whenever you want to use tapir. For example:
 
 ```scala
 object MyTapir extends Tapir
-  with TapirAkkaHttpServer
-  with TapirSttpClient
+  with AkkaHttpServerInterpreter
+  with SttpClientInterpreter
+  with OpenAPIDocsInterpreter
   with ValidatorDerivation
   with SchemaDerivation
   with TapirJsonCirce

--- a/generated-doc/out/quickstart.md
+++ b/generated-doc/out/quickstart.md
@@ -9,8 +9,8 @@ To use tapir, add the following dependency to your project:
 This will import only the core classes needed to create endpoint descriptions. To generate a server or a client, you
 will need to add further dependencies.
 
-Most of tapir functionalities are grouped into package objects which provide builder and extensions methods, hence it's
-easiest to work with tapir if you import whole packages, e.g.:
+Many of tapir functionalities come as builder methods in the main package, hence it's easiest to work with tapir if 
+you import the main package entirely, i.e.:
 
 ```scala
 import sttp.tapir._

--- a/generated-doc/out/server/akkahttp.md
+++ b/generated-doc/out/server/akkahttp.md
@@ -8,7 +8,7 @@ dependency:
 ```
 
 This will transitively pull some Akka modules in version 2.6. If you want to force
-your own Akka version (for example 2.5), use sbt exclusion.  Mind the Scala version in artifact name:
+your own Akka version (for example 2.5), use sbt exclusion. Mind the Scala version in artifact name:
 
 ```scala
 "com.softwaremill.sttp.tapir" %% "tapir-akka-http-server" % "0.17.0" exclude("com.typesafe.akka", "akka-stream_2.12")

--- a/generated-doc/out/server/akkahttp.md
+++ b/generated-doc/out/server/akkahttp.md
@@ -14,30 +14,30 @@ your own Akka version (for example 2.5), use sbt exclusion.  Mind the Scala vers
 "com.softwaremill.sttp.tapir" %% "tapir-akka-http-server" % "0.17.0" exclude("com.typesafe.akka", "akka-stream_2.12")
 ```
 
-Now import the package:
+Now import the object:
 
 ```scala
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 ```
 
-This adds extension methods to the `Endpoint` type: `toRoute`, `toRouteRecoverErrors` and `toDirective`.
+The `AkkaHttpServerInterpreter` objects contains methods such as: `toRoute`, `toRouteRecoverErrors` and `toDirective`.
 
 ## Using `toRoute` and `toRouteRecoverErrors`
 
-Method `toRoute` requires the logic of the endpoint to be given as a function of type:
+The `toRoute` method requires the logic of the endpoint to be given as a function of type:
 
 ```scala
 I => Future[Either[E, O]]
 ```
 
-Method `toRouteRecoverErrors` recovers errors from failed futures, and hence requires that `E` is a subclass of
+The `toRouteRecoverErrors` method recovers errors from failed futures, and hence requires that `E` is a subclass of
 `Throwable` (an exception); it expects a function of type `I => Future[O]`.
 
 For example:
 
 ```scala
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import scala.concurrent.Future
 import akka.http.scaladsl.server.Route
 
@@ -47,11 +47,11 @@ def countCharacters(s: String): Future[Either[Unit, Int]] =
 val countCharactersEndpoint: Endpoint[String, Unit, Int, Any] = 
   endpoint.in(stringBody).out(plainBody[Int])
   
-val countCharactersRoute: Route = countCharactersEndpoint.toRoute(countCharacters)
+val countCharactersRoute: Route = AkkaHttpServerInterpreter.toRoute(countCharactersEndpoint)(countCharacters)
 ```
 
-Note that these functions take one argument, which is a tuple of type `I`. This means that functions which take multiple 
-arguments need to be converted to a function using a single argument using `.tupled`:
+Note that the second argument to `toRoute` is a function with one argument, a tuple of type `I`. This means that 
+functions which take multiple arguments need to be converted to a function using a single argument using `.tupled`:
 
 ```scala
 import sttp.tapir._
@@ -61,19 +61,19 @@ import akka.http.scaladsl.server.Route
 
 def logic(s: String, i: Int): Future[Either[Unit, String]] = ???
 val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ???  
-val aRoute: Route = anEndpoint.toRoute((logic _).tupled)
+val aRoute: Route = AkkaHttpServerInterpreter.toRoute(anEndpoint)((logic _).tupled)
 ```
 
 ## Using `toDirective`
 
-Method `toDirective` splits parsing the input and encoding the output. The directive provides the
+The `toDirective` method splits parsing the input and encoding the output. The directive provides the
 input parameters, type `I`, and a function that can be used to encode the output.
 
 For example:
 
 ```scala
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import scala.concurrent.Future
 import akka.http.scaladsl.server.Route
 
@@ -83,8 +83,8 @@ def countCharacters(s: String): Future[Either[Unit, Int]] =
 val countCharactersEndpoint: Endpoint[String, Unit, Int, Any] = 
   endpoint.in(stringBody).out(plainBody[Int])
   
-val countCharactersRoute: Route = countCharactersEndpoint.toDirective { (input, completion) =>
-  completion(countCharacters(input))
+val countCharactersRoute: Route = AkkaHttpServerInterpreter.toDirective(countCharactersEndpoint).tapply { 
+  case (input, completion) => completion(countCharacters(input))
 }
 ```
 
@@ -101,7 +101,7 @@ using akka-http. For example:
 
 ```scala
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import akka.http.scaladsl.server._
 
 case class User(email: String)
@@ -111,7 +111,10 @@ val tapirEndpoint: Endpoint[String, Unit, Unit, Any] = endpoint.in(path[String](
 
 val myRoute: Route = metricsDirective {
   securityDirective { user =>
-    tapirEndpoint.toRoute(input => ??? /* here we can use both `user` and `input` values */)
+    AkkaHttpServerInterpreter.toRoute(tapirEndpoint) { input => 
+      ??? 
+      /* here we can use both `user` and `input` values */
+    }
   }
 }
 ```
@@ -125,7 +128,7 @@ import akka.http.scaladsl.server.Directives.Authenticator
 import akka.http.scaladsl.server.Directives.authenticateBasic
 import akka.http.scaladsl.server.Route
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
 import scala.concurrent.Future
 
@@ -141,10 +144,11 @@ def authorizationDirective(user: User, input: String): Directive0 = ???
 
 val countCharactersRoute: Route =
   authenticateBasic("realm", authenticator) { user =>
-    countCharactersEndpoint.toDirective { (input, completion) =>
-      authorizationDirective(user, input) {
-        completion(countCharacters(input))
-      }
+    AkkaHttpServerInterpreter.toDirective(countCharactersEndpoint).tapply { 
+      case (input, completion) =>
+        authorizationDirective(user, input) {
+          completion(countCharacters(input))
+        }
     }
   }
 ```

--- a/generated-doc/out/server/errors.md
+++ b/generated-doc/out/server/errors.md
@@ -12,7 +12,7 @@ However, any exceptions can be recovered from and mapped to an error value. For 
 
 ```scala
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import scala.concurrent.Future
 import scala.util._
 
@@ -28,11 +28,13 @@ def handleErrors[T](f: Future[T]): Future[Either[ErrorInfo, T]] =
       Success(Left(e.getMessage))
   }
 
-endpoint
-  .errorOut(plainBody[ErrorInfo])
-  .out(plainBody[Int])
-  .in(query[String]("name"))
-  .toRoute((logic _).andThen(handleErrors))
+AkkaHttpServerInterpreter.toRoute(
+  endpoint
+    .errorOut(plainBody[ErrorInfo])
+    .out(plainBody[Int])
+    .in(query[String]("name"))) {
+  (logic _).andThen(handleErrors)
+}
 ```
 
 In the above example, errors are represented as `String`s (aliased to `ErrorInfo` for readability). When the
@@ -78,7 +80,7 @@ a different format (other than textual):
 ```scala
 import sttp.tapir._
 import sttp.tapir.server._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.{ AkkaHttpServerInterpreter, AkkaHttpServerOptions }
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import sttp.model.StatusCode

--- a/generated-doc/out/server/http4s.md
+++ b/generated-doc/out/server/http4s.md
@@ -7,13 +7,13 @@ dependency:
 "com.softwaremill.sttp.tapir" %% "tapir-http4s-server" % "0.17.0"
 ```
 
-and import the package:
+and import the object:
 
 ```scala
-import sttp.tapir.server.http4s._
+import sttp.tapir.server.http4s.Http4sServerInterpreter
 ```
 
-This adds two extension methods to the `Endpoint` type: `toRoutes` and `toRoutesRecoverErrors`. This first requires the 
+This objects contains the `toRoutes` and `toRoutesRecoverErrors` methods. This first requires the 
 logic of the endpoint to be given as a function of type:
 
 ```scala
@@ -25,7 +25,7 @@ a subclass of `Throwable` (an exception); it expects a function of type `I => F[
 
 ```scala
 import sttp.tapir._
-import sttp.tapir.server.http4s._
+import sttp.tapir.server.http4s.Http4sServerInterpreter
 import cats.effect.IO
 import org.http4s.HttpRoutes
 import cats.effect.{ContextShift, Timer}
@@ -42,15 +42,15 @@ def countCharacters(s: String): IO[Either[Unit, Int]] =
 val countCharactersEndpoint: Endpoint[String, Unit, Int, Any] = 
   endpoint.in(stringBody).out(plainBody[Int])
 val countCharactersRoutes: HttpRoutes[IO] = 
-  countCharactersEndpoint.toRoutes(countCharacters _)
+  Http4sServerInterpreter.toRoutes(countCharactersEndpoint)(countCharacters _)
 ```
 
-Note that these functions take one argument, which is a tuple of type `I`. This means that functions which take multiple 
-arguments need to be converted to a function using a single argument using `.tupled`:
+Note that the second argument to `toRoute` is a function with one argument, a tuple of type `I`. This means that 
+functions which take multiple arguments need to be converted to a function using a single argument using `.tupled`:
 
 ```scala
 import sttp.tapir._
-import sttp.tapir.server.http4s._
+import sttp.tapir.server.http4s.Http4sServerInterpreter
 import cats.effect.IO
 import org.http4s.HttpRoutes
 import cats.effect.{ContextShift, Timer}
@@ -63,7 +63,7 @@ implicit val t: Timer[IO] =
 
 def logic(s: String, i: Int): IO[Either[Unit, String]] = ???
 val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ???  
-val routes: HttpRoutes[IO] = anEndpoint.toRoutes((logic _).tupled)
+val routes: HttpRoutes[IO] = Http4sServerInterpreter.toRoutes(anEndpoint)((logic _).tupled)
 ```
 
 The created `HttpRoutes` are the usual http4s `Kleisli`-based transformation of a `Request` to a `Response`, and can 

--- a/generated-doc/out/server/logic.md
+++ b/generated-doc/out/server/logic.md
@@ -16,7 +16,7 @@ The book example can be more concisely written as follows:
 ```scala
 import sttp.tapir._
 import sttp.tapir.server._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import scala.concurrent.Future
 import akka.http.scaladsl.server.Route
 
@@ -25,7 +25,7 @@ val countCharactersServerEndpoint: ServerEndpoint[String, Unit, Int, Any, Future
     Future.successful[Either[Unit, Int]](Right(s.length))
   }
 
-val countCharactersRoute: Route = countCharactersServerEndpoint.toRoute
+val countCharactersRoute: Route = AkkaHttpServerInterpreter.toRoute(countCharactersServerEndpoint)
 ```
 
 A `ServerEndpoint` can then be converted to a route using `.toRoute`/`.toRoutes` methods (without any additional
@@ -35,7 +35,7 @@ Moreover, a list of server endpoints can be converted to routes or documentation
 
 ```scala
 import sttp.tapir._
-import sttp.tapir.server.akkahttp._
+import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import scala.concurrent.Future
 import akka.http.scaladsl.server.Route
 
@@ -45,7 +45,7 @@ val endpoint1 = endpoint.in("hello").out(stringBody)
 val endpoint2 = endpoint.in("ping").out(stringBody)
   .serverLogic { _ => Future.successful[Either[Unit, String]](Right("pong")) }
 
-val route: Route = List(endpoint1, endpoint2).toRoute
+val route: Route = AkkaHttpServerInterpreter.toRoute(List(endpoint1, endpoint2))
 ```
 
 Note that when dealing with endpoints which have multiple input parameters, the server logic function is a function

--- a/generated-doc/out/server/play.md
+++ b/generated-doc/out/server/play.md
@@ -20,13 +20,13 @@ or
 
 depending on whether you want to use netty or akka based http-server under the hood.
 
-Then import the package:
+Then import the object:
 
 ```scala
-import sttp.tapir.server.play._
+import sttp.tapir.server.play.PlayServerInterpreter
 ```
 
-This adds two extension methods to the `Endpoint` type: `toRoute` and `toRoutesRecoverError`. This first requires the
+This object contains the `toRoute` and `toRoutesRecoverError` methods. This first requires the
 logic of the endpoint to be given as a function of type:
 
 ```scala
@@ -38,7 +38,7 @@ a subclass of `Throwable` (an exception); it expects a function of type `I => Fu
 
 ```scala
 import sttp.tapir._
-import sttp.tapir.server.play._
+import sttp.tapir.server.play.PlayServerInterpreter
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import akka.stream.Materializer
@@ -52,11 +52,11 @@ def countCharacters(s: String): Future[Either[Unit, Int]] =
 val countCharactersEndpoint: Endpoint[String, Unit, Int, Any] = 
   endpoint.in(stringBody).out(plainBody[Int])
 val countCharactersRoutes: Routes = 
-  countCharactersEndpoint.toRoute(countCharacters _)
+  PlayServerInterpreter.toRoute(countCharactersEndpoint)(countCharacters _)
 ```
 
-Note that these functions take one argument, which is a tuple of type `I`. This means that functions which take multiple 
-arguments need to be converted to a function using a single argument using `.tupled`:
+Note that the second argument to `toRoute` is a function with one argument, a tuple of type `I`. This means that 
+functions which take multiple arguments need to be converted to a function using a single argument using `.tupled`:
 
 ```scala
 import sttp.tapir._
@@ -70,7 +70,7 @@ implicit val materializer: Materializer = ???
 
 def logic(s: String, i: Int): Future[Either[Unit, String]] = ???
 val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ???  
-val aRoute: Routes = anEndpoint.toRoute((logic _).tupled)
+val aRoute: Routes = PlayServerInterpreter.toRoute(anEndpoint)((logic _).tupled)
 ```
 
 ## Bind the routes

--- a/generated-doc/out/server/vertx.md
+++ b/generated-doc/out/server/vertx.md
@@ -7,33 +7,34 @@ Use the following dependency
 "com.softwaremill.sttp.tapir" %% "tapir-vertx-server" % "0.17.0"
 ```
 
-Then import the package:
+Then import the object:
 
 ```scala
-import sttp.tapir.server.vertx._
+import sttp.tapir.server.vertx.VertxServerInterpreter
 ```
 
-This adds extension methods to the `Endpoint` type: 
-* `route(logic: I => Future[Either[E, O]])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. Errors will be recovered automatically (but generically)
-* `routeRecoverErrors(logic: I => Future[O])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. You're providing your own way to deal with errors happening in the `logic` function.
-* `blockingRoute(logic: I => Future[Either[E, O]])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an blocking handler. Errors will be recovered automatically (but generically)
-* `blockingRouteRecoverErrors(logic: I => Future[O])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as a blocking handler. You're providing your own way to deal with errors happening in the `logic` function.
+This object contains the following methods: 
+
+* `route(e: Endpoint[I, E, O, Any], logic: I => Future[Either[E, O]])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. Errors will be recovered automatically (but generically)
+* `routeRecoverErrors(e: Endpoint[I, E, O, Any], logic: I => Future[O])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. You're providing your own way to deal with errors happening in the `logic` function.
+* `blockingRoute(e: Endpoint[I, E, O, Any], logic: I => Future[Either[E, O]])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an blocking handler. Errors will be recovered automatically (but generically)
+* `blockingRouteRecoverErrors(e: Endpoint[I, E, O, Any], logic: I => Future[O])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as a blocking handler. You're providing your own way to deal with errors happening in the `logic` function.
 
 The methods recovering errors from failed effects, require `E` to be a subclass of `Throwable` (an exception); and expect a function of type `I => Future[O]`. For example:
 
-Note that these functions take one argument, which is a tuple of type `I`. This means that functions which take multiple 
-arguments need to be converted to a function using a single argument using `.tupled`:
+Note that the second argument to `route` etc. is a function with one argument, a tuple of type `I`. This means that 
+functions which take multiple arguments need to be converted to a function using a single argument using `.tupled`:
 
 ```scala
 import sttp.tapir._
-import sttp.tapir.server.vertx._
+import sttp.tapir.server.vertx.{ VertxServerInterpreter, VertxEndpointOptions }
 import io.vertx.scala.ext.web._
 import scala.concurrent.Future
 
 implicit val options: VertxEndpointOptions = ???
 def logic(s: String, i: Int): Future[Either[Unit, String]] = ???
 val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ???  
-val aRoute: Router => Route = anEndpoint.route((logic _).tupled)
+val aRoute: Router => Route = VertxServerInterpreter.route(anEndpoint)((logic _).tupled)
 ```
 
 In practice, routes will be mounted on a router, this router can then be used as a request handler for your http server. 
@@ -41,7 +42,7 @@ An HTTP server can then be started as in the following example:
 
 ```scala
 import sttp.tapir._
-import sttp.tapir.server.vertx._
+import sttp.tapir.server.vertx.{ VertxServerInterpreter, VertxEndpointOptions }
 import io.vertx.scala.core.Vertx
 import io.vertx.scala.ext.web._
 import scala.concurrent.Future
@@ -55,7 +56,7 @@ object Main {
     val router = Router.router(vertx)
     val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ??? // your definition here
     def logic(s: String, i: Int): Future[Either[Unit, String]] = ??? // your logic here 
-    val attach = anEndpoint.route((logic _).tupled)
+    val attach = VertxServerInterpreter.route(anEndpoint)((logic _).tupled)
     attach(router) // your endpoint is now attached to the router, and the route has been created
     server.requestHandler(router).listenFuture(9000)
   }

--- a/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
+++ b/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
@@ -116,8 +116,8 @@ object BooksExample extends App with StrictLogging {
 
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
 
-    val booksListingRequest: Request[Either[String, Vector[Book]], Any] = booksListing
-      .toSttpRequestUnsafe(uri"http://localhost:8080")
+    val booksListingRequest: Request[Either[String, Vector[Book]], Any] = SttpClientInterpreter
+      .toRequestUnsafe(booksListing)(uri"http://localhost:8080")
       .apply(Option(3))
 
     val result: Either[String, Vector[Book]] = booksListingRequest.send(backend).body

--- a/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
+++ b/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
@@ -56,7 +56,7 @@ object BooksExample extends App with StrictLogging {
     import sttp.tapir.openapi.circe.yaml._
 
     // interpreting the endpoint description to generate yaml openapi documentation
-    val docs = OpenAPIDocsInterpreter.fromEndpoints(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
+    val docs = OpenAPIDocsInterpreter.toOpenAPI(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
     docs.toYaml
   }
 

--- a/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
+++ b/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
@@ -56,7 +56,7 @@ object BooksExample extends App with StrictLogging {
     import sttp.tapir.openapi.circe.yaml._
 
     // interpreting the endpoint description to generate yaml openapi documentation
-    val docs = OpenAPIDocsInterpreter.endpoints(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
+    val docs = OpenAPIDocsInterpreter.fromEndpoints(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
     docs.toYaml
   }
 

--- a/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
+++ b/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
@@ -52,11 +52,11 @@ object BooksExample extends App with StrictLogging {
   import akka.http.scaladsl.server.Route
 
   def openapiYamlDocumentation: String = {
-    import sttp.tapir.docs.openapi._
+    import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
     import sttp.tapir.openapi.circe.yaml._
 
     // interpreting the endpoint description to generate yaml openapi documentation
-    val docs = List(addBook, booksListing, booksListingByGenre).toOpenAPI("The Tapir Library", "1.0")
+    val docs = OpenAPIDocsInterpreter.endpoints(List(addBook, booksListing, booksListingByGenre), "The Tapir Library", "1.0")
     docs.toYaml
   }
 

--- a/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
+++ b/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
@@ -91,9 +91,9 @@ object BooksExample extends App with StrictLogging {
 
     // interpreting the endpoint description and converting it to an akka-http route, providing the logic which
     // should be run when the endpoint is invoked.
-    addBook.toRoute((bookAddLogic _).tupled) ~
-      booksListing.toRoute(bookListingLogic) ~
-      booksListingByGenre.toRoute(bookListingByGenreLogic)
+    AkkaHttpServerInterpreter.toRoute(addBook)((bookAddLogic _).tupled) ~
+      AkkaHttpServerInterpreter.toRoute(booksListing)(bookListingLogic) ~
+      AkkaHttpServerInterpreter.toRoute(booksListingByGenre)(bookListingByGenreLogic)
   }
 
   def startServer(route: Route, yaml: String): Unit = {

--- a/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
+++ b/playground/src/main/scala/sttp/tapir/example/BooksExample.scala
@@ -117,7 +117,7 @@ object BooksExample extends App with StrictLogging {
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
 
     val booksListingRequest: Request[Either[String, Vector[Book]], Any] = SttpClientInterpreter
-      .toRequestUnsafe(booksListing)(uri"http://localhost:8080")
+      .toRequestUnsafe(booksListing, uri"http://localhost:8080")
       .apply(Option(3))
 
     val result: Either[String, Vector[Book]] = booksListingRequest.send(backend).body

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaHttpServerInterpreter.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaHttpServerInterpreter.scala
@@ -1,0 +1,49 @@
+package sttp.tapir.server.akkahttp
+
+import akka.http.scaladsl.server.{Directive, Route}
+import sttp.capabilities.WebSockets
+import sttp.capabilities.akka.AkkaStreams
+import sttp.tapir.Endpoint
+import sttp.tapir.server.ServerEndpoint
+
+import scala.concurrent.Future
+import scala.reflect.ClassTag
+
+trait AkkaHttpServerInterpreter {
+  def toDirective[I, E, O](e: Endpoint[I, E, O, AkkaStreams with WebSockets])(implicit
+      serverOptions: AkkaHttpServerOptions
+  ): Directive[(I, Future[Either[E, O]] => Route)] =
+    new EndpointToAkkaServer(serverOptions).toDirective(e)
+
+  def toRoute[I, E, O](e: Endpoint[I, E, O, AkkaStreams with WebSockets])(logic: I => Future[Either[E, O]])(implicit
+      serverOptions: AkkaHttpServerOptions
+  ): Route =
+    new EndpointToAkkaServer(serverOptions).toRoute(e.serverLogic(logic))
+
+  def toRouteRecoverErrors[I, E, O](
+      e: Endpoint[I, E, O, AkkaStreams with WebSockets]
+  )(logic: I => Future[O])(implicit eIsThrowable: E <:< Throwable, eClassTag: ClassTag[E], serverOptions: AkkaHttpServerOptions): Route = {
+    new EndpointToAkkaServer(serverOptions).toRoute(e.serverLogicRecoverErrors(logic))
+  }
+
+  //
+
+  def toDirective[I, E, O](serverEndpoint: ServerEndpoint[I, E, O, AkkaStreams with WebSockets, Future])(implicit
+      serverOptions: AkkaHttpServerOptions
+  ): Directive[(I, Future[Either[E, O]] => Route)] =
+    new EndpointToAkkaServer(serverOptions).toDirective(serverEndpoint.endpoint)
+
+  def toRoute[I, E, O](serverEndpoint: ServerEndpoint[I, E, O, AkkaStreams with WebSockets, Future])(implicit
+      serverOptions: AkkaHttpServerOptions
+  ): Route = new EndpointToAkkaServer(serverOptions).toRoute(serverEndpoint)
+
+  //
+
+  def toRoute(serverEndpoints: List[ServerEndpoint[_, _, _, AkkaStreams with WebSockets, Future]])(implicit
+      serverOptions: AkkaHttpServerOptions
+  ): Route = {
+    new EndpointToAkkaServer(serverOptions).toRoute(serverEndpoints)
+  }
+}
+
+object AkkaHttpServerInterpreter extends AkkaHttpServerInterpreter

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/EndpointToAkkaDirective.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/EndpointToAkkaDirective.scala
@@ -23,44 +23,40 @@ private[akkahttp] class EndpointToAkkaDirective(serverOptions: AkkaHttpServerOpt
     import akka.http.scaladsl.server.Directives._
     import akka.http.scaladsl.server._
 
-    val inputDirectives: Directive1[I] = {
-      def decodeBody(result: DecodeInputsResult): Directive1[DecodeInputsResult] = {
-        result match {
-          case values: DecodeInputsResult.Values =>
-            values.bodyInput match {
-              case Some(bodyInput @ EndpointIO.Body(bodyType, codec, _)) =>
-                rawBodyDirective(bodyType)
-                  .map { v =>
-                    codec.decode(v) match {
-                      case DecodeResult.Value(bodyV)     => values.setBodyInputValue(bodyV)
-                      case failure: DecodeResult.Failure => DecodeInputsResult.Failure(bodyInput, failure): DecodeInputsResult
-                    }
+    def decodeBody(result: DecodeInputsResult): Directive1[DecodeInputsResult] = {
+      result match {
+        case values: DecodeInputsResult.Values =>
+          values.bodyInput match {
+            case Some(bodyInput @ EndpointIO.Body(bodyType, codec, _)) =>
+              rawBodyDirective(bodyType)
+                .map { v =>
+                  codec.decode(v) match {
+                    case DecodeResult.Value(bodyV)     => values.setBodyInputValue(bodyV)
+                    case failure: DecodeResult.Failure => DecodeInputsResult.Failure(bodyInput, failure): DecodeInputsResult
                   }
-
-              case None => provide(values)
-            }
-          case failure: DecodeInputsResult.Failure => provide(failure)
-        }
-      }
-
-      extractRequestContext.flatMap { ctx =>
-        extractExecutionContext.flatMap { implicit ec =>
-          extractMaterializer.flatMap { implicit mat =>
-            decodeBody(DecodeInputs(e.input, new AkkaDecodeInputsContext(ctx))).flatMap {
-              case values: DecodeInputsResult.Values =>
-                InputValues(e.input, values) match {
-                  case InputValuesResult.Value(params, _)        => provide(params.asAny.asInstanceOf[I])
-                  case InputValuesResult.Failure(input, failure) => decodeFailureDirective(ctx, e, input, failure)
                 }
 
-              case DecodeInputsResult.Failure(input, failure) => decodeFailureDirective(ctx, e, input, failure)
-            }
+            case None => provide(values)
+          }
+        case failure: DecodeInputsResult.Failure => provide(failure)
+      }
+    }
+
+    extractRequestContext.flatMap { ctx =>
+      extractExecutionContext.flatMap { implicit ec =>
+        extractMaterializer.flatMap { implicit mat =>
+          decodeBody(DecodeInputs(e.input, new AkkaDecodeInputsContext(ctx))).flatMap {
+            case values: DecodeInputsResult.Values =>
+              InputValues(e.input, values) match {
+                case InputValuesResult.Value(params, _)        => provide(params.asAny.asInstanceOf[I])
+                case InputValuesResult.Failure(input, failure) => decodeFailureDirective(ctx, e, input, failure)
+              }
+
+            case DecodeInputsResult.Failure(input, failure) => decodeFailureDirective(ctx, e, input, failure)
           }
         }
       }
     }
-
-    inputDirectives
   }
 
   private def rawBodyDirective(bodyType: RawBodyType[_]): Directive1[Any] =

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/EndpointToAkkaServer.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/EndpointToAkkaServer.scala
@@ -13,7 +13,7 @@ import sttp.tapir.server.{ServerDefaults, ServerEndpoint}
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
-class EndpointToAkkaServer(serverOptions: AkkaHttpServerOptions) {
+private[akkahttp] class EndpointToAkkaServer(serverOptions: AkkaHttpServerOptions) {
 
   /** Converts the endpoint to a directive that -for matching requests- decodes the input parameters
     * and provides those input parameters and a function. The function can be called to complete the request.

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/TapirAkkaHttpServer.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/TapirAkkaHttpServer.scala
@@ -9,16 +9,20 @@ import sttp.tapir.server.ServerEndpoint
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
+@deprecated("Use AkkaHttpServerInterpreter", since = "0.17.1")
 trait TapirAkkaHttpServer {
   implicit class RichAkkaHttpEndpoint[I, E, O](e: Endpoint[I, E, O, AkkaStreams with WebSockets])(implicit
       serverOptions: AkkaHttpServerOptions
   ) {
+    @deprecated("Use AkkaHttpServerInterpreter.toDirective", since = "0.17.1")
     def toDirective: Directive[(I, Future[Either[E, O]] => Route)] =
       new EndpointToAkkaServer(serverOptions).toDirective(e)
 
+    @deprecated("Use AkkaHttpServerInterpreter.toRoute", since = "0.17.1")
     def toRoute(logic: I => Future[Either[E, O]]): Route =
       new EndpointToAkkaServer(serverOptions).toRoute(e.serverLogic(logic))
 
+    @deprecated("Use AkkaHttpServerInterpreter.toRouteRecoverErrors", since = "0.17.1")
     def toRouteRecoverErrors(
         logic: I => Future[O]
     )(implicit eIsThrowable: E <:< Throwable, eClassTag: ClassTag[E]): Route = {
@@ -29,15 +33,18 @@ trait TapirAkkaHttpServer {
   implicit class RichAkkaHttpServerEndpoint[I, E, O](serverEndpoint: ServerEndpoint[I, E, O, AkkaStreams with WebSockets, Future])(implicit
       serverOptions: AkkaHttpServerOptions
   ) {
+    @deprecated("Use AkkaHttpServerInterpreter.toDirective", since = "0.17.1")
     def toDirective: Directive[(I, Future[Either[E, O]] => Route)] =
       new EndpointToAkkaServer(serverOptions).toDirective(serverEndpoint.endpoint)
 
+    @deprecated("Use AkkaHttpServerInterpreter.toRoute", since = "0.17.1")
     def toRoute: Route = new EndpointToAkkaServer(serverOptions).toRoute(serverEndpoint)
   }
 
   implicit class RichAkkaHttpServerEndpoints(serverEndpoints: List[ServerEndpoint[_, _, _, AkkaStreams with WebSockets, Future]])(implicit
       serverOptions: AkkaHttpServerOptions
   ) {
+    @deprecated("Use AkkaHttpServerInterpreter.toRoute", since = "0.17.1")
     def toRoute: Route = {
       new EndpointToAkkaServer(serverOptions).toRoute(serverEndpoints)
     }

--- a/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerTests.scala
+++ b/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerTests.scala
@@ -36,7 +36,7 @@ class AkkaHttpServerTests extends TestSuite {
       def additionalTests(): List[Test] = List(
         Test("endpoint nested in a path directive") {
           val e = endpoint.get.in("test" and "directive").out(stringBody).serverLogic(_ => ("ok".asRight[Unit]).unit)
-          val route = Directives.pathPrefix("api")(e.toRoute)
+          val route = Directives.pathPrefix("api")(AkkaHttpServerInterpreter.toRoute(e))
           interpreter
             .server(NonEmptyList.of(route))
             .use { port =>

--- a/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerTests.scala
+++ b/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerTests.scala
@@ -30,7 +30,7 @@ class AkkaHttpServerTests extends TestSuite {
   override def tests: Resource[IO, List[Test]] = backendResource.flatMap { backend =>
     actorSystemResource.map { implicit actorSystem =>
       implicit val m: FutureMonad = new FutureMonad()(actorSystem.dispatcher)
-      val interpreter = new AkkaServerInterpreter()(actorSystem)
+      val interpreter = new AkkaHttpTestServerInterpreter()(actorSystem)
       val serverTests = new ServerTests(interpreter)
 
       def additionalTests(): List[Test] = List(

--- a/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpTestServerInterpreter.scala
+++ b/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpTestServerInterpreter.scala
@@ -10,13 +10,14 @@ import sttp.capabilities.WebSockets
 import sttp.capabilities.akka.AkkaStreams
 import sttp.tapir.Endpoint
 import sttp.tapir.server.{DecodeFailureHandler, ServerDefaults, ServerEndpoint}
-import sttp.tapir.server.tests.ServerInterpreter
+import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
-class AkkaServerInterpreter(implicit actorSystem: ActorSystem) extends ServerInterpreter[Future, AkkaStreams with WebSockets, Route] {
+class AkkaHttpTestServerInterpreter(implicit actorSystem: ActorSystem)
+    extends TestServerInterpreter[Future, AkkaStreams with WebSockets, Route] {
   override def route[I, E, O](
       e: ServerEndpoint[I, E, O, AkkaStreams with WebSockets, Future],
       decodeFailureHandler: Option[DecodeFailureHandler] = None

--- a/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaServerInterpreter.scala
+++ b/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaServerInterpreter.scala
@@ -12,7 +12,6 @@ import sttp.tapir.Endpoint
 import sttp.tapir.server.{DecodeFailureHandler, ServerDefaults, ServerEndpoint}
 import sttp.tapir.server.tests.ServerInterpreter
 import sttp.tapir.tests.Port
-import cats.syntax.all._
 
 import scala.concurrent.Future
 import scala.reflect.ClassTag
@@ -25,13 +24,13 @@ class AkkaServerInterpreter(implicit actorSystem: ActorSystem) extends ServerInt
     implicit val serverOptions: AkkaHttpServerOptions = AkkaHttpServerOptions.default.copy(
       decodeFailureHandler = decodeFailureHandler.getOrElse(ServerDefaults.decodeFailureHandler)
     )
-    e.toRoute
+    AkkaHttpServerInterpreter.toRoute(e)
   }
 
   override def routeRecoverErrors[I, E <: Throwable, O](e: Endpoint[I, E, O, AkkaStreams with WebSockets], fn: I => Future[O])(implicit
       eClassTag: ClassTag[E]
   ): Route = {
-    e.toRouteRecoverErrors(fn)
+    AkkaHttpServerInterpreter.toRouteRecoverErrors(e)(fn)
   }
 
   override def server(routes: NonEmptyList[Route]): Resource[IO, Port] = {

--- a/server/finatra-server/finatra-server-cats/src/main/scala/sttp/tapir/server/finatra/cats/FinatraCatsServerInterpreter.scala
+++ b/server/finatra-server/finatra-server-cats/src/main/scala/sttp/tapir/server/finatra/cats/FinatraCatsServerInterpreter.scala
@@ -1,0 +1,48 @@
+package sttp.tapir.server.finatra.cats
+
+import cats.effect.Effect
+import com.twitter.inject.Logging
+import io.catbird.util.Rerunnable
+import io.catbird.util.effect._
+import sttp.monad.MonadError
+import sttp.tapir.Endpoint
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.finatra.{FinatraRoute, FinatraServerInterpreter, FinatraServerOptions}
+
+import scala.reflect.ClassTag
+
+trait FinatraCatsServerInterpreter extends Logging {
+  def toRoute[I, E, O, F[_]](
+      e: Endpoint[I, E, O, Any]
+  )(logic: I => F[Either[E, O]])(implicit serverOptions: FinatraServerOptions, eff: Effect[F]): FinatraRoute = {
+    toRoute(e.serverLogic(logic))
+  }
+
+  def toRouteRecoverErrors[I, E, O, F[_]](e: Endpoint[I, E, O, Any])(logic: I => F[O])(implicit
+      eIsThrowable: E <:< Throwable,
+      eClassTag: ClassTag[E],
+      eff: Effect[F]
+  ): FinatraRoute = {
+    toRoute(e.serverLogicRecoverErrors(logic))
+  }
+
+  def toRoute[I, E, O, F[_]](
+      e: ServerEndpoint[I, E, O, Any, F]
+  )(implicit serverOptions: FinatraServerOptions, eff: Effect[F]): FinatraRoute = {
+    FinatraServerInterpreter.toRoute(e.endpoint.serverLogic(i => eff.toIO(e.logic(new CatsMonadError)(i)).to[Rerunnable].run))
+  }
+
+  private class CatsMonadError[F[_]](implicit F: Effect[F]) extends MonadError[F] {
+    override def unit[T](t: T): F[T] = F.pure(t)
+    override def map[T, T2](fa: F[T])(f: T => T2): F[T2] = F.map(fa)(f)
+    override def flatMap[T, T2](fa: F[T])(f: T => F[T2]): F[T2] = F.flatMap(fa)(f)
+    override def error[T](t: Throwable): F[T] = F.raiseError(t)
+    override protected def handleWrappedError[T](rt: F[T])(h: PartialFunction[Throwable, F[T]]): F[T] = F.recoverWith(rt)(h)
+    override def eval[T](t: => T): F[T] = F.delay(t)
+    override def suspend[T](t: => F[T]): F[T] = F.suspend(t)
+    override def flatten[T](ffa: F[F[T]]): F[T] = F.flatten(ffa)
+    override def ensure[T](f: F[T], e: => F[Unit]): F[T] = F.guarantee(f)(e)
+  }
+}
+
+object FinatraCatsServerInterpreter extends FinatraCatsServerInterpreter

--- a/server/finatra-server/finatra-server-cats/src/test/scala/sttp/tapir/server/finatra/cats/FinatraCatsTestServerInterpreter.scala
+++ b/server/finatra-server/finatra-server-cats/src/test/scala/sttp/tapir/server/finatra/cats/FinatraCatsTestServerInterpreter.scala
@@ -3,15 +3,15 @@ package sttp.tapir.server.finatra.cats
 import cats.data.NonEmptyList
 import cats.effect.{ContextShift, IO, Resource, Timer}
 import sttp.tapir.Endpoint
-import sttp.tapir.server.finatra.{FinatraRoute, FinatraServerInterpreter, FinatraServerOptions}
-import sttp.tapir.server.tests.ServerInterpreter
+import sttp.tapir.server.finatra.{FinatraRoute, FinatraTestServerInterpreter, FinatraServerOptions}
+import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.server.{DecodeFailureHandler, ServerDefaults, ServerEndpoint}
 import sttp.tapir.tests.Port
 
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
 
-class FinatraServerCatsInterpreter extends ServerInterpreter[IO, Any, FinatraRoute] {
+class FinatraCatsTestServerInterpreter extends TestServerInterpreter[IO, Any, FinatraRoute] {
   implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
   implicit val contextShift: ContextShift[IO] = IO.contextShift(ec)
   implicit val timer: Timer[IO] = IO.timer(ec)
@@ -22,12 +22,12 @@ class FinatraServerCatsInterpreter extends ServerInterpreter[IO, Any, FinatraRou
   ): FinatraRoute = {
     implicit val serverOptions: FinatraServerOptions =
       FinatraServerOptions.default.copy(decodeFailureHandler = decodeFailureHandler.getOrElse(ServerDefaults.decodeFailureHandler))
-    e.toRoute
+    FinatraCatsServerInterpreter.toRoute(e)
   }
 
   override def routeRecoverErrors[I, E <: Throwable, O](e: Endpoint[I, E, O, Any], fn: I => IO[O])(implicit
       eClassTag: ClassTag[E]
-  ): FinatraRoute = e.toRouteRecoverErrors(fn)
+  ): FinatraRoute = FinatraCatsServerInterpreter.toRouteRecoverErrors(e)(fn)
 
-  override def server(routes: NonEmptyList[FinatraRoute]): Resource[IO, Port] = FinatraServerInterpreter.server(routes)
+  override def server(routes: NonEmptyList[FinatraRoute]): Resource[IO, Port] = FinatraTestServerInterpreter.server(routes)
 }

--- a/server/finatra-server/finatra-server-cats/src/test/scala/sttp/tapir/server/finatra/cats/FinatraServerCatsTests.scala
+++ b/server/finatra-server/finatra-server-cats/src/test/scala/sttp/tapir/server/finatra/cats/FinatraServerCatsTests.scala
@@ -8,7 +8,7 @@ import sttp.tapir.tests.{Test, TestSuite}
 class FinatraServerCatsTests extends TestSuite {
   override def tests: Resource[IO, List[Test]] = backendResource.map { backend =>
     implicit val m: CatsMonadAsyncError[IO] = new CatsMonadAsyncError[IO]()
-    val interpreter = new FinatraServerCatsInterpreter()
+    val interpreter = new FinatraCatsTestServerInterpreter()
     val serverTests = new ServerTests(interpreter)
 
     new ServerBasicTests(backend, serverTests, interpreter).tests() ++ new ServerAuthenticationTests(backend, serverTests).tests()

--- a/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraServerInterpreter.scala
+++ b/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraServerInterpreter.scala
@@ -1,0 +1,132 @@
+package sttp.tapir.server.finatra
+
+import com.twitter.finagle.http.{Method, Request, Response, Status}
+import com.twitter.util.Future
+import com.twitter.util.logging.Logging
+import sttp.monad.MonadError
+import sttp.tapir.{DecodeResult, Endpoint, EndpointIO, EndpointInput}
+import sttp.tapir.internal._
+import sttp.tapir.EndpointInput.{FixedMethod, PathCapture}
+import sttp.tapir.server.{DecodeFailureContext, DecodeFailureHandling, ServerDefaults, ServerEndpoint}
+import sttp.tapir.server.internal.{DecodeInputs, DecodeInputsResult, InputValues, InputValuesResult}
+
+import java.nio.charset.Charset
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+
+trait FinatraServerInterpreter extends Logging {
+  def toRoute[I, E, O](e: Endpoint[I, E, O, Any])(logic: I => Future[Either[E, O]])(implicit
+      serverOptions: FinatraServerOptions
+  ): FinatraRoute =
+    toRoute(e.serverLogic(logic))
+
+  def toRouteRecoverErrors[I, E, O](e: Endpoint[I, E, O, Any])(logic: I => Future[O])(implicit
+      eIsThrowable: E <:< Throwable,
+      eClassTag: ClassTag[E]
+  ): FinatraRoute =
+    toRoute(e.serverLogicRecoverErrors(logic))
+
+  def toRoute[I, E, O](e: ServerEndpoint[I, E, O, Any, Future])(implicit serverOptions: FinatraServerOptions): FinatraRoute = {
+    val handler = { request: Request =>
+      def decodeBody(result: DecodeInputsResult): Future[DecodeInputsResult] = {
+        result match {
+          case values: DecodeInputsResult.Values =>
+            values.bodyInput match {
+              case Some(bodyInput @ EndpointIO.Body(bodyType, codec, _)) =>
+                new FinatraRequestToRawBody(serverOptions)
+                  .apply(bodyType, request.content, request.charset.map(Charset.forName), request)
+                  .map { rawBody =>
+                    val decodeResult = codec.decode(rawBody)
+                    decodeResult match {
+                      case DecodeResult.Value(bodyV)     => values.setBodyInputValue(bodyV)
+                      case failure: DecodeResult.Failure => DecodeInputsResult.Failure(bodyInput, failure): DecodeInputsResult
+                    }
+                  }
+              case None => Future.value(values)
+            }
+          case failure: DecodeInputsResult.Failure => Future.value(failure)
+        }
+      }
+
+      def valueToResponse(value: Any): Future[Response] = {
+        val i = value.asInstanceOf[I]
+
+        e.logic(FutureMonadError)(i)
+          .map {
+            case Right(result) => OutputToFinatraResponse(Status(ServerDefaults.StatusCodes.success.code), e.output, result)
+            case Left(err)     => OutputToFinatraResponse(Status(ServerDefaults.StatusCodes.error.code), e.errorOutput, err)
+          }
+          .map { result =>
+            serverOptions.logRequestHandling.requestHandled(e.endpoint, result.statusCode)
+            result
+          }
+          .onFailure { case NonFatal(ex) =>
+            serverOptions.logRequestHandling.logicException(e.endpoint, ex)
+            error(ex)
+          }
+      }
+
+      def handleDecodeFailure(
+          e: Endpoint[_, _, _, _],
+          input: EndpointInput[_],
+          failure: DecodeResult.Failure
+      ): Response = {
+        val decodeFailureCtx = DecodeFailureContext(input, failure, e)
+        val handling = serverOptions.decodeFailureHandler(decodeFailureCtx)
+
+        handling match {
+          case DecodeFailureHandling.NoMatch =>
+            serverOptions.logRequestHandling.decodeFailureNotHandled(e, decodeFailureCtx)
+            Response(Status.BadRequest)
+          case DecodeFailureHandling.RespondWithResponse(output, value) =>
+            serverOptions.logRequestHandling.decodeFailureHandled(e, decodeFailureCtx, value)
+            OutputToFinatraResponse(Status(ServerDefaults.StatusCodes.error.code), output, value)
+        }
+      }
+
+      decodeBody(DecodeInputs(e.input, new FinatraDecodeInputsContext(request))).flatMap {
+        case values: DecodeInputsResult.Values =>
+          InputValues(e.input, values) match {
+            case InputValuesResult.Value(params, _)        => valueToResponse(params.asAny)
+            case InputValuesResult.Failure(input, failure) => Future.value(handleDecodeFailure(e.endpoint, input, failure))
+          }
+        case DecodeInputsResult.Failure(input, failure) => Future.value(handleDecodeFailure(e.endpoint, input, failure))
+      }
+    }
+
+    FinatraRoute(handler, httpMethod(e.endpoint), path(e.input))
+  }
+
+  private[finatra] def path(input: EndpointInput[_]): String = {
+    val p = input
+      .asVectorOfBasicInputs()
+      .collect {
+        case segment: EndpointInput.FixedPath[_] => segment.show
+        case PathCapture(Some(name), _, _)       => s"/:$name"
+        case PathCapture(_, _, _)                => "/:param"
+        case EndpointInput.PathsCapture(_, _)    => "/:*"
+      }
+      .mkString
+    if (p.isEmpty) "/:*" else p
+  }
+
+  private[finatra] def httpMethod(endpoint: Endpoint[_, _, _, _]): Method = {
+    endpoint.input
+      .asVectorOfBasicInputs()
+      .collectFirst { case FixedMethod(m, _, _) =>
+        Method(m.method)
+      }
+      .getOrElse(Method("ANY"))
+  }
+
+  private[finatra] object FutureMonadError extends MonadError[Future] {
+    override def unit[T](t: T): Future[T] = Future(t)
+    override def map[T, T2](fa: Future[T])(f: (T) => T2): Future[T2] = fa.map(f)
+    override def flatMap[T, T2](fa: Future[T])(f: (T) => Future[T2]): Future[T2] = fa.flatMap(f)
+    override def error[T](t: Throwable): Future[T] = Future.exception(t)
+    override protected def handleWrappedError[T](rt: Future[T])(h: PartialFunction[Throwable, Future[T]]): Future[T] = rt.rescue(h)
+    override def ensure[T](f: Future[T], e: => Future[Unit]): Future[T] = f.ensure(e.toJavaFuture.get())
+  }
+}
+
+object FinatraServerInterpreter extends FinatraServerInterpreter

--- a/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/package.scala
+++ b/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/package.scala
@@ -1,132 +1,26 @@
 package sttp.tapir.server
 
-import java.nio.charset.Charset
-
-import com.twitter.finagle.http.{Method, Request, Response, Status}
-import com.twitter.util.logging.Logging
 import com.twitter.util.Future
-import sttp.monad.MonadError
-import sttp.tapir.EndpointInput.{FixedMethod, PathCapture}
-import sttp.tapir.internal._
-import sttp.tapir.server.internal.{DecodeInputs, DecodeInputsResult, InputValues, InputValuesResult}
-import sttp.tapir.{DecodeResult, Endpoint, EndpointIO, EndpointInput}
+import com.twitter.util.logging.Logging
+import sttp.tapir.Endpoint
 
 import scala.reflect.ClassTag
-import scala.util.control.NonFatal
 
 package object finatra {
   implicit class RichFinatraEndpoint[I, E, O](e: Endpoint[I, E, O, Any]) extends Logging {
+    @deprecated("Use FinatraServerInterpreter.toRoute", since = "0.17.1")
     def toRoute(logic: I => Future[Either[E, O]])(implicit serverOptions: FinatraServerOptions): FinatraRoute =
-      e.serverLogic(logic).toRoute
+      FinatraServerInterpreter.toRoute(e)(logic)
 
+    @deprecated("Use FinatraServerInterpreter.toRouteRecoverErrors", since = "0.17.1")
     def toRouteRecoverErrors(logic: I => Future[O])(implicit
         eIsThrowable: E <:< Throwable,
         eClassTag: ClassTag[E]
-    ): FinatraRoute =
-      e.serverLogicRecoverErrors(logic).toRoute
+    ): FinatraRoute = FinatraServerInterpreter.toRouteRecoverErrors(e)(logic)
   }
 
   implicit class RichFinatraServerEndpoint[I, E, O](e: ServerEndpoint[I, E, O, Any, Future]) extends Logging {
-    def toRoute(implicit serverOptions: FinatraServerOptions): FinatraRoute = {
-      val handler = { request: Request =>
-        def decodeBody(result: DecodeInputsResult): Future[DecodeInputsResult] = {
-          result match {
-            case values: DecodeInputsResult.Values =>
-              values.bodyInput match {
-                case Some(bodyInput @ EndpointIO.Body(bodyType, codec, _)) =>
-                  new FinatraRequestToRawBody(serverOptions)
-                    .apply(bodyType, request.content, request.charset.map(Charset.forName), request)
-                    .map { rawBody =>
-                      val decodeResult = codec.decode(rawBody)
-                      decodeResult match {
-                        case DecodeResult.Value(bodyV)     => values.setBodyInputValue(bodyV)
-                        case failure: DecodeResult.Failure => DecodeInputsResult.Failure(bodyInput, failure): DecodeInputsResult
-                      }
-                    }
-                case None => Future.value(values)
-              }
-            case failure: DecodeInputsResult.Failure => Future.value(failure)
-          }
-        }
-
-        def valueToResponse(value: Any): Future[Response] = {
-          val i = value.asInstanceOf[I]
-
-          e.logic(FutureMonadError)(i)
-            .map {
-              case Right(result) => OutputToFinatraResponse(Status(ServerDefaults.StatusCodes.success.code), e.output, result)
-              case Left(err)     => OutputToFinatraResponse(Status(ServerDefaults.StatusCodes.error.code), e.errorOutput, err)
-            }
-            .map { result =>
-              serverOptions.logRequestHandling.requestHandled(e.endpoint, result.statusCode)
-              result
-            }
-            .onFailure { case NonFatal(ex) =>
-              serverOptions.logRequestHandling.logicException(e.endpoint, ex)
-              error(ex)
-            }
-        }
-
-        def handleDecodeFailure(
-            e: Endpoint[_, _, _, _],
-            input: EndpointInput[_],
-            failure: DecodeResult.Failure
-        ): Response = {
-          val decodeFailureCtx = DecodeFailureContext(input, failure, e)
-          val handling = serverOptions.decodeFailureHandler(decodeFailureCtx)
-
-          handling match {
-            case DecodeFailureHandling.NoMatch =>
-              serverOptions.logRequestHandling.decodeFailureNotHandled(e, decodeFailureCtx)
-              Response(Status.BadRequest)
-            case DecodeFailureHandling.RespondWithResponse(output, value) =>
-              serverOptions.logRequestHandling.decodeFailureHandled(e, decodeFailureCtx, value)
-              OutputToFinatraResponse(Status(ServerDefaults.StatusCodes.error.code), output, value)
-          }
-        }
-
-        decodeBody(DecodeInputs(e.input, new FinatraDecodeInputsContext(request))).flatMap {
-          case values: DecodeInputsResult.Values =>
-            InputValues(e.input, values) match {
-              case InputValuesResult.Value(params, _)        => valueToResponse(params.asAny)
-              case InputValuesResult.Failure(input, failure) => Future.value(handleDecodeFailure(e.endpoint, input, failure))
-            }
-          case DecodeInputsResult.Failure(input, failure) => Future.value(handleDecodeFailure(e.endpoint, input, failure))
-        }
-      }
-
-      FinatraRoute(handler, httpMethod(e.endpoint), path(e.input))
-    }
-  }
-
-  private[finatra] def path(input: EndpointInput[_]): String = {
-    val p = input
-      .asVectorOfBasicInputs()
-      .collect {
-        case segment: EndpointInput.FixedPath[_] => segment.show
-        case PathCapture(Some(name), _, _)       => s"/:$name"
-        case PathCapture(_, _, _)                => "/:param"
-        case EndpointInput.PathsCapture(_, _)    => "/:*"
-      }
-      .mkString
-    if (p.isEmpty) "/:*" else p
-  }
-
-  private[finatra] def httpMethod(endpoint: Endpoint[_, _, _, _]): Method = {
-    endpoint.input
-      .asVectorOfBasicInputs()
-      .collectFirst { case FixedMethod(m, _, _) =>
-        Method(m.method)
-      }
-      .getOrElse(Method("ANY"))
-  }
-
-  private[finatra] object FutureMonadError extends MonadError[Future] {
-    override def unit[T](t: T): Future[T] = Future(t)
-    override def map[T, T2](fa: Future[T])(f: (T) => T2): Future[T2] = fa.map(f)
-    override def flatMap[T, T2](fa: Future[T])(f: (T) => Future[T2]): Future[T2] = fa.flatMap(f)
-    override def error[T](t: Throwable): Future[T] = Future.exception(t)
-    override protected def handleWrappedError[T](rt: Future[T])(h: PartialFunction[Throwable, Future[T]]): Future[T] = rt.rescue(h)
-    override def ensure[T](f: Future[T], e: => Future[Unit]): Future[T] = f.ensure(e.toJavaFuture.get())
+    @deprecated("Use FinatraServerInterpreter.toRoute", since = "0.17.1")
+    def toRoute(implicit serverOptions: FinatraServerOptions): FinatraRoute = FinatraServerInterpreter.toRoute(e)
   }
 }

--- a/server/finatra-server/src/test/scala/sttp/tapir/server/finatra/FinatraServerTests.scala
+++ b/server/finatra-server/src/test/scala/sttp/tapir/server/finatra/FinatraServerTests.scala
@@ -1,15 +1,15 @@
 package sttp.tapir.server.finatra
 
 import cats.effect.{IO, Resource}
-import sttp.tapir.server.finatra
+import sttp.tapir.server.finatra.FinatraServerInterpreter.FutureMonadError
 import sttp.tapir.server.tests.{ServerAuthenticationTests, ServerBasicTests, ServerTests, backendResource}
 import sttp.tapir.tests.{Test, TestSuite}
 
 class FinatraServerTests extends TestSuite {
 
   override def tests: Resource[IO, List[Test]] = backendResource.map { backend =>
-    implicit val m: finatra.FutureMonadError.type = FutureMonadError
-    val interpreter = new FinatraServerInterpreter()
+    implicit val m = FutureMonadError
+    val interpreter = new FinatraTestServerInterpreter()
     val serverTests = new ServerTests(interpreter)
 
     new ServerBasicTests(backend, serverTests, interpreter).tests() ++ new ServerAuthenticationTests(backend, serverTests).tests()

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/EndpointToHttp4sServer.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/EndpointToHttp4sServer.scala
@@ -14,7 +14,7 @@ import sttp.capabilities.WebSockets
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.monad.MonadError
 
-class EndpointToHttp4sServer[F[_]: Concurrent: ContextShift: Timer](serverOptions: Http4sServerOptions[F]) {
+private[http4s] class EndpointToHttp4sServer[F[_]: Concurrent: ContextShift: Timer](serverOptions: Http4sServerOptions[F]) {
   private val outputToResponse = new OutputToHttp4sResponse[F](serverOptions)
 
   def toHttp[I, E, O, G[_]: Sync](t: F ~> G, se: ServerEndpoint[I, E, O, Fs2Streams[F] with WebSockets, G]): Http[OptionT[G, *], F] = {

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sDecodeInputsContext.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sDecodeInputsContext.scala
@@ -6,7 +6,7 @@ import sttp.model.{Method, QueryParams}
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.internal.DecodeInputsContext
 
-class Http4sDecodeInputsContext[F[_]](req: Request[F]) extends DecodeInputsContext {
+private[http4s] class Http4sDecodeInputsContext[F[_]](req: Request[F]) extends DecodeInputsContext {
   override def method: Method = Method(req.method.name.toUpperCase)
   override def nextPathSegment: (Option[String], DecodeInputsContext) = {
     val nextStart = req.pathInfo.dropWhile(_ == '/')

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestToRawBody.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestToRawBody.scala
@@ -10,7 +10,7 @@ import org.http4s.{Charset, EntityDecoder, Request, multipart}
 import sttp.model.{Header, Part}
 import sttp.tapir.{RawPart, RawBodyType}
 
-class Http4sRequestToRawBody[F[_]: Sync: ContextShift](serverOptions: Http4sServerOptions[F]) {
+private[http4s] class Http4sRequestToRawBody[F[_]: Sync: ContextShift](serverOptions: Http4sServerOptions[F]) {
   def apply[R](body: fs2.Stream[F, Byte], bodyType: RawBodyType[R], charset: Option[Charset], req: Request[F]): F[R] = {
     def asChunk: F[Chunk[Byte]] = body.compile.to(Chunk)
     def asByteArray: F[Array[Byte]] = body.compile.to(Chunk).map(_.toByteBuffer.array())

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerInterpreter.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerInterpreter.scala
@@ -1,0 +1,90 @@
+package sttp.tapir.server.http4s
+
+import cats.data.OptionT
+import cats.effect.{Concurrent, ContextShift, Sync, Timer}
+import cats.~>
+import org.http4s.{Http, HttpRoutes}
+import sttp.capabilities.WebSockets
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.tapir.Endpoint
+import sttp.tapir.server.ServerEndpoint
+
+import scala.reflect.ClassTag
+
+trait Http4sServerInterpreter {
+  def toHttp[I, E, O, F[_], G[_]](e: Endpoint[I, E, O, Fs2Streams[F] with WebSockets])(t: F ~> G)(logic: I => G[Either[E, O]])(implicit
+      serverOptions: Http4sServerOptions[F],
+      gs: Sync[G],
+      fs: Concurrent[F],
+      fcs: ContextShift[F],
+      timer: Timer[F]
+  ): Http[OptionT[G, *], F] = {
+    new EndpointToHttp4sServer(serverOptions).toHttp(t, e.serverLogic(logic))
+  }
+
+  def toHttpRecoverErrors[I, E, O, F[_], G[_]](e: Endpoint[I, E, O, Fs2Streams[F] with WebSockets])(t: F ~> G)(logic: I => G[O])(implicit
+      serverOptions: Http4sServerOptions[F],
+      gs: Sync[G],
+      fs: Concurrent[F],
+      fcs: ContextShift[F],
+      eIsThrowable: E <:< Throwable,
+      eClassTag: ClassTag[E],
+      timer: Timer[F]
+  ): Http[OptionT[G, *], F] = {
+    new EndpointToHttp4sServer(serverOptions).toHttp(t, e.serverLogicRecoverErrors(logic))
+  }
+
+  def toRoutes[I, E, O, F[_]](e: Endpoint[I, E, O, Fs2Streams[F] with WebSockets])(
+      logic: I => F[Either[E, O]]
+  )(implicit serverOptions: Http4sServerOptions[F], fs: Concurrent[F], fcs: ContextShift[F], timer: Timer[F]): HttpRoutes[F] = {
+    new EndpointToHttp4sServer(serverOptions).toRoutes(e.serverLogic(logic))
+  }
+
+  def toRouteRecoverErrors[I, E, O, F[_]](e: Endpoint[I, E, O, Fs2Streams[F] with WebSockets])(logic: I => F[O])(implicit
+      serverOptions: Http4sServerOptions[F],
+      fs: Concurrent[F],
+      fcs: ContextShift[F],
+      eIsThrowable: E <:< Throwable,
+      eClassTag: ClassTag[E],
+      timer: Timer[F]
+  ): HttpRoutes[F] = {
+    new EndpointToHttp4sServer(serverOptions).toRoutes(e.serverLogicRecoverErrors(logic))
+  }
+
+  def toHttp[I, E, O, F[_], G[_]](se: ServerEndpoint[I, E, O, Fs2Streams[F] with WebSockets, G])(
+      t: F ~> G
+  )(implicit
+      serverOptions: Http4sServerOptions[F],
+      gs: Sync[G],
+      fs: Concurrent[F],
+      fcs: ContextShift[F],
+      timer: Timer[F]
+  ): Http[OptionT[G, *], F] =
+    new EndpointToHttp4sServer(serverOptions).toHttp(t, se)
+
+  def toRoutes[I, E, O, F[_]](
+      se: ServerEndpoint[I, E, O, Fs2Streams[F] with WebSockets, F]
+  )(implicit serverOptions: Http4sServerOptions[F], fs: Concurrent[F], fcs: ContextShift[F], timer: Timer[F]): HttpRoutes[F] =
+    new EndpointToHttp4sServer(serverOptions).toRoutes(se)
+
+  def toHttp[F[_], G[_]](serverEndpoints: List[ServerEndpoint[_, _, _, Fs2Streams[F] with WebSockets, G]])(t: F ~> G)(implicit
+      serverOptions: Http4sServerOptions[F],
+      gs: Sync[G],
+      fs: Concurrent[F],
+      fcs: ContextShift[F],
+      timer: Timer[F]
+  ): Http[OptionT[G, *], F] = {
+    new EndpointToHttp4sServer[F](serverOptions).toHttp(t)(serverEndpoints)
+  }
+
+  def toRoutes[F[_]](serverEndpoints: List[ServerEndpoint[_, _, _, Fs2Streams[F] with WebSockets, F]])(implicit
+      serverOptions: Http4sServerOptions[F],
+      fs: Concurrent[F],
+      fcs: ContextShift[F],
+      timer: Timer[F]
+  ): HttpRoutes[F] = {
+    new EndpointToHttp4sServer(serverOptions).toRoutes(serverEndpoints)
+  }
+}
+
+object Http4sServerInterpreter extends Http4sServerInterpreter

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerRequest.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerRequest.scala
@@ -7,7 +7,7 @@ import org.http4s.util.CaseInsensitiveString
 import sttp.model.Method
 import sttp.tapir.model.{ConnectionInfo, ServerRequest}
 
-class Http4sServerRequest[F[_]](req: Request[F]) extends ServerRequest {
+private[http4s] class Http4sServerRequest[F[_]](req: Request[F]) extends ServerRequest {
   override def method: Method = Method(req.method.name.toUpperCase)
   override def protocol: String = req.httpVersion.toString()
   override def uri: URI = new URI(req.uri.toString())

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/OutputToHttp4sResponse.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/OutputToHttp4sResponse.scala
@@ -18,7 +18,7 @@ import sttp.tapir.internal._
 import sttp.tapir.server.internal.{EncodeOutputBody, EncodeOutputs, OutputValues}
 import sttp.tapir.{CodecFormat, EndpointOutput, RawBodyType, RawPart, WebSocketBodyOutput}
 
-class OutputToHttp4sResponse[F[_]: Concurrent: ContextShift: Timer](serverOptions: Http4sServerOptions[F]) {
+private[http4s] class OutputToHttp4sResponse[F[_]: Concurrent: ContextShift: Timer](serverOptions: Http4sServerOptions[F]) {
   def apply[O](defaultStatusCode: sttp.model.StatusCode, output: EndpointOutput[O], v: O): F[Response[F]] = {
     val outputValues = encodeOutputs(output, ParamsAsAny(v), OutputValues.empty)
     val statusCode = outputValues.statusCode.map(statusCodeToHttp4sStatus).getOrElse(statusCodeToHttp4sStatus(defaultStatusCode))

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/TapirHttp4sServer.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/TapirHttp4sServer.scala
@@ -13,8 +13,10 @@ import scala.reflect.ClassTag
 
 // We need Concurrent[F] because we are creating an intermediate queue for handling websockets. It might be possible
 // to revert to Sync[F] after the WS changes in http4s 1.
+@deprecated("Use Http4sServerInterpreter", since = "0.17.1")
 trait TapirHttp4sServer {
   implicit class RichHttp4sHttpEndpoint[I, E, O, F[_]](e: Endpoint[I, E, O, Fs2Streams[F] with WebSockets]) {
+    @deprecated("Use Http4sServerInterpreter.toHttp", since = "0.17.1")
     def toHttp[G[_]](t: F ~> G)(logic: I => G[Either[E, O]])(implicit
         serverOptions: Http4sServerOptions[F],
         gs: Sync[G],
@@ -25,6 +27,7 @@ trait TapirHttp4sServer {
       new EndpointToHttp4sServer(serverOptions).toHttp(t, e.serverLogic(logic))
     }
 
+    @deprecated("Use Http4sServerInterpreter.toHttpRecoverErrors", since = "0.17.1")
     def toHttpRecoverErrors[G[_]](t: F ~> G)(logic: I => G[O])(implicit
         serverOptions: Http4sServerOptions[F],
         gs: Sync[G],
@@ -37,12 +40,14 @@ trait TapirHttp4sServer {
       new EndpointToHttp4sServer(serverOptions).toHttp(t, e.serverLogicRecoverErrors(logic))
     }
 
+    @deprecated("Use Http4sServerInterpreter.toRoutes", since = "0.17.1")
     def toRoutes(
         logic: I => F[Either[E, O]]
     )(implicit serverOptions: Http4sServerOptions[F], fs: Concurrent[F], fcs: ContextShift[F], timer: Timer[F]): HttpRoutes[F] = {
       new EndpointToHttp4sServer(serverOptions).toRoutes(e.serverLogic(logic))
     }
 
+    @deprecated("Use Http4sServerInterpreter.toRouteRecoverErrors", since = "0.17.1")
     def toRouteRecoverErrors(logic: I => F[O])(implicit
         serverOptions: Http4sServerOptions[F],
         fs: Concurrent[F],
@@ -56,6 +61,7 @@ trait TapirHttp4sServer {
   }
 
   implicit class RichHttp4sServerEndpoint0[I, E, O, F[_], G[_]](se: ServerEndpoint[I, E, O, Fs2Streams[F] with WebSockets, G]) {
+    @deprecated("Use Http4sServerInterpreter.toHttp", since = "0.17.1")
     def toHttp(
         t: F ~> G
     )(implicit
@@ -69,11 +75,13 @@ trait TapirHttp4sServer {
   }
 
   implicit class RichHttp4sServerEndpoint[I, E, O, F[_]](se: ServerEndpoint[I, E, O, Fs2Streams[F] with WebSockets, F]) {
+    @deprecated("Use Http4sServerInterpreter.toRoutes", since = "0.17.1")
     def toRoutes(implicit serverOptions: Http4sServerOptions[F], fs: Concurrent[F], fcs: ContextShift[F], timer: Timer[F]): HttpRoutes[F] =
       new EndpointToHttp4sServer(serverOptions).toRoutes(se)
   }
 
   implicit class RichHttp4sServerEndpoints0[F[_], G[_]](serverEndpoints: List[ServerEndpoint[_, _, _, Fs2Streams[F] with WebSockets, G]]) {
+    @deprecated("Use Http4sServerInterpreter.toHttp", since = "0.17.1")
     def toHttp(t: F ~> G)(implicit
         serverOptions: Http4sServerOptions[F],
         gs: Sync[G],
@@ -86,6 +94,7 @@ trait TapirHttp4sServer {
   }
 
   implicit class RichHttp4sServerEndpoints[F[_]](serverEndpoints: List[ServerEndpoint[_, _, _, Fs2Streams[F] with WebSockets, F]]) {
+    @deprecated("Use Http4sServerInterpreter.toRoutes", since = "0.17.1")
     def toRoutes(implicit
         serverOptions: Http4sServerOptions[F],
         fs: Concurrent[F],

--- a/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerTests.scala
+++ b/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerTests.scala
@@ -28,7 +28,7 @@ class Http4sServerTests[R >: Fs2Streams[IO] with WebSockets] extends TestSuite {
 
   override def tests: Resource[IO, List[Test]] = backendResource.map { backend =>
     implicit val m: CatsMonadError[IO] = new CatsMonadError[IO]
-    val interpreter = new Http4sServerInterpreter()
+    val interpreter = new Http4sTestServerInterpreter()
     val serverTests = new ServerTests(interpreter)
 
     import interpreter.timer
@@ -36,7 +36,7 @@ class Http4sServerTests[R >: Fs2Streams[IO] with WebSockets] extends TestSuite {
     def additionalTests(): List[Test] = List(
       Test("should work with a router and routes in a context") {
         val e = endpoint.get.in("test" / "router").out(stringBody).serverLogic(_ => IO.pure("ok".asRight[Unit]))
-        val routes = e.toRoutes
+        val routes = Http4sServerInterpreter.toRoutes(e)
 
         BlazeServerBuilder[IO](ExecutionContext.global)
           .bindHttp(0, "localhost")

--- a/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sTestServerInterpreter.scala
+++ b/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sTestServerInterpreter.scala
@@ -10,13 +10,13 @@ import sttp.capabilities.WebSockets
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.tapir.Endpoint
 import sttp.tapir.server.{DecodeFailureHandler, ServerDefaults, ServerEndpoint}
-import sttp.tapir.server.tests.ServerInterpreter
+import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
 
-class Http4sServerInterpreter extends ServerInterpreter[IO, Fs2Streams[IO] with WebSockets, HttpRoutes[IO]] {
+class Http4sTestServerInterpreter extends TestServerInterpreter[IO, Fs2Streams[IO] with WebSockets, HttpRoutes[IO]] {
   implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
   implicit val contextShift: ContextShift[IO] = IO.contextShift(ec)
   implicit val timer: Timer[IO] = IO.timer(ec)
@@ -30,13 +30,13 @@ class Http4sServerInterpreter extends ServerInterpreter[IO, Fs2Streams[IO] with 
       .copy(
         decodeFailureHandler = decodeFailureHandler.getOrElse(ServerDefaults.decodeFailureHandler)
       )
-    e.toRoutes
+    Http4sServerInterpreter.toRoutes(e)
   }
 
   override def routeRecoverErrors[I, E <: Throwable, O](e: Endpoint[I, E, O, Fs2Streams[IO] with WebSockets], fn: I => IO[O])(implicit
       eClassTag: ClassTag[E]
   ): HttpRoutes[IO] = {
-    e.toRouteRecoverErrors(fn)
+    Http4sServerInterpreter.toRouteRecoverErrors(e)(fn)
   }
 
   override def server(routes: NonEmptyList[HttpRoutes[IO]]): Resource[IO, Port] = {

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/OutputToPlayResponse.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/OutputToPlayResponse.scala
@@ -16,7 +16,7 @@ import sttp.tapir.internal.{NoStreams, ParamsAsAny}
 import sttp.tapir.server.internal.{EncodeOutputBody, EncodeOutputs, OutputValues}
 import sttp.tapir.{CodecFormat, EndpointOutput, RawBodyType, RawPart, WebSocketBodyOutput}
 
-object OutputToPlayResponse {
+private[play] object OutputToPlayResponse {
   def apply[O](
       defaultStatus: StatusCode,
       output: EndpointOutput[O],

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/OutputToPlayResponse.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/OutputToPlayResponse.scala
@@ -11,8 +11,6 @@ import akka.util.ByteString
 import play.api.http.{ContentTypes, HeaderNames, HttpEntity}
 import play.api.mvc.MultipartFormData.{DataPart, FilePart}
 import play.api.mvc.{Codec, MultipartFormData, ResponseHeader, Result}
-import sttp.capabilities
-import sttp.capabilities.Streams
 import sttp.model.{MediaType, Part, StatusCode}
 import sttp.tapir.internal.{NoStreams, ParamsAsAny}
 import sttp.tapir.server.internal.{EncodeOutputBody, EncodeOutputs, OutputValues}

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestToRawBody.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestToRawBody.scala
@@ -14,7 +14,7 @@ import sttp.tapir.internal._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class PlayRequestToRawBody(serverOptions: PlayServerOptions) {
+private[play] class PlayRequestToRawBody(serverOptions: PlayServerOptions) {
   def apply[R](bodyType: RawBodyType[R], charset: Option[Charset], request: Request[RawBuffer], body: ByteString)(implicit
       mat: Materializer
   ): Future[R] = {

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerInterpreter.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerInterpreter.scala
@@ -1,0 +1,131 @@
+package sttp.tapir.server.play
+
+import akka.stream.Materializer
+import akka.util.ByteString
+import play.api.http.HttpEntity
+import play.api.mvc.{ActionBuilder, AnyContent, Handler, RawBuffer, Request, RequestHeader, ResponseHeader, Result}
+import play.api.routing.Router.Routes
+import sttp.monad.FutureMonad
+import sttp.tapir.{DecodeResult, Endpoint, EndpointIO, EndpointInput}
+import sttp.tapir.server.ServerDefaults.StatusCodes
+import sttp.tapir.server.{DecodeFailureContext, DecodeFailureHandling, ServerDefaults, ServerEndpoint}
+import sttp.tapir.server.internal.{DecodeInputs, DecodeInputsResult, InputValues, InputValuesResult}
+
+import java.nio.charset.Charset
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.reflect.ClassTag
+
+trait PlayServerInterpreter {
+  def toRoute[I, E, O](e: Endpoint[I, E, O, Any])(
+      logic: I => Future[Either[E, O]]
+  )(implicit mat: Materializer, serverOptions: PlayServerOptions): Routes = {
+    toRoute(e.serverLogic(logic))
+  }
+
+  def toRouteRecoverErrors[I, E, O](e: Endpoint[I, E, O, Any])(logic: I => Future[O])(implicit
+      eIsThrowable: E <:< Throwable,
+      eClassTag: ClassTag[E],
+      mat: Materializer,
+      serverOptions: PlayServerOptions
+  ): Routes = {
+    toRoute(e.serverLogicRecoverErrors(logic))
+  }
+
+  def toRoute[I, E, O](e: ServerEndpoint[I, E, O, Any, Future])(implicit mat: Materializer, serverOptions: PlayServerOptions): Routes = {
+    def valueToResponse(value: Any): Future[Result] = {
+      val i = value.asInstanceOf[I]
+      e.logic(new FutureMonad())(i)
+        .map {
+          case Right(result) =>
+            serverOptions.logRequestHandling.requestHandled(e.endpoint, ServerDefaults.StatusCodes.success.code)(serverOptions.logger)
+            OutputToPlayResponse(ServerDefaults.StatusCodes.success, e.output, result)
+          case Left(err) =>
+            serverOptions.logRequestHandling.requestHandled(e.endpoint, ServerDefaults.StatusCodes.error.code)(serverOptions.logger)
+            OutputToPlayResponse(ServerDefaults.StatusCodes.error, e.errorOutput, err)
+        }
+    }
+    def handleDecodeFailure(
+        e: Endpoint[_, _, _, _],
+        input: EndpointInput[_],
+        failure: DecodeResult.Failure
+    ): Result = {
+      val decodeFailureCtx = DecodeFailureContext(input, failure, e)
+      val handling = serverOptions.decodeFailureHandler(decodeFailureCtx)
+      handling match {
+        case DecodeFailureHandling.NoMatch =>
+          serverOptions.logRequestHandling.decodeFailureNotHandled(e, decodeFailureCtx)(serverOptions.logger)
+          Result(header = ResponseHeader(StatusCodes.error.code), body = HttpEntity.NoEntity)
+        case DecodeFailureHandling.RespondWithResponse(output, value) =>
+          serverOptions.logRequestHandling.decodeFailureNotHandled(e, decodeFailureCtx)(serverOptions.logger)
+          OutputToPlayResponse(ServerDefaults.StatusCodes.error, output, value)
+      }
+    }
+
+    def decodeBody(request: Request[RawBuffer], result: DecodeInputsResult)(implicit mat: Materializer): Future[DecodeInputsResult] = {
+      result match {
+        case values: DecodeInputsResult.Values =>
+          values.bodyInput match {
+            case Some(bodyInput @ EndpointIO.Body(bodyType, codec, _)) =>
+              new PlayRequestToRawBody(serverOptions)
+                .apply(
+                  bodyType,
+                  request.charset.map(Charset.forName),
+                  request,
+                  request.body.asBytes().getOrElse(ByteString.apply(java.nio.file.Files.readAllBytes(request.body.asFile.toPath)))
+                )
+                .map { rawBody =>
+                  codec.decode(rawBody) match {
+                    case DecodeResult.Value(bodyV)     => values.setBodyInputValue(bodyV)
+                    case failure: DecodeResult.Failure => DecodeInputsResult.Failure(bodyInput, failure): DecodeInputsResult
+                  }
+                }
+            case None => Future(values)
+          }
+        case failure: DecodeInputsResult.Failure => Future(failure)
+      }
+    }
+
+    val res = new PartialFunction[RequestHeader, Handler] {
+      override def isDefinedAt(x: RequestHeader): Boolean = {
+        val decodeInputResult = DecodeInputs(e.input, new PlayDecodeInputContext(x, 0, serverOptions))
+        val handlingResult = decodeInputResult match {
+          case DecodeInputsResult.Failure(input, failure) =>
+            val decodeFailureCtx = DecodeFailureContext(input, failure, e.endpoint)
+            serverOptions.logRequestHandling.decodeFailureNotHandled(e.endpoint, decodeFailureCtx)(serverOptions.logger)
+            serverOptions.decodeFailureHandler(decodeFailureCtx) != DecodeFailureHandling.noMatch
+          case DecodeInputsResult.Values(_, _) => true
+        }
+        handlingResult
+      }
+
+      override def apply(v1: RequestHeader): Handler = {
+        serverOptions.defaultActionBuilder.async(serverOptions.playBodyParsers.raw) { request =>
+          decodeBody(request, DecodeInputs(e.input, new PlayDecodeInputContext(v1, 0, serverOptions))).flatMap {
+            case values: DecodeInputsResult.Values =>
+              InputValues(e.input, values) match {
+                case InputValuesResult.Value(params, _)        => valueToResponse(params.asAny)
+                case InputValuesResult.Failure(input, failure) => Future.successful(handleDecodeFailure(e.endpoint, input, failure))
+              }
+            case DecodeInputsResult.Failure(input, failure) =>
+              Future.successful(handleDecodeFailure(e.endpoint, input, failure))
+          }
+        }
+      }
+    }
+    res
+  }
+
+  def toRoute[I, E, O](
+      serverEndpoints: List[ServerEndpoint[_, _, _, Any, Future]]
+  )(implicit mat: Materializer, serverOptions: PlayServerOptions): Routes = {
+    serverEndpoints
+      .map(toRoute(_))
+      .reduce((a: Routes, b: Routes) => a.orElse(b))
+  }
+
+  implicit def actionBuilderFromPlayServerOptions(implicit playServerOptions: PlayServerOptions): ActionBuilder[Request, AnyContent] =
+    playServerOptions.defaultActionBuilder
+}
+
+object PlayServerInterpreter extends PlayServerInterpreter

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/TapirPlayServer.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/TapirPlayServer.scala
@@ -1,132 +1,37 @@
 package sttp.tapir.server.play
 
-import java.nio.charset.Charset
-
 import akka.stream.Materializer
-import akka.util.ByteString
-import play.api.http.HttpEntity
 import play.api.mvc._
 import play.api.routing.Router.Routes
-import sttp.monad.FutureMonad
-import sttp.tapir.server.internal.{DecodeInputs, DecodeInputsResult, InputValues, InputValuesResult}
-import sttp.tapir.server.ServerDefaults.StatusCodes
-import sttp.tapir.server.{DecodeFailureContext, DecodeFailureHandling, ServerDefaults, ServerEndpoint}
-import sttp.tapir.{DecodeResult, Endpoint, EndpointIO, EndpointInput}
+import sttp.tapir.Endpoint
+import sttp.tapir.server.ServerEndpoint
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
 trait TapirPlayServer {
   implicit class RichPlayEndpoint[I, E, O](e: Endpoint[I, E, O, Any]) {
+    @deprecated("Use PlayServerInterpreter.toRoute", since = "0.17.1")
     def toRoute(
         logic: I => Future[Either[E, O]]
-    )(implicit mat: Materializer, serverOptions: PlayServerOptions): Routes = {
-      e.serverLogic(logic).toRoute
-    }
+    )(implicit mat: Materializer, serverOptions: PlayServerOptions): Routes = PlayServerInterpreter.toRoute(e)(logic)
 
     def toRouteRecoverErrors(logic: I => Future[O])(implicit
         eIsThrowable: E <:< Throwable,
         eClassTag: ClassTag[E],
         mat: Materializer,
         serverOptions: PlayServerOptions
-    ): Routes = {
-      e.serverLogicRecoverErrors(logic).toRoute
-    }
+    ): Routes = PlayServerInterpreter.toRouteRecoverErrors(e)(logic)
   }
 
   implicit class RichPlayServerEndpoint[I, E, O](e: ServerEndpoint[I, E, O, Any, Future]) {
-    def toRoute(implicit mat: Materializer, serverOptions: PlayServerOptions): Routes = {
-      def valueToResponse(value: Any): Future[Result] = {
-        val i = value.asInstanceOf[I]
-        e.logic(new FutureMonad())(i)
-          .map {
-            case Right(result) =>
-              serverOptions.logRequestHandling.requestHandled(e.endpoint, ServerDefaults.StatusCodes.success.code)(serverOptions.logger)
-              OutputToPlayResponse(ServerDefaults.StatusCodes.success, e.output, result)
-            case Left(err) =>
-              serverOptions.logRequestHandling.requestHandled(e.endpoint, ServerDefaults.StatusCodes.error.code)(serverOptions.logger)
-              OutputToPlayResponse(ServerDefaults.StatusCodes.error, e.errorOutput, err)
-          }
-      }
-      def handleDecodeFailure(
-          e: Endpoint[_, _, _, _],
-          input: EndpointInput[_],
-          failure: DecodeResult.Failure
-      ): Result = {
-        val decodeFailureCtx = DecodeFailureContext(input, failure, e)
-        val handling = serverOptions.decodeFailureHandler(decodeFailureCtx)
-        handling match {
-          case DecodeFailureHandling.NoMatch =>
-            serverOptions.logRequestHandling.decodeFailureNotHandled(e, decodeFailureCtx)(serverOptions.logger)
-            Result(header = ResponseHeader(StatusCodes.error.code), body = HttpEntity.NoEntity)
-          case DecodeFailureHandling.RespondWithResponse(output, value) =>
-            serverOptions.logRequestHandling.decodeFailureNotHandled(e, decodeFailureCtx)(serverOptions.logger)
-            OutputToPlayResponse(ServerDefaults.StatusCodes.error, output, value)
-        }
-      }
-
-      def decodeBody(request: Request[RawBuffer], result: DecodeInputsResult)(implicit mat: Materializer): Future[DecodeInputsResult] = {
-        result match {
-          case values: DecodeInputsResult.Values =>
-            values.bodyInput match {
-              case Some(bodyInput @ EndpointIO.Body(bodyType, codec, _)) =>
-                new PlayRequestToRawBody(serverOptions)
-                  .apply(
-                    bodyType,
-                    request.charset.map(Charset.forName),
-                    request,
-                    request.body.asBytes().getOrElse(ByteString.apply(java.nio.file.Files.readAllBytes(request.body.asFile.toPath)))
-                  )
-                  .map { rawBody =>
-                    codec.decode(rawBody) match {
-                      case DecodeResult.Value(bodyV)     => values.setBodyInputValue(bodyV)
-                      case failure: DecodeResult.Failure => DecodeInputsResult.Failure(bodyInput, failure): DecodeInputsResult
-                    }
-                  }
-              case None => Future(values)
-            }
-          case failure: DecodeInputsResult.Failure => Future(failure)
-        }
-      }
-
-      val res = new PartialFunction[RequestHeader, Handler] {
-        override def isDefinedAt(x: RequestHeader): Boolean = {
-          val decodeInputResult = DecodeInputs(e.input, new PlayDecodeInputContext(x, 0, serverOptions))
-          val handlingResult = decodeInputResult match {
-            case DecodeInputsResult.Failure(input, failure) =>
-              val decodeFailureCtx = DecodeFailureContext(input, failure, e.endpoint)
-              serverOptions.logRequestHandling.decodeFailureNotHandled(e.endpoint, decodeFailureCtx)(serverOptions.logger)
-              serverOptions.decodeFailureHandler(decodeFailureCtx) != DecodeFailureHandling.noMatch
-            case DecodeInputsResult.Values(_, _) => true
-          }
-          handlingResult
-        }
-
-        override def apply(v1: RequestHeader): Handler = {
-          serverOptions.defaultActionBuilder.async(serverOptions.playBodyParsers.raw) { request =>
-            decodeBody(request, DecodeInputs(e.input, new PlayDecodeInputContext(v1, 0, serverOptions))).flatMap {
-              case values: DecodeInputsResult.Values =>
-                InputValues(e.input, values) match {
-                  case InputValuesResult.Value(params, _)        => valueToResponse(params.asAny)
-                  case InputValuesResult.Failure(input, failure) => Future.successful(handleDecodeFailure(e.endpoint, input, failure))
-                }
-              case DecodeInputsResult.Failure(input, failure) =>
-                Future.successful(handleDecodeFailure(e.endpoint, input, failure))
-            }
-          }
-        }
-      }
-      res
-    }
+    @deprecated("Use PlayServerInterpreter.toRoute", since = "0.17.1")
+    def toRoute(implicit mat: Materializer, serverOptions: PlayServerOptions): Routes = PlayServerInterpreter.toRoute(e)
   }
 
   implicit class RichPlayServerEndpoints[I, E, O](serverEndpoints: List[ServerEndpoint[_, _, _, Any, Future]]) {
-    def toRoute(implicit mat: Materializer, serverOptions: PlayServerOptions): Routes = {
-      serverEndpoints
-        .map(_.toRoute)
-        .reduce((a: Routes, b: Routes) => a.orElse(b))
-    }
+    @deprecated("Use PlayServerInterpreter.toRoute", since = "0.17.1")
+    def toRoute(implicit mat: Materializer, serverOptions: PlayServerOptions): Routes = PlayServerInterpreter.toRoute(serverEndpoints)
   }
 
   implicit def actionBuilderFromPlayServerOptions(implicit playServerOptions: PlayServerOptions): ActionBuilder[Request, AnyContent] =

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTests.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTests.scala
@@ -14,7 +14,7 @@ class PlayServerTests extends TestSuite {
   override def tests: Resource[IO, List[Test]] = backendResource.flatMap { backend =>
     actorSystemResource.map { implicit actorSystem =>
       implicit val m: FutureMonad = new FutureMonad()(actorSystem.dispatcher)
-      val interpreter = new PlayServerInterpreter()(actorSystem)
+      val interpreter = new PlayTestServerInterpreter()(actorSystem)
       val serverTests = new ServerTests(interpreter)
 
       new ServerBasicTests(

--- a/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/SttpClientTestUsingStub.scala
+++ b/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/SttpClientTestUsingStub.scala
@@ -45,7 +45,7 @@ class SttpClientTestUsingStub extends AnyFunSuite with Matchers {
             .thenSuccess(o)
       }
       val response: Identity[Response[Either[E, O]]] =
-        endpoint.toSttpRequestUnsafe(uri"http://test.com").apply(inputValue).send(backend)
+        SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(inputValue).send(backend)
       verifyResponse(response)
     }
   }

--- a/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/SttpClientTestUsingStub.scala
+++ b/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/SttpClientTestUsingStub.scala
@@ -45,7 +45,7 @@ class SttpClientTestUsingStub extends AnyFunSuite with Matchers {
             .thenSuccess(o)
       }
       val response: Identity[Response[Either[E, O]]] =
-        SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(inputValue).send(backend)
+        SttpClientInterpreter.toRequestUnsafe(endpoint, uri"http://test.com").apply(inputValue).send(backend)
       verifyResponse(response)
     }
   }

--- a/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/SttpStubServerTest.scala
+++ b/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/SttpStubServerTest.scala
@@ -31,7 +31,7 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
       .whenRequestMatchesEndpoint(endpoint)
       .thenSuccess(ResponseWrapper(1.0))
     val response: Identity[Response[Either[Unit, ResponseWrapper]]] =
-      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(11).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint, uri"http://test.com").apply(11).send(backend)
 
     response.body shouldBe Right(ResponseWrapper(1.0))
   }
@@ -50,7 +50,7 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
       .whenRequestMatchesEndpoint(endpoint)
       .thenError(ResponseWrapper(1.0), StatusCode.BadRequest)
     val response: Identity[Response[Either[ResponseWrapper, Unit]]] =
-      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(11).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint, uri"http://test.com").apply(11).send(backend)
 
     response shouldBe Response(Left(ResponseWrapper(1.0)), StatusCode.BadRequest)
   }
@@ -83,7 +83,7 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
       .whenRequestMatchesEndpoint(endpoint)
       .thenSuccess(ResponseWrapper(1.0))
     val response: Identity[Response[Either[Unit, ResponseWrapper]]] =
-      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply("id1" -> 11).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint, uri"http://test.com").apply("id1" -> 11).send(backend)
 
     response.body shouldBe Right(ResponseWrapper(1.0))
   }
@@ -99,7 +99,7 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
       .whenRequestMatchesEndpoint(endpoint)
       .thenSuccess("x")
     val response: Identity[Response[Either[Unit, String]]] =
-      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(()).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint, uri"http://test.com").apply(()).send(backend)
 
     response.body shouldBe Right("x")
     response.header("X") shouldBe Some("x")
@@ -123,9 +123,9 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
       .thenRespondServerError()
 
     val response1: Identity[Response[Either[Unit, ResponseWrapper]]] =
-      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(11).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint, uri"http://test.com").apply(11).send(backend)
     val response2: Identity[Response[Either[Unit, ResponseWrapper]]] =
-      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(-1).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint, uri"http://test.com").apply(-1).send(backend)
 
     response1.body shouldBe Right(ResponseWrapper(1.0))
     response2.body shouldBe Left(())
@@ -151,7 +151,7 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
       .generic
       .thenRespondWithCode(StatusCode.BadRequest)
     val response: Identity[Response[Either[Unit, ResponseWrapper]]] =
-      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(-1).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint, uri"http://test.com").apply(-1).send(backend)
 
     response shouldBe Response(Left(()), StatusCode.BadRequest)
   }

--- a/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/SttpStubServerTest.scala
+++ b/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/SttpStubServerTest.scala
@@ -31,7 +31,7 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
       .whenRequestMatchesEndpoint(endpoint)
       .thenSuccess(ResponseWrapper(1.0))
     val response: Identity[Response[Either[Unit, ResponseWrapper]]] =
-      endpoint.toSttpRequestUnsafe(uri"http://test.com").apply(11).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(11).send(backend)
 
     response.body shouldBe Right(ResponseWrapper(1.0))
   }
@@ -50,7 +50,7 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
       .whenRequestMatchesEndpoint(endpoint)
       .thenError(ResponseWrapper(1.0), StatusCode.BadRequest)
     val response: Identity[Response[Either[ResponseWrapper, Unit]]] =
-      endpoint.toSttpRequestUnsafe(uri"http://test.com").apply(11).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(11).send(backend)
 
     response shouldBe Response(Left(ResponseWrapper(1.0)), StatusCode.BadRequest)
   }
@@ -83,7 +83,7 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
       .whenRequestMatchesEndpoint(endpoint)
       .thenSuccess(ResponseWrapper(1.0))
     val response: Identity[Response[Either[Unit, ResponseWrapper]]] =
-      endpoint.toSttpRequestUnsafe(uri"http://test.com").apply("id1" -> 11).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply("id1" -> 11).send(backend)
 
     response.body shouldBe Right(ResponseWrapper(1.0))
   }
@@ -99,7 +99,7 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
       .whenRequestMatchesEndpoint(endpoint)
       .thenSuccess("x")
     val response: Identity[Response[Either[Unit, String]]] =
-      endpoint.toSttpRequestUnsafe(uri"http://test.com").apply(()).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(()).send(backend)
 
     response.body shouldBe Right("x")
     response.header("X") shouldBe Some("x")
@@ -123,9 +123,9 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
       .thenRespondServerError()
 
     val response1: Identity[Response[Either[Unit, ResponseWrapper]]] =
-      endpoint.toSttpRequestUnsafe(uri"http://test.com").apply(11).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(11).send(backend)
     val response2: Identity[Response[Either[Unit, ResponseWrapper]]] =
-      endpoint.toSttpRequestUnsafe(uri"http://test.com").apply(-1).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(-1).send(backend)
 
     response1.body shouldBe Right(ResponseWrapper(1.0))
     response2.body shouldBe Left(())
@@ -151,7 +151,7 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
       .generic
       .thenRespondWithCode(StatusCode.BadRequest)
     val response: Identity[Response[Either[Unit, ResponseWrapper]]] =
-      endpoint.toSttpRequestUnsafe(uri"http://test.com").apply(-1).send(backend)
+      SttpClientInterpreter.toRequestUnsafe(endpoint)(uri"http://test.com").apply(-1).send(backend)
 
     response shouldBe Response(Left(()), StatusCode.BadRequest)
   }

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -24,7 +24,7 @@ import scala.concurrent.duration.DurationInt
 class ServerBasicTests[F[_], ROUTE](
     backend: SttpBackend[IO, Any],
     serverTests: ServerTests[F, Any, ROUTE],
-    serverInterpreter: ServerInterpreter[F, Any, ROUTE],
+    serverInterpreter: TestServerInterpreter[F, Any, ROUTE],
     multipleValueHeaderSupport: Boolean = true,
     multipartInlineHeaderSupport: Boolean = true,
     inputStreamSupport: Boolean = true

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerTests.scala
@@ -12,7 +12,7 @@ import sttp.tapir._
 import sttp.tapir.server.{DecodeFailureHandler, ServerEndpoint}
 import sttp.tapir.tests._
 
-class ServerTests[F[_], +R, ROUTE](interpreter: ServerInterpreter[F, R, ROUTE])(implicit m: MonadError[F]) extends StrictLogging {
+class ServerTests[F[_], +R, ROUTE](interpreter: TestServerInterpreter[F, R, ROUTE])(implicit m: MonadError[F]) extends StrictLogging {
   def testServer[I, E, O](
       e: Endpoint[I, E, O, R],
       testNameSuffix: String = "",

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/TestServerInterpreter.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/TestServerInterpreter.scala
@@ -8,7 +8,7 @@ import sttp.tapir.tests.Port
 
 import scala.reflect.ClassTag
 
-trait ServerInterpreter[F[_], +R, ROUTE] {
+trait TestServerInterpreter[F[_], +R, ROUTE] {
   implicit lazy val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
   def route[I, E, O](e: ServerEndpoint[I, E, O, R, F], decodeFailureHandler: Option[DecodeFailureHandler] = None): ROUTE
   def routeRecoverErrors[I, E <: Throwable, O](e: Endpoint[I, E, O, R], fn: I => F[O])(implicit eClassTag: ClassTag[E]): ROUTE

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/VertxServerInterpreter.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/VertxServerInterpreter.scala
@@ -1,0 +1,147 @@
+package sttp.tapir.server.vertx
+
+import io.vertx.core.Handler
+import io.vertx.scala.ext.web.{Route, Router, RoutingContext}
+import sttp.monad.{FutureMonad, MonadError}
+import sttp.tapir.Endpoint
+import sttp.tapir.internal.Params
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.vertx.decoders.VertxInputDecoders.decodeBodyAndInputsThen
+import sttp.tapir.server.vertx.encoders.VertxOutputEncoders
+import sttp.tapir.server.vertx.handlers.{attachDefaultHandlers, encodeError, tryEncodeError}
+import sttp.tapir.server.vertx.routing.PathMapping.{RouteDefinition, createRoute, extractRouteDefinition}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success, Try}
+
+trait VertxServerInterpreter {
+
+  /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
+    * @param logic the logic to associate with the endpoint
+    * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
+    * @return A function, that given a router, will attach this endpoint to it
+    */
+  def route[I, E, O](e: Endpoint[I, E, O, Any])(logic: I => Future[Either[E, O]])(implicit
+      endpointOptions: VertxEndpointOptions
+  ): Router => Route =
+    route(e.serverLogic(logic))
+
+  /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
+    * The logic will be executed in a blocking context
+    * @param logic the logic to associate with the endpoint
+    * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
+    * @return A function, that given a router, will attach this endpoint to it
+    */
+  def blockingRoute[I, E, O](e: Endpoint[I, E, O, Any])(logic: I => Future[Either[E, O]])(implicit
+      endpointOptions: VertxEndpointOptions
+  ): Router => Route =
+    blockingRoute(e.serverLogic(logic))
+
+  /** Given a Router, creates and mounts a Route matching this endpoint, with custom error handling
+    * @param logic the logic to associate with the endpoint
+    * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
+    * @return A function, that given a router, will attach this endpoint to it
+    */
+  def routeRecoverErrors[I, E, O](e: Endpoint[I, E, O, Any])(
+      logic: I => Future[O]
+  )(implicit endpointOptions: VertxEndpointOptions, eIsThrowable: E <:< Throwable, eClassTag: ClassTag[E]): Router => Route =
+    route(e.serverLogicRecoverErrors(logic))
+
+  /** Given a Router, creates and mounts a Route matching this endpoint, with custom error handling
+    * The logic will be executed in a blocking context
+    * @param logic the logic to associate with the endpoint
+    * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
+    * @return A function, that given a router, will attach this endpoint to it
+    */
+  def blockingRouteRecoverErrors[I, E, O](e: Endpoint[I, E, O, Any])(
+      logic: I => Future[O]
+  )(implicit endpointOptions: VertxEndpointOptions, eIsThrowable: E <:< Throwable, eClassTag: ClassTag[E]): Router => Route =
+    blockingRoute(e.serverLogicRecoverErrors(logic))
+
+  /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
+    * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
+    * @return A function, that given a router, will attach this endpoint to it
+    */
+  def route[I, E, O](e: ServerEndpoint[I, E, O, Any, Future])(implicit endpointOptions: VertxEndpointOptions): Router => Route = { router =>
+    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint))(endpointOptions, None)
+      .handler(endpointHandler(e)(e.logic, responseHandlerWithError(e))(endpointOptions, None))
+  }
+
+  /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
+    * The logic will be executed in a blocking context
+    * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
+    * @return A function, that given a router, will attach this endpoint to it
+    */
+  def blockingRoute[I, E, O](e: ServerEndpoint[I, E, O, Any, Future])(implicit endpointOptions: VertxEndpointOptions): Router => Route = {
+    router =>
+      mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint))(endpointOptions, None)
+        .blockingHandler(endpointHandler(e)(e.logic, responseHandlerWithError(e))(endpointOptions, None))
+  }
+
+  private def mountWithDefaultHandlers[I, E, O](e: ServerEndpoint[I, E, O, Any, Future])(
+      router: Router,
+      routeDef: RouteDefinition
+  )(implicit endpointOptions: VertxEndpointOptions, ect: Option[ClassTag[E]]): Route =
+    attachDefaultHandlers(e.endpoint, createRoute(router, routeDef))
+
+  private def endpointHandler[I, E, O, A](e: ServerEndpoint[I, E, O, Any, Future])(
+      logic: MonadError[Future] => I => Future[A],
+      responseHandler: (A, RoutingContext) => Unit
+  )(implicit serverOptions: VertxEndpointOptions, ect: Option[ClassTag[E]]): Handler[RoutingContext] = { rc =>
+    val monad = new FutureMonad()(serverOptions.executionContextOrCurrentCtx(rc))
+    decodeBodyAndInputsThen[E](
+      e.endpoint,
+      rc,
+      { params => logicHandler(e)(logic(monad), responseHandler, rc)(serverOptions, ect)(params) }
+    )
+  }
+
+  private def logicHandler[I, E, O, T](
+      e: ServerEndpoint[I, E, O, Any, Future]
+  )(logic: I => Future[T], responseHandler: (T, RoutingContext) => Unit, rc: RoutingContext)(implicit
+      serverOptions: VertxEndpointOptions,
+      ect: Option[ClassTag[E]]
+  ): Params => Unit = { params =>
+    implicit val ec: ExecutionContext = serverOptions.executionContextOrCurrentCtx(rc)
+    Try(logic(params.asAny.asInstanceOf[I]))
+      .map { result =>
+        result.onComplete {
+          case Success(result) =>
+            responseHandler(result, rc)
+          case Failure(cause) =>
+            serverOptions.logRequestHandling.logicException(e.endpoint, cause)(serverOptions.logger)
+            tryEncodeError(e.endpoint, rc, cause)
+        }
+      }
+      .recover { case cause =>
+        tryEncodeError(e.endpoint, rc, cause)
+        serverOptions.logRequestHandling.logicException(e.endpoint, cause)(serverOptions.logger): Unit
+      }
+  }
+
+  private def responseHandlerWithError[I, E, O](
+      e: ServerEndpoint[I, E, O, Any, Future]
+  )(implicit endpointOptions: VertxEndpointOptions): (Either[E, O], RoutingContext) => Unit = { (output, rc) =>
+    output match {
+      case Left(failure) =>
+        encodeError(e.endpoint, rc, failure)
+      case Right(result) =>
+        responseHandlerNoError(e)(endpointOptions)(result, rc)
+    }
+  }
+
+  private def responseHandlerNoError[I, E, O](
+      e: ServerEndpoint[I, E, O, Any, Future]
+  )(implicit endpointOptions: VertxEndpointOptions): (O, RoutingContext) => Unit = { (result, rc) =>
+    VertxOutputEncoders.apply[O](e.output, result, isError = false, logRequestHandled(e))(endpointOptions)(rc)
+  }
+
+  private def logRequestHandled[I, E, O](e: ServerEndpoint[I, E, O, Any, Future])(implicit
+      endpointOptions: VertxEndpointOptions
+  ): Int => Unit =
+    status => endpointOptions.logRequestHandling.requestHandled(e.endpoint, status): Unit
+
+}
+
+object VertxServerInterpreter extends VertxServerInterpreter

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/decoders/VertxInputDecoders.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/decoders/VertxInputDecoders.scala
@@ -3,7 +3,6 @@ package sttp.tapir.server.vertx.decoders
 import java.io.{ByteArrayInputStream, File}
 import java.nio.ByteBuffer
 import java.util.Date
-import io.vertx.lang.scala.VertxExecutionContext
 import io.vertx.scala.ext.web.RoutingContext
 import sttp.model.Part
 import sttp.tapir.internal.Params
@@ -12,7 +11,7 @@ import sttp.tapir.server.vertx.VertxEndpointOptions
 import sttp.tapir.server.vertx.encoders.VertxOutputEncoders
 import sttp.tapir.server.vertx.handlers.tryEncodeError
 import sttp.tapir.server.{DecodeFailureContext, DecodeFailureHandling}
-import sttp.tapir.{DecodeResult, Endpoint, EndpointIO, EndpointInput, RawBodyType}
+import sttp.tapir.{DecodeResult, Endpoint, EndpointIO, RawBodyType}
 
 import java.nio.charset.Charset
 import java.nio.file.{Files, Paths}

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/package.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/package.scala
@@ -1,18 +1,10 @@
 package sttp.tapir.server
 
-import io.vertx.core.Handler
-import io.vertx.scala.ext.web.{Route, Router, RoutingContext}
-import sttp.monad.{FutureMonad, MonadError}
-import sttp.tapir._
-import sttp.tapir.internal.Params
-import sttp.tapir.server.vertx.decoders.VertxInputDecoders._
-import sttp.tapir.server.vertx.encoders.VertxOutputEncoders
-import sttp.tapir.server.vertx.handlers._
-import sttp.tapir.server.vertx.routing.PathMapping._
+import io.vertx.scala.ext.web.{Route, Router}
+import sttp.tapir.Endpoint
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.reflect.ClassTag
-import scala.util.{Failure, Success, Try}
 
 package object vertx {
 
@@ -23,8 +15,9 @@ package object vertx {
       * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
       * @return A function, that given a router, will attach this endpoint to it
       */
+    @deprecated("Use VertxServerInterpreter.route", since = "0.17.1")
     def route(logic: I => Future[Either[E, O]])(implicit endpointOptions: VertxEndpointOptions): Router => Route =
-      e.serverLogic(logic).route
+      VertxServerInterpreter.route(e)(logic)
 
     /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
       * The logic will be executed in a blocking context
@@ -32,18 +25,20 @@ package object vertx {
       * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
       * @return A function, that given a router, will attach this endpoint to it
       */
+    @deprecated("Use VertxServerInterpreter.blockingRoute", since = "0.17.1")
     def blockingRoute(logic: I => Future[Either[E, O]])(implicit endpointOptions: VertxEndpointOptions): Router => Route =
-      e.serverLogic(logic).blockingRoute
+      VertxServerInterpreter.blockingRoute(e)(logic)
 
     /** Given a Router, creates and mounts a Route matching this endpoint, with custom error handling
       * @param logic the logic to associate with the endpoint
       * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
       * @return A function, that given a router, will attach this endpoint to it
       */
+    @deprecated("Use VertxServerInterpreter.routeRecoverErrors", since = "0.17.1")
     def routeRecoverErrors(
         logic: I => Future[O]
     )(implicit endpointOptions: VertxEndpointOptions, eIsThrowable: E <:< Throwable, eClassTag: ClassTag[E]): Router => Route =
-      e.serverLogicRecoverErrors(logic).route
+      VertxServerInterpreter.routeRecoverErrors(e)(logic)
 
     /** Given a Router, creates and mounts a Route matching this endpoint, with custom error handling
       * The logic will be executed in a blocking context
@@ -51,10 +46,11 @@ package object vertx {
       * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
       * @return A function, that given a router, will attach this endpoint to it
       */
+    @deprecated("Use VertxServerInterpreter.blockingRouteRecoverErrors", since = "0.17.1")
     def blockingRouteRecoverErrors(
         logic: I => Future[O]
     )(implicit endpointOptions: VertxEndpointOptions, eIsThrowable: E <:< Throwable, eClassTag: ClassTag[E]): Router => Route =
-      e.serverLogicRecoverErrors(logic).blockingRoute
+      VertxServerInterpreter.blockingRouteRecoverErrors(e)(logic)
   }
 
   implicit class VertxServerEndpoint[I, E, O](e: ServerEndpoint[I, E, O, Any, Future]) {
@@ -63,75 +59,15 @@ package object vertx {
       * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
       * @return A function, that given a router, will attach this endpoint to it
       */
-    def route(implicit endpointOptions: VertxEndpointOptions): Router => Route = { router =>
-      mountWithDefaultHandlers(router, extractRouteDefinition(e.endpoint))(endpointOptions, None)
-        .handler(endpointHandler(e.logic, responseHandlerWithError)(endpointOptions, None))
-    }
+    @deprecated("Use VertxServerInterpreter.route", since = "0.17.1")
+    def route(implicit endpointOptions: VertxEndpointOptions): Router => Route = VertxServerInterpreter.route(e)
 
     /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
       * The logic will be executed in a blocking context
       * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
       * @return A function, that given a router, will attach this endpoint to it
       */
-    def blockingRoute(implicit endpointOptions: VertxEndpointOptions): Router => Route = { router =>
-      mountWithDefaultHandlers(router, extractRouteDefinition(e.endpoint))(endpointOptions, None)
-        .blockingHandler(endpointHandler(e.logic, responseHandlerWithError)(endpointOptions, None))
-    }
-
-    private def mountWithDefaultHandlers(
-        router: Router,
-        routeDef: RouteDefinition
-    )(implicit endpointOptions: VertxEndpointOptions, ect: Option[ClassTag[E]]): Route =
-      attachDefaultHandlers(e.endpoint, createRoute(router, routeDef))
-
-    private def endpointHandler[A](
-        logic: MonadError[Future] => I => Future[A],
-        responseHandler: (A, RoutingContext) => Unit
-    )(implicit serverOptions: VertxEndpointOptions, ect: Option[ClassTag[E]]): Handler[RoutingContext] = { rc =>
-      val monad = new FutureMonad()(serverOptions.executionContextOrCurrentCtx(rc))
-      decodeBodyAndInputsThen[E](
-        e.endpoint,
-        rc,
-        { params => logicHandler(logic(monad), responseHandler, rc)(serverOptions, ect)(params) }
-      )
-    }
-
-    private def logicHandler[T](logic: I => Future[T], responseHandler: (T, RoutingContext) => Unit, rc: RoutingContext)(implicit
-        serverOptions: VertxEndpointOptions,
-        ect: Option[ClassTag[E]]
-    ): Params => Unit = { params =>
-      implicit val ec: ExecutionContext = serverOptions.executionContextOrCurrentCtx(rc)
-      Try(logic(params.asAny.asInstanceOf[I]))
-        .map { result =>
-          result.onComplete {
-            case Success(result) =>
-              responseHandler(result, rc)
-            case Failure(cause) =>
-              serverOptions.logRequestHandling.logicException(e.endpoint, cause)(serverOptions.logger)
-              tryEncodeError(e.endpoint, rc, cause)
-          }
-        }
-        .recover { case cause =>
-          tryEncodeError(e.endpoint, rc, cause)
-          serverOptions.logRequestHandling.logicException(e.endpoint, cause)(serverOptions.logger): Unit
-        }
-    }
-
-    private def responseHandlerWithError(implicit endpointOptions: VertxEndpointOptions): (Either[E, O], RoutingContext) => Unit = {
-      (output, rc) =>
-        output match {
-          case Left(failure) =>
-            encodeError(e.endpoint, rc, failure)
-          case Right(result) =>
-            responseHandlerNoError(endpointOptions)(result, rc)
-        }
-    }
-
-    private def responseHandlerNoError(implicit endpointOptions: VertxEndpointOptions): (O, RoutingContext) => Unit = { (result, rc) =>
-      VertxOutputEncoders.apply[O](e.output, result, isError = false, logRequestHandled)(endpointOptions)(rc)
-    }
-
-    private def logRequestHandled(implicit endpointOptions: VertxEndpointOptions): Int => Unit =
-      status => endpointOptions.logRequestHandling.requestHandled(e.endpoint, status): Unit
+    @deprecated("Use VertxServerInterpreter.blockingRoute", since = "0.17.1")
+    def blockingRoute(implicit endpointOptions: VertxEndpointOptions): Router => Route = VertxServerInterpreter.route(e)
   }
 }

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxBlockingServerTests.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxBlockingServerTests.scala
@@ -15,7 +15,7 @@ class VertxBlockingServerTests extends TestSuite {
   override def tests: Resource[IO, List[Test]] = backendResource.flatMap { backend =>
     vertxResource.map { implicit vertx =>
       implicit val m: FutureMonad = new FutureMonad()(ExecutionContext.global)
-      val interpreter = new VertxServerBlockingInterpreter(vertx)
+      val interpreter = new VertxTestServerBlockingInterpreter(vertx)
       val serverTests = new ServerTests(interpreter)
 
       new ServerBasicTests(

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxServerTests.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxServerTests.scala
@@ -15,7 +15,7 @@ class VertxServerTests extends TestSuite {
   override def tests: Resource[IO, List[Test]] = backendResource.flatMap { backend =>
     vertxResource.map { implicit vertx =>
       implicit val m: FutureMonad = new FutureMonad()(ExecutionContext.global)
-      val interpreter = new VertxServerInterpreter(vertx)
+      val interpreter = new VertxTestServerInterpreter(vertx)
       val serverTests = new ServerTests(interpreter)
 
       new ServerBasicTests(

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxTestServerBlockingInterpreter.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxTestServerBlockingInterpreter.scala
@@ -8,15 +8,15 @@ import sttp.tapir.server.{DecodeFailureHandler, ServerDefaults, ServerEndpoint}
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
-class VertxServerBlockingInterpreter(vertx: Vertx) extends VertxServerInterpreter(vertx) {
+class VertxTestServerBlockingInterpreter(vertx: Vertx) extends VertxTestServerInterpreter(vertx) {
   override def route[I, E, O](
       e: ServerEndpoint[I, E, O, Any, Future],
       decodeFailureHandler: Option[DecodeFailureHandler]
   ): Router => Route =
-    e.blockingRoute(options.copy(decodeFailureHandler.getOrElse(ServerDefaults.decodeFailureHandler)))
+    VertxServerInterpreter.blockingRoute(e)(options.copy(decodeFailureHandler.getOrElse(ServerDefaults.decodeFailureHandler)))
 
   override def routeRecoverErrors[I, E <: Throwable, O](e: Endpoint[I, E, O, Any], fn: I => Future[O])(implicit
       eClassTag: ClassTag[E]
   ): Router => Route =
-    e.blockingRouteRecoverErrors(fn)
+    VertxServerInterpreter.blockingRouteRecoverErrors(e)(fn)
 }

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxTestServerInterpreter.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxTestServerInterpreter.scala
@@ -2,19 +2,18 @@ package sttp.tapir.server.vertx
 
 import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
-import cats.syntax.all._
 import io.vertx.scala.core.Vertx
 import io.vertx.scala.core.http.HttpServerOptions
 import io.vertx.scala.ext.web.{Route, Router}
 import sttp.tapir.Endpoint
-import sttp.tapir.server.tests.ServerInterpreter
+import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.server.{DecodeFailureHandler, ServerDefaults, ServerEndpoint}
 import sttp.tapir.tests.Port
 
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
-class VertxServerInterpreter(vertx: Vertx) extends ServerInterpreter[Future, Any, Router => Route] {
+class VertxTestServerInterpreter(vertx: Vertx) extends TestServerInterpreter[Future, Any, Router => Route] {
   implicit val options: VertxEndpointOptions = VertxEndpointOptions()
     .logWhenHandled(true)
     .logAllDecodeFailures(true)
@@ -23,12 +22,12 @@ class VertxServerInterpreter(vertx: Vertx) extends ServerInterpreter[Future, Any
       e: ServerEndpoint[I, E, O, Any, Future],
       decodeFailureHandler: Option[DecodeFailureHandler]
   ): Router => Route =
-    e.route(options.copy(decodeFailureHandler.getOrElse(ServerDefaults.decodeFailureHandler)))
+    VertxServerInterpreter.route(e)(options.copy(decodeFailureHandler.getOrElse(ServerDefaults.decodeFailureHandler)))
 
   override def routeRecoverErrors[I, E <: Throwable, O](e: Endpoint[I, E, O, Any], fn: I => Future[O])(implicit
       eClassTag: ClassTag[E]
   ): Router => Route =
-    e.routeRecoverErrors(fn)
+    VertxServerInterpreter.routeRecoverErrors(e)(fn)
 
   override def server(routes: NonEmptyList[Router => Route]): Resource[IO, Port] = {
     val router = Router.router(vertx)

--- a/server/zio-http4-server/src/main/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerInterpreter.scala
+++ b/server/zio-http4-server/src/main/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerInterpreter.scala
@@ -8,19 +8,30 @@ import zio.clock.Clock
 import zio.interop.catz._
 
 trait ZHttp4sServerInterpreter {
-  def toRoutes[I, E, O, R](e: ZEndpoint[I, E, O])(logic: I => ZIO[R, E, O])(implicit
+  def from[I, E, O, R](e: ZEndpoint[I, E, O])(logic: I => ZIO[R, E, O])(implicit
       serverOptions: Http4sServerOptions[RIO[R with Clock, *]]
-  ): HttpRoutes[RIO[R with Clock, *]] =
-    toRoutes[R, I, E, O](e.zServerLogic(logic))
+  ): ServerEndpointsToRoutes[R] =
+    from[R, I, E, O](e.zServerLogic(logic))
 
-  def toRoutes[R, I, E, O](se: ZServerEndpoint[R, I, E, O])(implicit
+  def from[R, I, E, O](se: ZServerEndpoint[R, I, E, O])(implicit
       serverOptions: Http4sServerOptions[RIO[R with Clock, *]]
-  ): HttpRoutes[RIO[R with Clock, *]] = toRoutes[R](List(se))
+  ): ServerEndpointsToRoutes[R] = from[R](List(se))
 
-  def toRoutes[R](
+  def from[R](
       serverEndpoints: List[ZServerEndpoint[R, _, _, _]]
-  )(implicit serverOptions: Http4sServerOptions[RIO[R with Clock, *]]): HttpRoutes[RIO[R with Clock, *]] = {
-    new EndpointToHttp4sServer(serverOptions).toRoutes(serverEndpoints.map(_.widen[R with Clock]))
+  )(implicit serverOptions: Http4sServerOptions[RIO[R with Clock, *]]): ServerEndpointsToRoutes[R] =
+    new ServerEndpointsToRoutes[R](serverEndpoints, serverOptions)
+
+  // This is needed to avoid too eager type inference. Having ZHttp4sServerInterpreter.toRoutes would require users
+  // to explicitly provide the env type (R) as a type argument - so that it's not automatically inferred to include
+  // Clock
+  class ServerEndpointsToRoutes[R](
+      serverEndpoints: List[ZServerEndpoint[R, _, _, _]],
+      serverOptions: Http4sServerOptions[RIO[R with Clock, *]]
+  ) {
+    def toRoutes: HttpRoutes[RIO[R with Clock, *]] = {
+      new EndpointToHttp4sServer(serverOptions).toRoutes(serverEndpoints.map(_.widen[R with Clock]))
+    }
   }
 }
 

--- a/server/zio-http4-server/src/main/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerInterpreter.scala
+++ b/server/zio-http4-server/src/main/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerInterpreter.scala
@@ -1,0 +1,27 @@
+package sttp.tapir.server.http4s.ztapir
+
+import org.http4s.HttpRoutes
+import sttp.tapir.server.http4s.{EndpointToHttp4sServer, Http4sServerOptions}
+import sttp.tapir.ztapir._
+import zio.{RIO, ZIO}
+import zio.clock.Clock
+import zio.interop.catz._
+
+trait ZHttp4sServerInterpreter {
+  def toRoutes[I, E, O, R](e: ZEndpoint[I, E, O])(logic: I => ZIO[R, E, O])(implicit
+      serverOptions: Http4sServerOptions[RIO[R with Clock, *]]
+  ): HttpRoutes[RIO[R with Clock, *]] =
+    toRoutes[R, I, E, O](e.zServerLogic(logic))
+
+  def toRoutes[R, I, E, O](se: ZServerEndpoint[R, I, E, O])(implicit
+      serverOptions: Http4sServerOptions[RIO[R with Clock, *]]
+  ): HttpRoutes[RIO[R with Clock, *]] = toRoutes[R](List(se))
+
+  def toRoutes[R](
+      serverEndpoints: List[ZServerEndpoint[R, _, _, _]]
+  )(implicit serverOptions: Http4sServerOptions[RIO[R with Clock, *]]): HttpRoutes[RIO[R with Clock, *]] = {
+    new EndpointToHttp4sServer(serverOptions).toRoutes(serverEndpoints.map(_.widen[R with Clock]))
+  }
+}
+
+object ZHttp4sServerInterpreter extends ZHttp4sServerInterpreter

--- a/server/zio-http4-server/src/main/scala/sttp/tapir/server/http4s/ztapir/package.scala
+++ b/server/zio-http4-server/src/main/scala/sttp/tapir/server/http4s/ztapir/package.scala
@@ -8,17 +8,21 @@ import zio.{RIO, ZIO}
 
 package object ztapir {
   implicit class RichZEndpointRoutes[I, E, O](e: ZEndpoint[I, E, O]) {
+    @deprecated("Use ZHttp4sServerInterpreter.toRoutes", since = "0.17.1")
     def toRoutes[R](logic: I => ZIO[R, E, O])(implicit
         serverOptions: Http4sServerOptions[RIO[R with Clock, *]]
     ): HttpRoutes[RIO[R with Clock, *]] =
-      e.zServerLogic(logic).toRoutes
+      ZHttp4sServerInterpreter.toRoutes[R, I, E, O](e.zServerLogic(logic))
   }
 
   implicit class RichZServerEndpointRoutes[R, I, E, O](se: ZServerEndpoint[R, I, E, O]) {
-    def toRoutes(implicit serverOptions: Http4sServerOptions[RIO[R with Clock, *]]): HttpRoutes[RIO[R with Clock, *]] = List(se).toRoutes
+    @deprecated("Use ZHttp4sServerInterpreter.toRoutes", since = "0.17.1")
+    def toRoutes(implicit serverOptions: Http4sServerOptions[RIO[R with Clock, *]]): HttpRoutes[RIO[R with Clock, *]] =
+      ZHttp4sServerInterpreter.toRoutes[R](List(se))
   }
 
   implicit class RichZServerEndpointsRoutes[R, I, E, O](serverEndpoints: List[ZServerEndpoint[R, _, _, _]]) {
+    @deprecated("Use ZHttp4sServerInterpreter.toRoutes", since = "0.17.1")
     def toRoutes(implicit serverOptions: Http4sServerOptions[RIO[R with Clock, *]]): HttpRoutes[RIO[R with Clock, *]] = {
       new EndpointToHttp4sServer(serverOptions).toRoutes(serverEndpoints.map(_.widen[R with Clock]))
     }

--- a/server/zio-http4-server/src/main/scala/sttp/tapir/server/http4s/ztapir/package.scala
+++ b/server/zio-http4-server/src/main/scala/sttp/tapir/server/http4s/ztapir/package.scala
@@ -3,28 +3,27 @@ package sttp.tapir.server.http4s
 import org.http4s.HttpRoutes
 import sttp.tapir.ztapir._
 import zio.clock.Clock
-import zio.interop.catz._
 import zio.{RIO, ZIO}
 
 package object ztapir {
   implicit class RichZEndpointRoutes[I, E, O](e: ZEndpoint[I, E, O]) {
-    @deprecated("Use ZHttp4sServerInterpreter.toRoutes", since = "0.17.1")
+    @deprecated("Use ZHttp4sServerInterpreter.from.toRoutes", since = "0.17.1")
     def toRoutes[R](logic: I => ZIO[R, E, O])(implicit
         serverOptions: Http4sServerOptions[RIO[R with Clock, *]]
     ): HttpRoutes[RIO[R with Clock, *]] =
-      ZHttp4sServerInterpreter.toRoutes[R, I, E, O](e.zServerLogic(logic))
+      ZHttp4sServerInterpreter.from[R, I, E, O](e.zServerLogic(logic)).toRoutes
   }
 
   implicit class RichZServerEndpointRoutes[R, I, E, O](se: ZServerEndpoint[R, I, E, O]) {
-    @deprecated("Use ZHttp4sServerInterpreter.toRoutes", since = "0.17.1")
+    @deprecated("Use ZHttp4sServerInterpreter.from.toRoutes", since = "0.17.1")
     def toRoutes(implicit serverOptions: Http4sServerOptions[RIO[R with Clock, *]]): HttpRoutes[RIO[R with Clock, *]] =
-      ZHttp4sServerInterpreter.toRoutes[R](List(se))
+      ZHttp4sServerInterpreter.from[R](List(se)).toRoutes
   }
 
   implicit class RichZServerEndpointsRoutes[R, I, E, O](serverEndpoints: List[ZServerEndpoint[R, _, _, _]]) {
-    @deprecated("Use ZHttp4sServerInterpreter.toRoutes", since = "0.17.1")
+    @deprecated("Use ZHttp4sServerInterpreter.from.toRoutes", since = "0.17.1")
     def toRoutes(implicit serverOptions: Http4sServerOptions[RIO[R with Clock, *]]): HttpRoutes[RIO[R with Clock, *]] = {
-      new EndpointToHttp4sServer(serverOptions).toRoutes(serverEndpoints.map(_.widen[R with Clock]))
+      ZHttp4sServerInterpreter.from(serverEndpoints).toRoutes
     }
   }
 }

--- a/server/zio-http4-server/src/test/scala/sttp/tapir/server/http4s/ztapir/ZEndpointTest.scala
+++ b/server/zio-http4-server/src/test/scala/sttp/tapir/server/http4s/ztapir/ZEndpointTest.scala
@@ -21,6 +21,7 @@ class ZEndpointTest extends AnyFlatSpec with Matchers {
       endpoint.serverLogic(_ => ZIO.succeed(Right(())): ZIO[Service2, Nothing, Either[Unit, Unit]])
 
     type Env = Service1 with Service2
-    val routes: HttpRoutes[RIO[Env with Clock, *]] = List(serverEndpoint1.widen[Env], serverEndpoint2.widen[Env]).toRoutes
+    val routes: HttpRoutes[RIO[Env with Clock, *]] =
+      ZHttp4sServerInterpreter.toRoutes[Env](List(serverEndpoint1.widen, serverEndpoint2.widen))
   }
 }

--- a/server/zio-http4-server/src/test/scala/sttp/tapir/server/http4s/ztapir/ZEndpointTest.scala
+++ b/server/zio-http4-server/src/test/scala/sttp/tapir/server/http4s/ztapir/ZEndpointTest.scala
@@ -22,6 +22,6 @@ class ZEndpointTest extends AnyFlatSpec with Matchers {
 
     type Env = Service1 with Service2
     val routes: HttpRoutes[RIO[Env with Clock, *]] =
-      ZHttp4sServerInterpreter.toRoutes[Env](List(serverEndpoint1.widen, serverEndpoint2.widen))
+      ZHttp4sServerInterpreter.from(List(serverEndpoint1.widen, serverEndpoint2.widen)).toRoutes
   }
 }

--- a/server/zio-http4-server/src/test/scala/sttp/tapir/server/http4s/ztapir/ZEndpointTest.scala
+++ b/server/zio-http4-server/src/test/scala/sttp/tapir/server/http4s/ztapir/ZEndpointTest.scala
@@ -22,6 +22,6 @@ class ZEndpointTest extends AnyFlatSpec with Matchers {
 
     type Env = Service1 with Service2
     val routes: HttpRoutes[RIO[Env with Clock, *]] =
-      ZHttp4sServerInterpreter.from(List(serverEndpoint1.widen, serverEndpoint2.widen)).toRoutes
+      ZHttp4sServerInterpreter.from(List(serverEndpoint1.widen[Env], serverEndpoint2.widen[Env])).toRoutes
   }
 }


### PR DESCRIPTION
The primary way of interpreting endpoints is now using `AkkaHttpServerInterpreter`, `SttpClientInterpreter`, `OpenAPIDocsInterpreter` etc.