### PR TITLE
Pass failure as a pure value

### DIFF
--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestToRawBody.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestToRawBody.scala
@@ -28,7 +28,7 @@ private[http4s] class Http4sRequestToRawBody[F[_]: Sync: ContextShift](serverOpt
         // TODO: use MultipartDecoder.mixedMultipart once available?
         implicitly[EntityDecoder[F, multipart.Multipart[F]]].decode(req, strict = false).value.flatMap {
           case Left(failure) =>
-            IO(failure).asInstanceOf[F[R]]
+            Sync[F].pure(failure.asInstanceOf[R])
           case Right(mp) =>
             val rawPartsF: Vector[F[RawPart]] = mp.parts
               .flatMap(part => part.name.flatMap(name => m.partType(name)).map((part, _)).toList)

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -261,6 +261,15 @@ class ServerBasicTests[F[_], ROUTE](
           r.body should include("file2:daisy luigi")
         }
     },
+    testServer(in_raw_multipart_out_string, "with error")((_: Seq[Part[Array[Byte]]]) => pureResult(Left(()))) { baseUri =>
+      val file1 = writeToFile("peach mario")
+      basicStringRequest
+        .post(uri"$baseUri/api/echo/multipart")
+        .header(HeaderNames.ContentType, sttp.model.MediaType.ApplicationJson.toString)
+        .multipartBody(multipartFile("file1", file1).fileName("file1.txt"))
+        .send(backend)
+        .map(r => r.code shouldBe StatusCode.BadRequest)
+    },
     testServer(in_query_out_string, "invalid query parameter")((fruit: String) => pureResult(s"fruit: $fruit".asRight[Unit])) { baseUri =>
       basicRequest.get(uri"$baseUri?fruit2=orange").send(backend).map(_.code shouldBe StatusCode.BadRequest)
     },


### PR DESCRIPTION
When `http4s` encounters an issue while decoding a body as part of a multipart request, it returns a failure, i.e. `DecodeFailure`. In my case this was happening while using `EntityLimiter` with `http4s` and submitting requests with bodies above the allowed limit. 

While this is all fine, tapir has been handling this failure by catching it in `Http4sRequestToRawBody` but acting on it by throwing an exception, causing the endpoint to close the connection with `503`, and thereby not providing any means more carefully return the right error code or message (or any other logic):

```
13:46:41.153 [pool-2-thread-2] ERROR org.http4s.server.service-errors - Error servicing request: POST /file/v1 from 0:0:0:0:0:0:0:1
java.lang.IllegalArgumentException: Cannot decode multipart body: org.http4s.InvalidMessageBodyFailure: Invalid message body: Invalid multipart body
	at sttp.tapir.server.http4s.Http4sRequestToRawBody.$anonfun$apply$9(Http4sRequestToRawBody.scala:32)
        ...
```
In this example `http4s` is sending down `org.http4s.InvalidMessageBodyFailure` which is the correct response since I have enabled `EntityLimiter` in this example.

Ideally we could raise an error (e.g. `Sync[F].raiseError(failure)`), but to avoid a larger refactor it seems like a reasonable middle ground to return `Sync[F].pure(failure.asInstanceOf[R])` instead. With this approach it's possible to catch the actual error (throwable) downstream using the `DecodeFailureHandler` pattern.