### PR TITLE
Handle responses with the same status code and different media types

### DIFF
--- a/apispec/openapi-model/src/main/scala/sttp/tapir/openapi/OpenAPI.scala
+++ b/apispec/openapi-model/src/main/scala/sttp/tapir/openapi/OpenAPI.scala
@@ -164,7 +164,15 @@ case object ResponsesDefaultKey extends ResponsesKey
 case class ResponsesCodeKey(code: Int) extends ResponsesKey
 
 // todo: links
-case class Response(description: String, headers: ListMap[String, ReferenceOr[Header]], content: ListMap[String, MediaType])
+case class Response(description: String, headers: ListMap[String, ReferenceOr[Header]], content: ListMap[String, MediaType]) {
+
+  def merge(other: Response): Response =
+    Response(
+      description,
+      headers ++ other.headers,
+      content ++ other.content
+    )
+}
 
 case class Example(summary: Option[String], description: Option[String], value: Option[ExampleValue], externalValue: Option[String])
 

--- a/core/src/main/scala/sttp/tapir/Endpoint.scala
+++ b/core/src/main/scala/sttp/tapir/Endpoint.scala
@@ -9,6 +9,7 @@ import sttp.tapir.server.{PartialServerEndpoint, ServerEndpoint, ServerEndpointI
 import sttp.tapir.typelevel.{FnComponents, ParamConcat, ParamSubtract}
 import sttp.tapir.internal._
 
+import scala.collection.immutable.Nil
 import scala.reflect.ClassTag
 
 /** @tparam I Input parameter types.
@@ -177,13 +178,13 @@ trait EndpointMetaOps[I, E, O, -R] {
     */
   def show: String = {
     def showOutputs(o: EndpointOutput[_]): String = {
-      val basicOutputsMap = o.asBasicOutputsMap
+      val basicOutputsMap = o.asBasicOutputsList
 
-      basicOutputsMap.get(None) match {
-        case Some(defaultOutputs) if basicOutputsMap.size == 1 =>
+      basicOutputsMap match {
+        case (None, defaultOutputs) :: Nil =>
           showMultiple(defaultOutputs.sortByType)
-        case _ =>
-          val mappings = basicOutputsMap.map { case (_, os) =>
+        case list =>
+          val mappings = list.map { case (_, os) =>
             showMultiple(os)
           }
           showOneOf(mappings.toSeq)

--- a/docs/openapi-docs/src/test/resources/expected_the_same_status_codes.yml
+++ b/docs/openapi-docs/src/test/resources/expected_the_same_status_codes.yml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: Fruits
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        '200':
+          description: not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFound'
+            text/plain:
+              schema:
+                type: string
+        '204':
+          description: unknown
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Unknown'
+components:
+  schemas:
+    NotFound:
+      required:
+        - what
+      type: object
+      properties:
+        what:
+          type: string
+    Unknown:
+      required:
+        - code
+        - msg
+      type: object
+      properties:
+        code:
+          type: integer
+        msg:
+          type: string


### PR DESCRIPTION
Accordingly OpenAPI documentation one status code may have several response schemas with different media types. For example,
```
  "200": {
    "description": "a pet to be returned",
    "content": {
      "application/json": {
        "schema": {
          "$ref": "#/components/schemas/Pet"
        }
      },
      "text/plain": {
        "schema": {
          "type": "string"
        }
      }
    }
  }
 ```

But function RichEndpointOutput.asBasicOutputsList returns map from status code to response. So OpenAPI contains only one response per status code.