### PR TITLE
make creation of http clients easier

### DIFF
--- a/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/internal/Util.scala
+++ b/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/internal/Util.scala
@@ -1,0 +1,10 @@
+package sttp.tapir.client.sttp.internal
+
+import sttp.tapir.Endpoint
+
+object Util {
+  def throwError[I, E, O, R](endpoint: Endpoint[I, E, O, R], agr: I, e: E): Nothing = {
+    val desc = endpoint.info.name.fold("")(name => s" $name")
+    sys.error(s"Server$desc returned error $e. Argument: $agr")
+  }
+}

--- a/client/sttp-client/src/main/scalajs/sttp/tapir/client/sttp/SttpClientInterpreterExtensions.scala
+++ b/client/sttp-client/src/main/scalajs/sttp/tapir/client/sttp/SttpClientInterpreterExtensions.scala
@@ -35,3 +35,4 @@ trait SttpClientInterpreterExtensions {
         )
   }
 }
+

--- a/client/sttp-client/src/main/scalajs/sttp/tapir/client/sttp/SttpClientInterpreterExtensions.scala
+++ b/client/sttp-client/src/main/scalajs/sttp/tapir/client/sttp/SttpClientInterpreterExtensions.scala
@@ -1,0 +1,37 @@
+package sttp.tapir.client.sttp
+
+import sttp.client3.FetchBackend
+import sttp.model.Uri
+import sttp.tapir.Endpoint
+import sttp.tapir.client.sttp.internal.Util
+
+import scala.concurrent.Future
+
+trait SttpClientInterpreterExtensions {
+  def toQuickClient[I, E, O](e: Endpoint[I, E, O, Any], baseUri: Uri)(implicit
+      clientOptions: SttpClientOptions
+  ): I => Future[Either[E, O]] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val backend = FetchBackend()
+    val req = new EndpointToSttpClient(clientOptions, WebSocketToPipe.webSocketsNotSupportedForAny).toSttpRequestUnsafe(e, baseUri)
+    (i: I) => backend.send(req(i)).map(_.body)
+  }
+
+  def toQuickClientThrowErrors[I, E, O](e: Endpoint[I, E, O, Any], baseUri: Uri)(implicit
+      clientOptions: SttpClientOptions
+  ): I => Future[O] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val backend = FetchBackend()
+    val req = new EndpointToSttpClient(clientOptions, WebSocketToPipe.webSocketsNotSupportedForAny).toSttpRequestUnsafe(e, baseUri)
+    (i: I) =>
+      backend
+        .send(req(i))
+        .map(resp =>
+          resp.body
+            .fold(
+              err => Util.throwError(e, i, err),
+              identity
+            )
+        )
+  }
+}

--- a/client/sttp-client/src/main/scalajvm/sttp/tapir/client/sttp/SttpClientInterpreterExtensions.scala
+++ b/client/sttp-client/src/main/scalajvm/sttp/tapir/client/sttp/SttpClientInterpreterExtensions.scala
@@ -1,0 +1,32 @@
+package sttp.tapir.client.sttp
+
+import sttp.client3.HttpURLConnectionBackend
+import sttp.model.Uri
+import sttp.tapir.Endpoint
+import sttp.tapir.client.sttp.internal.Util
+
+trait SttpClientInterpreterExtensions {
+
+  def toQuickClient[I, E, O](e: Endpoint[I, E, O, Any], baseUri: Uri)(implicit
+      clientOptions: SttpClientOptions
+  ): I => Either[E, O] = {
+    val backend = HttpURLConnectionBackend()
+    val req = new EndpointToSttpClient(clientOptions, WebSocketToPipe.webSocketsNotSupportedForAny).toSttpRequestUnsafe(e, baseUri)
+    (i: I) => backend.send(req(i)).body
+  }
+
+  def toQuickClientThrowErrors[I, E, O](e: Endpoint[I, E, O, Any], baseUri: Uri)(implicit
+      clientOptions: SttpClientOptions
+  ): I => O = {
+    val backend = HttpURLConnectionBackend()
+    val req = new EndpointToSttpClient(clientOptions, WebSocketToPipe.webSocketsNotSupportedForAny).toSttpRequestUnsafe(e, baseUri)
+    (i: I) =>
+      backend
+        .send(req(i))
+        .body
+        .fold(
+          err => Util.throwError[I, E, O, Any](e, i, err),
+          identity
+        )
+  }
+}


### PR DESCRIPTION
I'm trying to replicate spring-like (the good parts :) ) experience creating http clients.
Given an endpoint `Endpoint[I, E, O]` I want to easily create create clients of types `I => Either[E, O]`, `I => O`, `I => ZIO[Any, E, O]`... 

Currently I have to first create an interpreter (so, deal with `Request` and `Response` objects), then create a backend (so, probably deal with HKTs) and then do some plumbing.

This PR tries to
1) add `toClientUnsafe` method that puts together a backend and an interpreter
2) add helper methods for creating minimalistic synchronous backends

If this direction is right, let's also add Fetch and AsyncHttp backends