### PR TITLE
Support cats and zio in vertx interpreter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -695,10 +695,12 @@ lazy val vertxServer: ProjectMatrix = (projectMatrix in file("server/vertx"))
   .settings(
     name := "tapir-vertx-server",
     libraryDependencies ++= Seq(
-      "io.vertx" %% "vertx-web-scala" % Versions.vertx
+      "io.vertx" % "vertx-web" % Versions.vertx,
+      "com.softwaremill.sttp.shared" %% "fs2" % Versions.sttpShared % Optional,
+      "com.softwaremill.sttp.shared" %% "zio" % Versions.sttpShared % Optional
     )
   )
-  .jvmPlatform(scalaVersions = scala2_12Versions)
+  .jvmPlatform(scalaVersions = allScalaVersions)
   .dependsOn(core, serverTests % Test)
 
 lazy val zioServer: ProjectMatrix = (projectMatrix in file("server/zio-http4s-server"))

--- a/core/src/main/scala/sttp/tapir/server/internal/EncodeOutputs.scala
+++ b/core/src/main/scala/sttp/tapir/server/internal/EncodeOutputs.scala
@@ -39,7 +39,7 @@ class EncodeOutputs[B, W, S](encodeOutputBody: EncodeOutputBody[B, W, S]) {
       case EndpointIO.FixedHeader(header, _, _)     => ov.withHeader(header.name -> header.value)
       case EndpointIO.Body(rawValueType, codec, _)  => ov.withBody(encodeOutputBody.rawValueToBody(encoded[Any], codec.format, rawValueType))
       case EndpointIO.StreamBodyWrapper(StreamBodyIO(_, codec, _, charset)) =>
-        ov.withBody(encodeOutputBody.streamValueToBody(encoded[encodeOutputBody.streams.BinaryStream], codec.format, charset))
+        ov.withBody(encodeOutputBody.streamValueToBody(encoded, codec.format, charset))
       case EndpointIO.Header(name, _, _) =>
         encoded[List[String]].foldLeft(ov) { case (ovv, headerValue) => ovv.withHeader((name, headerValue)) }
       case EndpointIO.Headers(_, _)           => encoded[List[sttp.model.Header]].foldLeft(ov)((ov2, h) => ov2.withHeader((h.name, h.value)))

--- a/doc/server/vertx.md
+++ b/doc/server/vertx.md
@@ -2,39 +2,43 @@
 
 Endpoints can be mounted as Vert.x `Route`s on top of a Vert.x `Router`.
 
-Use the following dependency
+Vert.x interpreter can be used with different effect systems (cats-effect, ZIO) as well as Scala's standard `Future`.
+
+## Scala's standard `Future`
+
+Add the following dependency
 ```scala
 "com.softwaremill.sttp.tapir" %% "tapir-vertx-server" % "@VERSION@"
 ```
+to use this interpreter with `Future`.
 
 Then import the object:
-
 ```scala mdoc:compile-only
-import sttp.tapir.server.vertx.VertxServerInterpreter
+import sttp.tapir.server.vertx.VertxFutureServerInterpreter._
 ```
 
-This object contains the following methods: 
+This object contains the following methods:
 
-* `route(e: Endpoint[I, E, O, Any], logic: I => Future[Either[E, O]])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. Errors will be recovered automatically (but generically)
-* `routeRecoverErrors(e: Endpoint[I, E, O, Any], logic: I => Future[O])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. You're providing your own way to deal with errors happening in the `logic` function.
-* `blockingRoute(e: Endpoint[I, E, O, Any], logic: I => Future[Either[E, O]])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an blocking handler. Errors will be recovered automatically (but generically)
-* `blockingRouteRecoverErrors(e: Endpoint[I, E, O, Any], logic: I => Future[O])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as a blocking handler. You're providing your own way to deal with errors happening in the `logic` function.
+* `route(e: Endpoint[I, E, O, Any])(logic: I => Future[Either[E, O]])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. Errors will be recovered automatically (but generically)
+* `routeRecoverErrors(e: Endpoint[I, E, O, Any])(logic: I => Future[O])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. You're providing your own way to deal with errors happening in the `logic` function.
+* `blockingRoute(e: Endpoint[I, E, O, Any])(logic: I => Future[Either[E, O]])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an blocking handler. Errors will be recovered automatically (but generically)
+* `blockingRouteRecoverErrors(e: Endpoint[I, E, O, Any])(logic: I => Future[O])`: returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as a blocking handler. You're providing your own way to deal with errors happening in the `logic` function.
 
-The methods recovering errors from failed effects, require `E` to be a subclass of `Throwable` (an exception); and expect a function of type `I => Future[O]`. For example:
+The methods recovering errors from failed effects, require `E` to be a subclass of `Throwable` (an exception); and expect a function of type `I => Future[O]`.
 
 Note that the second argument to `route` etc. is a function with one argument, a tuple of type `I`. This means that 
 functions which take multiple arguments need to be converted to a function using a single argument using `.tupled`:
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.vertx.{ VertxServerInterpreter, VertxEndpointOptions }
-import io.vertx.scala.ext.web._
+import sttp.tapir.server.vertx.{ VertxFutureEndpointOptions, VertxFutureServerInterpreter }
+import io.vertx.ext.web._
 import scala.concurrent.Future
 
-implicit val options: VertxEndpointOptions = ???
+implicit val options: VertxFutureEndpointOptions = ???
 def logic(s: String, i: Int): Future[Either[Unit, String]] = ???
 val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ??? 
-val aRoute: Router => Route = VertxServerInterpreter.route(anEndpoint)((logic _).tupled)
+val aRoute: Router => Route = VertxFutureServerInterpreter.route(anEndpoint)((logic _).tupled)
 ```
 
 In practice, routes will be mounted on a router, this router can then be used as a request handler for your http server. 
@@ -42,33 +46,171 @@ An HTTP server can then be started as in the following example:
 
 ```scala mdoc:compile-only
 import sttp.tapir._
-import sttp.tapir.server.vertx.{ VertxServerInterpreter, VertxEndpointOptions }
-import io.vertx.scala.core.Vertx
-import io.vertx.scala.ext.web._
-import scala.concurrent.Future
+import sttp.tapir.server.vertx.VertxFutureEndpointOptions
+import sttp.tapir.server.vertx.VertxFutureServerInterpreter._
+import io.vertx.core.Vertx
+import io.vertx.ext.web._
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
 
 object Main {
   // JVM entry point that starts the HTTP server
   def main(args: Array[String]): Unit = {
-    implicit val options: VertxEndpointOptions = ???
+    implicit val options: VertxFutureEndpointOptions = ???
     val vertx = Vertx.vertx()
     val server = vertx.createHttpServer()
     val router = Router.router(vertx)
     val anEndpoint: Endpoint[(String, Int), Unit, String, Any] = ??? // your definition here
-    def logic(s: String, i: Int): Future[Either[Unit, String]] = ??? // your logic here 
-    val attach = VertxServerInterpreter.route(anEndpoint)((logic _).tupled)
+    def logic(s: String, i: Int): Future[Either[Unit, String]] = ??? // your logic here
+    val attach = route(anEndpoint)((logic _).tupled)
     attach(router) // your endpoint is now attached to the router, and the route has been created
-    server.requestHandler(router).listenFuture(9000)
+    Await.result(server.requestHandler(router).listen(9000).asScala, Duration.Inf)
   }
 }
 ```
 
 ## Configuration
 
-Every endpoint can be configured by providing an implicit `VertxEndpointOptions`, see [server options](options.md) for details.
+Every endpoint can be configured by providing an implicit `VertxFutureEndpointOptions`, see [server options](options.md) for details.
 You can also provide your own `ExecutionContext` to execute the logic.
 
 ## Defining an endpoint together with the server logic
 
 It's also possible to define an endpoint together with the server logic in a single, more concise step. See
 [server logic](logic.md) for details.
+
+## Cats Effect typeclasses
+
+Add the following dependency
+```scala
+"com.softwaremill.sttp.tapir" %% "tapir-vertx-server" % "@VERSION@"
+"com.softwaremill.sttp.shared" %% "fs2" % "LatestVersion"
+```
+to use this interpreter with Cats Effect typeclasses.
+
+Then import the object:
+```scala mdoc:compile-only
+import sttp.tapir.server.vertx.VertxCatsServerInterpreter._
+```
+
+This object contains the following methods:
+
+* `route[F[_], I, E, O](e: Endpoint[I, E, O, Fs2Streams[F]])(logic: I => F[Either[E, O]])` returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your logic as an handler. Errors will be recovered automatically.
+* `routeRecoverErrors[F[_], I, E, O](e: Endpoint[I, E, O, Fs2Streams[F]])(logic: I => F[O])` returns a function `Router => Route` that will create a route matching the endpoint definition, and attach your `logic` as an handler. You're providing your own way to deal with errors happening in the `logic` function.
+
+Here is simple example which starts HTTP server with one route:
+```scala mdoc:compile-only
+import cats.effect._
+import cats.syntax.flatMap._
+import io.vertx.core.Vertx
+import io.vertx.ext.web.Router
+import sttp.tapir._
+import sttp.tapir.server.vertx.VertxCatsServerInterpreter._
+import sttp.tapir.server.vertx.VertxEffectfulEndpointOptions
+
+object App extends IOApp {
+
+  implicit val opts = VertxEffectfulEndpointOptions()
+
+  val responseEndpoint =
+    endpoint
+      .in("response")
+      .in(query[String]("key"))
+      .out(plainBody[String])
+
+  def handler(req: String): IO[Either[Unit, String]] =
+    IO.pure(Right(req))
+
+  val attach = route(responseEndpoint)(handler)
+
+  override def run(args: List[String]): IO[ExitCode] =
+    Resource.make(IO.delay{
+      val vertx = Vertx.vertx()
+      val server = vertx.createHttpServer()
+      val router = Router.router(vertx)
+      attach(router)
+      server.requestHandler(router).listen(8080)
+    } >>= (_.liftF[IO]))({ server =>
+      IO.delay(server.close) >>= (_.liftF[IO].void)
+    }).use(_ => IO.never)
+}
+```
+
+This interpreter also supports streaming using FS2 streams:
+```scala mdoc:compile-only
+import cats.effect._
+import fs2._
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.tapir._
+import sttp.tapir.server.vertx.VertxCatsServerInterpreter._
+import sttp.tapir.server.vertx.VertxEffectfulEndpointOptions
+
+implicit val effect: ConcurrentEffect[IO] = ???
+
+implicit val opts = VertxEffectfulEndpointOptions()
+
+val streamedResponse =
+  endpoint
+    .in("stream")
+    .in(query[Int]("key"))
+    .out(streamBody(Fs2Streams[IO])(Schema.string, CodecFormat.TextPlain()))
+
+val attach = route(streamedResponse) { key =>
+  IO.pure(Right(Stream.chunk(Chunk.array("Hello world!".getBytes)).repeatN(key)))
+}
+```
+
+## ZIO
+
+Add the following dependency
+```scala
+"com.softwaremill.sttp.tapir" %% "tapir-vertx-server" % "@VERSION@"
+"com.softwaremill.sttp.shared" %% "zio" % "LatestVersion"
+```
+to use this interpreter with ZIO.
+
+Then import the object:
+```scala mdoc:compile-only
+import sttp.tapir.server.vertx.VertxZioServerInterpreter._
+```
+
+This object contains method `route[R, I, E, O](e: Endpoint[I, E, O, ZioStreams])(logic: I => ZIO[R, E, O])` which returns a function `Router => Route` that will create a route maching the endpoint definition, and attach your logic as an handler.
+
+Here is simple example which starts HTTP server with one route:
+```scala mdoc:reset
+import io.vertx.core.Vertx
+import io.vertx.ext.web.Router
+import sttp.tapir._
+import sttp.tapir.server.vertx.VertxZioServerInterpreter._
+import sttp.tapir.server.vertx.VertxEffectfulEndpointOptions
+
+import zio._
+
+object Short extends zio.App {
+
+  implicit val opts = VertxEffectfulEndpointOptions()
+
+  implicit val runtime = Runtime.default
+
+  val responseEndpoint =
+    endpoint
+      .in("response")
+      .in(query[String]("key"))
+      .out(plainBody[String])
+
+  val attach = route(responseEndpoint) { key => UIO.succeed(key) }
+
+  override def run(args: List[String]): URIO[ZEnv, ExitCode] =
+    ZManaged.make(ZIO.effect {
+      val vertx = Vertx.vertx()
+      val server = vertx.createHttpServer()
+      val router = Router.router(vertx)
+      attach(router)
+      server.requestHandler(router).listen(8080)
+    } >>= (_.asTask))({ server =>
+      ZIO.effect(server.close()).flatMap(_.asTask).orDie
+    }).useForever.as(ExitCode.success).orDie
+}
+```
+
+This interpreter supports streaming using ZStreams.

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -25,6 +25,6 @@ object Versions {
   val playClient = "2.1.2"
   val playServer = "2.8.7"
   val tethys = "0.20.0"
-  val vertx = "3.9.1"
+  val vertx = "4.0.0"
   val jsScalaJavaTime = "2.1.0"
 }

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/VertxEndpointOptions.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/VertxEndpointOptions.scala
@@ -2,36 +2,70 @@ package sttp.tapir.server.vertx
 
 import java.io.File
 
+import io.vertx.core.Context
+import io.vertx.core.Vertx
 import io.vertx.core.logging.{Logger, LoggerFactory}
-import io.vertx.lang.scala.VertxExecutionContext
-import io.vertx.scala.ext.web.RoutingContext
+import io.vertx.ext.web.RoutingContext
 import sttp.tapir.server.{DecodeFailureHandler, LogRequestHandling, ServerDefaults}
 
 import scala.concurrent.ExecutionContext
 
-case class VertxEndpointOptions(
+sealed trait VertxEndpointOptions {
+
+  def decodeFailureHandler: DecodeFailureHandler
+
+  def logger: Logger
+
+  def logRequestHandling: LogRequestHandling[Logger => Unit]
+
+  def uploadDirectory: File
+
+  type Self
+
+  protected def updateLogRequestHandling(logRequestHandling: LogRequestHandling[Logger => Unit]): Self
+
+  def logWhenHandled(shouldLog: Boolean): Self =
+    updateLogRequestHandling(logRequestHandling.copy(logWhenHandled = shouldLog))
+
+  def logAllDecodeFailures(shouldLog: Boolean): Self =
+    updateLogRequestHandling(logRequestHandling.copy(logAllDecodeFailures = shouldLog))
+
+  def logLogicExceptions(shouldLog: Boolean): Self =
+    updateLogRequestHandling(logRequestHandling.copy(logLogicExceptions = shouldLog))
+}
+
+final case class VertxFutureEndpointOptions(
     decodeFailureHandler: DecodeFailureHandler = ServerDefaults.decodeFailureHandler,
     logger: Logger = LoggerFactory.getLogger("tapir-vertx"),
     logRequestHandling: LogRequestHandling[Logger => Unit] = VertxEndpointOptions.defaultLogRequestHandling,
     uploadDirectory: File = File.createTempFile("tapir", null).getParentFile.getAbsoluteFile,
     private val specificExecutionContext: Option[ExecutionContext] = None
-) {
+) extends VertxEndpointOptions {
+
+  override type Self = VertxFutureEndpointOptions
+
+  override protected def updateLogRequestHandling(logRequestHandling: LogRequestHandling[Logger => Unit]) =
+    this.copy(logRequestHandling = logRequestHandling)
 
   def executionContextOr(default: ExecutionContext): ExecutionContext =
     specificExecutionContext.getOrElse(default)
 
   private[vertx] def executionContextOrCurrentCtx(rc: RoutingContext) =
-    executionContextOr(VertxExecutionContext(rc.vertx.getOrCreateContext))
+    executionContextOr(new VertxExecutionContext(rc.vertx, rc.vertx.getOrCreateContext))
+}
 
-  def logWhenHandled(shouldLog: Boolean): VertxEndpointOptions =
-    copy(logRequestHandling = logRequestHandling.copy(logWhenHandled = shouldLog))
+final case class VertxEffectfulEndpointOptions(
+    decodeFailureHandler: DecodeFailureHandler = ServerDefaults.decodeFailureHandler,
+    logger: Logger = LoggerFactory.getLogger("tapir-vertx"),
+    logRequestHandling: LogRequestHandling[Logger => Unit] = VertxEndpointOptions.defaultLogRequestHandling,
+    uploadDirectory: File = File.createTempFile("tapir", null).getParentFile.getAbsoluteFile,
+    maxQueueSizeForReadStream: Int = 16
+) extends VertxEndpointOptions {
 
-  def logAllDecodeFailures(shouldLog: Boolean): VertxEndpointOptions =
-    copy(logRequestHandling = logRequestHandling.copy(logAllDecodeFailures = shouldLog))
+  override type Self = VertxEffectfulEndpointOptions
 
-  def logLogicExceptions(shouldLog: Boolean): VertxEndpointOptions =
-    copy(logRequestHandling = logRequestHandling.copy(logLogicExceptions = shouldLog))
-
+  override protected def updateLogRequestHandling(logRequestHandling: LogRequestHandling[Logger => Unit]) =
+    this.copy(logRequestHandling = logRequestHandling)
 }
 
 object VertxEndpointOptions {
@@ -44,14 +78,31 @@ object VertxEndpointOptions {
 
   private def debugLog(msg: String, exOpt: Option[Throwable]): Logger => Unit =
     exOpt match {
-      case None     => log => log.debug(msg, List(): _*)
+      case None     => log => log.debug(msg, Nil: _*)
       case Some(ex) => log => log.debug(s"$msg; exception: {}", ex)
     }
 
   private def infoLog(msg: String, exOpt: Option[Throwable]): Logger => Unit =
     exOpt match {
-      case None     => log => log.info(msg, List(): _*)
+      case None     => log => log.info(msg, Nil: _*)
       case Some(ex) => log => log.info(s"$msg; exception: {}", ex)
     }
+}
 
+class VertxExecutionContext(val vertx: Vertx, val ctx: Context) extends ExecutionContext {
+
+  override def execute(runnable: Runnable): Unit =
+    if (vertx.getOrCreateContext() != ctx) {
+      ctx.runOnContext((_: Void) => runnable.run())
+    } else {
+      runnable.run()
+    }
+
+  override def reportFailure(cause: Throwable): Unit =
+    VertxExecutionContext.Log.error("Failed executing on contet", cause)
+}
+
+object VertxExecutionContext {
+
+  private[vertx] val Log = LoggerFactory.getLogger(classOf[VertxExecutionContext].getName)
 }

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/decoders/VertxDecodeInputsContext.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/decoders/VertxDecodeInputsContext.scala
@@ -1,20 +1,26 @@
 package sttp.tapir.server.vertx.decoders
 
 import io.vertx.core.buffer.Buffer
-import io.vertx.scala.core.streams.ReadStream
-import io.vertx.scala.ext.web.RoutingContext
+import io.vertx.core.streams.ReadStream
+import io.vertx.ext.web.RoutingContext
 import sttp.model.{Method, QueryParams}
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.internal.DecodeInputsContext
 import sttp.tapir.server.vertx.routing.MethodMapping
+import sttp.tapir.server.vertx.streams.ReadStreamCompatible
 
-private[vertx] class VertxDecodeInputsContext(rc: RoutingContext, pathConsumed: Int = 0) extends DecodeInputsContext {
+import scala.collection.JavaConverters._
+
+private[vertx] class VertxDecodeInputsContext[S: ReadStreamCompatible](
+    rc: RoutingContext,
+    pathConsumed: Int = 0
+) extends DecodeInputsContext {
   private lazy val request = rc.request
   private lazy val _headers = request.headers
   private lazy val params = request.params
   override def method: Method = MethodMapping.vertxToSttp(rc.request)
   override def nextPathSegment: (Option[String], DecodeInputsContext) = {
-    val path = request.path.get.drop(pathConsumed)
+    val path = Option(request.path).getOrElse("").drop(pathConsumed)
     val nextStart = path.dropWhile(_ == '/')
     val segment = nextStart.split("/", 2) match {
       case Array("")   => None
@@ -24,14 +30,15 @@ private[vertx] class VertxDecodeInputsContext(rc: RoutingContext, pathConsumed: 
     val charactersConsumed = segment.map(_.length).getOrElse(0) + (path.length - nextStart.length)
     (segment, new VertxDecodeInputsContext(rc, pathConsumed + charactersConsumed))
   }
-  override def header(name: String): List[String] = request.headers.getAll(name).toList
-  override def headers: Seq[(String, String)] = _headers.names.map { key => (key, _headers.get(key).get) }.toSeq
-  override def queryParameter(name: String): Seq[String] = params.getAll(name)
+  override def header(name: String): List[String] = request.headers.getAll(name).asScala.toList
+  override def headers: Seq[(String, String)] =
+    _headers.entries.asScala.iterator.map({ case e => (e.getKey, e.getValue) }).toList
+  override def queryParameter(name: String): Seq[String] = params.getAll(name).asScala.toList
   override def queryParameters: QueryParams =
     QueryParams.fromMultiMap(
-      params.names.map { key => (key, params.getAll(key)) }.toMap
+      params.names.asScala.map { key => (key, params.getAll(key).asScala.toList) }.toMap
     )
   override def bodyStream: Any =
-    rc.request.asInstanceOf[ReadStream[Buffer]]
+    ReadStreamCompatible[S].fromReadStream(rc.request.asInstanceOf[ReadStream[Buffer]])
   override def serverRequest: ServerRequest = new VertxServerRequest(rc)
 }

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/decoders/VertxInputDecoders.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/decoders/VertxInputDecoders.scala
@@ -2,22 +2,25 @@ package sttp.tapir.server.vertx.decoders
 
 import java.io.{ByteArrayInputStream, File}
 import java.nio.ByteBuffer
+import java.nio.charset.Charset
+import java.nio.file.{Files, Paths}
 import java.util.Date
-import io.vertx.scala.ext.web.RoutingContext
+import java.util.function.{Function => JFunction}
+import io.vertx.ext.web.RoutingContext
+import io.vertx.core.Future
 import sttp.model.Part
 import sttp.tapir.internal.Params
 import sttp.tapir.server.internal.{DecodeInputs, DecodeInputsResult, InputValues, InputValuesResult}
 import sttp.tapir.server.vertx.VertxEndpointOptions
 import sttp.tapir.server.vertx.encoders.VertxOutputEncoders
 import sttp.tapir.server.vertx.handlers.tryEncodeError
+import sttp.tapir.server.vertx.streams.ReadStreamCompatible
 import sttp.tapir.server.{DecodeFailureContext, DecodeFailureHandling}
 import sttp.tapir.{DecodeResult, Endpoint, EndpointIO, RawBodyType}
 
-import java.nio.charset.Charset
-import java.nio.file.{Files, Paths}
-import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 import scala.util.Random
+import scala.collection.JavaConverters._
 
 object VertxInputDecoders {
 
@@ -29,12 +32,15 @@ object VertxInputDecoders {
     * @param ect the error class to convert to, if the user recovers error
     * @tparam E Error parameter type, if it should be caught and handled by the user
     */
-  private[vertx] def decodeBodyAndInputsThen[E](
+  private[vertx] def decodeBodyAndInputsThen[E, S: ReadStreamCompatible](
       endpoint: Endpoint[_, E, _, _],
       rc: RoutingContext,
       logicHandler: Params => Unit
-  )(implicit endpointOptions: VertxEndpointOptions, ect: Option[ClassTag[E]]): Unit = {
-    decodeBodyAndInputs(endpoint, rc).map {
+  )(implicit
+      endpointOptions: VertxEndpointOptions,
+      ect: Option[ClassTag[E]]
+  ): Unit = {
+    decodeBodyAndInputs(endpoint, rc).map(scalaFuncToJava[DecodeInputsResult, Unit] {
       case values: DecodeInputsResult.Values =>
         InputValues(endpoint.input, values) match {
           case InputValuesResult.Value(params, _) =>
@@ -48,14 +54,17 @@ object VertxInputDecoders {
           case DecodeFailureHandling.NoMatch =>
             endpointOptions.logRequestHandling.decodeFailureNotHandled(endpoint, decodeFailureCtx)(endpointOptions.logger)
             rc.response.setStatusCode(404).end()
+            ()
           case DecodeFailureHandling.RespondWithResponse(output, value) =>
             endpointOptions.logRequestHandling.decodeFailureHandled(endpoint, decodeFailureCtx, value)(endpointOptions.logger)
-            VertxOutputEncoders.apply(output, value)(endpointOptions)(rc)
+            VertxOutputEncoders.apply(output, value).apply(rc)
         }
-    }(endpointOptions.executionContextOrCurrentCtx(rc)): Unit
+    })
+
+    ()
   }
 
-  private def decodeBodyAndInputs(e: Endpoint[_, _, _, _], rc: RoutingContext)(implicit
+  private def decodeBodyAndInputs[S: ReadStreamCompatible](e: Endpoint[_, _, _, _], rc: RoutingContext)(implicit
       serverOptions: VertxEndpointOptions
   ): Future[DecodeInputsResult] =
     decodeBody(DecodeInputs(e.input, new VertxDecodeInputsContext(rc)), rc)
@@ -63,45 +72,53 @@ object VertxInputDecoders {
   private def decodeBody(result: DecodeInputsResult, rc: RoutingContext)(implicit
       serverOptions: VertxEndpointOptions
   ): Future[DecodeInputsResult] = {
-    implicit val ec: ExecutionContext = serverOptions.executionContextOrCurrentCtx(rc)
     result match {
       case values: DecodeInputsResult.Values =>
         values.bodyInput match {
-          case None => Future.successful(values)
+          case None =>
+            Future.succeededFuture(values)
           case Some(bodyInput @ EndpointIO.Body(bodyType, codec, _)) =>
-            extractRawBody(bodyType, rc).map(codec.decode).map {
-              case DecodeResult.Value(body)      => values.setBodyInputValue(body)
-              case failure: DecodeResult.Failure => DecodeInputsResult.Failure(bodyInput, failure): DecodeInputsResult
+            extractRawBody(bodyType, rc).flatMap(raw => Future.succeededFuture(codec.decode(raw))).flatMap {
+              case DecodeResult.Value(body) =>
+                Future.succeededFuture(values.setBodyInputValue(body))
+              case failure: DecodeResult.Failure =>
+                Future.succeededFuture(DecodeInputsResult.Failure(bodyInput, failure): DecodeInputsResult)
             }
         }
-      case failure: DecodeInputsResult.Failure => Future.successful(failure)
+      case failure: DecodeInputsResult.Failure => Future.succeededFuture(failure)
     }
   }
 
   private def extractRawBody[B](bodyType: RawBodyType[B], rc: RoutingContext)(implicit serverOptions: VertxEndpointOptions): Future[B] = {
-    implicit val ec: ExecutionContext = serverOptions.executionContextOrCurrentCtx(rc)
     bodyType match {
-      case RawBodyType.StringBody(defaultCharset) => Future.successful(rc.getBodyAsString(defaultCharset.toString).get)
-      case RawBodyType.ByteArrayBody              => Future.successful(rc.getBody.get.getBytes)
-      case RawBodyType.ByteBufferBody             => Future.successful(rc.getBody.get.getByteBuf.nioBuffer())
-      case RawBodyType.InputStreamBody            => Future.successful(new ByteArrayInputStream(rc.getBody.get.getBytes))
+      case RawBodyType.StringBody(defaultCharset) =>
+        Future.succeededFuture(Option(rc.getBodyAsString(defaultCharset.toString)).getOrElse(""))
+      case RawBodyType.ByteArrayBody =>
+        Future.succeededFuture(Option(rc.getBody).fold(Array.emptyByteArray)(_.getBytes))
+      case RawBodyType.ByteBufferBody =>
+        Future.succeededFuture(Option(rc.getBody).fold(ByteBuffer.allocate(0))(_.getByteBuf.nioBuffer()))
+      case RawBodyType.InputStreamBody =>
+        val bytes = Option(rc.getBody).fold(Array.emptyByteArray)(_.getBytes)
+        Future.succeededFuture(new ByteArrayInputStream(bytes))
       case RawBodyType.FileBody =>
-        rc.fileUploads().toList match {
-          case List(upload) =>
-            Future.successful(new File(upload.uploadedFileName()))
-          case List() if rc.getBody.isDefined =>
+        rc.fileUploads().asScala.headOption match {
+          case Some(upload) =>
+            Future.succeededFuture(new File(upload.uploadedFileName()))
+          case None if rc.getBody != null =>
             val filePath = s"${serverOptions.uploadDirectory.getAbsolutePath}/tapir-${new Date().getTime}-${Random.nextLong()}"
             val fs = rc.vertx.fileSystem
-            fs.createFileFuture(filePath).flatMap { _ =>
-              fs.writeFileFuture(filePath, rc.getBody.get)
-                .map(_ => new File(filePath))
-            }
+            val result = fs.createFile(filePath)
+              .flatMap(_ => fs.writeFile(filePath, rc.getBody))
+              .flatMap(_ => Future.succeededFuture(new File(filePath)))
+            result
+          case None =>
+            Future.failedFuture[File]("No body")
         }
       case RawBodyType.MultipartBody(partTypes, defaultType) =>
         val defaultParts = defaultType
           .fold(Map.empty[String, RawBodyType[_]]) { bodyType =>
-            val files = rc.fileUploads().map(_.name())
-            val form = rc.request().formAttributes().names()
+            val files = rc.fileUploads().asScala.map(_.name())
+            val form = rc.request().formAttributes().names().asScala
 
             (files ++ form)
               .diff(partTypes.keySet)
@@ -109,7 +126,7 @@ object VertxInputDecoders {
               .toMap
           }
         val allParts = defaultParts ++ partTypes
-        Future.successful(
+        Future.succeededFuture(
           allParts.map { case (partName, rawBodyType) =>
             Part(partName, extractPart(partName, rawBodyType, rc))
           }.toSeq
@@ -124,7 +141,7 @@ object VertxInputDecoders {
       case RawBodyType.ByteBufferBody      => ByteBuffer.wrap(readBytes(name, rc, Charset.defaultCharset()))
       case RawBodyType.InputStreamBody     => throw new IllegalArgumentException("Cannot create a multipart as an InputStream")
       case RawBodyType.FileBody =>
-        val f = rc.fileUploads.find(_.name == name).get
+        val f = rc.fileUploads.asScala.find(_.name == name).get
         new File(f.uploadedFileName())
       case RawBodyType.MultipartBody(partTypes, _) =>
         partTypes.map { case (partName, rawBodyType) =>
@@ -136,12 +153,16 @@ object VertxInputDecoders {
   private def readBytes(name: String, rc: RoutingContext, charset: Charset) = {
     val formAttributes = rc.request.formAttributes
 
-    val formBytes = formAttributes.get(name).map(_.getBytes(charset))
-    val fileBytes = rc.fileUploads().find(_.name() == name).map { upload =>
+    val formBytes = Option(formAttributes.get(name)).map(_.getBytes(charset))
+    val fileBytes = rc.fileUploads().asScala.find(_.name() == name).map { upload =>
       Files.readAllBytes(Paths.get(upload.uploadedFileName()))
     }
 
     formBytes.orElse(fileBytes).get
   }
 
+  implicit private def scalaFuncToJava[A, B](fn: A => B): JFunction[A, B] =
+    new JFunction[A, B] {
+      override def apply(a: A): B = fn(a)
+    }
 }

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/decoders/VertxServerRequest.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/decoders/VertxServerRequest.scala
@@ -2,10 +2,13 @@ package sttp.tapir.server.vertx.decoders
 
 import java.net.{InetSocketAddress, URI}
 
-import io.vertx.scala.core.net.SocketAddress
-import io.vertx.scala.ext.web.RoutingContext
+import io.vertx.core.net.SocketAddress
+import io.vertx.ext.web.RoutingContext
 import sttp.model.Method
 import sttp.tapir.model.{ConnectionInfo, ServerRequest}
+import sttp.tapir.server.vertx.routing.MethodMapping
+
+import scala.collection.JavaConverters._
 
 private[vertx] class VertxServerRequest(rc: RoutingContext) extends ServerRequest {
   private lazy val req = rc.request
@@ -18,11 +21,13 @@ private[vertx] class VertxServerRequest(rc: RoutingContext) extends ServerReques
       Option(conn.isSsl)
     )
   }
-  override def method: Method = Method.apply(req.rawMethod)
-  override def protocol: String = req.scheme.get
+  override def method: Method = MethodMapping.vertxToSttp(req)
+  override def protocol: String = Option(req.scheme).getOrElse("")
   override def uri: URI = new URI(req.uri)
-  override def headers: Seq[(String, String)] = _headers.names.map { key => (key, _headers.get(key).get) }.toSeq
-  override def header(name: String): Option[String] = _headers.get(name)
+  override def headers: Seq[(String, String)] =
+    _headers.entries.asScala.iterator.map({ case e => (e.getKey, e.getValue) }).toList
+  override def header(name: String): Option[String] =
+    Option(_headers.get(name))
   override def underlying: Any = rc
 
   private def asInetSocketAddress(address: SocketAddress): InetSocketAddress =

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/encoders/package.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/encoders/package.scala
@@ -3,9 +3,8 @@ package sttp.tapir.server.vertx
 import java.io.{ByteArrayInputStream, InputStream}
 
 import io.vertx.core.buffer.Buffer
-import io.vertx.scala.core.Vertx
-
-import scala.concurrent.Future
+import io.vertx.core.Future
+import io.vertx.core.Vertx
 
 package object encoders {
 
@@ -16,8 +15,10 @@ package object encoders {
     */
   private[vertx] def inputStreamToBuffer(is: InputStream, vertx: Vertx): Future[Buffer] = {
     is match {
-      case _: ByteArrayInputStream => Future.successful(inputStreamToBufferUnsafe(is))
-      case _                       => vertx.executeBlocking(() => inputStreamToBufferUnsafe(is))
+      case _: ByteArrayInputStream =>
+        Future.succeededFuture(inputStreamToBufferUnsafe(is))
+      case _ =>
+        vertx.executeBlocking { promise => promise.complete(inputStreamToBufferUnsafe(is)) }
     }
   }
 

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/handlers/package.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/handlers/package.scala
@@ -1,12 +1,13 @@
 package sttp.tapir.server.vertx
 
 import io.vertx.core.Handler
-import io.vertx.scala.ext.web.{Route, RoutingContext}
-import io.vertx.scala.ext.web.handler.BodyHandler
+import io.vertx.ext.web.{Route, RoutingContext}
+import io.vertx.ext.web.handler.BodyHandler
 import sttp.tapir.{Endpoint, EndpointIO}
-import sttp.tapir.internal._
 import sttp.tapir.RawBodyType.MultipartBody
+import sttp.tapir.internal._
 import sttp.tapir.server.vertx.encoders.VertxOutputEncoders
+import sttp.tapir.server.vertx.streams.ReadStreamCompatible
 
 import scala.reflect.ClassTag
 
@@ -14,37 +15,35 @@ package object handlers {
 
   private[vertx] lazy val bodyHandler = BodyHandler.create()
 
-  private[vertx] lazy val streamPauseHandler: Handler[RoutingContext] = { rc =>
-    rc.request.pause()
-    rc.next()
-  }
-
   private[vertx] lazy val multipartHandler: Handler[RoutingContext] = { rc =>
     rc.request.setExpectMultipart(true)
     rc.next()
   }
 
-  private[vertx] def bodyHandlers(body: EndpointIO.Body[_, _]) =
-    body.bodyType match {
-      case MultipartBody(_, _) => List(multipartHandler, bodyHandler)
-      case _                   => List(bodyHandler)
-    }
+  private[vertx] lazy val streamPauseHandler: Handler[RoutingContext] = { rc =>
+    rc.request.pause()
+    rc.next()
+  }
 
-  private[vertx] def attachDefaultHandlers[E](
+  private[vertx] def attachDefaultHandlers[E, S: ReadStreamCompatible](
       e: Endpoint[_, E, _, _],
       route: Route
   )(implicit serverOptions: VertxEndpointOptions, ect: Option[ClassTag[E]]): Route = {
     route.failureHandler(rc => tryEncodeError(e, rc, rc.failure))
-    val inputs = e.input.asVectorOfBasicInputs()
-    inputs
-      .foldLeft(List[Handler[RoutingContext]]()) { (handlers, ep) =>
-        ep match {
-          case body: EndpointIO.Body[_, _]           => bodyHandlers(body) ++ handlers
-          case _: EndpointIO.StreamBodyWrapper[_, _] => streamPauseHandler :: handlers
-          case _                                     => handlers
+    e.input.asVectorOfBasicInputs() foreach {
+      case body: EndpointIO.Body[_, _] =>
+        body.bodyType match {
+          case MultipartBody(_, _) =>
+            route.handler(multipartHandler)
+            route.handler(bodyHandler)
+          case _ =>
+            route.handler(bodyHandler)
         }
-      }
-      .foreach(route.handler)
+      case _: EndpointIO.StreamBodyWrapper[_, _] =>
+        route.handler(streamPauseHandler)
+      case _ =>
+        ()
+    }
     route
   }
 
@@ -56,7 +55,11 @@ package object handlers {
     * @param ect an eventual ClassTag for user-defined exceptions
     * @tparam E the type of the error
     */
-  private[vertx] def tryEncodeError[E](endpoint: Endpoint[_, E, _, _], rc: RoutingContext, error: Any)(implicit
+  private[vertx] def tryEncodeError[E, S: ReadStreamCompatible](
+      endpoint: Endpoint[_, E, _, _],
+      rc: RoutingContext,
+      error: Any
+  )(implicit
       endpointOptions: VertxEndpointOptions,
       ect: Option[ClassTag[E]]
   ): Unit =
@@ -65,16 +68,22 @@ package object handlers {
         encodeError(endpoint, rc, error.asInstanceOf[E])
       case _ =>
         rc.response.setStatusCode(500).end()
+        ()
     }
 
-  private[vertx] def encodeError[E](endpoint: Endpoint[_, E, _, _], rc: RoutingContext, error: E)(implicit
+  private[vertx] def encodeError[E, S: ReadStreamCompatible](
+      endpoint: Endpoint[_, E, _, _],
+      rc: RoutingContext,
+      error: E
+  )(implicit
       endpointOptions: VertxEndpointOptions
   ): Unit = {
     try {
-      VertxOutputEncoders.apply[E](endpoint.errorOutput, error, isError = true)(endpointOptions)(rc)
+      VertxOutputEncoders.apply[E, S](endpoint.errorOutput, error, isError = true).apply(rc)
     } catch {
-      case _: Throwable => rc.response.setStatusCode(500).end()
+      case _: Throwable =>
+        rc.response.setStatusCode(500).end()
+        ()
     }
   }
-
 }

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/interpreters/CommonInterpreter.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/interpreters/CommonInterpreter.scala
@@ -1,0 +1,39 @@
+package sttp.tapir.server.vertx.interpreters
+
+import io.vertx.ext.web.{Route, Router, RoutingContext}
+import sttp.tapir.server.vertx.encoders.VertxOutputEncoders
+import sttp.tapir.server.vertx.handlers.{attachDefaultHandlers, encodeError}
+import sttp.tapir.server.vertx.routing.PathMapping.{RouteDefinition, createRoute}
+import sttp.tapir.server.vertx.streams.ReadStreamCompatible
+import sttp.tapir.server.vertx.VertxEndpointOptions
+import sttp.tapir.server.ServerEndpoint
+import sttp.capabilities.Streams
+
+import scala.reflect.ClassTag
+
+trait CommonServerInterpreter {
+
+  protected def mountWithDefaultHandlers[F[_], I, E, O, C, S: ReadStreamCompatible](e: ServerEndpoint[I, E, O, C, F])(
+      router: Router,
+      routeDef: RouteDefinition
+  )(implicit endpointOptions: VertxEndpointOptions, ect: Option[ClassTag[E]]): Route =
+    attachDefaultHandlers(e.endpoint, createRoute(router, routeDef))
+
+  protected def responseHandlerWithError[F[_], I, E, O, S: ReadStreamCompatible, C <: Streams[S]](
+      e: ServerEndpoint[I, E, O, C, F],
+  )(implicit
+      endpointOptions: VertxEndpointOptions
+  ): (Either[E, O], RoutingContext) => Unit = {
+    case (Right(result), rc) =>
+      VertxOutputEncoders.apply[O, S](e.output, result, isError = false, logRequestHandled(e)).apply(rc)
+    case (Left(failure), rc) =>
+      encodeError(e.endpoint, rc, failure)
+  }
+
+  protected def logRequestHandled[F[_], I, E, O, C](e: ServerEndpoint[I, E, O, C, F])(implicit
+      endpointOptions: VertxEndpointOptions
+  ): Int => Unit = status => {
+    endpointOptions.logRequestHandling.requestHandled(e.endpoint, status)
+    ()
+  }
+}

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/interpreters/VertxCatsServerInterpreter.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/interpreters/VertxCatsServerInterpreter.scala
@@ -1,0 +1,126 @@
+package sttp.tapir.server.vertx.interpreters
+
+import cats.effect.{Async, ConcurrentEffect, Effect}
+import io.vertx.core.{Future, Handler}
+import io.vertx.ext.web.{Route, Router, RoutingContext}
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.monad.MonadError
+import sttp.tapir.server.vertx.handlers.tryEncodeError
+import sttp.tapir.server.vertx.decoders.VertxInputDecoders.decodeBodyAndInputsThen
+import sttp.tapir.server.vertx.routing.PathMapping.extractRouteDefinition
+import sttp.tapir.server.vertx.streams.ReadStreamCompatible
+import sttp.tapir.server.vertx.VertxEffectfulEndpointOptions
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.internal.Params
+import sttp.tapir.Endpoint
+
+import scala.reflect.ClassTag
+
+trait VertxCatsServerInterpreter extends CommonServerInterpreter {
+
+  /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
+    * @param logic the logic to associate with the endpoint
+    * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
+    * @return A function, that given a router, will attach this endpoint to it
+    */
+  def route[F[_], I, E, O](e: Endpoint[I, E, O, Fs2Streams[F]])(logic: I => F[Either[E, O]])(implicit
+      endpointOptions: VertxEffectfulEndpointOptions,
+      effect: ConcurrentEffect[F]
+  ): Router => Route =
+    route(e.serverLogic(logic))
+
+  /** Given a Router, creates and mounts a Route matching this endpoint, with custom error handling
+    * @param logic the logic to associate with the endpoint
+    * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
+    * @return A function, that given a router, will attach this endpoint to it
+    */
+  def routeRecoverErrors[F[_], I, E, O](e: Endpoint[I, E, O, Fs2Streams[F]])(
+      logic: I => F[O]
+  )(implicit
+      endpointOptions: VertxEffectfulEndpointOptions,
+      effect: ConcurrentEffect[F],
+      eIsThrowable: E <:< Throwable,
+      eClassTag: ClassTag[E]
+  ): Router => Route =
+    route(e.serverLogicRecoverErrors(logic))
+
+  /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
+    * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
+    * @return A function, that given a router, will attach this endpoint to it
+    */
+  def route[F[_], I, E, O](
+      e: ServerEndpoint[I, E, O, Fs2Streams[F], F]
+  )(implicit
+      endpointOptions: VertxEffectfulEndpointOptions,
+      effect: ConcurrentEffect[F]
+  ): Router => Route = { router =>
+    implicit val ect: Option[ClassTag[E]] = None
+    import sttp.tapir.server.vertx.streams.fs2._
+    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint))
+      .handler(endpointHandler(e)(e.logic, responseHandlerWithError(e)))
+  }
+
+  private def endpointHandler[F[_], I, E, O, A, S: ReadStreamCompatible](e: ServerEndpoint[I, E, O, _, F])(
+      logic: MonadError[F] => I => F[A],
+      responseHandler: (A, RoutingContext) => Unit
+  )(implicit
+      serverOptions: VertxEffectfulEndpointOptions,
+      effect: Effect[F],
+      ect: Option[ClassTag[E]]
+  ): Handler[RoutingContext] = { rc =>
+    decodeBodyAndInputsThen(
+      e.endpoint,
+      rc,
+      logicHandler(e)(logic(monadError[F]), responseHandler, rc)
+    )
+  }
+
+  def monadError[F[_]](implicit F: Effect[F]): MonadError[F] = new MonadError[F] {
+    override def unit[T](t: T): F[T] = F.pure(t)
+    override def map[T, T2](fa: F[T])(f: T => T2): F[T2] = F.map(fa)(f)
+    override def flatMap[T, T2](fa: F[T])(f: T => F[T2]): F[T2] = F.flatMap(fa)(f)
+    override def error[T](t: Throwable): F[T] = F.raiseError(t)
+    override protected def handleWrappedError[T](rt: F[T])(h: PartialFunction[Throwable, F[T]]): F[T] =
+      F.recoverWith(rt)(h)
+    override def eval[T](t: => T): F[T] = F.delay(t)
+    override def suspend[T](t: => F[T]): F[T] = F.suspend(t)
+    override def flatten[T](ffa: F[F[T]]): F[T] = F.flatten(ffa)
+    override def ensure[T](f: F[T], e: => F[Unit]): F[T] = F.guarantee(f)(e)
+  }
+
+  private def logicHandler[F[_], I, E, O, T, S: ReadStreamCompatible](
+      e: ServerEndpoint[I, E, O, _, F]
+  )(logic: I => F[T], responseHandler: (T, RoutingContext) => Unit, rc: RoutingContext)(implicit
+      effect: Effect[F],
+      serverOptions: VertxEffectfulEndpointOptions,
+      ect: Option[ClassTag[E]]
+  ): Params => Unit = { params =>
+    val cancelToken = effect.toIO(logic(params.asAny.asInstanceOf[I])).unsafeRunCancelable {
+      case Right(result) =>
+        responseHandler(result, rc)
+      case Left(cause) =>
+        serverOptions.logRequestHandling.logicException(e.endpoint, cause)(serverOptions.logger)
+        tryEncodeError[E, S](e.endpoint, rc, cause)
+    }
+
+    rc.response.exceptionHandler { _ =>
+      cancelToken.unsafeRunSync()
+    }
+
+    ()
+  }
+
+  implicit class VertxFutureForCats[A](future: => Future[A]) {
+
+    def liftF[F[_]: Async]: F[A] =
+      Async[F].async { cb =>
+        future.onComplete({ handler =>
+          if (handler.succeeded()) {
+            cb(Right(handler.result()))
+          } else {
+            cb(Left(handler.cause()))
+          }
+        }): Unit
+      }
+  }
+}

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/interpreters/VertxFutureServerInterpreter.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/interpreters/VertxFutureServerInterpreter.scala
@@ -1,21 +1,21 @@
-package sttp.tapir.server.vertx
+package sttp.tapir.server.vertx.interpreters
 
-import io.vertx.core.Handler
-import io.vertx.scala.ext.web.{Route, Router, RoutingContext}
+import io.vertx.core.{Future => VFuture, Handler}
+import io.vertx.ext.web.{Route, Router, RoutingContext}
 import sttp.monad.{FutureMonad, MonadError}
-import sttp.tapir.Endpoint
-import sttp.tapir.internal.Params
-import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.vertx.handlers.tryEncodeError
 import sttp.tapir.server.vertx.decoders.VertxInputDecoders.decodeBodyAndInputsThen
-import sttp.tapir.server.vertx.encoders.VertxOutputEncoders
-import sttp.tapir.server.vertx.handlers.{attachDefaultHandlers, encodeError, tryEncodeError}
-import sttp.tapir.server.vertx.routing.PathMapping.{RouteDefinition, createRoute, extractRouteDefinition}
+import sttp.tapir.server.vertx.routing.PathMapping.extractRouteDefinition
+import sttp.tapir.server.vertx.VertxFutureEndpointOptions
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.internal.Params
+import sttp.tapir.Endpoint
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 
-trait VertxServerInterpreter {
+trait VertxFutureServerInterpreter extends CommonServerInterpreter {
 
   /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
     * @param logic the logic to associate with the endpoint
@@ -23,7 +23,7 @@ trait VertxServerInterpreter {
     * @return A function, that given a router, will attach this endpoint to it
     */
   def route[I, E, O](e: Endpoint[I, E, O, Any])(logic: I => Future[Either[E, O]])(implicit
-      endpointOptions: VertxEndpointOptions
+      endpointOptions: VertxFutureEndpointOptions
   ): Router => Route =
     route(e.serverLogic(logic))
 
@@ -34,7 +34,7 @@ trait VertxServerInterpreter {
     * @return A function, that given a router, will attach this endpoint to it
     */
   def blockingRoute[I, E, O](e: Endpoint[I, E, O, Any])(logic: I => Future[Either[E, O]])(implicit
-      endpointOptions: VertxEndpointOptions
+      endpointOptions: VertxFutureEndpointOptions
   ): Router => Route =
     blockingRoute(e.serverLogic(logic))
 
@@ -45,7 +45,7 @@ trait VertxServerInterpreter {
     */
   def routeRecoverErrors[I, E, O](e: Endpoint[I, E, O, Any])(
       logic: I => Future[O]
-  )(implicit endpointOptions: VertxEndpointOptions, eIsThrowable: E <:< Throwable, eClassTag: ClassTag[E]): Router => Route =
+  )(implicit endpointOptions: VertxFutureEndpointOptions, eIsThrowable: E <:< Throwable, eClassTag: ClassTag[E]): Router => Route =
     route(e.serverLogicRecoverErrors(logic))
 
   /** Given a Router, creates and mounts a Route matching this endpoint, with custom error handling
@@ -56,15 +56,16 @@ trait VertxServerInterpreter {
     */
   def blockingRouteRecoverErrors[I, E, O](e: Endpoint[I, E, O, Any])(
       logic: I => Future[O]
-  )(implicit endpointOptions: VertxEndpointOptions, eIsThrowable: E <:< Throwable, eClassTag: ClassTag[E]): Router => Route =
+  )(implicit endpointOptions: VertxFutureEndpointOptions, eIsThrowable: E <:< Throwable, eClassTag: ClassTag[E]): Router => Route =
     blockingRoute(e.serverLogicRecoverErrors(logic))
 
   /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
     * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
     * @return A function, that given a router, will attach this endpoint to it
     */
-  def route[I, E, O](e: ServerEndpoint[I, E, O, Any, Future])(implicit endpointOptions: VertxEndpointOptions): Router => Route = { router =>
-    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint))(endpointOptions, None)
+  def route[I, E, O](e: ServerEndpoint[I, E, O, Any, Future])(implicit endpointOptions: VertxFutureEndpointOptions): Router => Route = { router =>
+    implicit val ect: Option[ClassTag[E]] = None
+    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint))
       .handler(endpointHandler(e)(e.logic, responseHandlerWithError(e))(endpointOptions, None))
   }
 
@@ -73,34 +74,29 @@ trait VertxServerInterpreter {
     * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
     * @return A function, that given a router, will attach this endpoint to it
     */
-  def blockingRoute[I, E, O](e: ServerEndpoint[I, E, O, Any, Future])(implicit endpointOptions: VertxEndpointOptions): Router => Route = {
+  def blockingRoute[I, E, O](e: ServerEndpoint[I, E, O, Any, Future])(implicit endpointOptions: VertxFutureEndpointOptions): Router => Route = {
     router =>
-      mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint))(endpointOptions, None)
+      implicit val ect: Option[ClassTag[E]] = None
+      mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint))
         .blockingHandler(endpointHandler(e)(e.logic, responseHandlerWithError(e))(endpointOptions, None))
   }
-
-  private def mountWithDefaultHandlers[I, E, O](e: ServerEndpoint[I, E, O, Any, Future])(
-      router: Router,
-      routeDef: RouteDefinition
-  )(implicit endpointOptions: VertxEndpointOptions, ect: Option[ClassTag[E]]): Route =
-    attachDefaultHandlers(e.endpoint, createRoute(router, routeDef))
 
   private def endpointHandler[I, E, O, A](e: ServerEndpoint[I, E, O, Any, Future])(
       logic: MonadError[Future] => I => Future[A],
       responseHandler: (A, RoutingContext) => Unit
-  )(implicit serverOptions: VertxEndpointOptions, ect: Option[ClassTag[E]]): Handler[RoutingContext] = { rc =>
+  )(implicit serverOptions: VertxFutureEndpointOptions, ect: Option[ClassTag[E]]): Handler[RoutingContext] = { rc =>
     val monad = new FutureMonad()(serverOptions.executionContextOrCurrentCtx(rc))
-    decodeBodyAndInputsThen[E](
+    decodeBodyAndInputsThen(
       e.endpoint,
       rc,
-      { params => logicHandler(e)(logic(monad), responseHandler, rc)(serverOptions, ect)(params) }
+      logicHandler(e)(logic(monad), responseHandler, rc)
     )
   }
 
   private def logicHandler[I, E, O, T](
       e: ServerEndpoint[I, E, O, Any, Future]
   )(logic: I => Future[T], responseHandler: (T, RoutingContext) => Unit, rc: RoutingContext)(implicit
-      serverOptions: VertxEndpointOptions,
+      serverOptions: VertxFutureEndpointOptions,
       ect: Option[ClassTag[E]]
   ): Params => Unit = { params =>
     implicit val ec: ExecutionContext = serverOptions.executionContextOrCurrentCtx(rc)
@@ -118,30 +114,21 @@ trait VertxServerInterpreter {
         tryEncodeError(e.endpoint, rc, cause)
         serverOptions.logRequestHandling.logicException(e.endpoint, cause)(serverOptions.logger): Unit
       }
+    ()
   }
 
-  private def responseHandlerWithError[I, E, O](
-      e: ServerEndpoint[I, E, O, Any, Future]
-  )(implicit endpointOptions: VertxEndpointOptions): (Either[E, O], RoutingContext) => Unit = { (output, rc) =>
-    output match {
-      case Left(failure) =>
-        encodeError(e.endpoint, rc, failure)
-      case Right(result) =>
-        responseHandlerNoError(e)(endpointOptions)(result, rc)
+  implicit class VertxFutureForScala[A](future: => VFuture[A]) {
+
+    def asScala: Future[A] = {
+      val promise = Promise[A]()
+      future.onComplete { handler =>
+        if (handler.succeeded()) {
+          promise.success(handler.result())
+        } else {
+          promise.failure(handler.cause())
+        }
+      }
+      promise.future
     }
   }
-
-  private def responseHandlerNoError[I, E, O](
-      e: ServerEndpoint[I, E, O, Any, Future]
-  )(implicit endpointOptions: VertxEndpointOptions): (O, RoutingContext) => Unit = { (result, rc) =>
-    VertxOutputEncoders.apply[O](e.output, result, isError = false, logRequestHandled(e))(endpointOptions)(rc)
-  }
-
-  private def logRequestHandled[I, E, O](e: ServerEndpoint[I, E, O, Any, Future])(implicit
-      endpointOptions: VertxEndpointOptions
-  ): Int => Unit =
-    status => endpointOptions.logRequestHandling.requestHandled(e.endpoint, status): Unit
-
 }
-
-object VertxServerInterpreter extends VertxServerInterpreter

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/interpreters/VertxZioServerInterpreter.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/interpreters/VertxZioServerInterpreter.scala
@@ -1,0 +1,100 @@
+package sttp.tapir.server.vertx.interpreters
+
+import io.vertx.core.{Future, Handler}
+import io.vertx.ext.web.{Route, Router, RoutingContext}
+import sttp.capabilities.zio.ZioStreams
+import sttp.monad.MonadError
+import sttp.tapir.server.vertx.decoders.VertxInputDecoders.decodeBodyAndInputsThen
+import sttp.tapir.server.vertx.handlers.tryEncodeError
+import sttp.tapir.server.vertx.routing.PathMapping.extractRouteDefinition
+import sttp.tapir.server.vertx.streams.zio._
+import sttp.tapir.server.vertx.VertxEffectfulEndpointOptions
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.internal.Params
+import sttp.tapir.Endpoint
+import zio._
+
+import scala.reflect.ClassTag
+
+trait VertxZioServerInterpreter extends CommonServerInterpreter {
+
+  def route[R, I, E, O](e: Endpoint[I, E, O, ZioStreams])(logic: I => ZIO[R, E, O])(implicit
+      endpointOptions: VertxEffectfulEndpointOptions,
+      runtime: Runtime[R]
+  ): Router => Route =
+    route(ServerEndpoint[I, E, O, ZioStreams, RIO[R, *]](e, _ => logic(_).either))
+
+  def route[R, I, E, O](e: ServerEndpoint[I, E, O, ZioStreams, RIO[R, *]])(implicit
+      endpointOptions: VertxEffectfulEndpointOptions,
+      runtime: Runtime[R]
+  ): Router => Route = { router =>
+    implicit val ect: Option[ClassTag[E]] = None
+    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint))
+      .handler(endpointHandler(e)(e.logic, responseHandlerWithError(e)))
+  }
+
+  private def endpointHandler[R, I, E, O, A](e: ServerEndpoint[I, E, O, ZioStreams, RIO[R, *]])(
+      logic: MonadError[RIO[R, *]] => I => RIO[R, A],
+      responseHandler: (A, RoutingContext) => Unit
+  )(implicit
+      serverOptions: VertxEffectfulEndpointOptions,
+      runtime: Runtime[R],
+      ect: Option[ClassTag[E]]
+  ): Handler[RoutingContext] = { rc =>
+    decodeBodyAndInputsThen(
+      e.endpoint,
+      rc,
+      logicHandler(e)(logic(monadError.asInstanceOf[MonadError[RIO[R, *]]]), responseHandler, rc)
+    )
+  }
+
+  private def logicHandler[R, I, E, O, T](
+      e: ServerEndpoint[I, E, O, ZioStreams, RIO[R, *]]
+  )(logic: I => RIO[R, T], responseHandler: (T, RoutingContext) => Unit, rc: RoutingContext)(implicit
+      serverOptions: VertxEffectfulEndpointOptions,
+      runtime: Runtime[R],
+      ect: Option[ClassTag[E]]
+  ): Params => Unit = { params =>
+    val canceler = runtime.unsafeRunAsyncCancelable(logic(params.asAny.asInstanceOf[I])) {
+      case Exit.Success(result) =>
+        responseHandler(result, rc)
+      case Exit.Failure(cause) =>
+        serverOptions.logRequestHandling.logicException(e.endpoint, cause.squash)(serverOptions.logger)
+        tryEncodeError(e.endpoint, rc, cause.squash)
+    }
+
+    rc.response.exceptionHandler { _ =>
+      canceler(Fiber.Id.None)
+      ()
+    }
+
+    ()
+  }
+
+  private val monadError = new MonadError[Task] {
+    override def unit[T](t: T): Task[T] = Task.succeed(t)
+    override def map[T, T2](fa: Task[T])(f: T => T2): Task[T2] = fa.map(f)
+    override def flatMap[T, T2](fa: Task[T])(f: T => Task[T2]): Task[T2] = fa.flatMap(f)
+    override def error[T](t: Throwable): Task[T] = Task.fail(t)
+    override protected def handleWrappedError[T](rt: Task[T])(h: PartialFunction[Throwable, Task[T]]): Task[T] =
+      rt.catchSome(h)
+    override def eval[T](t: => T): Task[T] = Task.effect(t)
+    override def suspend[T](t: => Task[T]): Task[T] = Task.effectSuspend(t)
+    override def flatten[T](ffa: Task[Task[T]]): Task[T] = ffa.flatten
+    override def ensure[T](f: Task[T], e: => Task[Unit]): Task[T] = f.ensuring(e.catchAll(_ => Task.unit))
+  }
+
+  implicit class VertxFutureForZio[A](future: => Future[A]) {
+
+    def asTask: Task[A] =
+      Task.effectAsync { cb =>
+        future.onComplete { handler =>
+          if (handler.succeeded()) {
+            cb(Task.succeed(handler.result()))
+          } else {
+            cb(Task.fail(handler.cause()))
+          }
+        }
+      }
+  }
+}

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/package.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/package.scala
@@ -1,73 +1,14 @@
 package sttp.tapir.server
 
-import io.vertx.scala.ext.web.{Route, Router}
-import sttp.tapir.Endpoint
-
-import scala.concurrent.Future
-import scala.reflect.ClassTag
+import sttp.tapir.server.vertx.interpreters.VertxCatsServerInterpreter
+import sttp.tapir.server.vertx.interpreters.VertxFutureServerInterpreter
+import sttp.tapir.server.vertx.interpreters.VertxZioServerInterpreter
 
 package object vertx {
 
-  implicit class VertxEndpoint[I, E, O](e: Endpoint[I, E, O, Any]) {
+  object VertxZioServerInterpreter extends VertxZioServerInterpreter
 
-    /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
-      * @param logic the logic to associate with the endpoint
-      * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
-      * @return A function, that given a router, will attach this endpoint to it
-      */
-    @deprecated("Use VertxServerInterpreter.route", since = "0.17.1")
-    def route(logic: I => Future[Either[E, O]])(implicit endpointOptions: VertxEndpointOptions): Router => Route =
-      VertxServerInterpreter.route(e)(logic)
+  object VertxCatsServerInterpreter extends VertxCatsServerInterpreter
 
-    /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
-      * The logic will be executed in a blocking context
-      * @param logic the logic to associate with the endpoint
-      * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
-      * @return A function, that given a router, will attach this endpoint to it
-      */
-    @deprecated("Use VertxServerInterpreter.blockingRoute", since = "0.17.1")
-    def blockingRoute(logic: I => Future[Either[E, O]])(implicit endpointOptions: VertxEndpointOptions): Router => Route =
-      VertxServerInterpreter.blockingRoute(e)(logic)
-
-    /** Given a Router, creates and mounts a Route matching this endpoint, with custom error handling
-      * @param logic the logic to associate with the endpoint
-      * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
-      * @return A function, that given a router, will attach this endpoint to it
-      */
-    @deprecated("Use VertxServerInterpreter.routeRecoverErrors", since = "0.17.1")
-    def routeRecoverErrors(
-        logic: I => Future[O]
-    )(implicit endpointOptions: VertxEndpointOptions, eIsThrowable: E <:< Throwable, eClassTag: ClassTag[E]): Router => Route =
-      VertxServerInterpreter.routeRecoverErrors(e)(logic)
-
-    /** Given a Router, creates and mounts a Route matching this endpoint, with custom error handling
-      * The logic will be executed in a blocking context
-      * @param logic the logic to associate with the endpoint
-      * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
-      * @return A function, that given a router, will attach this endpoint to it
-      */
-    @deprecated("Use VertxServerInterpreter.blockingRouteRecoverErrors", since = "0.17.1")
-    def blockingRouteRecoverErrors(
-        logic: I => Future[O]
-    )(implicit endpointOptions: VertxEndpointOptions, eIsThrowable: E <:< Throwable, eClassTag: ClassTag[E]): Router => Route =
-      VertxServerInterpreter.blockingRouteRecoverErrors(e)(logic)
-  }
-
-  implicit class VertxServerEndpoint[I, E, O](e: ServerEndpoint[I, E, O, Any, Future]) {
-
-    /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
-      * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
-      * @return A function, that given a router, will attach this endpoint to it
-      */
-    @deprecated("Use VertxServerInterpreter.route", since = "0.17.1")
-    def route(implicit endpointOptions: VertxEndpointOptions): Router => Route = VertxServerInterpreter.route(e)
-
-    /** Given a Router, creates and mounts a Route matching this endpoint, with default error handling
-      * The logic will be executed in a blocking context
-      * @param endpointOptions options associated to the endpoint, like its logging capabilities, or execution context
-      * @return A function, that given a router, will attach this endpoint to it
-      */
-    @deprecated("Use VertxServerInterpreter.blockingRoute", since = "0.17.1")
-    def blockingRoute(implicit endpointOptions: VertxEndpointOptions): Router => Route = VertxServerInterpreter.route(e)
-  }
+  object VertxFutureServerInterpreter extends VertxFutureServerInterpreter
 }

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/routing/MethodMapping.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/routing/MethodMapping.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.server.vertx.routing
 
 import io.vertx.core.http.HttpMethod
-import io.vertx.scala.core.http.HttpServerRequest
+import io.vertx.core.http.HttpServerRequest
 import sttp.model.Method
 
 /** Utility object to convert HTTP methods between Vert.x and Tapir
@@ -24,6 +24,6 @@ private[vertx] object MethodMapping {
     method.flatMap(conversions.get)
 
   def vertxToSttp(request: HttpServerRequest): Method =
-    Method(request.rawMethod.toUpperCase)
+    Method.unsafeApply(request.method.name.toUpperCase)
 
 }

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/routing/PathMapping.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/routing/PathMapping.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.server.vertx.routing
 
 import io.vertx.core.http.HttpMethod
-import io.vertx.scala.ext.web.{Route, Router}
+import io.vertx.ext.web.{Route, Router}
 import sttp.tapir.{Endpoint, EndpointInput}
 import sttp.tapir.EndpointInput.PathCapture
 import sttp.tapir.internal._

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/streams/ReadStreamCompatible.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/streams/ReadStreamCompatible.scala
@@ -1,0 +1,35 @@
+package sttp.tapir.server.vertx.streams
+
+import io.vertx.core.buffer.Buffer
+import io.vertx.core.streams.ReadStream
+import sttp.capabilities.Streams
+import sttp.tapir.internal.NoStreams
+
+trait ReadStreamCompatible[S] {
+
+  type Capability <: Streams[S]
+
+  val streams: Capability
+
+  def asReadStream(s: Capability#BinaryStream): ReadStream[Buffer]
+
+  def fromReadStream(s: ReadStream[Buffer]): Capability#BinaryStream
+}
+
+object ReadStreamCompatible {
+
+  def apply[S](implicit ev: ReadStreamCompatible[S]): ReadStreamCompatible[S] =
+    ev
+
+  implicit val incompatible: ReadStreamCompatible[Nothing] = new ReadStreamCompatible[Nothing] {
+    override type Capability = NoStreams
+
+    override val streams = NoStreams
+
+    override def asReadStream(s: Capability#BinaryStream): ReadStream[Buffer] =
+      ???
+
+    override def fromReadStream(s: ReadStream[Buffer]): Capability#BinaryStream =
+      ???
+  }
+}

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/streams/domain.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/streams/domain.scala
@@ -1,0 +1,119 @@
+package sttp.tapir.server.vertx.streams
+
+import io.vertx.core.buffer.Buffer
+import io.vertx.core.Handler
+
+import scala.collection.immutable.{Queue => SQueue}
+
+private[streams] trait DeferredLike[F[_], A] {
+
+  def complete(a: A): F[Unit]
+
+  def get: F[A]
+}
+
+private[streams] sealed trait Queue[F[_], A] {
+  def size: Int
+
+  def enqueue(a: A): (Queue[F, A], Option[F[Unit]])
+
+  def dequeue(dfd: DeferredLike[F, A]): (Queue[F, A], Either[DeferredLike[F, A], A])
+}
+
+private[streams] final case class Queued[F[_], A](queue: SQueue[A]) extends Queue[F, A] {
+  override def size: Int =
+    queue.size
+
+  override def enqueue(a: A): (Queue[F, A], Option[F[Unit]]) =
+    (Queued[F, A](queue.enqueue(a)), None)
+
+  override def dequeue(dfd: DeferredLike[F, A]): (Queue[F, A], Either[DeferredLike[F, A], A]) =
+    queue.dequeueOption match {
+      case None =>
+        (Empty(dfd), Left(dfd))
+      case Some((head, tail)) =>
+        (Queued(tail), Right(head))
+    }
+}
+
+private[streams] final case class Empty[F[_], A](dfd: DeferredLike[F, A]) extends Queue[F, A] {
+  override def size: Int =
+    -1
+
+  override def enqueue(a: A): (Queue[F, A], Option[F[Unit]]) =
+    (Queued[F, A](SQueue.empty), Some(dfd.complete(a)))
+
+  override def dequeue(x: DeferredLike[F, A]): (Queue[F, A], Either[DeferredLike[F, A], A]) =
+    (this, Left(dfd))
+}
+
+private[streams] sealed trait ActivationEvent
+private[streams] case object Pause extends ActivationEvent
+private[streams] case object Resume extends ActivationEvent
+
+private[streams] object ReadStreamState {
+  type WrappedBuffer[C] = Either[Option[Throwable], C]
+  type WrappedEvent = Option[ActivationEvent]
+}
+
+import ReadStreamState._
+
+private[streams] final case class ReadStreamState[F[_], C](
+  buffers: Queue[F, WrappedBuffer[C]],
+  activationEvents: Queue[F, WrappedEvent]
+) { self =>
+
+  def enqueue(chunk: C, maxSize: Int): (ReadStreamState[F, C], List[F[Unit]]) = {
+    val (newBuffers, mbAction1) = buffers.enqueue(Right(chunk))
+    val (newActivationEvents, mbAction2) = if (newBuffers.size == maxSize) {
+      activationEvents.enqueue(Some(Pause))
+    } else {
+      (activationEvents, None)
+    }
+    (ReadStreamState(newBuffers, newActivationEvents), mbAction1.toList ::: mbAction2.toList)
+  }
+
+  def halt(cause: Option[Throwable]): (ReadStreamState[F, C], List[F[Unit]]) = {
+    val (newBuffers, mbAction1) = buffers.enqueue(Left(cause))
+    val (newActivationEvents, mbAction2) = activationEvents.enqueue(None)
+    (ReadStreamState(newBuffers, newActivationEvents), mbAction1.toList ::: mbAction2.toList)
+  }
+
+  def dequeueBuffer(dfd: DeferredLike[F, WrappedBuffer[C]]):
+      (ReadStreamState[F, C], (Either[DeferredLike[F, WrappedBuffer[C]], WrappedBuffer[C]], Option[F[Unit]])) = {
+    val (newBuffers, mbA) = buffers.dequeue(dfd)
+    mbA match {
+      case left @ Left(_) =>
+        if (buffers.size == 0 && newBuffers.size == -1) {
+          val (newActivationEvents, mbAction) = activationEvents.enqueue(Some(Resume))
+          (ReadStreamState(newBuffers, newActivationEvents), (left, mbAction))
+        } else {
+          (ReadStreamState(newBuffers, activationEvents), (left, None))
+        }
+      case Right(buffer) =>
+        (ReadStreamState(newBuffers, activationEvents), (Right(buffer), None))
+    }
+  }
+
+  def dequeueActivationEvent(dfd: DeferredLike[F, WrappedEvent]):
+      (ReadStreamState[F, C], Either[DeferredLike[F, WrappedEvent], WrappedEvent]) = {
+    val (newActivationEvents, mbEvent) = activationEvents.dequeue(dfd)
+    (ReadStreamState(buffers, newActivationEvents), mbEvent)
+  }
+}
+
+private[streams] final case class StreamState[F[_]](
+  paused: Option[DeferredLike[F, Unit]],
+  handler: Handler[Buffer],
+  errorHandler: Handler[Throwable],
+  endHandler: Handler[Void]
+)
+
+private[streams] object StreamState {
+  def empty[F[_]](promise: DeferredLike[F, Unit]) = StreamState(
+    Some(promise),
+    (_: Buffer) => (),
+    (_: Throwable) => (),
+    (_: Void) => ()
+  )
+}

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/streams/fs2.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/streams/fs2.scala
@@ -1,0 +1,161 @@
+package sttp.tapir.server.vertx.streams
+
+import cats.effect.concurrent.Deferred
+import cats.effect.concurrent.Ref
+import cats.effect.syntax.concurrent._
+import cats.effect.ConcurrentEffect
+import cats.effect.ExitCase
+import cats.syntax.applicative._
+import cats.syntax.flatMap._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import cats.syntax.traverse._
+import _root_.fs2.Chunk
+import _root_.fs2.Stream
+import io.vertx.core.buffer.Buffer
+import io.vertx.core.streams.ReadStream
+import io.vertx.core.Handler
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.tapir.server.vertx.streams.ReadStreamState._
+import sttp.tapir.server.vertx.VertxEffectfulEndpointOptions
+
+import scala.collection.immutable.{Queue => SQueue}
+
+object fs2 {
+
+  implicit class DeferredOps[F[_], A](dfd: Deferred[F, A]) extends DeferredLike[F, A] {
+    override def complete(a: A): F[Unit] =
+      dfd.complete(a)
+
+    override def get: F[A] =
+      dfd.get
+  }
+
+  implicit def fs2ReadStreamCompatible[F[_]](implicit opts: VertxEffectfulEndpointOptions, F: ConcurrentEffect[F]) =
+    new ReadStreamCompatible[Fs2Streams[F]] {
+      override type Capability = Fs2Streams[F]
+
+      override val streams: Capability = Fs2Streams[F]
+
+      override def asReadStream(stream: Capability#BinaryStream): ReadStream[Buffer] =
+        F.toIO(for {
+          promise <- Deferred[F, Unit]
+          state <- Ref.of(StreamState.empty[F](promise))
+          _ <- stream.chunks.evalMap({ chunk =>
+            val buffer = Buffer.buffer(chunk.toArray)
+            state.get.flatMap {
+              case StreamState(None, handler, _, _) =>
+                F.delay(handler.handle(buffer))
+              case StreamState(Some(promise), handler, _, _) =>
+                promise.get.flatMap { _ =>
+                  F.delay(handler.handle(buffer))
+                }
+              case _ =>
+                F.unit
+            }
+          }).onFinalizeCase({
+            case ExitCase.Completed =>
+              state.get.flatMap { state =>
+                F.delay(state.endHandler.handle(null))
+              }
+            case ExitCase.Canceled =>
+              state.get.flatMap { state =>
+                F.delay(state.errorHandler.handle(new Exception("Cancelled!")))
+              }
+            case ExitCase.Error(cause) =>
+              state.get.flatMap { state =>
+                F.delay(state.errorHandler.handle(cause))
+              }
+          }).compile.drain.start
+        } yield new ReadStream[Buffer] { self =>
+
+          override def handler(handler: Handler[Buffer]): ReadStream[Buffer] =
+            F.toIO(state.update(_.copy(handler = handler)).as(self))
+              .unsafeRunSync()
+
+          override def endHandler(handler: Handler[Void]): ReadStream[Buffer] =
+            F.toIO(state.update(_.copy(endHandler = handler)).as(self))
+              .unsafeRunSync()
+
+          override def exceptionHandler(handler: Handler[Throwable]): ReadStream[Buffer] =
+            F.toIO(state.update(_.copy(errorHandler = handler)).as(self))
+              .unsafeRunSync()
+
+          override def pause(): ReadStream[Buffer] =
+            F.toIO(for {
+              deferred <- Deferred[F, Unit]
+              _ <- state.update {
+                case cur @ StreamState(Some(_), _, _, _) =>
+                  cur
+                case cur @ StreamState(None, _, _, _) =>
+                  cur.copy(paused = Some(deferred))
+              }
+            } yield self).unsafeRunSync()
+
+          override def resume(): ReadStream[Buffer] =
+            F.toIO(for {
+              oldState <- state.getAndUpdate(_.copy(paused = None))
+              _ <- oldState.paused.fold(F.unit)(_.complete(()))
+            } yield self).unsafeRunSync()
+
+          override def fetch(n: Long): ReadStream[Buffer] =
+            self
+        }).unsafeRunSync()
+
+      override def fromReadStream(readStream: ReadStream[Buffer]): Capability#BinaryStream =
+        F.toIO(for {
+          stateRef <- Ref.of(ReadStreamState[F, Chunk[Byte]](Queued(SQueue.empty), Queued(SQueue.empty)))
+          stream = Stream.unfoldChunkEval[F, Unit, Byte](()) { _ =>
+            for {
+              dfd <- Deferred[F, WrappedBuffer[Chunk[Byte]]]
+              tuple <- stateRef.modify(_.dequeueBuffer(dfd))
+              (mbBuffer, mbAction) = tuple
+              _ <- mbAction.traverse(identity)
+              wrappedBuffer <- mbBuffer match {
+                case Left(deferred) =>
+                  deferred.get
+                case Right(buffer) =>
+                  buffer.pure[F]
+              }
+              result <- wrappedBuffer match {
+                case Right(buffer) => Some((buffer, ())).pure[F]
+                case Left(None) => None.pure[F]
+                case Left(Some(cause)) => ConcurrentEffect[F].raiseError(cause)
+              }
+            } yield result
+          }
+
+          _ <- Stream.unfoldEval[F, Unit, ActivationEvent](())({ _ =>
+            for {
+              dfd <- Deferred[F, WrappedEvent]
+              mbEvent <- stateRef.modify(_.dequeueActivationEvent(dfd))
+              result <- mbEvent match {
+                case Left(deferred) =>
+                  deferred.get
+                case Right(event) =>
+                  event.pure[F]
+              }
+            } yield result.map((_, ()))
+          }).evalMap({
+            case Pause =>
+              ConcurrentEffect[F].delay(readStream.pause())
+            case Resume =>
+              ConcurrentEffect[F].delay(readStream.resume())
+          }).compile.drain.start
+        } yield {
+          readStream.endHandler { _ =>
+            F.toIO(stateRef.modify(_.halt(None)).flatMap(_.sequence_)).unsafeRunSync()
+          }
+          readStream.exceptionHandler { cause =>
+            F.toIO(stateRef.modify(_.halt(Some(cause))).flatMap(_.sequence_)).unsafeRunSync()
+          }
+          readStream.handler { buffer =>
+            val chunk = Chunk.array(buffer.getBytes)
+            val maxSize = opts.maxQueueSizeForReadStream
+            F.toIO(stateRef.modify(_.enqueue(chunk, maxSize)).flatMap(_.sequence_)).unsafeRunSync()
+          }
+
+          stream
+        }).unsafeRunSync()
+    }
+}

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/streams/zio.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/streams/zio.scala
@@ -1,0 +1,157 @@
+package sttp.tapir.server.vertx.streams
+
+import io.vertx.core.buffer.Buffer
+import io.vertx.core.streams.ReadStream
+import io.vertx.core.Handler
+import sttp.capabilities.zio.ZioStreams
+import sttp.tapir.server.vertx.streams._
+import sttp.tapir.server.vertx.streams.ReadStreamState._
+import sttp.tapir.server.vertx.VertxEffectfulEndpointOptions
+import _root_.zio._
+import _root_.zio.stream.ZStream
+
+import scala.collection.immutable.{Queue => SQueue}
+import scala.language.postfixOps
+
+object zio {
+
+  implicit class DeferredOps[A](dfd: Promise[Nothing, A]) extends DeferredLike[UIO, A] {
+    override def complete(a: A): UIO[Unit] =
+      dfd.done(Exit.Success(a)).unit
+
+    override def get: UIO[A] =
+      dfd.await
+  }
+
+  implicit def zioReadStreamCompatible(implicit opts: VertxEffectfulEndpointOptions, runtime: Runtime[Any]) =
+    new ReadStreamCompatible[ZioStreams] {
+      override type Capability = ZioStreams
+
+      override val streams: Capability = ZioStreams
+
+      override def asReadStream(stream: Capability#BinaryStream): ReadStream[Buffer] =
+        runtime.unsafeRunSync(for {
+          promise <- Promise.make[Nothing, Unit]
+          state <- ZRef.make(StreamState.empty(promise))
+          _ <- stream.foreachChunk { chunk =>
+            val buffer = Buffer.buffer(chunk.toArray)
+            state.get.flatMap {
+              case StreamState(None, handler, _, _) =>
+                ZIO.effect(handler.handle(buffer))
+              case StreamState(Some(promise), handler, _, _) =>
+                promise.get.flatMap { _ =>
+                  ZIO.effect(handler.handle(buffer))
+                }
+              case _ =>
+                UIO.unit
+            }
+          } onExit {
+            case Exit.Success(()) =>
+              state.get.flatMap { state =>
+                ZIO.effect(state.endHandler.handle(null))
+                  .catchAll(cause2 => ZIO.effect(state.errorHandler.handle(cause2)).either)
+              }
+            case Exit.Failure(cause) =>
+              state.get.flatMap { state =>
+                ZIO.effect(state.errorHandler.handle(cause.squash))
+                  .catchAll(cause2 => ZIO.effect(state.errorHandler.handle(cause2)).either)
+              }
+          } forkDaemon
+        } yield new ReadStream[Buffer] { self =>
+
+          override def handler(handler: Handler[Buffer]): ReadStream[Buffer] =
+            runtime.unsafeRunSync(state.update(_.copy(handler = handler)))
+              .toEither
+              .fold(throw _, _ => self)
+
+          override def exceptionHandler(handler: Handler[Throwable]): ReadStream[Buffer] =
+            runtime.unsafeRunSync(state.update(_.copy(errorHandler = handler)))
+              .toEither
+              .fold(throw _, _ => self)
+
+          override def endHandler(handler: Handler[Void]): ReadStream[Buffer] =
+            runtime.unsafeRunSync(state.update(_.copy(endHandler = handler)))
+              .toEither
+              .fold(throw _, _ => self)
+
+          override def pause(): ReadStream[Buffer] =
+            runtime.unsafeRunSync(for {
+              promise <- Promise.make[Nothing, Unit]
+              _ <- state.update {
+                case cur @ StreamState(Some(_), _, _, _) =>
+                  cur
+                case cur @ StreamState(None, _, _, _) =>
+                  cur.copy(paused = Some(promise))
+              }
+            } yield self).toEither.fold(throw _, identity)
+
+          override def resume(): ReadStream[Buffer] =
+            runtime.unsafeRunSync(for {
+              oldState <- state.getAndUpdate(_.copy(paused = None))
+              _ <- oldState.paused.fold[UIO[Any]](UIO.unit)(_.complete(()))
+            } yield self).toEither.fold(throw _, identity)
+
+          override def fetch(x: Long): ReadStream[Buffer] =
+            self
+
+        }).toEither.fold(throw _, identity)
+
+      override def fromReadStream(readStream: ReadStream[Buffer]): Capability#BinaryStream =
+        runtime.unsafeRunSync(for {
+          stateRef <- ZRef.make(ReadStreamState[UIO, Chunk[Byte]](Queued(SQueue.empty), Queued(SQueue.empty)))
+          stream = ZStream.unfoldChunkM(()) { _ =>
+            for {
+              dfd <- Promise.make[Nothing, WrappedBuffer[Chunk[Byte]]]
+              tuple <- stateRef.modify(_.dequeueBuffer(dfd).swap)
+              (mbBuffer, mbAction) = tuple
+              _ <- ZIO.foreach(mbAction)(identity)
+              wrappedBuffer <- mbBuffer match {
+                case Left(deferred) =>
+                  deferred.get
+                case Right(buffer) =>
+                  UIO.succeed(buffer)
+              }
+              result <- wrappedBuffer match {
+                case Right(buffer) => UIO.succeed(Some((buffer, ())))
+                case Left(None) => UIO.succeed(None)
+                case Left(Some(cause)) => IO.fail(cause)
+              }
+            } yield result
+          }
+          _ <- ZStream.unfoldM(())({ _ =>
+            for {
+              dfd <- Promise.make[Nothing, WrappedEvent]
+              mbEvent <- stateRef.modify(_.dequeueActivationEvent(dfd).swap)
+              result <- mbEvent match {
+                case Left(deferred) =>
+                  deferred.get
+                case Right(event) =>
+                  UIO.succeed(event)
+              }
+            } yield result.map((_, ()))
+          }).mapM({
+            case Pause =>
+              IO.effect(readStream.pause())
+            case Resume =>
+              IO.effect(readStream.resume())
+          }).runDrain.forkDaemon
+        } yield {
+          readStream.endHandler { _ =>
+            runtime.unsafeRunSync(stateRef.modify(_.halt(None).swap).flatMap(ZIO.foreach_(_)(identity)))
+              .fold(c => throw c.squash, identity)
+          }
+          readStream.exceptionHandler { cause =>
+            runtime.unsafeRunSync(stateRef.modify(_.halt(Some(cause)).swap).flatMap(ZIO.foreach_(_)(identity)))
+              .fold(c => throw c.squash, identity)
+          }
+          readStream.handler { buffer =>
+            val chunk = Chunk.fromArray(buffer.getBytes)
+            val maxSize = opts.maxQueueSizeForReadStream
+            runtime.unsafeRunSync(stateRef.modify(_.enqueue(chunk, maxSize).swap).flatMap(ZIO.foreach_(_)(identity)))
+              .fold(c => throw c.squash, identity)
+          }
+
+          stream
+        }).toEither.fold(throw _, identity)
+    }
+}

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/CatsVertxServerTests.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/CatsVertxServerTests.scala
@@ -1,0 +1,32 @@
+package sttp.tapir.server.vertx
+
+import cats.effect.{IO, Resource}
+import io.vertx.core.Vertx
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.monad.MonadError
+import sttp.tapir.server.tests.{ServerAuthenticationTests, ServerBasicTests, ServerStreamingTests, ServerTests, backendResource}
+import sttp.tapir.tests.{Test, TestSuite}
+
+class CatsVertxServerTests extends TestSuite {
+  import CatsVertxTestServerInterpreter._
+
+  def vertxResource: Resource[IO, Vertx] =
+    Resource.make(IO.delay(Vertx.vertx()))(vertx => vertxFutureToIo(vertx.close).void)
+
+  override def tests: Resource[IO, List[Test]] = backendResource.flatMap { backend =>
+    vertxResource.map { implicit vertx =>
+      implicit val m: MonadError[IO] = VertxCatsServerInterpreter.monadError[IO]
+      val interpreter = new CatsVertxTestServerInterpreter(vertx)
+      val serverTests = new ServerTests(interpreter)
+
+      new ServerBasicTests(
+        backend,
+        serverTests,
+        interpreter,
+        multipartInlineHeaderSupport = false // README: doesn't seem supported but I may be wrong
+      ).tests() ++
+        new ServerAuthenticationTests(backend, serverTests).tests() ++
+        new ServerStreamingTests(backend, serverTests, Fs2Streams.apply[IO]).tests()
+    }
+  }
+}

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxBlockingServerTests.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxBlockingServerTests.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.server.vertx
 
 import cats.effect.{IO, Resource}
-import io.vertx.scala.core.Vertx
+import io.vertx.core.Vertx
 import sttp.monad.FutureMonad
 import sttp.tapir.server.tests.{ServerAuthenticationTests, ServerBasicTests, ServerTests, backendResource}
 import sttp.tapir.tests.{Test, TestSuite}

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxServerTests.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxServerTests.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.server.vertx
 
 import cats.effect.{IO, Resource}
-import io.vertx.scala.core.Vertx
+import io.vertx.core.Vertx
 import sttp.monad.FutureMonad
 import sttp.tapir.server.tests.{ServerAuthenticationTests, ServerBasicTests, ServerTests, backendResource}
 import sttp.tapir.tests.{Test, TestSuite}

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxTestServerBlockingInterpreter.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxTestServerBlockingInterpreter.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.server.vertx
 
-import io.vertx.scala.core.Vertx
-import io.vertx.scala.ext.web.{Route, Router}
+import io.vertx.core.Vertx
+import io.vertx.ext.web.{Route, Router}
 import sttp.tapir.Endpoint
 import sttp.tapir.server.{DecodeFailureHandler, ServerDefaults, ServerEndpoint}
 
@@ -13,10 +13,10 @@ class VertxTestServerBlockingInterpreter(vertx: Vertx) extends VertxTestServerIn
       e: ServerEndpoint[I, E, O, Any, Future],
       decodeFailureHandler: Option[DecodeFailureHandler]
   ): Router => Route =
-    VertxServerInterpreter.blockingRoute(e)(options.copy(decodeFailureHandler.getOrElse(ServerDefaults.decodeFailureHandler)))
+    VertxFutureServerInterpreter.blockingRoute(e)(options.copy(decodeFailureHandler.getOrElse(ServerDefaults.decodeFailureHandler)))
 
   override def routeRecoverErrors[I, E <: Throwable, O](e: Endpoint[I, E, O, Any], fn: I => Future[O])(implicit
       eClassTag: ClassTag[E]
   ): Router => Route =
-    VertxServerInterpreter.blockingRouteRecoverErrors(e)(fn)
+    VertxFutureServerInterpreter.blockingRouteRecoverErrors(e)(fn)
 }

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/streams/FakeStream.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/streams/FakeStream.scala
@@ -1,0 +1,73 @@
+package sttp.tapir.server.vertx.streams
+
+import io.vertx.core.buffer.Buffer
+import io.vertx.core.streams.ReadStream
+import io.vertx.core.Handler
+
+class FakeStream extends ReadStream[Buffer] { self =>
+
+  private var demand = Long.MaxValue
+  private var eventHandler: Handler[Buffer] = _
+  private var endHandler: Handler[Void] = _
+  private var exceptionHandler: Handler[Throwable] = _
+  @volatile var pauseCount: Int = 0
+  @volatile var resumeCount: Int = 0
+
+  val lock = new Object()
+
+  override def exceptionHandler(handler: Handler[Throwable]): ReadStream[Buffer] = {
+    exceptionHandler = handler
+    self
+  }
+
+  override def handler(handler: Handler[Buffer]): ReadStream[Buffer] = {
+    eventHandler = handler
+    self
+  }
+
+  override def fetch(amount: Long): ReadStream[Buffer] =
+    lock.synchronized {
+      demand += amount
+      if (demand < 0L) {
+        demand = Long.MaxValue
+      }
+      lock.notifyAll
+      self
+    }
+
+  override def pause(): ReadStream[Buffer] = {
+    demand = 0L
+    pauseCount += 1
+
+    self
+  }
+
+  override def resume(): ReadStream[Buffer] = {
+    resumeCount += 1
+    fetch(Long.MaxValue)
+  }
+
+  override def endHandler(handler: Handler[Void]): ReadStream[Buffer] = {
+    endHandler = handler
+    self
+  }
+
+  def isPaused(): Boolean =
+    demand == 0L
+
+  def handle(s: String): Unit =
+    handle(Buffer.buffer(s))
+
+  def handle(buff: Buffer): Unit =
+    lock.synchronized {
+      if (demand == 0L) lock.wait
+      if (demand != Long.MaxValue) demand -= 1
+      eventHandler.handle(buff)
+    }
+
+  def fail(err: Throwable): Unit =
+    exceptionHandler.handle(err)
+
+  def end(): Unit =
+    endHandler.handle(null)
+}

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/streams/Fs2StreamTest.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/streams/Fs2StreamTest.scala
@@ -1,0 +1,218 @@
+package sttp.tapir.server.vertx.streams
+
+import java.nio.ByteBuffer
+
+import cats.effect.{ContextShift, IO, Timer}
+import cats.effect.concurrent.Ref
+import cats.syntax.flatMap._
+import cats.syntax.option._
+import _root_.fs2.Stream
+import _root_.fs2.Chunk
+import io.vertx.core.buffer.Buffer
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.tapir.server.vertx.VertxEffectfulEndpointOptions
+
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+class Fs2StreamTest extends AnyFlatSpec with Matchers {
+
+  implicit val options = VertxEffectfulEndpointOptions(maxQueueSizeForReadStream = 4)
+
+  def intAsBuffer(int: Int): Chunk[Byte] = {
+    val buffer = ByteBuffer.allocate(4)
+    buffer.putInt(int)
+    buffer.flip()
+    Chunk.array(buffer.array)
+  }
+
+  def intAsVertxBuffer(int: Int): Buffer =
+    Buffer.buffer(intAsBuffer(int).toArray)
+
+  def bufferAsInt(buffer: Buffer): Int = {
+    val bs = buffer.getBytes()
+    (bs(0) & 0xff) << 24 | (bs(1) & 0xff) << 16 | (bs(2) & 0xff) << 8 | (bs(3) & 0xff)
+  }
+
+  def chunkAsInt(chunk: Chunk[Byte]): Int =
+    bufferAsInt(Buffer.buffer(chunk.toArray))
+
+  def shouldIncreaseMonotonously(xs: List[Int]): Unit = {
+    all(xs.iterator.sliding(2).map(_.toList).toList) should matchPattern {
+      case (first: Int) :: (second: Int) :: Nil if first + 1 == second =>
+    }
+    ()
+  }
+
+  implicit val cs: ContextShift[IO] = IO.contextShift(scala.concurrent.ExecutionContext.global)
+
+  implicit val timer: Timer[IO] = IO.timer(scala.concurrent.ExecutionContext.global)
+
+  def eventually[A](io: IO[A])(cond: PartialFunction[A, Unit]): IO[A] = {
+    val frequency = 50.millis
+    val timeout = 15.seconds
+    val maxAttempts = (timeout / frequency).toInt
+
+    def internal(attempts: Int): IO[A] =
+      io.flatTap(a => IO.delay(cond(a)))
+        .handleErrorWith({ case NonFatal(e) =>
+          if (attempts < maxAttempts) {
+            timer.sleep(frequency) *> internal(attempts + 1)
+          } else {
+            IO.raiseError(e)
+          }
+        })
+
+    internal(0)
+  }
+
+
+  "Fs2ReadStreamCompatiable" should "convert fs2 stream to read stream" in {
+    val stream = Stream.unfoldChunkEval(0)({ num =>
+      IO.delay(100.millis).as(((intAsBuffer(num), num + 1)).some)
+    }).interruptAfter(4.seconds)
+
+    (for {
+      ref <- Ref.of[IO, List[Int]](Nil)
+      readStream = fs2.fs2ReadStreamCompatible[IO].asReadStream(stream)
+      completed <- Ref[IO].of(false)
+      _ <- IO.delay {
+        readStream.handler { buffer =>
+          ref.update(_ :+ bufferAsInt(buffer)).unsafeRunSync()
+        }
+      }
+      _ <- IO.delay {
+        readStream.endHandler { _ =>
+          completed.set(true).unsafeRunSync()
+        }
+      }
+      _ <- IO.delay(readStream.resume())
+      _ <- eventually(ref.get)({ case _ :: _ => () })
+      _ <- IO.delay(readStream.pause())
+      _ <- IO.sleep(1.second)
+      snapshot2 <- ref.get
+      _ <- IO.delay(readStream.resume())
+      snapshot3 <- eventually(ref.get)({ case list => list.length should be > snapshot2.length })
+      _ = shouldIncreaseMonotonously(snapshot3)
+      _ <- eventually(completed.get)({ case true => () })
+    } yield ()).unsafeRunSync()
+  }
+
+  it should "interrupt read stream after zio stream interruption" in {
+    val stream = Stream.unfoldChunkEval(0)({ num =>
+      if (num > 20) {
+        IO.raiseError(new Exception("!"))
+      } else {
+        timer.sleep(100.millis).as(((intAsBuffer(num), num + 1)).some)
+      }
+    })//.interruptAfter(2.seconds)
+    val readStream = fs2.fs2ReadStreamCompatible[IO].asReadStream(stream)
+    (for {
+      ref <- Ref.of[IO, List[Int]](Nil)
+      completedRef <- Ref[IO].of(false)
+      interruptedRef <- Ref.of[IO, Option[Throwable]](None)
+      _ <- IO.delay {
+        readStream.handler { buffer =>
+          ref.update(_ :+ bufferAsInt(buffer)).unsafeRunSync()
+        }
+      }
+      _ <- IO.delay {
+        readStream.endHandler { _ =>
+          completedRef.set(true).unsafeRunSync()
+        }
+      }
+      _ <- IO.delay {
+        readStream.exceptionHandler { cause =>
+          interruptedRef.set(Some(cause)).unsafeRunSync()
+        }
+      }
+      _ <- IO.delay(readStream.resume())
+      snapshot <- eventually(ref.get)({ case list => list.length should be > 10 })
+      _ = shouldIncreaseMonotonously(snapshot)
+      _ <- eventually(for {
+        completed <- completedRef.get
+        interrupted <- interruptedRef.get
+      } yield (completed, interrupted))({
+        case (false, Some(_)) =>
+      })
+    } yield ()).unsafeRunSync()
+  }
+
+  it should "drain read stream without pauses if buffer has enough space" in {
+    val opts = options.copy(maxQueueSizeForReadStream = 128)
+    val count = 100
+    val readStream = new FakeStream()
+    val stream = fs2.fs2ReadStreamCompatible[IO](opts, implicitly).fromReadStream(readStream)
+    (for {
+      resultFiber <- stream.chunkN(4)
+        .map(chunkAsInt)
+        .compile
+        .toList
+        .start
+      _ <- IO.delay {
+        (1 to count).foreach { i =>
+          readStream.handle(intAsVertxBuffer(i))
+        }
+        readStream.end()
+      }
+      result <- resultFiber.join
+    } yield {
+      shouldIncreaseMonotonously(result)
+      result should have size count.toLong
+      readStream.pauseCount shouldBe 0
+      // readStream.resumeCount should be <= 1
+    }).unsafeRunSync()
+  }
+
+  it should "drain read stream with small buffer" in {
+    val count = 100
+    val readStream = new FakeStream()
+    val stream = fs2.fs2ReadStreamCompatible[IO].fromReadStream(readStream)
+    (for {
+      resultFiber <- stream.chunkN(4)
+        .map(chunkAsInt)
+        .evalMap(i => IO.sleep(50.millis).as(i))
+        .compile
+        .toList
+        .start
+      _ <- IO.delay({
+        (1 to count).foreach { i =>
+          Thread.sleep(25)
+          readStream.handle(intAsVertxBuffer(i))
+        }
+        readStream.end()
+      }).start
+      result <- resultFiber.join
+    } yield {
+      shouldIncreaseMonotonously(result)
+      result should have size count.toLong
+      readStream.pauseCount should be > 0
+      readStream.resumeCount should be > 0
+    }).unsafeRunSync()
+  }
+
+  it should "drain failed read stream" in {
+    val count = 50
+    val readStream = new FakeStream()
+    val stream = fs2.fs2ReadStreamCompatible[IO].fromReadStream(readStream)
+    (for {
+      resultFiber <- stream.chunkN(4)
+        .map(chunkAsInt)
+        .evalMap(i => IO.sleep(50.millis).as(i))
+        .compile
+        .toList
+        .start
+      _ <- IO.delay({
+        (1 to count).foreach { i =>
+          Thread.sleep(25)
+          readStream.handle(intAsVertxBuffer(i))
+        }
+        readStream.fail(new Exception("!"))
+      }).start
+      result <- resultFiber.join.attempt
+    } yield {
+      result.isLeft shouldBe true
+    }).unsafeRunSync()
+  }
+}

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/streams/ZStreamTest.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/streams/ZStreamTest.scala
@@ -1,0 +1,206 @@
+package sttp.tapir.server.vertx.streams
+
+import java.nio.ByteBuffer
+
+import io.vertx.core.buffer.Buffer
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.EitherValues._
+import sttp.tapir.server.vertx.VertxEffectfulEndpointOptions
+import _root_.zio._
+import _root_.zio.clock
+import _root_.zio.duration._
+import _root_.zio.stream.ZStream
+import _root_.zio.clock.Clock
+import _root_.zio.internal.tracing.TracingConfig
+
+class ZStreamTest extends AnyFlatSpec with Matchers {
+
+  val runtime = Runtime.default.mapPlatform(_.withTracingConfig(TracingConfig.disabled))
+
+  val options = VertxEffectfulEndpointOptions(maxQueueSizeForReadStream = 4)
+
+  def intAsBuffer(int: Int): Chunk[Byte] = {
+    val buffer = ByteBuffer.allocate(4)
+    buffer.putInt(int)
+    buffer.flip()
+    Chunk.fromByteBuffer(buffer)
+  }
+
+  def intAsVertxBuffer(int: Int): Buffer =
+    Buffer.buffer(intAsBuffer(int).toArray)
+
+  def bufferAsInt(buffer: Buffer): Int = {
+    val bs = buffer.getBytes()
+    (bs(0) & 0xff) << 24 | (bs(1) & 0xff) << 16 | (bs(2) & 0xff) << 8 | (bs(3) & 0xff)
+  }
+
+  def chunkAsInt(chunk: Chunk[Byte]): Int =
+    bufferAsInt(Buffer.buffer(chunk.toArray))
+
+  def shouldIncreaseMonotonously(xs: List[Int]): Unit = {
+    all(xs.iterator.sliding(2).map(_.toList).toList) should matchPattern {
+      case (first: Int) :: (second: Int) :: Nil if first + 1 == second =>
+    }
+    ()
+  }
+
+  val schedule = (Schedule.spaced(50.millis) >>> Schedule.elapsed).whileOutput(_ < 15.seconds)
+
+  def eventually[A](task: Task[A])(cond: PartialFunction[A, Unit]): Task[A] =
+    task.tap(a => ZIO.effect(cond(a))).retry(schedule).provideLayer(Clock.live)
+
+  "ZioReadStreamCompatible" should "convert zio stream to read stream" in {
+    val stream = ZStream.tick(100.millis)
+      .mapAccum(0)((acc, _) => (acc + 1, acc))
+      .haltAfter(3.seconds)
+      .map(intAsBuffer)
+      .flattenChunks
+      .provideLayer(clock.Clock.live)
+    val readStream = zio.zioReadStreamCompatible(options, runtime).asReadStream(stream)
+    runtime.unsafeRunSync(for {
+      ref <- ZRef.make[List[Int]](Nil)
+      completed <- ZRef.make[Boolean](false)
+      _ <- Task.effect {
+        readStream.handler { buffer =>
+          runtime.unsafeRunSync(ref.update(_ :+ bufferAsInt(buffer)))
+          ()
+        }
+      }
+      _ <- Task.effect {
+        readStream.endHandler { _ =>
+          runtime.unsafeRunSync(completed.set(true))
+          ()
+        }
+      }
+      _ <- Task.effect(readStream.resume())
+      _ <- eventually(ref.get)({ case _ :: _ => () })
+      _ <- Task.effect(readStream.pause())
+      _ <- ZIO.sleep(1.seconds)
+      snapshot2 <- ref.get
+      _ <- Task.effect(readStream.resume())
+      snapshot3 <- eventually(ref.get)({ case list => list.length should be > snapshot2.length })
+      _ = shouldIncreaseMonotonously(snapshot3)
+      _ <- eventually(completed.get)({ case true => () })
+    } yield ()).toEither.value
+  }
+
+  it should "interrupt read stream after zio stream interruption" in {
+    val stream = ZStream.tick(100.millis)
+      .mapAccum(0)((acc, _) => (acc + 1, acc))
+      .haltAfter(7.seconds)
+      .map(intAsBuffer)
+      .flattenChunks
+      .provideLayer(clock.Clock.live) ++ ZStream.fail(new Exception("!"))
+    val readStream = zio.zioReadStreamCompatible(options, runtime).asReadStream(stream)
+    runtime.unsafeRunSync(for {
+      ref <- ZRef.make[List[Int]](Nil)
+      completedRef <- ZRef.make[Boolean](false)
+      interruptedRef <- ZRef.make[Option[Throwable]](None)
+      _ <- Task.effect {
+        readStream.handler { buffer =>
+          runtime.unsafeRunSync(ref.update(_ :+ bufferAsInt(buffer)))
+          ()
+        }
+      }
+      _ <- Task.effect {
+        readStream.endHandler { _ =>
+          runtime.unsafeRunSync(completedRef.set(true))
+          ()
+        }
+      }
+      _ <- Task.effect {
+        readStream.exceptionHandler { cause =>
+          runtime.unsafeRunSync(interruptedRef.set(Some(cause)))
+          ()
+        }
+      }
+      _ <- Task.effect(readStream.resume())
+      snapshot <- eventually(ref.get)({ case list => list.length should be > 3 })
+      _ = shouldIncreaseMonotonously(snapshot)
+      _ <- eventually(completedRef.get &&& interruptedRef.get)({
+        case (false, Some(_)) =>
+      })
+    } yield ()).toEither.value
+  }
+
+  it should "drain read stream without pauses if buffer has enough space" in {
+    val opts = options.copy(maxQueueSizeForReadStream = 128)
+    val count = 100
+    val readStream = new FakeStream()
+    val stream = zio.zioReadStreamCompatible(opts, runtime).fromReadStream(readStream)
+    runtime.unsafeRunSync(for {
+      resultFiber <- stream
+        .mapChunks((chunkAsInt _).andThen(Chunk.single))
+        .toIterator.map(_.toList).useNow.fork
+      _ <- ZIO.effect {
+        (1 to count).foreach { i =>
+          readStream.handle(intAsVertxBuffer(i))
+        }
+        readStream.end()
+      }
+      result <- resultFiber.join
+    } yield {
+      val successes = result.collect { case Right(i) => i }
+      shouldIncreaseMonotonously(successes)
+      successes should have size count.toLong
+      readStream.pauseCount shouldBe 0
+      // readStream.resumeCount shouldBe 0
+    }).toEither.value
+  }
+
+  it should "drain read stream with small buffer" in {
+    val opts = options.copy(maxQueueSizeForReadStream = 4)
+    val count = 100
+    val readStream = new FakeStream()
+    val stream = zio.zioReadStreamCompatible(opts, runtime).fromReadStream(readStream)
+    runtime.unsafeRunSync(for {
+      resultFiber <- stream
+        .mapChunks((chunkAsInt _).andThen(Chunk.single))
+        .mapM(i => ZIO.sleep(50.millis).as(i))
+        .toIterator.map(_.toList).useNow.fork
+      _ <- ZIO.effect({
+        (1 to count).foreach { i =>
+          Thread.sleep(25)
+          readStream.handle(intAsVertxBuffer(i))
+        }
+        readStream.end()
+      }).fork
+      result <- resultFiber.join
+    } yield {
+      val successes = result.collect { case Right(i) => i }
+      shouldIncreaseMonotonously(successes)
+      successes should have size count.toLong
+      readStream.pauseCount should be > 0
+      readStream.resumeCount should be > 0
+    }).toEither.value
+  }
+
+  it should "drain failed read stream" in {
+    val opts = options.copy(maxQueueSizeForReadStream = 4)
+    val count = 50
+    val readStream = new FakeStream()
+    val stream = zio.zioReadStreamCompatible(opts, runtime).fromReadStream(readStream)
+    runtime.unsafeRunSync(for {
+      resultFiber <- stream
+        .mapChunks((chunkAsInt _).andThen(Chunk.single))
+        .mapM(i => ZIO.sleep(50.millis).as(i))
+        .toIterator.map(_.toList).useNow.fork
+      _ <- ZIO.effect({
+        (1 to count).foreach { i =>
+          Thread.sleep(25)
+          readStream.handle(intAsVertxBuffer(i))
+        }
+        readStream.fail(new Exception("!"))
+      }).fork
+      result <- resultFiber.join
+    } yield {
+      val successes = result.collect { case Right(i) => i }
+      shouldIncreaseMonotonously(successes)
+      successes should have size count.toLong
+      readStream.pauseCount should be > 0
+      readStream.resumeCount should be > 0
+      result.lastOption.collect { case Left(e) => e } should not be empty
+    }).toEither.value
+  }
+}


### PR DESCRIPTION
I would to make some changes in vertx interpreter to support streaming and zio.

I replaced `vertx-web-scala` by plain java `vertx-web` because:
1. `vertx-web-scala` is only available for scala 2.12. Using java `vertx-web` we can compile this interpreter even for dotty.
2. `vertx-web-scala` replaces `io.vertx.core.Future` by scala `Future` and it doesn't allow interrupt evaluation of effect if connection is already closed.

I added two new interpreters `ZioVertxServerInterpreter` and `CatsVertxServerInterpreter`. Both interpreters support interruption and streaming. `CatsVertxServerInterpreter` supports streaming based on fs2 streams. `ZioVertxServerInterpreter` supports ZStreams.

Work is still in progress. I need to make more tests. But it seems that general functionality already works. What do you think about these changes?