### PR TITLE
Include the `_root_` prefix in quasiquotes to ensure macro hygiene

### DIFF
--- a/core/src/main/scala/sttp/tapir/generic/internal/CaseClassUtil.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/CaseClassUtil.scala
@@ -26,7 +26,7 @@ private[generic] class CaseClassUtil[C <: blackbox.Context, T: C#WeakTypeTag](va
     q"$companion.tupled.asInstanceOf[Any => $t].apply(sttp.tapir.internal.SeqToParams(values))"
   }
 
-  lazy val schema: Tree = c.typecheck(q"implicitly[sttp.tapir.Schema[$t]]")
+  lazy val schema: Tree = c.typecheck(q"_root_.scala.Predef.implicitly[_root_.sttp.tapir.Schema[$t]]")
 
   lazy val classSymbol = t.typeSymbol.asClass
 

--- a/core/src/main/scala/sttp/tapir/generic/internal/EndpointAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/EndpointAnnotations.scala
@@ -83,7 +83,7 @@ abstract class EndpointAnnotations(val c: blackbox.Context) extends Tapir {
     if (codec == EmptyTree) {
       c.abort(c.enclosingPosition, s"Unable to resolve implicit value of type ${codecTpe.dealias}")
     }
-    q"sttp.tapir.EndpointIO.Body(${c.untypecheck(ann.tree)}.bodyType, $codec, sttp.tapir.EndpointIO.Info.empty)"
+    q"_root_.sttp.tapir.EndpointIO.Body(${c.untypecheck(ann.tree)}.bodyType, $codec, sttp.tapir.EndpointIO.Info.empty)"
   }
 
   protected def mapToTargetFunc[A](fieldIdxToInputIdx: mutable.Map[Int, Int], util: CaseClassUtil[c.type, A]) = {
@@ -113,7 +113,7 @@ abstract class EndpointAnnotations(val c: blackbox.Context) extends Tapir {
     util.findAnnotation(field, apikeyType).fold(inputWithDeprecation) { a =>
       val challenge = authChallenge(a)
       setSecuritySchemeName(
-        q"sttp.tapir.EndpointInput.Auth.ApiKey($inputWithDeprecation, $challenge, None)",
+        q"_root_.sttp.tapir.EndpointInput.Auth.ApiKey($inputWithDeprecation, $challenge, None)",
         util.findAnnotation(field, securitySchemeNameType)
       )
     }

--- a/core/src/main/scala/sttp/tapir/generic/internal/EndpointInputAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/EndpointInputAnnotations.scala
@@ -126,13 +126,13 @@ class EndpointInputAnnotations(override val c: blackbox.Context) extends Endpoin
   private def makeBearerAuthInput(field: c.Symbol, schemeName: Option[Annotation], auth: Annotation): Tree = {
     val challenge = authChallenge(auth)
     val codec = summonCodec(field, stringListConstructor)
-    setSecuritySchemeName(q"sttp.tapir.TapirAuth.bearer($challenge)($codec)", schemeName)
+    setSecuritySchemeName(q"_root_.sttp.tapir.TapirAuth.bearer($challenge)($codec)", schemeName)
   }
 
   private def makeBasicAuthInput(field: c.Symbol, schemeName: Option[Annotation], annotation: Annotation): Tree = {
     val challenge = authChallenge(annotation)
     val codec = summonCodec(field, stringListConstructor)
-    setSecuritySchemeName(q"sttp.tapir.TapirAuth.basic($challenge)($codec)", schemeName)
+    setSecuritySchemeName(q"_root_.sttp.tapir.TapirAuth.basic($challenge)($codec)", schemeName)
   }
 
 }

--- a/core/src/main/scala/sttp/tapir/generic/internal/FormCodecDerivation.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/FormCodecDerivation.scala
@@ -52,7 +52,7 @@ object FormCodecMacros {
             ${util.instanceFromValues}
           }
         }
-        def encode(o: $t): _root_.scala.Seq[(_root_.java.lang.String, _root.java.lang.String)] = _root_.scala.List(..$encodeParams).flatten
+        def encode(o: $t): _root_.scala.Seq[(_root_.java.lang.String, _root_.java.lang.String)] = _root_.scala.List(..$encodeParams).flatten
 
         _root_.sttp.tapir.Codec.formSeqCodecUtf8
           .mapDecode(decode _)(encode _)

--- a/core/src/main/scala/sttp/tapir/generic/internal/FormCodecDerivation.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/FormCodecDerivation.scala
@@ -24,7 +24,7 @@ object FormCodecMacros {
     val fields = util.fields
 
     val fieldsWithCodecs = fields.map { field =>
-      (field, c.typecheck(q"implicitly[sttp.tapir.Codec[List[String], ${field.typeSignature}, sttp.tapir.CodecFormat.TextPlain]]"))
+      (field, c.typecheck(q"_root_.scala.Predef.implicitly[_root_.sttp.tapir.Codec[List[String], ${field.typeSignature}, _root_.sttp.tapir.CodecFormat.TextPlain]]"))
     }
 
     val encodedNameType = c.weakTypeOf[encodedName]
@@ -48,13 +48,13 @@ object FormCodecMacros {
         def decode(params: Seq[(String, String)]): sttp.tapir.DecodeResult[$t] = {
           val paramsMap: Map[String, Seq[String]] = params.groupBy(_._1).transform((_, v) => v.map(_._2))
           val decodeResults = List(..$decodeParams)
-          sttp.tapir.DecodeResult.sequence(decodeResults).map { values =>
+          _root_.sttp.tapir.DecodeResult.sequence(decodeResults).map { values =>
             ${util.instanceFromValues}
           }
         }
-        def encode(o: $t): Seq[(String, String)] = List(..$encodeParams).flatten
+        def encode(o: $t): _root_.scala.Seq[(_root_.java.lang.String, _root.java.lang.String)] = _root_.scala.List(..$encodeParams).flatten
 
-        sttp.tapir.Codec.formSeqCodecUtf8
+        _root_.sttp.tapir.Codec.formSeqCodecUtf8
           .mapDecode(decode _)(encode _)
           .schema(${util.schema})
       }

--- a/core/src/main/scala/sttp/tapir/generic/internal/MagnoliaDerivedMacro.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/MagnoliaDerivedMacro.scala
@@ -8,6 +8,6 @@ object MagnoliaDerivedMacro {
 
   def derivedGen[T: c.WeakTypeTag](c: whitebox.Context): c.Expr[Derived[T]] = {
     import c.universe._
-    c.Expr[Derived[T]](q"sttp.tapir.generic.Derived(${Magnolia.gen[T](c)(implicitly[c.WeakTypeTag[T]])})")
+    c.Expr[Derived[T]](q"_root_.sttp.tapir.generic.Derived(${Magnolia.gen[T](c)(implicitly[c.WeakTypeTag[T]])})")
   }
 }

--- a/core/src/main/scala/sttp/tapir/generic/internal/MultipartCodecDerivation.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/MultipartCodecDerivation.scala
@@ -140,7 +140,7 @@ object MultipartCodecDerivation {
           val values = _root_.scala.List(..$decodeParams)
           ${util.instanceFromValues}
         }
-        def encode(o: $t): _root_.scala.Seq[_root_sttp.tapir.RawPart] = _root_.scala.List(..$encodeParams)
+        def encode(o: $t): _root_.scala.Seq[_root_.sttp.tapir.RawPart] = _root_.scala.List(..$encodeParams)
 
         _root_.sttp.tapir.Codec.multipartCodec($partCodecs, _root_.scala.None)
           .map(decode _)(encode _)

--- a/core/src/main/scala/sttp/tapir/generic/internal/MultipartCodecDerivation.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/MultipartCodecDerivation.scala
@@ -42,38 +42,38 @@ object MultipartCodecDerivation {
       val codecsToCheck = List(
         () =>
           (
-            q"sttp.tapir.RawBodyType.StringBody(java.nio.charset.StandardCharsets.UTF_8)",
-            q"implicitly[sttp.tapir.Codec[List[String], $codecType, sttp.tapir.CodecFormat.TextPlain]]"
+            q"_root_.sttp.tapir.RawBodyType.StringBody(_root_.java.nio.charset.StandardCharsets.UTF_8)",
+            q"_root_.scala.Predef.implicitly[_root_.sttp.tapir.Codec[_root_.scala.List[_root_.java.lang.String], $codecType, _root_.sttp.tapir.CodecFormat.TextPlain]]"
           ),
         () =>
           (
-            q"sttp.tapir.RawBodyType.StringBody(java.nio.charset.StandardCharsets.UTF_8)",
-            q"implicitly[sttp.tapir.Codec[List[String], $codecType, _ <: sttp.tapir.CodecFormat]]"
+            q"_root_.sttp.tapir.RawBodyType.StringBody(_root_.java.nio.charset.StandardCharsets.UTF_8)",
+            q"_root_.scala.Predef.implicitly[_root_.sttp.tapir.Codec[_root_.scala.List[_root_.java.lang.String], $codecType, _ <: _root_.sttp.tapir.CodecFormat]]"
           ),
         () =>
           (
-            q"sttp.tapir.RawBodyType.ByteArrayBody",
-            q"implicitly[sttp.tapir.Codec[List[Array[Byte]], $codecType, _ <: sttp.tapir.CodecFormat]]"
+            q"_root_.sttp.tapir.RawBodyType.ByteArrayBody",
+            q"_root_.scala.Predef.implicitly[_root_.sttp.tapir.Codec[_root_.scala.List[_root_.scala.Array[_root_.scala.Byte]], $codecType, _ <: _root_.sttp.tapir.CodecFormat]]"
           ),
         () =>
           (
-            q"sttp.tapir.RawBodyType.InputStreamBody",
-            q"implicitly[sttp.tapir.Codec[List[java.io.InputStream], $codecType, _ <: sttp.tapir.CodecFormat]]"
+            q"_root_.sttp.tapir.RawBodyType.InputStreamBody",
+            q"_root_.scala.Predef.implicitly[_root_.sttp.tapir.Codec[_root_.scala.List[_root_.java.io.InputStream], $codecType, _ <: _root_.sttp.tapir.CodecFormat]]"
           ),
         () =>
           (
-            q"sttp.tapir.RawBodyType.ByteBufferBody",
-            q"implicitly[sttp.tapir.Codec[List[java.nio.ByteBuffer], $codecType, _ <: sttp.tapir.CodecFormat]]"
+            q"_root_.sttp.tapir.RawBodyType.ByteBufferBody",
+            q"_root_.scala.Predef.implicitly[_root_.sttp.tapir.Codec[_root_.scala.List[_root_.java.nio.ByteBuffer], $codecType, _ <: _root_.sttp.tapir.CodecFormat]]"
           ),
         () =>
           (
-            q"sttp.tapir.RawBodyType.FileBody",
-            q"implicitly[sttp.tapir.Codec[List[java.io.File], $codecType, _ <: sttp.tapir.CodecFormat]]"
+            q"_root_.sttp.tapir.RawBodyType.FileBody",
+            q"_root_.scala.Predef.implicitly[_root_.sttp.tapir.Codec[_root_.scala.List[_root_.java.io.File], $codecType, _ <: _root_.sttp.tapir.CodecFormat]]"
           ),
         () =>
           (
-            q"sttp.tapir.RawBodyType.FileBody",
-            q"implicitly[sttp.tapir.Codec[List[org.scalajs.dom.raw.File], $codecType, _ <: sttp.tapir.CodecFormat]]"
+            q"_root_.sttp.tapir.RawBodyType.FileBody",
+            q"_root_.scala.Predef.implicitly[_root_.sttp.tapir.Codec[_root_.scala.List[_root_.org.scalajs.dom.raw.File], $codecType, _ <: _root_.sttp.tapir.CodecFormat]]"
           )
       )
 
@@ -89,10 +89,10 @@ object MultipartCodecDerivation {
     val partCodecPairs = fieldsWithCodecs.map { case (field, (bodyType, codec)) =>
       val fieldName = field.name.decodedName.toString
       val encodedName = util.extractArgFromAnnotation(field, encodedNameType)
-      q"""$encodedName.getOrElse($conf.toEncodedName($fieldName)) -> sttp.tapir.PartCodec($bodyType, $codec)"""
+      q"""($encodedName.getOrElse($conf.toEncodedName($fieldName)), _root_.sttp.tapir.PartCodec($bodyType, $codec))"""
     }
 
-    val partCodecs = q"""Map(..$partCodecPairs)"""
+    val partCodecs = q"""_root_.scala.collection.immutable.Map(..$partCodecPairs)"""
 
     val encodeParams: Iterable[Tree] = fields.map { field =>
       val fieldName = field.name.asInstanceOf[TermName]
@@ -105,7 +105,7 @@ object MultipartCodecDerivation {
             o.$fieldName.copy(name = transformedName)"""
       } else {
         val base = q"""$transformedName
-                       sttp.model.Part(transformedName, o.$fieldName)"""
+                       _root_.sttp.model.Part(transformedName, o.$fieldName)"""
 
         // if the field is a File/Path, and is not wrapped in a Part, during encoding adding the file's name
         val fieldTypeName = field.typeSignature.typeSymbol.fullName
@@ -135,14 +135,14 @@ object MultipartCodecDerivation {
 
     val codecTree = q"""
       {
-        def decode(parts: Seq[sttp.tapir.RawPart]): $t = {
-          val partsByName: Map[String, sttp.tapir.RawPart] = parts.map(p => p.name -> p).toMap
-          val values = List(..$decodeParams)
+        def decode(parts: _root_.scala.Seq[_root_.sttp.tapir.RawPart]): $t = {
+          val partsByName: _root_.scala.collection.immutable.Map[_root_.java.lang.String, _root_.sttp.tapir.RawPart] = parts.map(p => p.name -> p).toMap
+          val values = _root_.scala.List(..$decodeParams)
           ${util.instanceFromValues}
         }
-        def encode(o: $t): Seq[sttp.tapir.RawPart] = List(..$encodeParams)
+        def encode(o: $t): _root_.scala.Seq[_root_sttp.tapir.RawPart] = _root_.scala.List(..$encodeParams)
 
-        sttp.tapir.Codec.multipartCodec($partCodecs, None)
+        _root_.sttp.tapir.Codec.multipartCodec($partCodecs, _root_.scala.None)
           .map(decode _)(encode _)
           .schema(${util.schema})
       }

--- a/core/src/main/scala/sttp/tapir/generic/internal/OneOfMacro.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/OneOfMacro.scala
@@ -45,16 +45,13 @@ object OneOfMacro {
 
     val name = resolveFunctionName(extractor.tree.asInstanceOf[Function])
 
-    // FIXME: Despite the imports, `Discriminator`, `Schema`, `SCoproduct`, `SRef` and `SObject` should be fully qualified from `_root_`.
-    // I think that even with these imports, terms defined in the same scope with the same names will be given priority
-    // over the imported (and intended) ones. Someone will need to find where each of these types lives.
     val schemaForE =
       q"""{
             import _root_.sttp.tapir.Schema._
             import _root_.sttp.tapir.SchemaType._
             val rawMapping = _root_.scala.collection.immutable.Map(..$mapping)
-            val discriminator = Discriminator($name, rawMapping.map{case (k, sf)=> $asString.apply(k) -> SRef(sf.schemaType.asInstanceOf[SObject].info)})
-            Schema(SCoproduct(SObjectInfo(${weakTypeE.typeSymbol.fullName},${extractTypeArguments(weakTypeE)}), rawMapping.values.toList, _root_.scala.Some(discriminator)))
+            val discriminator = _root_.sttp.tapir.SchemaType.Discriminator($name, rawMapping.map { case (k, sf) => $asString.apply(k) -> _root_.sttp.tapir.SchemaType.SRef(sf.schemaType.asInstanceOf[_root_.sttp.tapir.SchemaType.SObject].info)})
+            _root_.sttp.tapir.Schema(_root_.sttp.tapir.SchemaType.SCoproduct(_root_.sttp.tapir.SchemaType.SObjectInfo(${weakTypeE.typeSymbol.fullName},${extractTypeArguments(weakTypeE)}), rawMapping.values.toList, _root_.scala.Some(discriminator)))
           }"""
 
     Debug.logGeneratedCode(c)(weakTypeE.typeSymbol.fullName, schemaForE)

--- a/core/src/main/scala/sttp/tapir/generic/internal/OneOfMacro.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/OneOfMacro.scala
@@ -44,13 +44,17 @@ object OneOfMacro {
     }
 
     val name = resolveFunctionName(extractor.tree.asInstanceOf[Function])
+
+    // FIXME: Despite the imports, `Discriminator`, `Schema`, `SCoproduct`, `SRef` and `SObject` should be fully qualified from `_root_`.
+    // I think that even with these imports, terms defined in the same scope with the same names will be given priority
+    // over the imported (and intended) ones. Someone will need to find where each of these types lives.
     val schemaForE =
       q"""{
-            import sttp.tapir.Schema._
-            import sttp.tapir.SchemaType._
-            val rawMapping = scala.collection.immutable.Map(..$mapping)
+            import _root_.sttp.tapir.Schema._
+            import _root_.sttp.tapir.SchemaType._
+            val rawMapping = _root_.scala.collection.immutable.Map(..$mapping)
             val discriminator = Discriminator($name, rawMapping.map{case (k, sf)=> $asString.apply(k) -> SRef(sf.schemaType.asInstanceOf[SObject].info)})
-            Schema(SCoproduct(SObjectInfo(${weakTypeE.typeSymbol.fullName},${extractTypeArguments(weakTypeE)}), rawMapping.values.toList, Some(discriminator)))
+            Schema(SCoproduct(SObjectInfo(${weakTypeE.typeSymbol.fullName},${extractTypeArguments(weakTypeE)}), rawMapping.values.toList, _root_.scala.Some(discriminator)))
           }"""
 
     Debug.logGeneratedCode(c)(weakTypeE.typeSymbol.fullName, schemaForE)

--- a/core/src/main/scala/sttp/tapir/generic/internal/SchemaMapMacro.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/SchemaMapMacro.scala
@@ -23,9 +23,9 @@ object SchemaMapMacro {
     val schemaForMap =
       q"""{
           val s = $schemaForV
-          val v = sttp.tapir.Validator.openProduct(s.validator)
-          sttp.tapir.Schema(
-            sttp.tapir.SchemaType.SOpenProduct(sttp.tapir.SchemaType.SObjectInfo("Map", $genericTypeParametersM), s),
+          val v = _root_.sttp.tapir.Validator.openProduct(s.validator)
+          _root_.sttp.tapir.Schema(
+            _root_.sttp.tapir.SchemaType.SOpenProduct(_root_.sttp.tapir.SchemaType.SObjectInfo("Map", $genericTypeParametersM), s),
             validator = v)
          }"""
     Debug.logGeneratedCode(c)(weakTypeV.typeSymbol.fullName, schemaForMap)

--- a/core/src/main/scala/sttp/tapir/generic/internal/ValidatorEnumMacro.scala
+++ b/core/src/main/scala/sttp/tapir/generic/internal/ValidatorEnumMacro.scala
@@ -19,7 +19,7 @@ trait ValidatorEnumMacro {
         c.abort(c.enclosingPosition, "All children must be objects.")
       } else {
         val instances = subclasses.map(x => Ident(x.asInstanceOf[scala.reflect.internal.Symbols#Symbol].sourceModule.asInstanceOf[Symbol]))
-        val validatorEnum = q"sttp.tapir.Validator.enum($instances)"
+        val validatorEnum = q"_root_.sttp.tapir.Validator.enum($instances)"
         Debug.logGeneratedCode(c)(t.typeSymbol.fullName, validatorEnum)
         c.Expr[Validator.Enum[E]](validatorEnum)
       }

--- a/core/src/main/scala/sttp/tapir/internal/ModifySchemaMacro.scala
+++ b/core/src/main/scala/sttp/tapir/internal/ModifySchemaMacro.scala
@@ -24,7 +24,7 @@ object ModifySchemaMacro {
   ): c.Tree = {
     import c.universe._
     q"""{
-      ${c.prefix}.modifyUnsafe($path:_*)((v: sttp.tapir.Schema[${c.weakTypeOf[T]}]) => v.description($description))
+      ${c.prefix}.modifyUnsafe($path:_*)((v: _root_.sttp.tapir.Schema[${c.weakTypeOf[T]}]) => v.description($description))
      }"""
   }
 

--- a/core/src/main/scala/sttp/tapir/internal/StatusMappingMacro.scala
+++ b/core/src/main/scala/sttp/tapir/internal/StatusMappingMacro.scala
@@ -24,6 +24,6 @@ object StatusMappingMacro {
       )
     }
 
-    c.Expr[StatusMapping[O]](q"sttp.tapir.statusMappingClassMatcher($statusCode, $output, $ct.runtimeClass)")
+    c.Expr[StatusMapping[O]](q"_root_.sttp.tapir.statusMappingClassMatcher($statusCode, $output, $ct.runtimeClass)")
   }
 }


### PR DESCRIPTION
I have mechanically gone through and made the macros hygienic by fully-qualifying every type used in quasiquotes. (With the exception of some in `OneOfMacro`—I didn't have time to look up where all of the types are defined, so I added a FIXME.) If nobody gets there before me, I may get a chance to come back to this later...

How well-tested are the macros? I've made quite a lot of changes, and a small typo would certainly break that macro. Can I rely on CI to tell me if I've made a mistake?