### PR TITLE
Add redocVersion parameter for RedocHttp4s 

### DIFF
--- a/docs/redoc-http4s/src/main/resources/redoc.html
+++ b/docs/redoc-http4s/src/main/resources/redoc.html
@@ -19,6 +19,6 @@
 </head>
 <body>
 <redoc spec-url='{{docsPath}}' expand-responses="200,201"></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.22/bundles/redoc.standalone.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/redoc@{{redocVersion}}/bundles/redoc.standalone.js"></script>
 </body>
 </html>

--- a/docs/redoc-http4s/src/main/scala/sttp/tapir/redoc/http4s/RedocHttp4s.scala
+++ b/docs/redoc-http4s/src/main/scala/sttp/tapir/redoc/http4s/RedocHttp4s.scala
@@ -13,15 +13,16 @@ import scala.io.Source
   * @param title       The title of the HTML page.
   * @param yaml        The yaml with the OpenAPI documentation.
   * @param yamlName    The name of the file, through which the yaml documentation will be served. Defaults to `docs.yaml`.
+  * @param redocVersion The semver version of Redoc to use. Defaults to `2.0.0-rc.23`.
   */
-class RedocHttp4s(title: String, yaml: String, yamlName: String = "docs.yaml") {
+class RedocHttp4s(title: String, yaml: String, yamlName: String = "docs.yaml", redocVersion: String = "2.0.0-rc.23") {
   private lazy val html = {
     val fileName = "redoc.html"
     val is = getClass.getClassLoader.getResourceAsStream(fileName)
     assert(Option(is).nonEmpty, s"Could not find file ${fileName} on classpath.")
     val rawHtml = Source.fromInputStream(is).mkString
     // very poor man's templating engine
-    rawHtml.replace("{{docsPath}}", yamlName).replace("{{title}}", title)
+    rawHtml.replace("{{docsPath}}", yamlName).replace("{{title}}", title).replace("{{redocVersion}}", redocVersion)
   }
 
   def routes[F[_]: ContextShift: Sync]: HttpRoutes[F] = {


### PR DESCRIPTION
Hi,

Thank you for creating this library.

A very small contribution allowing to specify which Redoc version you want to use with Http4sRedoc.
Actually, the version used (rc.22) has a real annoying bug: https://github.com/Redocly/redoc/issues/1177 
