### PR TITLE
Add InvariantSemigroupal instances for Endpoint(Input|IO|Output)

### DIFF
--- a/core/src/main/scala/sttp/tapir/EndpointIO.scala
+++ b/core/src/main/scala/sttp/tapir/EndpointIO.scala
@@ -367,7 +367,7 @@ object EndpointOutput {
 }
 
 sealed trait EndpointIO[T] extends EndpointInput[T] with EndpointOutput[T] {
-  private[tapir] type ThisType[X] <: EndpointInput[X] with EndpointOutput[X]
+  private[tapir] type ThisType[X] <: EndpointIO[X]
 
   def and[J, IJ](other: EndpointIO[J])(implicit concat: ParamConcat.Aux[T, J, IJ]): EndpointIO[IJ] =
     EndpointIO.Pair(this, other, mkCombine(concat), mkSplit(concat))

--- a/integrations/cats/src/main/scala/sttp/tapir/integ/cats/EndpointIOInstances.scala
+++ b/integrations/cats/src/main/scala/sttp/tapir/integ/cats/EndpointIOInstances.scala
@@ -1,0 +1,35 @@
+package sttp.tapir.integ.cats
+
+import cats.{InvariantMonoidal, InvariantSemigroupal}
+import sttp.tapir.{EndpointInput, EndpointOutput, EndpointIO, emptyOutput}
+
+trait EndpointIOInstances {
+  implicit val endpointIOInvariantSemigroupal: InvariantSemigroupal[EndpointIO] =
+    new InvariantSemigroupal[EndpointIO] {
+      override def imap[A, B](fa: EndpointIO[A])(f: A => B)(g: B => A): EndpointIO[B] =
+        fa.map(f)(g)
+
+      override def product[A, B](fa: EndpointIO[A], fb: EndpointIO[B]): EndpointIO[(A, B)] =
+        fa.and(fb)
+    }
+
+  implicit val endpointInputInvariantSemigroupal: InvariantSemigroupal[EndpointInput] =
+    new InvariantSemigroupal[EndpointInput] {
+      override def imap[A, B](fa: EndpointInput[A])(f: A => B)(g: B => A): EndpointInput[B] =
+        fa.map(f)(g)
+
+      override def product[A, B](fa: EndpointInput[A], fb: EndpointInput[B]): EndpointInput[(A, B)] =
+        fa.and(fb)
+    }
+
+  implicit val endpointOutputInvariantMonoidal: InvariantMonoidal[EndpointOutput] =
+    new InvariantMonoidal[EndpointOutput] {
+      override def imap[A, B](fa: EndpointOutput[A])(f: A => B)(g: B => A): EndpointOutput[B] =
+        fa.map(f)(g)
+
+      override def product[A, B](fa: EndpointOutput[A], fb: EndpointOutput[B]): EndpointOutput[(A, B)] =
+        fa.and(fb)
+
+      override def unit: EndpointOutput[Unit] = emptyOutput
+    }
+}

--- a/integrations/cats/src/main/scala/sttp/tapir/integ/cats/instances.scala
+++ b/integrations/cats/src/main/scala/sttp/tapir/integ/cats/instances.scala
@@ -1,3 +1,3 @@
 package sttp.tapir.integ.cats
 
-object instances extends ExampleInstances
+object instances extends ExampleInstances with EndpointIOInstances

--- a/integrations/cats/src/test/scala/sttp/tapir/integ/cats/EndpointIOInstancesSpec.scala
+++ b/integrations/cats/src/test/scala/sttp/tapir/integ/cats/EndpointIOInstancesSpec.scala
@@ -1,0 +1,26 @@
+package sttp.tapir.integ.cats
+
+import cats.implicits._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import sttp.model.StatusCode
+import sttp.tapir.integ.cats.instances._
+import sttp.tapir._
+
+class EndpointIOInstancesSpec extends AnyFunSuite with Matchers {
+  test("InvariantSemigroupal syntax should work with EndpointInput") {
+    """|(query[Int]("foo"): EndpointInput[Int],
+       |  query[String]("bar")
+       |).tupled: EndpointInput[(Int, String)]""".stripMargin should compile
+  }
+  test("InvariantSemigroupal syntax should work with EndpointOutput") {
+    """|(statusCode: EndpointOutput[StatusCode],
+       |  statusCode
+       |).tupled: EndpointOutput[(StatusCode, StatusCode)]""".stripMargin should compile
+  }
+  test("InvariantSemigroupal syntax should work with EndpointIO") {
+    """|(header[Int]("foo"): EndpointIO[Int],
+       |  header[String]("bar")
+       |).tupled: EndpointIO[(Int, String)]""".stripMargin should compile
+  }
+}


### PR DESCRIPTION
Closes #1020

This turned out to be less useful than I imagined. :frowning: Combinators in `sttp.tapir` tend to return specific subtypes of `EndpointInput` etc., which means that the tuple doesn't get unified to the type we can have an instance for. A little nudge (specifying a wider type for an element of the tuple) helps, but that's ugly. Still, this notation might be useful when combining a lot of inputs.

I'm also not sure about `InvariantMonoidal`. It's possible to make an instance of it for `EndpointInput`, but that would expose the package-private value `emptyInput` as `unit` - I'm not sure we want that. However, I did add an instance of `InvariantMonoidal[EndpointOutput]`. This is based on the assumption that `emptyOutput` is an identity WRT `and`. From what I can see, this should be the case - but because of how the library is structured (pattern-matching on `EndpointOutput` etc.) it's difficult to say for sure.

This brings me to my final point - testing. Ideally, there should be law tests for these instances. However, even wiring those up (`Arbitrary` instances) would require a lot of work. An even deeper rabbit hole is defining equality for the types in question. For example, is `Pair(...).map(identity)(identity)` (which would be a `MappedPair`) **equivalent** to the original `Pair`? I want to think that it is - but structurally they are different, and since in different parts of the library (and possibly outside it) the code inspects this structure, we can't be certain. So ultimately these instances are less about proving laws, and more about common sense and nice syntax. Which is not to say they won't be useful.