### PR TITLE
[BUG-1047] Don't discard inner validator for collections or product types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,19 +89,19 @@ tapir documentation is available at [tapir.softwaremill.com](http://tapir.softwa
 
 Add the following dependency:
 
-```scala
+```sbt
 "com.softwaremill.sttp.tapir" %% "tapir-core" % "0.17.13"
 ```
 
 You'll need partial unification enabled in the compiler (alternatively, you'll need to manually provide type arguments in some cases):
 
-```scala
+```sbt
 scalacOptions += "-Ypartial-unification"
 ```
 
 Then, import:
 
-```scala
+```sbt
 import sttp.tapir._
 ```
 
@@ -113,7 +113,7 @@ Sidenote for scala 2.12.4 and higher: if you encounter an issue with compiling y
 a `StackOverflowException` related to [this](https://github.com/scala/bug/issues/10604) scala bug, 
 please increase your stack memory. Example:
 
-```
+```shell
 sbt -J-Xss4M clean compile
 ```
 

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/ValidatorUtil.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/ValidatorUtil.scala
@@ -3,13 +3,13 @@ package sttp.tapir.docs.apispec
 import sttp.tapir.Validator
 
 private[docs] object ValidatorUtil {
-  private[docs] def elementValidator(v: Validator[_]): Validator[_] = {
-    val result = asSingleValidators(v).collect {
+  private[docs] def elementValidator(collectionValidator: Validator[_], validators: Validator[_]*): Validator[_] = {
+    val result = asSingleValidators(collectionValidator).collect {
       case Validator.OpenProduct(elementValidator)           => elementValidator
       case Validator.CollectionElements(elementValidator, _) => elementValidator
     }
 
-    Validator.all(result: _*)
+    Validator.all(validators ++ result: _*)
   }
 
   private[docs] def asSingleValidators(v: Validator[_]): Seq[Validator.Single[_]] = {
@@ -37,8 +37,8 @@ private[docs] object ValidatorUtil {
     }
   }
 
-  private[docs] def fieldValidator(v: Validator[_], fieldName: String): Validator[_] = {
-    Validator.all(asSingleValidators(v).collect {
+  private[docs] def fieldValidator(parentValidator: Validator[_], fieldName: String, validators: Validator[_]*): Validator[_] = {
+    Validator.all(validators ++ asSingleValidators(parentValidator).collect {
       case Validator.CollectionElements(Validator.Product(fields), _) if fields.isDefinedAt(fieldName) => fields(fieldName).validator
       case Validator.Product(fields) if fields.isDefinedAt(fieldName)                                  => fields(fieldName).validator
     }: _*)

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/ObjectTypeData.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/ObjectTypeData.scala
@@ -55,7 +55,7 @@ object ObjectTypeData {
   }
 
   private def fieldsSchemaWithValidator(p: TSchemaType.SProduct, v: Validator[_]): Seq[TypeData[_]] = {
-    p.fields.map { f => TypeData(f._2, fieldValidator(v, f._1.name)) }.toList
+    p.fields.map { f => TypeData(f._2, fieldValidator(v, f._1.name, f._2.validator)) }.toList
   }
 
   private def subtypesSchemaWithValidator(st: TSchemaType.SCoproduct, v: Validator[_]): Seq[TypeData[_]] = {

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/ObjectTypeData.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/ObjectTypeData.scala
@@ -29,14 +29,14 @@ object ObjectTypeData {
   def apply(typeData: TypeData[_]): List[ObjectTypeData] = {
     typeData match {
       case TypeData(TSchema(TSchemaType.SArray(o), _, _, _, _, _, _, _), validator) =>
-        apply(TypeData(o, elementValidator(validator)))
+        apply(TypeData(o, elementValidator(validator, o.validator)))
       case TypeData(s @ TSchema(st: TSchemaType.SProduct, _, _, _, _, _, _, _), validator) =>
         productSchemas(s, st, validator)
       case TypeData(s @ TSchema(st: TSchemaType.SCoproduct, _, _, _, _, _, _, _), validator) =>
         coproductSchemas(s, st, validator)
       case TypeData(s @ TSchema(st: TSchemaType.SOpenProduct, _, _, _, _, _, _, _), validator) =>
         (st.info -> TypeData(s, validator): ObjectTypeData) +: apply(
-          TypeData(st.valueSchema, elementValidator(validator))
+          TypeData(st.valueSchema, elementValidator(validator, st.valueSchema.validator))
         )
       case _ => List.empty
     }

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
@@ -24,14 +24,16 @@ private[schema] class TSchemaToASchema(
               case (fieldName, TSchema(s: TSchemaType.SObject, _, _, _, _, _, _, _)) =>
                 fieldName.encodedName -> Left(objectToSchemaReference.map(s.info))
               case (fieldName, fieldSchema) =>
-                fieldName.encodedName -> apply(TypeData(fieldSchema, fieldValidator(typeData.validator, fieldName.name)))
+                fieldName.encodedName -> apply(
+                  TypeData(fieldSchema, fieldValidator(typeData.validator, fieldName.name, fieldSchema.validator))
+                )
             }.toListMap
           )
         )
       case TSchemaType.SArray(TSchema(el: TSchemaType.SObject, _, _, _, _, _, _, _)) =>
         Right(ASchema(SchemaType.Array).copy(items = Some(Left(objectToSchemaReference.map(el.info)))))
       case TSchemaType.SArray(el) =>
-        Right(ASchema(SchemaType.Array).copy(items = Some(apply(TypeData(el, elementValidator(typeData.validator))))))
+        Right(ASchema(SchemaType.Array).copy(items = Some(apply(TypeData(el, elementValidator(typeData.validator, el.validator))))))
       case TSchemaType.SBinary        => Right(ASchema(SchemaType.String).copy(format = SchemaFormat.Binary))
       case TSchemaType.SDate          => Right(ASchema(SchemaType.String).copy(format = SchemaFormat.Date))
       case TSchemaType.SDateTime      => Right(ASchema(SchemaType.String).copy(format = SchemaFormat.DateTime))


### PR DESCRIPTION
[Description](https://gitter.im/softwaremill/tapir?at=603910cbb5131f4f28db2266) of my issue

Should also address https://github.com/softwaremill/tapir/issues/1047

Right now when converting from a tapir schema to an open-api schema representation validators for members of product types - or elements of collections types - are discarded. Instead a new validator is created based on the "parent" validator. 

My change makes it so the child validator is _also_ used in the computing of the validator.

Let me know if this is right and makes sense - it was bit clumsy to get the existential type stuff to compile, perhaps there is a more elegant way of doing this.