### PR TITLE
fixed Play JSON error message when input is not a valid JSON document

### DIFF
--- a/json/playjson/src/main/scala/sttp/tapir/json/play/TapirJsonPlay.scala
+++ b/json/playjson/src/main/scala/sttp/tapir/json/play/TapirJsonPlay.scala
@@ -7,24 +7,32 @@ import sttp.tapir.Codec.JsonCodec
 import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
 import sttp.tapir.DecodeResult.{Error, Value}
 
+import scala.util.{Failure, Success, Try}
+
 trait TapirJsonPlay {
   def jsonBody[T: Reads: Writes: Schema]: EndpointIO.Body[String, T] = anyFromUtf8StringBody(readsWritesCodec[T])
 
   implicit def readsWritesCodec[T: Reads: Writes: Schema]: JsonCodec[T] =
     Codec.json[T] { s =>
-      implicitly[Reads[T]].reads(Json.parse(s)) match {
-        case JsError(errors) =>
-          val jsonErrors = errors
-            .flatMap { case (path, validationErrors) =>
-              val fields = path.toJsonString.split("\\.").toList.map(FieldName.apply)
-              validationErrors.map(error => fields -> error)
-            }
-            .map { case (fields, validationError) =>
-              JsonError(validationError.message, fields)
-            }
-            .toList
-          Error(s, JsonDecodeException(jsonErrors, JsResultException(errors)))
-        case JsSuccess(value, _) => Value(value)
+      Try(Json.parse(s)) match {
+        case Failure(exception) =>
+          Error(s, JsonDecodeException(List.empty, exception))
+        case Success(jsValue) =>
+          implicitly[Reads[T]].reads(jsValue) match {
+            case JsError(errors) =>
+              val jsonErrors = errors
+                .flatMap { case (path, validationErrors) =>
+                  val fields = path.toJsonString.split("\\.").toList.map(FieldName.apply)
+                  validationErrors.map(error => fields -> error)
+                }
+                .map { case (fields, validationError) =>
+                  JsonError(validationError.message, fields)
+                }
+                .toList
+              Error(s, JsonDecodeException(jsonErrors, JsResultException(errors)))
+            case JsSuccess(value, _) =>
+              Value(value)
+          }
       }
     } { t => Json.stringify(Json.toJson(t)) }
 


### PR DESCRIPTION
Currently, when submitting an invalid JSON document such as (missing comma):
```json
{
  "title": "Pride and Prejudice"
  "year": 1813
}
```
to an endpoint using Play-JSON, the output will be the following:
```
Invalid value for: body
```
this PR allows to produce this output instead:
```
Invalid value for: body (Unexpected character ('"' (code 34)): was expecting comma to separate Object entries
 at [Source: (String)"{
  "title": "Pride and Prejudice"
  "year": 1813
}"; line: 3, column: 4])
```