### PR TITLE
fix(server): URL-decode captured path segments

### DIFF
--- a/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraDecodeInputsContext.scala
+++ b/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraDecodeInputsContext.scala
@@ -1,6 +1,7 @@
 package sttp.tapir.server.finatra
 
 import com.twitter.finagle.http.Request
+import io.netty.handler.codec.http.QueryStringDecoder
 import sttp.model.{Method, QueryParams}
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.internal.DecodeInputsContext
@@ -18,7 +19,7 @@ class FinatraDecodeInputsContext(request: Request, pathConsumed: Int = 0) extend
     }
     val charactersConsumed = segment.map(_.length).getOrElse(0) + (path.length - nextStart.length)
 
-    (segment, new FinatraDecodeInputsContext(request, pathConsumed + charactersConsumed))
+    (segment.map(QueryStringDecoder.decodeComponent), new FinatraDecodeInputsContext(request, pathConsumed + charactersConsumed))
   }
   override def header(name: String): List[String] = request.headerMap.getAll(name).toList
   override def headers: Seq[(String, String)] = request.headerMap.toList

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sDecodeInputsContext.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sDecodeInputsContext.scala
@@ -22,7 +22,7 @@ private[http4s] class Http4sDecodeInputsContext[F[_]](req: Request[F]) extends D
     val segmentSlashLength = segment.map(_.length).getOrElse(0) + 1
     val reqWithNewCaret = req.withAttribute(Request.Keys.PathInfoCaret, oldCaret + segmentSlashLength)
 
-    (segment, new Http4sDecodeInputsContext(reqWithNewCaret))
+    (segment.map(org.http4s.Uri.decode(_)), new Http4sDecodeInputsContext(reqWithNewCaret))
   }
   override def header(name: String): List[String] = req.headers.get(CaseInsensitiveString(name)).map(_.value).toList
   override def headers: Seq[(String, String)] = req.headers.toList.map(h => (h.name.value, h.value))

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayDecodeInputContext.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayDecodeInputContext.scala
@@ -2,9 +2,12 @@ package sttp.tapir.server.play
 
 import akka.stream.Materializer
 import play.api.mvc.RequestHeader
+import play.utils.UriEncoding
 import sttp.model.{Method, QueryParams}
-import sttp.tapir.server.internal.DecodeInputsContext
 import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.internal.DecodeInputsContext
+
+import java.nio.charset.StandardCharsets
 
 private[play] class PlayDecodeInputContext(request: RequestHeader, pathConsumed: Int = 0, serverOptions: PlayServerOptions)(implicit
     mat: Materializer
@@ -20,8 +23,9 @@ private[play] class PlayDecodeInputContext(request: RequestHeader, pathConsumed:
       case Array(s, _) => Some(s)
     }
     val charactersConsumed = segment.map(_.length).getOrElse(0) + (path.length - nextStart.length)
+    val urlDecodedSegment = segment.map(UriEncoding.decodePathSegment(_, StandardCharsets.UTF_8))
 
-    (segment, new PlayDecodeInputContext(request, pathConsumed + charactersConsumed, serverOptions))
+    (urlDecodedSegment, new PlayDecodeInputContext(request, pathConsumed + charactersConsumed, serverOptions))
   }
   override def header(name: String): List[String] = request.headers.toMap.get(name).toList.flatten
   override def headers: Seq[(String, String)] = request.headers.headers

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/decoders/VertxDecodeInputsContext.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/decoders/VertxDecodeInputsContext.scala
@@ -1,5 +1,6 @@
 package sttp.tapir.server.vertx.decoders
 
+import io.netty.handler.codec.http.QueryStringDecoder
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.streams.ReadStream
 import io.vertx.ext.web.RoutingContext
@@ -28,7 +29,8 @@ private[vertx] class VertxDecodeInputsContext[S: ReadStreamCompatible](
       case Array(s, _) => Some(s)
     }
     val charactersConsumed = segment.map(_.length).getOrElse(0) + (path.length - nextStart.length)
-    (segment, new VertxDecodeInputsContext(rc, pathConsumed + charactersConsumed))
+
+    (segment.map(QueryStringDecoder.decodeComponent), new VertxDecodeInputsContext(rc, pathConsumed + charactersConsumed))
   }
   override def header(name: String): List[String] = request.headers.getAll(name).asScala.toList
   override def headers: Seq[(String, String)] =


### PR DESCRIPTION
Fixes https://github.com/softwaremill/tapir/issues/896.

Http4s, Play, Finatra and Vert.x all seem to decode URL path segments. For each server interpreter, I used the same decoder as in the original implementation.

Links to the code where decoding seems to be done in the original implementations:
- [http4s](https://github.com/http4s/http4s/blob/c5509ce4bbe47398229e5c16f38f9a2eb5d58433/core/src/main/scala/org/http4s/Uri.scala#L390) 
- Play: [(1)](https://github.com/playframework/playframework/blob/814f0c73f86eb0e85bcae7f2167c73a08fed9fd7/core/play/src/main/scala/play/api/routing/sird/PathExtractor.scala#L38) [(2)](https://github.com/playframework/playframework/blob/814f0c73f86eb0e85bcae7f2167c73a08fed9fd7/core/play-java/src/main/scala/play/routing/RouterBuilderHelper.scala#L57)
- [Finatra](https://github.com/twitter/finatra/commit/a79f56347acd2194e415975ab125e2509c8e91e5#diff-55ab21988fba70014c304f3d395842246cd376e20e427a80f4049594661ea270R61)
- [Vert.x](https://github.com/vert-x3/vertx-web/pull/443/files#diff-1ddd6931545856eae625d256298d4252ce3c89150ad3ee83db5c9d985427b79bR255) 