### PR TITLE
Add Streaming support to Play server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -745,7 +745,8 @@ lazy val playServer: ProjectMatrix = (projectMatrix in file("server/play-server"
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-server" % Versions.playServer,
       "com.typesafe.play" %% "play-akka-http-server" % Versions.playServer,
-      "com.typesafe.play" %% "play" % Versions.playServer
+      "com.typesafe.play" %% "play" % Versions.playServer,
+      "com.softwaremill.sttp.shared" %% "akka" % Versions.sttpShared
     )
   )
   .jvmPlatform(scalaVersions = allScalaVersions)

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/OutputToPlayResponse.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/OutputToPlayResponse.scala
@@ -1,26 +1,32 @@
 package sttp.tapir.server.play
 
+import akka.NotUsed
+import akka.stream.scaladsl.{FileIO, Flow, Source, StreamConverters}
+import akka.util.ByteString
+import play.api.http.websocket.{BinaryMessage, Message, TextMessage}
+import play.api.http.{ContentTypes, HeaderNames, HttpEntity}
+import play.api.mvc.MultipartFormData.{DataPart, FilePart}
+import play.api.mvc.{Codec, MultipartFormData, ResponseHeader, Result}
+import sttp.capabilities.akka.AkkaStreams
+import sttp.model.{MediaType, Part, StatusCode}
+import sttp.tapir.internal.ParamsAsAny
+import sttp.tapir.server.internal.{EncodeOutputBody, EncodeOutputs, OutputValues}
+import sttp.tapir.{CodecFormat, DecodeResult, EndpointOutput, RawBodyType, RawPart, WebSocketBodyOutput, WebSocketFrameDecodeFailure}
+import sttp.ws.{WebSocketClosed, WebSocketFrame}
+
 import java.io.{File, InputStream}
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.nio.file.Files
-
-import akka.NotUsed
-import akka.stream.scaladsl.{FileIO, Source, StreamConverters}
-import akka.util.ByteString
-import play.api.http.{ContentTypes, HeaderNames, HttpEntity}
-import play.api.mvc.MultipartFormData.{DataPart, FilePart}
-import play.api.mvc.{Codec, MultipartFormData, ResponseHeader, Result}
-import sttp.model.{MediaType, Part, StatusCode}
-import sttp.tapir.internal.{NoStreams, ParamsAsAny}
-import sttp.tapir.server.internal.{EncodeOutputBody, EncodeOutputs, OutputValues}
-import sttp.tapir.{CodecFormat, EndpointOutput, RawBodyType, RawPart, WebSocketBodyOutput}
+import scala.concurrent.Future
 
 private[play] object OutputToPlayResponse {
+  private type EntityFromLength = Option[Long] => HttpEntity
+
   def apply[O](
       defaultStatus: StatusCode,
       output: EndpointOutput[O],
-      v: Any
+      v: O
   ): Result = {
     val outputValues = encodeOutputs(output, ParamsAsAny(v), OutputValues.empty)
     val headers: Map[String, String] = outputValues.headers
@@ -35,28 +41,45 @@ private[play] object OutputToPlayResponse {
     val status = outputValues.statusCode.getOrElse(defaultStatus)
 
     outputValues.body match {
-      case Some(entity) =>
-        val result = Result(ResponseHeader(status.code, headers), entity.merge)
+      case Some(Left(entityFromLength)) =>
+        val entity = entityFromLength(outputValues.contentLength)
+        val result = Result(ResponseHeader(status.code, headers), entity)
         headers.find(_._1.toLowerCase == "content-type").map(ct => result.as(ct._2)).getOrElse(result)
-      case None => Result(ResponseHeader(status.code, headers), HttpEntity.NoEntity)
+      case Some(Right(flow)) =>
+        // TODO figure out how to convert `flow` to a play `Result`
+//        val akkaResp = WebSocketHandler.handleWebSocket(???, flow, 0, None)
+//        val result = Result(ResponseHeader(status.code, headers), akkaResp)
+//        headers.find(_._1.toLowerCase == "content-type").map(ct => result.as(ct._2)).getOrElse(result)
+        ???
+      case None =>
+        Result(ResponseHeader(status.code, headers), HttpEntity.NoEntity)
     }
   }
 
-  private val encodeOutputs: EncodeOutputs[HttpEntity, Nothing, Nothing] =
-    new EncodeOutputs[HttpEntity, Nothing, Nothing](new EncodeOutputBody[HttpEntity, Nothing, Nothing] {
-      override val streams: NoStreams = NoStreams
-      override def rawValueToBody[R](v: R, format: CodecFormat, bodyType: RawBodyType[R]): HttpEntity =
-        rawValueToResponseEntity(bodyType.asInstanceOf[RawBodyType[Any]], formatToContentType(format), v)
-      override def streamValueToBody(v: Nothing, format: CodecFormat, charset: Option[Charset]): HttpEntity =
-        v
-      override def webSocketPipeToBody[REQ, RESP](
-          pipe: Nothing,
-          o: WebSocketBodyOutput[streams.Pipe[REQ, RESP], REQ, RESP, _, Nothing]
-      ): Nothing =
-        pipe
-    })
+  private val encodeOutputs: EncodeOutputs[EntityFromLength, Flow[Message, Message, Any], AkkaStreams] =
+    new EncodeOutputs[EntityFromLength, Flow[Message, Message, Any], AkkaStreams](
+      new EncodeOutputBody[EntityFromLength, Flow[Message, Message, Any], AkkaStreams] {
+        override val streams: AkkaStreams = AkkaStreams
 
-  private def rawValueToResponseEntity[R](bodyType: RawBodyType[R], contentType: Option[String], r: R): HttpEntity = {
+        override def rawValueToBody[R](v: R, format: CodecFormat, bodyType: RawBodyType[R]): EntityFromLength =
+          contentLength => rawValueToResponseEntity(bodyType.asInstanceOf[RawBodyType[Any]], contentLength, formatToContentType(format), v)
+
+        override def streamValueToBody(v: Source[ByteString, Any], format: CodecFormat, charset: Option[Charset]): EntityFromLength =
+          contentLength => HttpEntity.Streamed(v, contentLength, formatToContentType(format))
+
+        override def webSocketPipeToBody[REQ, RESP](
+            pipe: Flow[REQ, RESP, Any],
+            o: WebSocketBodyOutput[streams.Pipe[REQ, RESP], REQ, RESP, _, AkkaStreams]
+        ): Flow[Message, Message, Any] = pipeToBody(pipe, o)
+      }
+    )
+
+  private def rawValueToResponseEntity[R](
+      bodyType: RawBodyType[R],
+      contentLength: Option[Long],
+      contentType: Option[String],
+      r: R
+  ): HttpEntity = {
     bodyType match {
       case RawBodyType.StringBody(charset) =>
         val str = r.asInstanceOf[String]
@@ -72,7 +95,7 @@ private[play] object OutputToPlayResponse {
 
       case RawBodyType.InputStreamBody =>
         val stream = r.asInstanceOf[InputStream]
-        HttpEntity.Streamed(StreamConverters.fromInputStream(() => stream), None, contentType)
+        HttpEntity.Streamed(StreamConverters.fromInputStream(() => stream), contentLength, contentType)
 
       case RawBodyType.FileBody =>
         val path = r.asInstanceOf[File].toPath
@@ -92,7 +115,7 @@ private[play] object OutputToPlayResponse {
               case _                          => false
             }
           }
-          .flatMap(rawPartsToDataPart(m, _))
+          .flatMap(rawPartsToDataPart(m, _, contentLength))
 
         val fileParts = rawParts
           .filter { part =>
@@ -102,18 +125,19 @@ private[play] object OutputToPlayResponse {
               case _                           => false
             }
           }
-          .flatMap(rawPartsToFilePart(m, _))
+          .flatMap(rawPartsToFilePart(m, _, contentLength))
 
-        HttpEntity.Streamed(multipartFormToStream(dataParts, fileParts), None, contentType)
+        HttpEntity.Streamed(multipartFormToStream(dataParts, fileParts), contentLength, contentType)
     }
   }
 
   private def rawPartsToFilePart[T](
       m: RawBodyType.MultipartBody,
-      part: Part[T]
+      part: Part[T],
+      contentLength: Option[Long]
   ): Option[MultipartFormData.FilePart[Source[ByteString, _]]] = {
     m.partType(part.name).flatMap { partType =>
-      val entity: HttpEntity = rawValueToResponseEntity(partType.asInstanceOf[RawBodyType[Any]], part.contentType, part.body)
+      val entity: HttpEntity = rawValueToResponseEntity(partType.asInstanceOf[RawBodyType[Any]], contentLength, part.contentType, part.body)
 
       for {
         fileName <- part.fileName
@@ -123,7 +147,11 @@ private[play] object OutputToPlayResponse {
     }
   }
 
-  private def rawPartsToDataPart[T](m: RawBodyType.MultipartBody, part: Part[T]): Option[MultipartFormData.DataPart] = {
+  private def rawPartsToDataPart[T](
+      m: RawBodyType.MultipartBody,
+      part: Part[T],
+      contentLength: Option[Long]
+  ): Option[MultipartFormData.DataPart] = {
     m.partType(part.name).flatMap { partType =>
       val charset = partType match {
         case valueType: RawBodyType.StringBody => valueType.charset
@@ -131,7 +159,7 @@ private[play] object OutputToPlayResponse {
       }
 
       val maybeData: Option[String] =
-        rawValueToResponseEntity(partType.asInstanceOf[RawBodyType[Any]], part.contentType, part.body) match {
+        rawValueToResponseEntity(partType.asInstanceOf[RawBodyType[Any]], contentLength, part.contentType, part.body) match {
           case HttpEntity.Strict(data, _)   => Some(data.decodeString(charset))
           case HttpEntity.Streamed(_, _, _) => None
           case HttpEntity.Chunked(_, _)     => None
@@ -193,5 +221,45 @@ private[play] object OutputToPlayResponse {
           .concat(Source.single(ByteString("\r\n", Charset.forName("UTF-8"))))
           .concat(Source.single(ByteString(s"--$boundary--", "UTF-8")))
       })
+  }
+
+  private def pipeToBody[REQ, RESP](
+      pipe: Flow[REQ, RESP, Any],
+      o: WebSocketBodyOutput[Flow[REQ, RESP, Any], REQ, RESP, _, AkkaStreams]
+  ): Flow[Message, Message, Any] = {
+
+    def messageToFrame(m: Message) = m match {
+      case msg: TextMessage =>
+        Some(WebSocketFrame.text(msg.data))
+      case msg: BinaryMessage =>
+        Some(WebSocketFrame.binary(msg.data.toArray))
+      case _ =>
+        None
+    }
+
+    def frameToMessage(w: WebSocketFrame) = w match {
+      case WebSocketFrame.Text(p, _, _)   => Some(TextMessage(p))
+      case WebSocketFrame.Binary(p, _, _) => Some(BinaryMessage(ByteString(p)))
+      case WebSocketFrame.Ping(_)         => None
+      case WebSocketFrame.Pong(_)         => None
+      case WebSocketFrame.Close(_, _)     => throw WebSocketClosed(None)
+    }
+
+    Flow[Message]
+      .mapAsync(1)(msg => Future.successful(messageToFrame(msg)))
+      .mapConcat(_.toList)
+      .map(f =>
+        o.requests.decode(f) match {
+          case failure: DecodeResult.Failure => throw new WebSocketFrameDecodeFailure(f, failure)
+          case DecodeResult.Value(v)         => v
+        }
+      )
+      .via(pipe)
+      .map(o.responses.encode)
+      .takeWhile {
+        case WebSocketFrame.Close(_, _) => false
+        case _                          => true
+      }
+      .mapConcat(frameToMessage(_).toList)
   }
 }

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/TapirPlayServer.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/TapirPlayServer.scala
@@ -3,6 +3,8 @@ package sttp.tapir.server.play
 import akka.stream.Materializer
 import play.api.mvc._
 import play.api.routing.Router.Routes
+import sttp.capabilities.WebSockets
+import sttp.capabilities.akka.AkkaStreams
 import sttp.tapir.Endpoint
 import sttp.tapir.server.ServerEndpoint
 
@@ -10,7 +12,7 @@ import scala.concurrent.Future
 import scala.reflect.ClassTag
 
 trait TapirPlayServer {
-  implicit class RichPlayEndpoint[I, E, O](e: Endpoint[I, E, O, Any]) {
+  implicit class RichPlayEndpoint[I, E, O](e: Endpoint[I, E, O, AkkaStreams with WebSockets]) {
     @deprecated("Use PlayServerInterpreter.toRoute", since = "0.17.1")
     def toRoute(
         logic: I => Future[Either[E, O]]
@@ -24,12 +26,12 @@ trait TapirPlayServer {
     ): Routes = PlayServerInterpreter.toRouteRecoverErrors(e)(logic)
   }
 
-  implicit class RichPlayServerEndpoint[I, E, O](e: ServerEndpoint[I, E, O, Any, Future]) {
+  implicit class RichPlayServerEndpoint[I, E, O](e: ServerEndpoint[I, E, O, AkkaStreams with WebSockets, Future]) {
     @deprecated("Use PlayServerInterpreter.toRoute", since = "0.17.1")
     def toRoute(implicit mat: Materializer, serverOptions: PlayServerOptions): Routes = PlayServerInterpreter.toRoute(e)
   }
 
-  implicit class RichPlayServerEndpoints[I, E, O](serverEndpoints: List[ServerEndpoint[_, _, _, Any, Future]]) {
+  implicit class RichPlayServerEndpoints[I, E, O](serverEndpoints: List[ServerEndpoint[_, _, _, AkkaStreams with WebSockets, Future]]) {
     @deprecated("Use PlayServerInterpreter.toRoute", since = "0.17.1")
     def toRoute(implicit mat: Materializer, serverOptions: PlayServerOptions): Routes = PlayServerInterpreter.toRoute(serverEndpoints)
   }

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
@@ -8,6 +8,7 @@ import play.api.mvc.{Handler, RequestHeader}
 import play.api.routing.Router
 import play.api.routing.Router.Routes
 import play.core.server.{DefaultAkkaHttpServerComponents, ServerConfig}
+import sttp.capabilities.akka.AkkaStreams
 import sttp.tapir.Endpoint
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.server.{DecodeFailureHandler, ServerDefaults, ServerEndpoint}
@@ -16,11 +17,11 @@ import sttp.tapir.tests.Port
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
-class PlayTestServerInterpreter(implicit actorSystem: ActorSystem) extends TestServerInterpreter[Future, Any, Router.Routes] {
+class PlayTestServerInterpreter(implicit actorSystem: ActorSystem) extends TestServerInterpreter[Future, AkkaStreams, Router.Routes] {
   import actorSystem.dispatcher
 
   override def route[I, E, O](
-      e: ServerEndpoint[I, E, O, Any, Future],
+      e: ServerEndpoint[I, E, O, AkkaStreams, Future],
       decodeFailureHandler: Option[DecodeFailureHandler]
   ): Routes = {
     implicit val serverOptions: PlayServerOptions =
@@ -28,7 +29,7 @@ class PlayTestServerInterpreter(implicit actorSystem: ActorSystem) extends TestS
     PlayServerInterpreter.toRoute(e)
   }
 
-  override def routeRecoverErrors[I, E <: Throwable, O](e: Endpoint[I, E, O, Any], fn: I => Future[O])(implicit
+  override def routeRecoverErrors[I, E <: Throwable, O](e: Endpoint[I, E, O, AkkaStreams], fn: I => Future[O])(implicit
       eClassTag: ClassTag[E]
   ): Routes = {
     PlayServerInterpreter.toRouteRecoverErrors(e)(fn)


### PR DESCRIPTION
Changes are inspired by / copied from `OutputToAkkaRoute`.

------

Two missing things:
- There is no implementation yet for websockets since I couldn't figure out how to convert a Akka `Flow` to a Play `Result`. I couldn't even figure out how to use `WebSocketHandler.handleWebSocket` to create a Akka `HttpResponse`. Anyone knows how to do this conversion?
- There are no tests yet since I couldn't find tests that are specific for the play server support. If I shall create some tests just point me to the location where I can add them.