### PR TITLE
Update derevo integration;

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -342,12 +342,12 @@ lazy val derevo: ProjectMatrix = (projectMatrix in file("integrations/derevo"))
   .settings(
     name := "tapir-derevo",
     libraryDependencies ++= Seq(
-      "org.manatki" %% "derevo-core" % Versions.derevo,
+      "tf.tofu" %% "derevo-core" % Versions.derevo,
       scalaTest.value % Test
     )
   )
   .jvmPlatform(scalaVersions = allScalaVersions)
-  .dependsOn(core)
+  .dependsOn(core, newtype)
 
 lazy val newtype: ProjectMatrix = (projectMatrix in file("integrations/newtype"))
   .settings(commonSettings)

--- a/doc/endpoint/integrations.md
+++ b/doc/endpoint/integrations.md
@@ -113,3 +113,21 @@ object Currency {
 
 The annotation will simply generate a `Schema[T]` for your type `T` and put it into companion object.
 Generation rules are the same as in `Schema.derived[T]`.
+
+This will also work for newtypes — [estatico](https://github.com/estatico/scala-newtype) or [supertagged](https://github.com/rudogma/scala-supertagged):
+
+```scala
+import derevo.derive
+import sttp.tapir.derevo.schema
+import io.estatico.newtype.macros.newtype
+
+object types {
+  
+  @derive(schema)
+  @newtype
+  case class Amount(i: Int)
+}
+```
+
+Resulting schema will be equivalent to `implicitly[Schema[Int]].map(i => Some(types.Amount(i)))`.
+Note that due to limitations of the `derevo` library one can't provide custom description for generated schema.

--- a/integrations/derevo/src/main/scala/sttp/tapir/derevo/schema.scala
+++ b/integrations/derevo/src/main/scala/sttp/tapir/derevo/schema.scala
@@ -1,14 +1,16 @@
 package sttp.tapir.derevo
 
 import derevo.Derivation
+import derevo.NewTypeDerivation
 import sttp.tapir.Schema
 
 import scala.reflect.macros.blackbox
 
-object schema extends Derivation[Schema] {
+object schema extends Derivation[Schema] with NewTypeDerivation[Schema] {
   def instance[A]: Schema[A] = macro SchemaCustomDerived.schema[A]
 
   def apply[A](description: String): Schema[A] = macro SchemaCustomDerived.schemaDescription[A]
+
 }
 
 class SchemaCustomDerived(val c: blackbox.Context) {

--- a/integrations/derevo/src/test/scala/sttp/tapir/derevo/DerevoSchemaDerivationSpec.scala
+++ b/integrations/derevo/src/test/scala/sttp/tapir/derevo/DerevoSchemaDerivationSpec.scala
@@ -1,6 +1,7 @@
 package sttp.tapir.derevo
 
 import derevo.derive
+import io.estatico.newtype.macros.newtype
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.tapir.Schema
@@ -22,6 +23,14 @@ class DerevoSchemaDerivationSpec extends AnyFlatSpec with Matchers {
     generatedSchema.show shouldBe expectedSchema.show
   }
 
+  "Generated schema by derevo for newtype" should "be the same as mapped Schema" in {
+
+    val expectedSchema: Schema[types.Amount] = implicitly[Schema[Int]].map(i => Some(types.Amount(i)))(_.i)
+    val generatedSchema: Schema[types.Amount] = implicitly[Schema[types.Amount]]
+
+    generatedSchema.show shouldBe expectedSchema.show
+  }
+
   "Generated schema by derevo with custom description" should "be the same as Schema.derived with altered description" in {
 
     val testDescription = "test description"
@@ -37,5 +46,12 @@ class DerevoSchemaDerivationSpec extends AnyFlatSpec with Matchers {
     generatedSchema.description shouldBe Some(testDescription)
     generatedSchema.show shouldBe expectedSchema.show
   }
+
+}
+
+object types {
+  @derive(schema)
+  @newtype
+  case class Amount(i: Int)
 
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -28,6 +28,6 @@ object Versions {
   val vertx = "4.0.3"
   val jsScalaJavaTime = "2.2.0"
   val jwtScala = "5.0.0"
-  val derevo = "0.11.6"
+  val derevo = "0.12.1"
   val newtype = "0.4.4"
 }


### PR DESCRIPTION
Derevo recently got support for newtypes (NB it does not need a dependency on any of the newtype libraries) and also changed the organization.
This PR addresses both of those changes.