### PR TITLE
[Minor] Add convenience method for empty outputs 

### DIFF
--- a/core/src/main/scala/sttp/tapir/Tapir.scala
+++ b/core/src/main/scala/sttp/tapir/Tapir.scala
@@ -251,6 +251,10 @@ trait Tapir extends TapirExtensions with TapirDerivedInputs with ModifyMacroSupp
     */
   val emptyOutput: EndpointOutput[Unit] = EndpointIO.Empty(Codec.idPlain(), EndpointIO.Info.empty)
 
+  /** An empty output. Useful if one of the [[oneOf]] branches of a coproduct type is a case object that should be mapped to an empty body.
+    */
+  def emptyOutputAs[T](value: T): EndpointOutput[T] = emptyOutput.map(_ => value)(_ => ())
+
   private[tapir] val emptyInput: EndpointInput[Unit] = EndpointIO.Empty(Codec.idPlain(), EndpointIO.Info.empty)
 
   val infallibleEndpoint: Endpoint[Unit, Nothing, Unit, Any] =

--- a/core/src/test/scala/sttp/tapir/EndpointTest.scala
+++ b/core/src/test/scala/sttp/tapir/EndpointTest.scala
@@ -71,6 +71,20 @@ class EndpointTest extends AnyFlatSpec with EndpointTestExtensions with Matchers
       )
   }
 
+  it should "compile one-of empty output of a custom type" in {
+    sealed trait Error
+    final case class BadRequest(message: String) extends Error
+    final case object NotFound extends Error
+
+    endpoint.post
+      .errorOut(
+        sttp.tapir.oneOf(
+          statusMapping(StatusCode.BadRequest, stringBody.map(BadRequest)(_.message)),
+          statusMapping(StatusCode.NotFound, emptyOutputAs(NotFound))
+        )
+      )
+  }
+
   def pairToTuple(input: EndpointInput[_]): Any =
     input match {
       case EndpointInput.Pair(left, right, _, _) => (pairToTuple(left), pairToTuple(right))

--- a/generated-doc/out/endpoint/statuscodes.md
+++ b/generated-doc/out/endpoint/statuscodes.md
@@ -34,7 +34,7 @@ val baseEndpoint = endpoint.errorOut(
   oneOf[ErrorInfo](
     statusMapping(StatusCode.NotFound, jsonBody[NotFound].description("not found")),
     statusMapping(StatusCode.Unauthorized, jsonBody[Unauthorized].description("unauthorized")),
-    statusMapping(StatusCode.NoContent, emptyOutput.map(_ => NoContent)(_ => ())),
+    statusMapping(StatusCode.NoContent, emptyOutputAs(NoContent)),
     statusDefaultMapping(jsonBody[Unknown].description("unknown"))
   )
 )


### PR DESCRIPTION
The recommended use of `oneOf` combinator for outputs involves providing outputs for every sub-type of a coproduct (`sealed trait`). For parameterless case objects you will often want an empty body output. 

Right now the only convenient way of declaring an empty body `Endpoint.Output` is by using the `emptyOutput` value. Using this will then require a `.map(_ => ...)(_ => ())` conversion. This piece of boiler-plate adds noise to the code and its necessity can make it harder to discover the correct pattern for defining `oneOf` statements. 

The method I add removes the need for boilerplate and covers a large number of empty body use cases. 

 