### PR TITLE
[Minor] Add case insensitive enumeratum codec

### DIFF
--- a/integrations/enumeratum/src/main/scala/sttp/tapir/codec/enumeratum/TapirCodecEnumeratum.scala
+++ b/integrations/enumeratum/src/main/scala/sttp/tapir/codec/enumeratum/TapirCodecEnumeratum.scala
@@ -13,7 +13,7 @@ trait TapirCodecEnumeratum {
   implicit def schemaForEnumEntry[E <: EnumEntry](implicit enum: Enum[E]): Schema[E] =
     Schema(SchemaType.SString, validator = validatorEnumEntry)
 
-  private def plainCodecEnumEntryUsing[E <: EnumEntry](f: String => Option[E])(implicit enum: Enum[E]) =
+  def plainCodecEnumEntryUsing[E <: EnumEntry](f: String => Option[E])(implicit enum: Enum[E]): Codec[String, E, CodecFormat.TextPlain] =
     Codec.string
       .mapDecode { s =>
         f(s)


### PR DESCRIPTION
- Leave the existing one as the default but add a case-insensitive method too.
- Thought about adding similar methods for upper/lower/other cases but I think the `enumeratum` stackable traits should address those needs, perhaps. Can add.