### PR TITLE
Add newtype support for scala.js

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -355,11 +355,15 @@ lazy val newtype: ProjectMatrix = (projectMatrix in file("integrations/newtype")
   .settings(
     name := "tapir-newtype",
     libraryDependencies ++= Seq(
-      "io.estatico" %% "newtype" % Versions.newtype,
+      "io.estatico" %%% "newtype" % Versions.newtype,
       scalaTest.value % Test
     )
   )
   .jvmPlatform(scalaVersions = allScalaVersions)
+  .jsPlatform(
+    scalaVersions = allScalaVersions,
+    settings = commonJsSettings
+  )
   .dependsOn(core)
 
 // json


### PR DESCRIPTION
Hi,

This PR allows to use endpoints with newtype in a scala.js context.
I was able to `+publishLocal` and use the generated artifacts in a shared module js/jvm where the endpoints are defined.
These endpoints are then used from frontend (js) and backend (jvm) modules.

Please, let me know if it requires some extra changes in order to be merged.

Regards,