### PR TITLE
Fix ZIO issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -328,10 +328,12 @@ lazy val zio: ProjectMatrix = (projectMatrix in file("integrations/zio"))
   .settings(commonSettings)
   .settings(
     name := "tapir-zio",
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio" % Versions.zio,
       "dev.zio" %% "zio-streams" % Versions.zio,
-      scalaTest.value % Test,
+      "dev.zio" %% "zio-test" % Versions.zio % Test,
+      "dev.zio" %% "zio-test-sbt" % Versions.zio % Test,
       "com.softwaremill.sttp.shared" %% "zio" % Versions.sttpShared
     )
   )

--- a/integrations/zio/src/main/scala/sttp/tapir/ztapir/ZPartialServerEndpoint.scala
+++ b/integrations/zio/src/main/scala/sttp/tapir/ztapir/ZPartialServerEndpoint.scala
@@ -74,7 +74,7 @@ abstract class ZPartialServerEndpoint[R, U, I, E, O](val endpoint: ZEndpoint[I, 
     ServerEndpoint(
       endpoint.prependIn(tInput): ZEndpoint[(T, I), E, O],
       _ => { case (t, i) =>
-        partialLogic(t).flatMap(u => g((u, i))).either
+        partialLogic(t).flatMap(u => g((u, i))).either.resurrect
       }
     )
 }

--- a/integrations/zio/src/main/scala/sttp/tapir/ztapir/ZServerEndpointInParts.scala
+++ b/integrations/zio/src/main/scala/sttp/tapir/ztapir/ZServerEndpointInParts.scala
@@ -56,7 +56,7 @@ abstract class ZServerEndpointInParts[R, U, J, I, E, O](val endpoint: ZEndpoint[
       { _ => i =>
         {
           val (t, j): (T, J) = splitInput(i)
-          logicFragment(t).flatMap(u => remainingLogic((u, j))).either
+          logicFragment(t).flatMap(u => remainingLogic((u, j))).either.resurrect
         }
       }
     )

--- a/integrations/zio/src/main/scala/sttp/tapir/ztapir/ZTapir.scala
+++ b/integrations/zio/src/main/scala/sttp/tapir/ztapir/ZTapir.scala
@@ -11,7 +11,7 @@ trait ZTapir {
   type ZServerEndpoint[R, I, E, O] = ServerEndpoint[I, E, O, Any, RIO[R, *]]
 
   implicit class RichZEndpoint[I, E, O](e: ZEndpoint[I, E, O]) {
-    def zServerLogic[R](logic: I => ZIO[R, E, O]): ZServerEndpoint[R, I, E, O] = ServerEndpoint(e, _ => logic(_).either)
+    def zServerLogic[R](logic: I => ZIO[R, E, O]): ZServerEndpoint[R, I, E, O] = ServerEndpoint(e, _ => logic(_).either.resurrect)
 
     /** Combine this endpoint description with a function, which implements a part of the server-side logic.
       *

--- a/integrations/zio/src/test/scala/sttp/tapir/ztapir/TestError.scala
+++ b/integrations/zio/src/test/scala/sttp/tapir/ztapir/TestError.scala
@@ -1,0 +1,18 @@
+package sttp.tapir.ztapir
+
+import sttp.tapir.{Codec, CodecFormat, DecodeResult, Schema}
+import sttp.tapir.CodecFormat.TextPlain
+
+sealed trait TestError
+
+object TestError {
+  case object SomeError extends TestError
+
+  implicit val schema: Schema[TestError] =
+    Schema.schemaForString.map(value => if (value == "SomeError") Some(SomeError: TestError) else None)(_.toString)
+
+  implicit val codec: Codec[String, TestError, TextPlain] = Codec.anyStringCodec(CodecFormat.TextPlain()) {
+    case "SomeError" => DecodeResult.Value(SomeError: TestError)
+    case value       => DecodeResult.Error(value, new RuntimeException(s"Unable to decode value $value"))
+  }(_.toString)
+}

--- a/integrations/zio/src/test/scala/sttp/tapir/ztapir/ZTapirTest.scala
+++ b/integrations/zio/src/test/scala/sttp/tapir/ztapir/ZTapirTest.scala
@@ -1,0 +1,127 @@
+package sttp.tapir.ztapir
+
+import sttp.tapir.server.interpreter.{RawValue, RequestBody, ServerInterpreter, ToResponseBody}
+import sttp.capabilities.Streams
+import sttp.model.{HasHeaders, Header, Method, QueryParams, StatusCode, Uri}
+import sttp.tapir.{CodecFormat, Endpoint, RawBodyType, WebSocketBodyOutput}
+import sttp.tapir.model.{ConnectionInfo, ServerRequest, ServerResponse}
+import zio.{UIO, ZIO}
+import sttp.tapir.ztapir.instances.TestMonadError._
+import zio.test.DefaultRunnableSpec
+import zio.test._
+import zio.test.Assertion._
+import zio.test.environment._
+
+import java.nio.charset.Charset
+
+object ZTapirTest extends DefaultRunnableSpec with ZTapir {
+
+  def spec: ZSpec[TestEnvironment, Any] =
+    suite("ZTapir tests")(testZServerLogicErrorHandling, testZServerLogicPartErrorHandling, testZServerLogicForCurrentErrorHandling)
+
+  type ResponseBodyType = String
+
+  type RequestBodyType = String
+
+  private val exampleRequestBody = new RequestBody[TestEffect, RequestBodyType] {
+    override val streams: Streams[RequestBodyType] = null.asInstanceOf[Streams[RequestBodyType]]
+
+    override def toRaw[R](bodyType: RawBodyType[R]): TestEffect[RawValue[R]] = ???
+
+    override def toStream(): streams.BinaryStream = ???
+  }
+
+  private val exampleToResponse: ToResponseBody[ResponseBodyType, RequestBodyType] = new ToResponseBody[ResponseBodyType, RequestBodyType] {
+    override val streams: Streams[RequestBodyType] = null.asInstanceOf[Streams[RequestBodyType]]
+
+    override def fromRawValue[R](v: R, headers: HasHeaders, format: CodecFormat, bodyType: RawBodyType[R]): ResponseBodyType = "Sample body"
+
+    override def fromStreamValue(
+        v: streams.BinaryStream,
+        headers: HasHeaders,
+        format: CodecFormat,
+        charset: Option[Charset]
+    ): ResponseBodyType = ???
+
+    override def fromWebSocketPipe[REQ, RESP](
+        pipe: streams.Pipe[REQ, RESP],
+        o: WebSocketBodyOutput[streams.Pipe[REQ, RESP], REQ, RESP, _, RequestBodyType]
+    ): ResponseBodyType = ???
+  }
+
+  private val testRequest: ServerRequest = new ServerRequest {
+    override def protocol: String = ???
+
+    override def connectionInfo: ConnectionInfo = ???
+
+    override def underlying: Any = ???
+
+    /** Can differ from `uri.path`, if the endpoint is deployed in a context */
+    override def pathSegments: List[String] = List("foo", "bar")
+
+    override def queryParameters: QueryParams = QueryParams()
+
+    override def method: Method = ???
+
+    override def uri: Uri = ???
+
+    override def headers: scala.collection.immutable.Seq[Header] = scala.collection.immutable.Seq(Header("X-User-Name", "John"))
+  }
+
+  private def errorToResponse(error: Throwable): UIO[Option[ServerResponse[ResponseBodyType]]] =
+    ZIO.some(ServerResponse(StatusCode.InternalServerError, scala.collection.immutable.Seq.empty[Header], Some(error.getMessage)))
+
+  final case class User(name: String)
+
+  private def failedAutLogic(userName: String): UIO[User] = ZIO(10 / 0).orDie.as(User(userName))
+
+  val interpreter = new ServerInterpreter[Any, TestEffect, ResponseBodyType, RequestBodyType](
+    exampleRequestBody,
+    exampleToResponse,
+    List.empty,
+    _ => ZIO.unit
+  )
+
+  private val testZServerLogicErrorHandling = testM("zServerLogic error handling") {
+    val testEndpoint: Endpoint[Unit, TestError, String, Any] = endpoint.in("foo" / "bar").errorOut(plainBody[TestError]).out(stringBody)
+
+    def logic(input: Unit): ZIO[Any, TestError, String] = {
+      ZIO(10 / 0).orDie.map(_.toString)
+    }
+    val serverEndpoint: ZServerEndpoint[Any, Unit, TestError, String] = testEndpoint.zServerLogic(logic)
+
+    interpreter[Unit, TestError, String](testRequest, serverEndpoint)
+      .catchAll(errorToResponse)
+      .map(maybeResponse => assert(maybeResponse.map(_.code))(equalTo(Some(StatusCode.InternalServerError))))
+  }
+
+  private val testZServerLogicPartErrorHandling = testM("zServerLogicPart error handling") {
+    val testEndpoint: Endpoint[String, TestError, String, Any] =
+      endpoint.in(header[String]("X-User-Name")).in("foo" / "bar").errorOut(plainBody[TestError]).out(stringBody)
+
+    def logic(user: User, rest: Unit): ZIO[Any, TestError, String] = ZIO.succeed("Hello World")
+
+    val serverEndpoint: ZServerEndpoint[Any, String, TestError, String] =
+      testEndpoint.zServerLogicPart(failedAutLogic).andThen { case (user, rest) => logic(user, rest) }
+
+    interpreter[String, TestError, String](testRequest, serverEndpoint)
+      .catchAll(errorToResponse)
+      .map(maybeResponse => assert(maybeResponse.map(_.code))(equalTo(Some(StatusCode.InternalServerError))))
+  }
+
+  private val testZServerLogicForCurrentErrorHandling = testM("zServerLogicForCurrent error handling") {
+    val securedEndpoint: ZPartialServerEndpoint[Any, User, Unit, TestError, Unit] =
+      endpoint.in(header[String]("X-User-Name")).errorOut(plainBody[TestError]).zServerLogicForCurrent[Any, User](failedAutLogic)
+
+    val testPartialEndpoint: ZPartialServerEndpoint[Any, User, Unit, TestError, String] = securedEndpoint.in("foo" / "bar").out(stringBody)
+
+    def logic(user: User, rest: Unit): ZIO[Any, TestError, String] = ZIO.succeed("Hello World")
+
+    val serverEndpoint: ZServerEndpoint[Any, (testPartialEndpoint.T, Unit), TestError, String] =
+      testPartialEndpoint.serverLogic[Any]((logic _).tupled)
+
+    interpreter(testRequest, serverEndpoint)
+      .catchAll(errorToResponse)
+      .map(maybeResponse => assert(maybeResponse.map(_.code))(equalTo(Some(StatusCode.InternalServerError))))
+  }
+}

--- a/integrations/zio/src/test/scala/sttp/tapir/ztapir/instances/TestMonadError.scala
+++ b/integrations/zio/src/test/scala/sttp/tapir/ztapir/instances/TestMonadError.scala
@@ -1,0 +1,23 @@
+package sttp.tapir.ztapir.instances
+
+import sttp.monad.MonadError
+import zio.{RIO, ZIO}
+
+object TestMonadError {
+  type TestEffect[A] = RIO[Any, A]
+
+  implicit val testEffectMonadError: MonadError[TestEffect] = new MonadError[TestEffect] {
+    override def unit[T](t: T): TestEffect[T] = ZIO.succeed(t)
+
+    override def map[T, T2](fa: TestEffect[T])(f: T => T2): TestEffect[T2] = fa.map(f)
+
+    override def flatMap[T, T2](fa: TestEffect[T])(f: T => TestEffect[T2]): TestEffect[T2] = fa.flatMap(f)
+
+    override def error[T](t: Throwable): TestEffect[T] = ZIO.fail(t)
+
+    override protected def handleWrappedError[T](rt: TestEffect[T])(h: PartialFunction[Throwable, TestEffect[T]]): TestEffect[T] =
+      rt.catchSome(h)
+
+    override def ensure[T](f: TestEffect[T], e: => TestEffect[Unit]): TestEffect[T] = f.ensuring(e.ignore)
+  }
+}

--- a/server/zio-http4s-server/src/main/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerInterpreter.scala
+++ b/server/zio-http4s-server/src/main/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerInterpreter.scala
@@ -20,15 +20,14 @@ trait ZHttp4sServerInterpreter {
   def from[R](
       serverEndpoints: List[ZServerEndpoint[R, _, _, _]]
   )(implicit serverOptions: Http4sServerOptions[RIO[R with Clock, *], RIO[R with Clock, *]]): ServerEndpointsToRoutes[R] =
-    new ServerEndpointsToRoutes[R](serverEndpoints, serverOptions)
+    new ServerEndpointsToRoutes[R](serverEndpoints)
 
   // This is needed to avoid too eager type inference. Having ZHttp4sServerInterpreter.toRoutes would require users
   // to explicitly provide the env type (R) as a type argument - so that it's not automatically inferred to include
   // Clock
   class ServerEndpointsToRoutes[R](
-      serverEndpoints: List[ZServerEndpoint[R, _, _, _]],
-      serverOptions: Http4sServerOptions[RIO[R with Clock, *], RIO[R with Clock, *]]
-  ) {
+      serverEndpoints: List[ZServerEndpoint[R, _, _, _]]
+  )(implicit serverOptions: Http4sServerOptions[RIO[R with Clock, *], RIO[R with Clock, *]]) {
     def toRoutes: HttpRoutes[RIO[R with Clock, *]] = {
       Http4sServerInterpreter.toRoutes(serverEndpoints.map(_.widen[R with Clock]))
     }


### PR DESCRIPTION
It fixes following issues related to ZIO:

* By default, errors from failure channel are forwarded to the main entry point (omitting Tapir and Http4s error handling). This causes the server to terminate in the case of an error that is not of type `E` (e.g. caused by `Task(10/0).orDie`).
* `Http4sServerOptions` is not passed to the next method, but is silently ignored. This causes any changes we make are ignored, instead the default `Http4sServerOptions` is used.