### PR TITLE
fix: 🐛 #1272 Allow exposing Swagger on a non-root route

### DIFF
--- a/docs/swagger-ui-play/src/main/scala/sttp/tapir/swagger/play/SwaggerPlay.scala
+++ b/docs/swagger-ui-play/src/main/scala/sttp/tapir/swagger/play/SwaggerPlay.scala
@@ -52,17 +52,22 @@ class SwaggerPlay(
   )
 
   def routes: Routes = {
-    case GET(p"/$path") if path == contextPath =>
-      actionBuilder {
-        MovedPermanently(redirectPath)
-      }
-    case GET(p"/$path/$file") if path == contextPath =>
-      actionBuilder {
-        file match {
-          case `yamlName` =>
-            Ok(yaml).as("text/yaml")
-          case _ =>
-            Ok.sendResource(s"$resourcePathPrefix/$file")
+    case GET(p"/$path*") if path.startsWith(contextPath) =>
+      val filePart = path.substring(contextPath.length)
+      // Remove the first '/' if present
+      val file = if (filePart.nonEmpty) filePart.substring(1) else filePart
+      if (file.isEmpty) {
+        actionBuilder {
+          MovedPermanently(redirectPath)
+        }
+      } else {
+        actionBuilder {
+          file match {
+            case `yamlName` =>
+              Ok(yaml).as("text/yaml")
+            case _ =>
+              Ok.sendResource(s"$resourcePathPrefix/$file")
+          }
         }
       }
   }


### PR DESCRIPTION
This aims to fix https://github.com/softwaremill/tapir/issues/1272

I've tested it manually on a Play project of mine but I admit I did not spend time writing a proper test in the project as there was no existing test and not sure how to write such a test.