### PR TITLE
fix(http4s-client): exclude empty query params from URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ interpreted as:
   Currently supported:
   * [sttp](https://tapir.softwaremill.com/en/latest/client/sttp.html).
   * [Play](https://tapir.softwaremill.com/en/latest/client/play.html).
+  * [http4s](https://tapir.softwaremill.com/en/latest/client/http4s.html)
 * documentation. Currently supported: 
   * [OpenAPI](https://tapir.softwaremill.com/en/latest/docs/openapi.html)
   * [AsyncAPI](https://tapir.softwaremill.com/en/latest/docs/asyncapi.html)

--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,6 @@ lazy val allAggregates = core.projectRefs ++
   http4sClient.projectRefs ++
   sttpClient.projectRefs ++
   playClient.projectRefs ++
-  http4sClient.projectRefs ++
   tests.projectRefs ++
   examples.projectRefs ++
   playground.projectRefs ++

--- a/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
+++ b/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
@@ -81,8 +81,10 @@ private[http4s] class EndpointToHttp4sClient(blocker: Blocker, clientOptions: Ht
         val uri = pathFragments.foldLeft(req.uri)(_.addPath(_))
         req.withUri(uri)
       case EndpointInput.Query(name, codec, _) =>
-        val encodedParams = codec.encode(value)
-        req.withUri(req.uri.withQueryParam(name, encodedParams))
+        codec.encode(value) match {
+          case values if values.nonEmpty => req.withUri(req.uri.withQueryParam(name, values))
+          case _                         => req
+        }
       case EndpointInput.Cookie(name, codec, _) =>
         codec.encode(value).foldLeft(req)(_.addCookie(name, _))
       case EndpointInput.QueryParams(codec, _) =>

--- a/client/http4s-client/src/test/scala/sttp/tapir/client/http4s/Http4sClientRequestTests.scala
+++ b/client/http4s-client/src/test/scala/sttp/tapir/client/http4s/Http4sClientRequestTests.scala
@@ -1,0 +1,26 @@
+package sttp.tapir.client.http4s
+
+import cats.effect._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import sttp.tapir._
+
+import scala.concurrent.ExecutionContext.global
+
+class Http4sClientRequestTests extends AnyFunSuite with Matchers {
+  private implicit val cs: ContextShift[IO] = IO.contextShift(global)
+  private implicit val blocker: Blocker = Blocker.liftExecutionContext(global)
+
+  test("should exclude optional query parameter when its value is None") {
+    // given
+    val testEndpoint = endpoint.get.in(query[Option[String]]("param"))
+
+    // when
+    val (http4sRequest, _) = Http4sClientInterpreter[IO]
+      .toRequest(testEndpoint, baseUri = None)
+      .apply(None)
+
+    // then
+    http4sRequest.queryString shouldBe empty
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/softwaremill/tapir/issues/1306