### PR TITLE
fixed referencing enums for optional fields

### DIFF
--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
@@ -25,6 +25,17 @@ private[schema] class TSchemaToASchema(
               f.schema match {
                 case TSchema(s: TSchemaType.SObject[_], _, _, _, _, _, _, _) =>
                   f.name.encodedName -> Left(objectToSchemaReference.map(s.info))
+                case TSchema(
+                      TSchemaType.SOption(TSchema(_: TSchemaType.SString[_], _, _, _, _, _, _, Validator.Enumeration(_, _, Some(info)))),
+                      _,
+                      _,
+                      _,
+                      _,
+                      _,
+                      _,
+                      _
+                    ) if referenceEnums(info) =>
+                  f.name.encodedName -> Left(objectToSchemaReference.map(info))
                 case schema @ TSchema(_, _, _, _, _, _, _, v) =>
                   v.traversePrimitives { case Validator.Enumeration(_, _, Some(info)) => Vector(info) } match {
                     case info +: _ if referenceEnums(info) => f.name.encodedName -> Left(objectToSchemaReference.map(info))

--- a/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_enum_collection_component.yml
+++ b/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_enum_collection_component.yml
@@ -1,0 +1,36 @@
+openapi: 3.0.3
+info:
+  title: Countries
+  version: '1.0'
+paths:
+  /countryCollection:
+    get:
+      operationId: getCountrycollection
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CountryCollection'
+components:
+  schemas:
+    CountryCode:
+      type: string
+      enum:
+        - PL
+        - BE
+        - LU
+    CountryCollection:
+      required:
+        - countryCode
+      type: object
+      properties:
+        countryCode:
+          $ref: '#/components/schemas/CountryCode'
+        countryCodeOpt:
+          $ref: '#/components/schemas/CountryCode'
+        countryCodeMulti:
+          type: array
+          items:
+            $ref: '#/components/schemas/CountryCode'

--- a/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_enum_component.yml
+++ b/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_enum_component.yml
@@ -33,16 +33,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Luxembourg'
-  /maybeCountry:
-    get:
-      operationId: getMaybecountry
-      responses:
-        '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MaybeCountry'
 components:
   schemas:
     Belgium:
@@ -64,15 +54,6 @@ components:
       type: object
       properties:
         countryCode:
-          $ref: '#/components/schemas/CountryCode'
-    MaybeCountry:
-      required:
-          - countryCode
-      type: object
-      properties:
-        countryCode:
-          $ref: '#/components/schemas/CountryCode'
-        countryCodeOpt:
           $ref: '#/components/schemas/CountryCode'
     Poland:
       required:

--- a/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_enum_component.yml
+++ b/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_enum_component.yml
@@ -33,6 +33,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Luxembourg'
+  /maybeCountry:
+    get:
+      operationId: getMaybecountry
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MaybeCountry'
 components:
   schemas:
     Belgium:
@@ -54,6 +64,15 @@ components:
       type: object
       properties:
         countryCode:
+          $ref: '#/components/schemas/CountryCode'
+    MaybeCountry:
+      required:
+          - countryCode
+      type: object
+      properties:
+        countryCode:
+          $ref: '#/components/schemas/CountryCode'
+        countryCodeOpt:
           $ref: '#/components/schemas/CountryCode'
     Poland:
       required:

--- a/docs/openapi-docs/src/test/scala-2/sttp/tapir/docs/openapi/VerifyYamlEnumerationTest.scala
+++ b/docs/openapi-docs/src/test/scala-2/sttp/tapir/docs/openapi/VerifyYamlEnumerationTest.scala
@@ -47,13 +47,14 @@ class VerifyYamlEnumerationTest extends AnyFunSuite with Matchers {
         Seq(
           endpoint.in("poland").out(jsonBody[Poland]),
           endpoint.in("belgium").out(jsonBody[Belgium]),
-          endpoint.in("luxembourg").out(jsonBody[Luxembourg])
+          endpoint.in("luxembourg").out(jsonBody[Luxembourg]),
+          endpoint.in("maybeCountry").out(jsonBody[MaybeCountry])
         ),
         "Countries",
         "1.0"
       )
       .toYaml
-
+    println(actualYaml)
     val expectedYaml = load("enum/expected_enumeratum_enum_component.yml")
 
     noIndentation(actualYaml) shouldBe expectedYaml
@@ -103,6 +104,7 @@ object VerifyYamlEnumerationTest {
   case class Poland(countryCode: CountryCode)
   case class Belgium(countryCode: CountryCode)
   case class Luxembourg(countryCode: CountryCode)
+  case class MaybeCountry(countryCode: CountryCode, countryCodeOpt: Option[CountryCode])
 
   sealed abstract class ErrorCode(val value: Int) extends IntEnumEntry
 

--- a/docs/openapi-docs/src/test/scala-2/sttp/tapir/docs/openapi/VerifyYamlEnumerationTest.scala
+++ b/docs/openapi-docs/src/test/scala-2/sttp/tapir/docs/openapi/VerifyYamlEnumerationTest.scala
@@ -47,15 +47,32 @@ class VerifyYamlEnumerationTest extends AnyFunSuite with Matchers {
         Seq(
           endpoint.in("poland").out(jsonBody[Poland]),
           endpoint.in("belgium").out(jsonBody[Belgium]),
-          endpoint.in("luxembourg").out(jsonBody[Luxembourg]),
-          endpoint.in("maybeCountry").out(jsonBody[MaybeCountry])
+          endpoint.in("luxembourg").out(jsonBody[Luxembourg])
         ),
         "Countries",
         "1.0"
       )
       .toYaml
-    println(actualYaml)
     val expectedYaml = load("enum/expected_enumeratum_enum_component.yml")
+
+    noIndentation(actualYaml) shouldBe expectedYaml
+  }
+
+  test("should create component for optional and collections of enums") {
+    import sttp.tapir.codec.enumeratum._
+
+    implicit val options: OpenAPIDocsOptions = OpenAPIDocsOptions.default.copy(referenceEnums = _ => true)
+
+    val actualYaml = OpenAPIDocsInterpreter
+      .toOpenAPI(
+        Seq(
+          endpoint.in("countryCollection").out(jsonBody[CountryCollection])
+        ),
+        "Countries",
+        "1.0"
+      )
+      .toYaml
+    val expectedYaml = load("enum/expected_enumeratum_enum_collection_component.yml")
 
     noIndentation(actualYaml) shouldBe expectedYaml
   }
@@ -104,7 +121,7 @@ object VerifyYamlEnumerationTest {
   case class Poland(countryCode: CountryCode)
   case class Belgium(countryCode: CountryCode)
   case class Luxembourg(countryCode: CountryCode)
-  case class MaybeCountry(countryCode: CountryCode, countryCodeOpt: Option[CountryCode])
+  case class CountryCollection(countryCode: CountryCode, countryCodeOpt: Option[CountryCode], countryCodeMulti: List[CountryCode])
 
   sealed abstract class ErrorCode(val value: Int) extends IntEnumEntry
 


### PR DESCRIPTION
I've found that during documentation generation if a class contains an optional enum field then `referenceEnums` isn't affecting the result.
For example, if I have the enum:
```scala
sealed abstract class MyEnum extends EnumEntry

  object MyEnum extends Enum[MyEnum] {
    case object Foo1 extends MyEnum
    case object Foo2 extends MyEnum
    override def values: immutable.IndexedSeq[MyEnum] = findValues
  }
```
and use it in the class:
```scala
  case class MyResult(enumField: MyEnum, enumFieldOpt: Option[MyEnum])
```
Then generated documentation would use a reference to specify the type of `enumField` and will inline all options for `enumFieldOpt`.

I've found that the problem was inside `TSchemaToASchema.scala` because was not handled in a case when an option field might contain an enum.