### PR TITLE
Enable more http4s modules for scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -235,7 +235,7 @@ lazy val clientTestServer = (projectMatrix in file("client/testserver"))
     clientTestServerPort := 51823,
     startClientTestServer := reStart.toTask("").value
   )
-  .jvmPlatform(scalaVersions = List(scala2_13))
+  .jvmPlatform(scalaVersions = scala2And3Versions)
 
 lazy val clientTestServer2_13 = clientTestServer.jvm(scala2_13)
 
@@ -733,7 +733,7 @@ lazy val swaggerUiHttp4s: ProjectMatrix = (projectMatrix in file("docs/swagger-u
       scalaTest.value % Test
     )
   )
-  .jvmPlatform(scalaVersions = scala2Versions)
+  .jvmPlatform(scalaVersions = scala2And3Versions)
 
 lazy val redocHttp4s: ProjectMatrix = (projectMatrix in file("docs/redoc-http4s"))
   .settings(commonJvmSettings)
@@ -741,7 +741,7 @@ lazy val redocHttp4s: ProjectMatrix = (projectMatrix in file("docs/redoc-http4s"
     name := "tapir-redoc-http4s",
     libraryDependencies += "org.http4s" %% "http4s-dsl" % Versions.http4s
   )
-  .jvmPlatform(scalaVersions = scala2Versions)
+  .jvmPlatform(scalaVersions = scala2And3Versions)
 
 lazy val swaggerUiFinatra: ProjectMatrix = (projectMatrix in file("docs/swagger-ui-finatra"))
   .settings(commonJvmSettings)
@@ -1072,7 +1072,7 @@ lazy val http4sClient: ProjectMatrix = (projectMatrix in file("client/http4s-cli
       "com.softwaremill.sttp.shared" %% "fs2-ce2" % Versions.sttpShared % Optional
     )
   )
-  .jvmPlatform(scalaVersions = scala2Versions)
+  .jvmPlatform(scalaVersions = scala2And3Versions)
   .dependsOn(core, clientTests % Test)
 
 lazy val sttpClient: ProjectMatrix = (projectMatrix in file("client/sttp-client"))

--- a/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
+++ b/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
@@ -108,8 +108,10 @@ private[http4s] class EndpointToHttp4sClient(blocker: Blocker, clientOptions: Ht
       case a: EndpointInput.Auth[_]                  => setInputParams(a.input, params, req)
       case EndpointInput.Pair(left, right, _, split) => handleInputPair(left, right, params, split, req)
       case EndpointIO.Pair(left, right, _, split)    => handleInputPair(left, right, params, split, req)
-      case EndpointInput.MappedPair(wrapped, codec)  => handleMapped(wrapped, codec.asInstanceOf[Mapping[Any, Any]], params, req)
-      case EndpointIO.MappedPair(wrapped, codec)     => handleMapped(wrapped, codec.asInstanceOf[Mapping[Any, Any]], params, req)
+      case EndpointInput.MappedPair(wrapped, codec) =>
+        handleMapped(wrapped.asInstanceOf[EndpointInput.Pair[Any, Any, Any]], codec.asInstanceOf[Mapping[Any, Any]], params, req)
+      case EndpointIO.MappedPair(wrapped, codec) =>
+        handleMapped(wrapped.asInstanceOf[EndpointIO.Pair[Any, Any, Any]], codec.asInstanceOf[Mapping[Any, Any]], params, req)
     }
   }
 

--- a/docs/swagger-ui-http4s/src/main/scala/sttp/tapir/swagger/http4s/SwaggerHttp4s.scala
+++ b/docs/swagger-ui-http4s/src/main/scala/sttp/tapir/swagger/http4s/SwaggerHttp4s.scala
@@ -54,7 +54,7 @@ class SwaggerHttp4s(
         Ok(yaml)
       case GET -> `rootPath` / swaggerResource =>
         StaticFile
-          .fromResource(
+          .fromResource[F](
             s"/META-INF/resources/webjars/swagger-ui/$swaggerVersion/$swaggerResource",
             Blocker.liftExecutionContext(ExecutionContext.global)
           )


### PR DESCRIPTION
Enables for following modules for scala 3. 
* `testing-server`
* `tapir-swagger-ui-http4s`
*  `tapir-redoc-http4s`
*  `tapir-http4s-client`

Only a slight type description for SwaggerHttp4s.scala needed for compilation.

