### PR TITLE
Support AkkaStreams capacity in Play server interpreter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -816,7 +816,8 @@ lazy val playServer: ProjectMatrix = (projectMatrix in file("server/play-server"
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-server" % Versions.playServer,
       "com.typesafe.play" %% "play-akka-http-server" % Versions.playServer,
-      "com.typesafe.play" %% "play" % Versions.playServer
+      "com.typesafe.play" %% "play" % Versions.playServer,
+      "com.softwaremill.sttp.shared" %% "akka" % Versions.sttpShared
     )
   )
   .jvmPlatform(scalaVersions = scala2Versions)

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
@@ -2,6 +2,7 @@ package sttp.tapir.server.play
 
 import akka.actor.ActorSystem
 import cats.effect.{IO, Resource}
+import sttp.capabilities.akka.AkkaStreams
 import sttp.monad.FutureMonad
 import sttp.tapir.server.tests.{
   DefaultCreateServerTest,
@@ -10,6 +11,7 @@ import sttp.tapir.server.tests.{
   ServerFileMultipartTests,
   ServerMetricsTest,
   ServerStaticContentTests,
+  ServerStreamingTests,
   backendResource
 }
 import sttp.tapir.tests.{Test, TestSuite}
@@ -27,6 +29,7 @@ class PlayServerTest extends TestSuite {
       val createServerTest = new DefaultCreateServerTest(backend, interpreter)
 
       new ServerBasicTests(createServerTest, interpreter, multipleValueHeaderSupport = false, inputStreamSupport = false).tests() ++
+        new ServerStreamingTests(createServerTest, AkkaStreams).tests() ++
         new ServerFileMultipartTests(createServerTest, multipartInlineHeaderSupport = false).tests() ++
         new ServerAuthenticationTests(createServerTest).tests() ++
         new ServerMetricsTest(createServerTest).tests() ++

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
@@ -8,6 +8,7 @@ import play.api.mvc.{Handler, RequestHeader}
 import play.api.routing.Router
 import play.api.routing.Router.Routes
 import play.core.server.{DefaultAkkaHttpServerComponents, ServerConfig}
+import sttp.capabilities.akka.AkkaStreams
 import sttp.tapir.Endpoint
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
@@ -18,11 +19,11 @@ import sttp.tapir.tests.Port
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
-class PlayTestServerInterpreter(implicit actorSystem: ActorSystem) extends TestServerInterpreter[Future, Any, Router.Routes] {
+class PlayTestServerInterpreter(implicit actorSystem: ActorSystem) extends TestServerInterpreter[Future, AkkaStreams, Router.Routes] {
   import actorSystem.dispatcher
 
   override def route[I, E, O](
-      e: ServerEndpoint[I, E, O, Any, Future],
+      e: ServerEndpoint[I, E, O, AkkaStreams, Future],
       decodeFailureHandler: Option[DecodeFailureHandler],
       metricsInterceptor: Option[MetricsRequestInterceptor[Future]] = None
   ): Routes = {
@@ -34,9 +35,9 @@ class PlayTestServerInterpreter(implicit actorSystem: ActorSystem) extends TestS
     PlayServerInterpreter(serverOptions).toRoutes(e)
   }
 
-  override def route[I, E, O](es: List[ServerEndpoint[I, E, O, Any, Future]]): Routes = PlayServerInterpreter().toRoutes(es)
+  override def route[I, E, O](es: List[ServerEndpoint[I, E, O, AkkaStreams, Future]]): Routes = PlayServerInterpreter().toRoutes(es)
 
-  override def routeRecoverErrors[I, E <: Throwable, O](e: Endpoint[I, E, O, Any], fn: I => Future[O])(implicit
+  override def routeRecoverErrors[I, E <: Throwable, O](e: Endpoint[I, E, O, AkkaStreams], fn: I => Future[O])(implicit
       eClassTag: ClassTag[E]
   ): Routes = {
     PlayServerInterpreter().toRoutesRecoverErrors(e)(fn)


### PR DESCRIPTION
This aims to solve #1385.

It's a draft because only the response as stream is implemented for now: I'm not sure how to implement request as a stream.

Either:
- we accept to implement only for response and not request (but then either we remove the tests about streaming or we split them in streaming request vs streaming response)
- or, we wait until finding the good way to implement request streaming (`PlayRequestBody#toStream()`)