### PR TITLE
Use strings for big decimal schemas when using circe

### DIFF
--- a/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
+++ b/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
@@ -35,4 +35,8 @@ trait TapirJsonCirce {
     )
 
   implicit val schemaForCirceJsonObject: Schema[JsonObject] = Schema(SProduct(Nil), Some(SName("io.circe.JsonObject")))
+
+  // #321: circe encodes big decimals as numbers - adjusting the schemas (which by default are strings) to that format
+  implicit val schemaForBigDecimal: Schema[BigDecimal] = Schema(SNumber())
+  implicit val schemaForJBigDecimal: Schema[java.math.BigDecimal] = Schema(SNumber())
 }

--- a/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
+++ b/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
@@ -8,7 +8,7 @@ import sttp.tapir.Codec.JsonCodec
 import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
 import sttp.tapir.SchemaType.{SCoproduct, SProduct}
 import sttp.tapir.generic.auto._
-import sttp.tapir.{DecodeResult, FieldName}
+import sttp.tapir.{DecodeResult, FieldName, Schema, SchemaType}
 
 class TapirJsonCirceTests extends AnyFlatSpecLike with Matchers {
 

--- a/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
+++ b/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.json.circe
 
-import io.circe.DecodingFailure
+import io.circe.{DecodingFailure, Encoder, Json}
 import io.circe.generic.auto._
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -58,4 +58,9 @@ class TapirJsonCirceTests extends AnyFlatSpecLike with Matchers {
     schemaForCirceJsonObject.schemaType shouldBe a[SProduct[_]]
   }
 
+  it should "represent big decimals as numbers" in {
+    val n = BigDecimal(10)
+    implicitly[Encoder[BigDecimal]].apply(n) shouldBe Json.fromDoubleOrNull(10)
+    implicitly[Schema[BigDecimal]] shouldBe Schema(SchemaType.SNumber())
+  }
 }


### PR DESCRIPTION
Closes #321