### PR TITLE
Enable errors accumulations by default with Circe

### DIFF
--- a/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
+++ b/json/circe/src/main/scala/sttp/tapir/json/circe/TapirJsonCirce.scala
@@ -1,27 +1,38 @@
 package sttp.tapir.json.circe
 
+import cats.data.Validated
 import io.circe._
 import io.circe.syntax._
+import sttp.tapir._
 import sttp.tapir.Codec.JsonCodec
-import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
 import sttp.tapir.DecodeResult.{Error, Value}
+import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
 import sttp.tapir.Schema.SName
 import sttp.tapir.SchemaType._
-import sttp.tapir._
 
 trait TapirJsonCirce {
   def jsonBody[T: Encoder: Decoder: Schema]: EndpointIO.Body[String, T] = anyFromUtf8StringBody(circeCodec[T])
 
   implicit def circeCodec[T: Encoder: Decoder: Schema]: JsonCodec[T] =
     sttp.tapir.Codec.json[T] { s =>
-      io.circe.parser.decode[T](s) match {
-        case Left(failure @ ParsingFailure(msg, _)) =>
-          Error(s, JsonDecodeException(List(JsonError(msg, path = List.empty)), failure))
-        case Left(failure: DecodingFailure) =>
-          val path = CursorOp.opsToPath(failure.history)
-          val fields = path.split("\\.").toList.filter(_.nonEmpty).map(FieldName.apply)
-          Error(s, JsonDecodeException(List(JsonError(failure.message, fields)), failure))
-        case Right(v) => Value(v)
+      io.circe.parser.decodeAccumulating[T](s) match {
+        case Validated.Valid(v) => Value(v)
+        case Validated.Invalid(circeFailures) =>
+          val tapirJsonErrors = circeFailures.map {
+            case ParsingFailure(msg, _) => JsonError(msg, path = List.empty)
+            case failure: DecodingFailure =>
+              val path = CursorOp.opsToPath(failure.history)
+              val fields = path.split("\\.").toList.filter(_.nonEmpty).map(FieldName.apply)
+              JsonError(failure.message, fields)
+          }
+
+          Error(
+            original = s,
+            error = JsonDecodeException(
+              errors = tapirJsonErrors.toList,
+              underlying = Errors(circeFailures)
+            )
+          )
       }
     } { t => jsonPrinter.print(t.asJson) }
 

--- a/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
+++ b/json/circe/src/test/scalajvm/sttp/tapir/json/circe/TapirJsonCirceTests.scala
@@ -1,14 +1,14 @@
 package sttp.tapir.json.circe
 
-import io.circe.{DecodingFailure, Encoder, Json}
+import io.circe.{Encoder, Errors, Json}
 import io.circe.generic.auto._
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
+import sttp.tapir.{DecodeResult, FieldName, Schema, SchemaType}
 import sttp.tapir.Codec.JsonCodec
 import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
 import sttp.tapir.SchemaType.{SCoproduct, SProduct}
 import sttp.tapir.generic.auto._
-import sttp.tapir.{DecodeResult, FieldName, Schema, SchemaType}
 
 class TapirJsonCirceTests extends AnyFlatSpecLike with Matchers {
 
@@ -30,8 +30,10 @@ class TapirJsonCirceTests extends AnyFlatSpecLike with Matchers {
 
     val error = failure.error.asInstanceOf[JsonDecodeException]
     error.errors shouldEqual
-      List(JsonError("Attempt to decode value on failed cursor", List(FieldName("name"))))
-    error.underlying shouldBe a[DecodingFailure]
+      List(
+        JsonError("Attempt to decode value on failed cursor", List(FieldName("name"))),
+        JsonError("Attempt to decode value on failed cursor", List(FieldName("yearOfBirth")))
+      )
   }
 
   it should "return a JSON specific error on array decode failure" in {
@@ -46,8 +48,11 @@ class TapirJsonCirceTests extends AnyFlatSpecLike with Matchers {
 
     val error = failure.error.asInstanceOf[JsonDecodeException]
     error.errors shouldEqual
-      List(JsonError("Attempt to decode value on failed cursor", List(FieldName("[0]"), FieldName("serialNumber"))))
-    error.underlying shouldBe a[DecodingFailure]
+      List(
+        JsonError("Attempt to decode value on failed cursor", List(FieldName("[0]"), FieldName("serialNumber"))),
+        JsonError("Attempt to decode value on failed cursor", List(FieldName("[0]"), FieldName("price")))
+      )
+    error.underlying shouldBe a[Errors]
   }
 
   it should "return a coproduct schema for a Json" in {


### PR DESCRIPTION
The purpose of this PR is just to enable error accumulation for Circe users. 
Currently if there are missing keys in the Json(or typo) the error from Tapir is just for the first missing key

So, in this case:
```scala
case class Person(name: String, surname: String, age: Int)
```
```json
{
  "name": "Foo"
}
```

We have an error that say `Attempt to decode value on failed cursor at 'name'` but nothing for `age`.

Using `decodeAccumulating` from `Circe` we'll have all errors and not only the first one.
```
Attempt to decode value on failed cursor at 'name'
Attempt to decode value on failed cursor at 'age'
```