### PR TITLE
#1400: fix play server interpreter when routes are put in context for 0.18

### DIFF
--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerInterpreter.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerInterpreter.scala
@@ -57,10 +57,10 @@ trait PlayServerInterpreter {
         }
       }
 
-      override def apply(v1: RequestHeader): Handler = {
+      override def apply(header: RequestHeader): Handler = {
         playServerOptions.defaultActionBuilder.async(playServerOptions.playBodyParsers.raw) { request =>
           implicit val bodyListener: BodyListener[Future, HttpEntity] = new PlayBodyListener
-          val serverRequest = new PlayServerRequest(request)
+          val serverRequest = new PlayServerRequest(header)
           val interpreter = new ServerInterpreter[Any, Future, HttpEntity, NoStreams](
             new PlayRequestBody(request, playServerOptions),
             new PlayToResponseBody,

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
@@ -25,15 +25,11 @@ class PlayServerTest extends TestSuite {
       val interpreter = new PlayTestServerInterpreter()(actorSystem)
       val createServerTest = new DefaultCreateServerTest(backend, interpreter)
 
-      new ServerBasicTests(
-        createServerTest,
-        interpreter,
-        multipleValueHeaderSupport = false,
-        inputStreamSupport = false
-      ).tests() ++
+      new ServerBasicTests(createServerTest, interpreter, multipleValueHeaderSupport = false, inputStreamSupport = false).tests() ++
         new ServerFileMultipartTests(createServerTest, multipartInlineHeaderSupport = false).tests()
       new ServerAuthenticationTests(createServerTest).tests() ++
-        new ServerMetricsTest(createServerTest).tests()
+        new ServerMetricsTest(createServerTest).tests() ++
+        new PlayServerWithContextTest(backend).tests()
     }
   }
 }

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerWithContextTest.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerWithContextTest.scala
@@ -1,0 +1,38 @@
+package sttp.tapir.server.play
+
+import akka.actor.ActorSystem
+import cats.effect.IO
+import org.scalatest.matchers.should.Matchers._
+import play.api.Mode
+import play.api.routing.Router
+import play.core.server.{DefaultAkkaHttpServerComponents, ServerConfig}
+import sttp.client3._
+import sttp.tapir._
+import sttp.tapir.tests.Test
+
+import scala.concurrent.Future
+
+class PlayServerWithContextTest(backend: SttpBackend[IO, Any])(implicit _actorSystem: ActorSystem) {
+  import _actorSystem.dispatcher
+
+  def tests(): List[Test] = List(
+    Test("server with play.http.context set") {
+      val e = endpoint.get.in("hello").out(stringBody).serverLogic[Future](_ => Future.successful(Right("world")))
+      val components = new DefaultAkkaHttpServerComponents {
+        override lazy val serverConfig: ServerConfig = ServerConfig(port = Some(0), address = "127.0.0.1", mode = Mode.Test)
+        override lazy val actorSystem: ActorSystem = ActorSystem("tapir", defaultExecutionContext = Some(_actorSystem.dispatcher))
+        override def router: Router = Router.from(PlayServerInterpreter().toRoutes(e)).withPrefix("/test")
+      }
+      val s = components.server
+      val r = Future.successful(()).flatMap { _ =>
+        basicRequest
+          .get(uri"http://localhost:${s.mainAddress.getPort}/test/hello")
+          .send(backend)
+          .map(_.body shouldBe Right("world"))
+          .unsafeToFuture()
+      }
+      r.onComplete(_ => s.stop())
+      r
+    }
+  )
+}


### PR DESCRIPTION
(cherry picked from commit 343995a5680fb79527897d1f5cef9fdd674149b4)