### PR TITLE
Use numbers for BigDecimal schemas when using zio-json

### DIFF
--- a/json/zio/src/main/scala/sttp/tapir/json/zio/TapirJsonZio.scala
+++ b/json/zio/src/main/scala/sttp/tapir/json/zio/TapirJsonZio.scala
@@ -4,13 +4,11 @@ import sttp.tapir.Codec.JsonCodec
 import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
 import sttp.tapir.DecodeResult.{Error, Value}
 import sttp.tapir.Schema.SName
-import sttp.tapir.SchemaType.{SCoproduct, SProduct}
+import sttp.tapir.SchemaType.{SCoproduct, SNumber, SProduct}
 import sttp.tapir.{EndpointIO, FieldName, Schema, anyFromUtf8StringBody}
 import zio.json.ast.Json
 import zio.json.ast.Json.Obj
 import zio.json.{JsonDecoder, JsonEncoder, _}
-
-import scala.collection.immutable.ListMap
 
 trait TapirJsonZio {
 
@@ -47,4 +45,8 @@ trait TapirJsonZio {
   implicit val schemaForZioJsonObject: Schema[Obj] =
     Schema(SProduct(Nil), Some(SName("zio.json.ast.Json.Obj")))
 
+  // zio-json encodes big decimals as numbers - adjusting the schemas (which by default are strings) to that format
+  // refer to #321 (circe case)
+  implicit val schemaForBigDecimal: Schema[BigDecimal] = Schema(SNumber())
+  implicit val schemaForJBigDecimal: Schema[java.math.BigDecimal] = Schema(SNumber())
 }

--- a/json/zio/src/test/scalajvm/sttp/tapir/json/zio/TapirJsonZioTest.scala
+++ b/json/zio/src/test/scalajvm/sttp/tapir/json/zio/TapirJsonZioTest.scala
@@ -6,10 +6,11 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 import sttp.tapir.Codec.JsonCodec
 import sttp.tapir.DecodeResult.Error.{JsonDecodeException, JsonError}
-import sttp.tapir.{DecodeResult, FieldName, Schema}
+import sttp.tapir.{DecodeResult, FieldName, Schema, SchemaType}
 import sttp.tapir.DecodeResult.Value
 import sttp.tapir.SchemaType.{SCoproduct, SProduct}
-import zio.json.DeriveJsonCodec
+import zio.json.{DeriveJsonCodec, JsonEncoder}
+import zio.json.ast.Json
 
 class TapirJsonZioTest extends AnyFlatSpecLike with Matchers {
 
@@ -93,4 +94,9 @@ class TapirJsonZioTest extends AnyFlatSpecLike with Matchers {
     schemaForZioJsonObject.schemaType shouldBe a[SProduct[_]]
   }
 
+  it should "represent big decimals as numbers" in {
+    val n = BigDecimal(10)
+    implicitly[JsonEncoder[BigDecimal]].toJsonAST(n) shouldBe Right(Json.Num(10))
+    implicitly[Schema[BigDecimal]] shouldBe Schema(SchemaType.SNumber())
+  }
 }


### PR DESCRIPTION
The same case as #321 and #1405.