### PR TITLE
(core): fix output media type matching

### DIFF
--- a/core/src/main/scala/sttp/tapir/internal/package.scala
+++ b/core/src/main/scala/sttp/tapir/internal/package.scala
@@ -1,6 +1,6 @@
 package sttp.tapir
 
-import sttp.model.{MediaType, Method, StatusCode}
+import sttp.model.{ContentTypeRange, MediaType, Method, StatusCode}
 import sttp.monad.MonadError
 import sttp.tapir.EndpointOutput.WebSocketBodyWrapper
 import sttp.tapir.typelevel.{BinaryTupleOp, ParamConcat, ParamSubtract}
@@ -211,7 +211,10 @@ package object internal {
         case m                                 => m
       }
 
-      supportedMediaTypes.exists(_ == contentToMatch)
+      val contentTypeRange =
+        ContentTypeRange(contentToMatch.mainType, contentToMatch.subType, contentToMatch.charset.getOrElse(ContentTypeRange.Wildcard))
+
+      supportedMediaTypes.exists(_.matches(contentTypeRange))
     }
   }
 

--- a/core/src/test/scala/sttp/tapir/internal/RichEndpointOutputTest.scala
+++ b/core/src/test/scala/sttp/tapir/internal/RichEndpointOutputTest.scala
@@ -1,0 +1,21 @@
+package sttp.tapir.internal
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.model.MediaType
+import sttp.tapir._
+
+class RichEndpointOutputTest extends AnyFlatSpec with Matchers {
+  "output media type" should "match content type with lower case charset" in {
+    MediaType.parse("text/plain; charset=utf-8") match {
+      case Right(mediaType) =>
+        endpoint.put
+          .in("api" / path[String]("version"))
+          .out(stringBody)
+          .output
+          .hasBodyMatchingContent(mediaType) should be(true)
+
+      case Left(error) => fail(s"unable to parse media type: $error")
+    }
+  }
+}


### PR DESCRIPTION
Hi softwaremill,
thanks for tapir, I think it is an interesting approach. 

I stumbled upon an issue: since the media type parser retains the case of the charset, a comparison with the (uppercase) charset name might fail (for example when a service mesh/API gateway lowercases all headers, which is still valid). See the test case.

In my fix attempt, the comparison is now using the `matches` method of `MediaType` which already takes this into account.