### PR TITLE
Fix access to underlying request in PlayServerInterpreter

### DIFF
--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerInterpreter.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerInterpreter.scala
@@ -54,7 +54,7 @@ trait PlayServerInterpreter {
 
     new PartialFunction[RequestHeader, Handler] {
       override def isDefinedAt(request: RequestHeader): Boolean = {
-        val serverRequest = new PlayServerRequest(request)
+        val serverRequest = new PlayServerRequest(request, request)
         serverEndpoints.exists { se =>
           DecodeBasicInputs(se.input, serverRequest) match {
             case DecodeBasicInputsResult.Values(_, _) => true
@@ -67,7 +67,7 @@ trait PlayServerInterpreter {
       override def apply(header: RequestHeader): Handler = {
         playServerOptions.defaultActionBuilder.async(streamParser) { request =>
           implicit val bodyListener: BodyListener[Future, HttpEntity] = new PlayBodyListener
-          val serverRequest = new PlayServerRequest(header)
+          val serverRequest = new PlayServerRequest(header, request)
           val interpreter = new ServerInterpreter(
             new PlayRequestBody(request, playServerOptions),
             new PlayToResponseBody,

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerRequest.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerRequest.scala
@@ -8,14 +8,14 @@ import sttp.tapir.model.{ConnectionInfo, ServerRequest}
 import java.nio.charset.StandardCharsets
 import scala.collection.immutable._
 
-private[play] class PlayServerRequest(request: RequestHeader) extends ServerRequest {
-  override lazy val method: Method = Method(request.method.toUpperCase)
-  override def protocol: String = request.version
-  override lazy val uri: Uri = Uri.unsafeParse(request.uri)
-  override lazy val connectionInfo: ConnectionInfo = ConnectionInfo(None, None, Some(request.secure))
-  override lazy val headers: Seq[Header] = request.headers.headers.map { case (k, v) => Header(k, v) }.toList
-  override lazy val queryParameters: QueryParams = QueryParams.fromMultiMap(request.queryString)
+private[play] class PlayServerRequest(requestHeader: RequestHeader, requestWithContext: RequestHeader) extends ServerRequest {
+  override lazy val method: Method = Method(requestHeader.method.toUpperCase)
+  override def protocol: String = requestHeader.version
+  override lazy val uri: Uri = Uri.unsafeParse(requestHeader.uri)
+  override lazy val connectionInfo: ConnectionInfo = ConnectionInfo(None, None, Some(requestHeader.secure))
+  override lazy val headers: Seq[Header] = requestHeader.headers.headers.map { case (k, v) => Header(k, v) }.toList
+  override lazy val queryParameters: QueryParams = QueryParams.fromMultiMap(requestHeader.queryString)
   override lazy val pathSegments: List[String] =
-    request.path.dropWhile(_ == '/').split("/").toList.map(UriEncoding.decodePathSegment(_, StandardCharsets.UTF_8))
-  override def underlying: Any = request
+    requestHeader.path.dropWhile(_ == '/').split("/").toList.map(UriEncoding.decodePathSegment(_, StandardCharsets.UTF_8))
+  override def underlying: Any = requestWithContext
 }


### PR DESCRIPTION
Play's `Request` may contain additional context like authentication when it is produced by `ActionBuilder`. Access to that data was possible it Tapir 0.18.1 by casting `ServerRequest.underlying` to type that is produced by `defaultActionBuilder`.

Unfortunately, this was broken in 0.18.3. Fix in #1423 replaced `Request` with `RequestHeader` that misses that context.

This pull request provider better fix for #1400, that fixes that problem without affecting `underlying`. In Play Framework, any `Request` extends `RequestHeader`, so this change is backward compatible and should no break code that works with 0.18.3.