### PR TITLE
#499 Add support for native Netty transports

### DIFF
--- a/doc/server/netty.md
+++ b/doc/server/netty.md
@@ -21,6 +21,7 @@ import sttp.tapir.server.netty.{NettyFutureServer, NettyFutureServerBinding}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import java.net.InetSocketAddress
 
 val helloWorld = endpoint
   .get
@@ -28,7 +29,7 @@ val helloWorld = endpoint
   .out(stringBody)
   .serverLogic(name => Future.successful[Either[Unit, String]](Right(s"Hello, $name!")))
 
-val binding: Future[NettyFutureServerBinding] = 
+val binding: Future[NettyFutureServerBinding[InetSocketAddress]] = 
   NettyFutureServer().addEndpoint(helloWorld).start()
 ```
 

--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettyServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettyServer.scala
@@ -22,7 +22,9 @@ object HelloWorldNettyServer extends App {
   val serverBinding =
     Await.result(
       NettyFutureServer
-        .tcp(_.port(8888))
+        .tcp
+        .port(8080)
+        .endpoints
         .addEndpoint(helloWorldServerEndpoint)
         .start(),
       Duration.Inf

--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettyServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettyServer.scala
@@ -21,8 +21,7 @@ object HelloWorldNettyServer extends App {
   // Creating handler for netty bootstrap
   val serverBinding =
     Await.result(
-      NettyFutureServer
-        .tcp
+      NettyFutureServer.tcp
         .port(8080)
         .addEndpoint(helloWorldServerEndpoint)
         .start(),

--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettyServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettyServer.scala
@@ -24,7 +24,6 @@ object HelloWorldNettyServer extends App {
       NettyFutureServer
         .tcp
         .port(8080)
-        .endpoints
         .addEndpoint(helloWorldServerEndpoint)
         .start(),
       Duration.Inf

--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettyServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettyServer.scala
@@ -2,7 +2,7 @@ package sttp.tapir.examples
 
 import sttp.client3.{HttpURLConnectionBackend, Identity, SttpBackend, UriContext, asStringAlways, basicRequest}
 import sttp.model.StatusCode
-import sttp.tapir.server.netty.{NettyFutureServer, NettyFutureServerBinding}
+import sttp.tapir.server.netty.{NettyFutureServer, NettyFutureServerBinding, NettyFutureServerOptions, NettyOptionsBuilder}
 import sttp.tapir.{Endpoint, endpoint, query, stringBody}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -20,7 +20,13 @@ object HelloWorldNettyServer extends App {
 
   // Creating handler for netty bootstrap
   val serverBinding =
-    Await.result(NettyFutureServer().port(8888).addEndpoint(helloWorldServerEndpoint).start(), Duration.Inf)
+    Await.result(
+      NettyFutureServer()
+        .options(NettyFutureServerOptions.default.nettyOptions(NettyOptionsBuilder.make().tcp().port(8888).build))
+        .addEndpoint(helloWorldServerEndpoint)
+        .start(),
+      Duration.Inf
+    )
 
   // Bind and start to accept incoming connections.
   val port = serverBinding.port

--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettyServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettyServer.scala
@@ -29,8 +29,8 @@ object HelloWorldNettyServer extends App {
     )
 
   // Bind and start to accept incoming connections.
-  val port = serverBinding.port
-  println(s"Server started at port = ${serverBinding.port}")
+  val port = serverBinding.localSocket.getPort
+  println(s"Server started at port = ${serverBinding.localSocket.getPort}")
 
   val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
   val badUrl = uri"http://localhost:$port/bad_url"

--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettyServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldNettyServer.scala
@@ -21,8 +21,8 @@ object HelloWorldNettyServer extends App {
   // Creating handler for netty bootstrap
   val serverBinding =
     Await.result(
-      NettyFutureServer()
-        .options(NettyFutureServerOptions.default.nettyOptions(NettyOptionsBuilder.make().tcp().port(8888).build))
+      NettyFutureServer
+        .tcp(_.port(8888))
         .addEndpoint(helloWorldServerEndpoint)
         .start(),
       Duration.Inf

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyCatsServer.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyCatsServer.scala
@@ -9,23 +9,24 @@ import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.netty.internal.CatsUtil._
 import sttp.tapir.server.netty.internal.{NettyBootstrap, NettyServerHandler}
 
-import java.net.InetSocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 
-case class NettyCatsServer[F[_]: Async](routes: Vector[Route[F]], options: NettyCatsServerOptions[F]) {
-  def addEndpoint(se: ServerEndpoint[_, _, _, Any, F]): NettyCatsServer[F] = addEndpoints(List(se))
-  def addEndpoint(se: ServerEndpoint[_, _, _, Any, F], overrideOptions: NettyCatsServerOptions[F]): NettyCatsServer[F] =
+case class NettyCatsServer[F[_]: Async, S <: SocketAddress](routes: Vector[Route[F]], options: NettyCatsServerOptions[F, S]) {
+  def addEndpoint(se: ServerEndpoint[_, _, _, Any, F]): NettyCatsServer[F, S] = addEndpoints(List(se))
+  def addEndpoint(se: ServerEndpoint[_, _, _, Any, F], overrideOptions: NettyCatsServerOptions[F, S]): NettyCatsServer[F, S] =
     addEndpoints(List(se), overrideOptions)
-  def addEndpoints(ses: List[ServerEndpoint[_, _, _, Any, F]]): NettyCatsServer[F] = addRoute(
+  def addEndpoints(ses: List[ServerEndpoint[_, _, _, Any, F]]): NettyCatsServer[F, S] = addRoute(
     NettyCatsServerInterpreter(options).toRoute(ses)
   )
-  def addEndpoints(ses: List[ServerEndpoint[_, _, _, Any, F]], overrideOptions: NettyCatsServerOptions[F]): NettyCatsServer[F] = addRoute(
-    NettyCatsServerInterpreter(overrideOptions).toRoute(ses)
-  )
+  def addEndpoints(ses: List[ServerEndpoint[_, _, _, Any, F]], overrideOptions: NettyCatsServerOptions[F, S]): NettyCatsServer[F, S] =
+    addRoute(
+      NettyCatsServerInterpreter(overrideOptions).toRoute(ses)
+    )
 
-  def addRoute(r: Route[F]): NettyCatsServer[F] = copy(routes = routes :+ r)
-  def addRoutes(r: Iterable[Route[F]]): NettyCatsServer[F] = copy(routes = routes ++ r)
+  def addRoute(r: Route[F]): NettyCatsServer[F, S] = copy(routes = routes :+ r)
+  def addRoutes(r: Iterable[Route[F]]): NettyCatsServer[F, S] = copy(routes = routes ++ r)
 
-  def options(o: NettyCatsServerOptions[F]): NettyCatsServer[F] = copy(options = o)
+  def options(o: NettyCatsServerOptions[F, S]): NettyCatsServer[F, S] = copy(options = o)
 
   def start(): F[NettyCatsServerBinding[F]] = Async[F].defer {
     val eventLoopGroup = options.nettyOptions.eventLoopConfig.builder()
@@ -59,13 +60,13 @@ case class NettyCatsServer[F[_]: Async](routes: Vector[Route[F]], options: Netty
 }
 
 object NettyCatsServer {
-  def apply[F[_]: Async](dispatcher: Dispatcher[F]): NettyCatsServer[F] =
+  def apply[F[_]: Async](dispatcher: Dispatcher[F]): NettyCatsServer[F, InetSocketAddress] =
     NettyCatsServer(Vector.empty, NettyCatsServerOptions.default[F](dispatcher))
 
-  def apply[F[_]: Async](options: NettyCatsServerOptions[F]): NettyCatsServer[F] =
+  def apply[F[_]: Async, S <: SocketAddress](options: NettyCatsServerOptions[F, S]): NettyCatsServer[F, S] =
     NettyCatsServer(Vector.empty, options)
 
-  def io(): Resource[IO, NettyCatsServer[IO]] = Dispatcher[IO].map(apply[IO](_))
+  def io(): Resource[IO, NettyCatsServer[IO, InetSocketAddress]] = Dispatcher[IO].map(apply[IO](_))
 }
 
 case class NettyCatsServerBinding[F[_]](localSocket: InetSocketAddress, stop: () => F[Unit]) {

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyCatsServer.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyCatsServer.scala
@@ -26,8 +26,6 @@ case class NettyCatsServer[F[_]: Async](routes: Vector[Route[F]], options: Netty
   def addRoutes(r: Iterable[Route[F]]): NettyCatsServer[F] = copy(routes = routes ++ r)
 
   def options(o: NettyCatsServerOptions[F]): NettyCatsServer[F] = copy(options = o)
-  def host(s: String): NettyCatsServer[F] = copy(options = options.host(s))
-  def port(p: Int): NettyCatsServer[F] = copy(options = options.port(p))
 
   def start(): F[NettyCatsServerBinding[F]] = Async[F].defer {
     val eventLoopGroup = options.nettyOptions.eventLoopConfig.builder()
@@ -39,10 +37,8 @@ case class NettyCatsServer[F[_]: Async](routes: Vector[Route[F]], options: Netty
       new NettyServerHandler(route, (f: F[Unit]) => options.dispatcher.unsafeToFuture(f)),
       eventLoopGroup,
       options.nettyOptions.eventLoopConfig.serverChannel,
-      options.host,
-      options.port
+      options.nettyOptions.socketAddress
     )
-
     nettyChannelFutureToScala(channelFuture).map(ch =>
       NettyCatsServerBinding(
         ch.localAddress().asInstanceOf[InetSocketAddress],

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyCatsServer.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyCatsServer.scala
@@ -30,7 +30,7 @@ case class NettyCatsServer[F[_]: Async](routes: Vector[Route[F]], options: Netty
   def port(p: Int): NettyCatsServer[F] = copy(options = options.port(p))
 
   def start(): F[NettyCatsServerBinding[F]] = Async[F].defer {
-    val eventLoopGroup = options.nettyOptions.eventLoopGroup()
+    val eventLoopGroup = options.nettyOptions.eventLoopConfig.builder()
     implicit val monadError: MonadError[F] = new CatsMonadError[F]()
     val route: Route[F] = Route.combine(routes)
 
@@ -38,6 +38,7 @@ case class NettyCatsServer[F[_]: Async](routes: Vector[Route[F]], options: Netty
       options.nettyOptions,
       new NettyServerHandler(route, (f: F[Unit]) => options.dispatcher.unsafeToFuture(f)),
       eventLoopGroup,
+      options.nettyOptions.eventLoopConfig.serverChannel,
       options.host,
       options.port
     )

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyCatsServerOptions.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyCatsServerOptions.scala
@@ -9,17 +9,12 @@ import sttp.tapir.server.interceptor.log.{DefaultServerLog, ServerLog, ServerLog
 import sttp.tapir.server.interceptor.{CustomInterceptors, Interceptor}
 
 case class NettyCatsServerOptions[F[_]](
-    host: String,
-    port: Int,
     interceptors: List[Interceptor[F]],
     createFile: ServerRequest => F[TapirFile],
     deleteFile: TapirFile => F[Unit],
     dispatcher: Dispatcher[F],
     nettyOptions: NettyOptions
 ) {
-  def host(s: String): NettyCatsServerOptions[F] = copy(host = s)
-  def port(p: Int): NettyCatsServerOptions[F] = copy(port = p)
-  def randomPort: NettyCatsServerOptions[F] = port(0)
   def prependInterceptor(i: Interceptor[F]): NettyCatsServerOptions[F] = copy(interceptors = i :: interceptors)
   def appendInterceptor(i: Interceptor[F]): NettyCatsServerOptions[F] = copy(interceptors = interceptors :+ i)
   def nettyOptions(o: NettyOptions): NettyCatsServerOptions[F] = copy(nettyOptions = o)
@@ -30,13 +25,11 @@ object NettyCatsServerOptions {
 
   def default[F[_]: Async](interceptors: List[Interceptor[F]], dispatcher: Dispatcher[F]): NettyCatsServerOptions[F] =
     NettyCatsServerOptions(
-      NettyDefaults.DefaultHost,
-      NettyDefaults.DefaultPort,
       interceptors,
       _ => Sync[F].delay(Defaults.createTempFile()),
       file => Sync[F].delay(Defaults.deleteFile()(file)),
       dispatcher,
-      NettyOptions.default
+      NettyOptionsBuilder.default.build
     )
 
   def customInterceptors[F[_]: Async](dispatcher: Dispatcher[F]): CustomInterceptors[F, Logger => F[Unit], NettyCatsServerOptions[F]] =

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
@@ -12,7 +12,9 @@ import java.net.{InetSocketAddress, SocketAddress}
 import java.nio.file.Path
 import scala.concurrent.{ExecutionContext, Future}
 
-case class NettyFutureServer[S <: SocketAddress](routes: Vector[FutureRoute], options: NettyFutureServerOptions)(implicit ec: ExecutionContext) {
+abstract class NettyFutureServer[S <: SocketAddress](private var routes: Vector[FutureRoute])(implicit ec: ExecutionContext) {
+  def options: NettyFutureServerOptions
+
   def addEndpoint(se: ServerEndpoint[_, _, _, Any, Future]): NettyFutureServer[S] = addEndpoints(List(se))
   def addEndpoint(se: ServerEndpoint[_, _, _, Any, Future], overrideOptions: NettyFutureServerOptions): NettyFutureServer[S] =
     addEndpoints(List(se), overrideOptions)
@@ -24,8 +26,14 @@ case class NettyFutureServer[S <: SocketAddress](routes: Vector[FutureRoute], op
       NettyFutureServerInterpreter(overrideOptions).toRoute(ses)
     )
 
-  def addRoute(r: FutureRoute): NettyFutureServer[S] = copy(routes = routes :+ r)
-  def addRoutes(r: Iterable[FutureRoute]): NettyFutureServer[S] = copy(routes = routes ++ r)
+  def addRoute(r: FutureRoute): NettyFutureServer[S] = {
+    routes = routes :+ r
+    this
+  }
+  def addRoutes(r: Iterable[FutureRoute]): NettyFutureServer[S] = {
+    routes = routes ++ r
+    this
+  }
 
   def start(): Future[NettyFutureServerBinding[S]] = {
     val eventLoopGroup = options.nettyOptions.eventLoopConfig.builder()
@@ -57,30 +65,38 @@ case class NettyFutureServer[S <: SocketAddress](routes: Vector[FutureRoute], op
   }
 }
 
-case class TcpFutureServerBuilder(nettyOptions: TcpOptionsBuilder)(implicit ec: ExecutionContext) {
-  def port(port: Int) = copy(nettyOptions = nettyOptions.port(port))
-  def host(host: String) = copy(nettyOptions = nettyOptions.host(host))
+class TcpFutureServerBuilder(private var nettyOptions: TcpOptionsBuilder)(implicit ec: ExecutionContext) extends NettyFutureServer[InetSocketAddress](Vector.empty) {
+  def port(port: Int) = {
+    nettyOptions = nettyOptions.port(port)
+    this
+  }
+  def host(host: String) = {
+    nettyOptions = nettyOptions.host(host)
+    this
+  }
 
-  def endpoints: NettyFutureServer[InetSocketAddress] = NettyFutureServer(Vector.empty, NettyFutureServerOptions.default.nettyOptions(nettyOptions.build))
+  override def options: NettyFutureServerOptions = NettyFutureServerOptions.default.nettyOptions(nettyOptions.build)
 }
 
-case class DomainSocketFutureServerBuilder(nettyOptions: DomainSocketOptionsBuilder)(implicit ec: ExecutionContext) {
-  def path(path: Path) = copy(nettyOptions = nettyOptions.path(path))
+class DomainSocketFutureServerBuilder(private var nettyOptions: DomainSocketOptionsBuilder)(implicit ec: ExecutionContext) extends NettyFutureServer[DomainSocketAddress](Vector.empty) {
+  def path(path: Path) = {
+    nettyOptions = nettyOptions.path(path)
+    this
+  }
 
-  def endpoints: NettyFutureServer[DomainSocketAddress] = NettyFutureServer(Vector.empty, NettyFutureServerOptions.default.nettyOptions(nettyOptions.build))
-
+  override def options: NettyFutureServerOptions = NettyFutureServerOptions.default.nettyOptions(nettyOptions.build)
 }
 
 object NettyFutureServer {
   def apply(serverOptions: NettyFutureServerOptions = NettyFutureServerOptions.default)(implicit ec: ExecutionContext): NettyFutureServer[InetSocketAddress] =
-    NettyFutureServer(Vector.empty, serverOptions)
+    ???//NettyFutureServer(Vector.empty, serverOptions)
 
   def tcp(implicit ec: ExecutionContext) = {
-    TcpFutureServerBuilder(NettyOptionsBuilder.make().tcp())
+    new TcpFutureServerBuilder(NettyOptionsBuilder.make().tcp())
   }
 
   def unixDomainSocket(implicit ec: ExecutionContext) = {
-    DomainSocketFutureServerBuilder(NettyOptionsBuilder.make().domainSocket())
+    new DomainSocketFutureServerBuilder(NettyOptionsBuilder.make().domainSocket())
   }
 }
 

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
@@ -29,7 +29,7 @@ case class NettyFutureServer(routes: Vector[FutureRoute], options: NettyFutureSe
   def port(p: Int): NettyFutureServer = copy(options = options.port(p))
 
   def start(): Future[NettyFutureServerBinding] = {
-    val eventLoopGroup = options.nettyOptions.eventLoopGroup()
+    val eventLoopGroup = options.nettyOptions.eventLoopConfig.builder()
     implicit val monadError: MonadError[Future] = new FutureMonad()
     val route = Route.combine(routes)
 
@@ -37,6 +37,7 @@ case class NettyFutureServer(routes: Vector[FutureRoute], options: NettyFutureSe
       options.nettyOptions,
       new NettyServerHandler(route, (f: Future[Unit]) => f),
       eventLoopGroup,
+      options.nettyOptions.eventLoopConfig.serverChannel,
       options.host,
       options.port
     )

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
@@ -25,8 +25,6 @@ case class NettyFutureServer(routes: Vector[FutureRoute], options: NettyFutureSe
   def addRoutes(r: Iterable[FutureRoute]): NettyFutureServer = copy(routes = routes ++ r)
 
   def options(o: NettyFutureServerOptions): NettyFutureServer = copy(options = o)
-  def host(s: String): NettyFutureServer = copy(options = options.host(s))
-  def port(p: Int): NettyFutureServer = copy(options = options.port(p))
 
   def start(): Future[NettyFutureServerBinding] = {
     val eventLoopGroup = options.nettyOptions.eventLoopConfig.builder()
@@ -38,8 +36,7 @@ case class NettyFutureServer(routes: Vector[FutureRoute], options: NettyFutureSe
       new NettyServerHandler(route, (f: Future[Unit]) => f),
       eventLoopGroup,
       options.nettyOptions.eventLoopConfig.serverChannel,
-      options.host,
-      options.port
+      options.nettyOptions.socketAddress
     )
 
     nettyChannelFutureToScala(channelFuture).map(ch =>

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
@@ -1,31 +1,32 @@
 package sttp.tapir.server.netty
 
 import io.netty.channel._
+import io.netty.channel.unix.DomainSocketAddress
 import sttp.monad.{FutureMonad, MonadError}
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.netty.NettyOptionsBuilder.{DomainSocketOptionsBuilder, TcpOptionsBuilder}
 import sttp.tapir.server.netty.internal.FutureUtil._
 import sttp.tapir.server.netty.internal.{NettyBootstrap, NettyServerHandler}
 
-import java.net.InetSocketAddress
+import java.net.{InetSocketAddress, SocketAddress}
 import scala.concurrent.{ExecutionContext, Future}
 
-case class NettyFutureServer(routes: Vector[FutureRoute], options: NettyFutureServerOptions)(implicit ec: ExecutionContext) {
-  def addEndpoint(se: ServerEndpoint[_, _, _, Any, Future]): NettyFutureServer = addEndpoints(List(se))
-  def addEndpoint(se: ServerEndpoint[_, _, _, Any, Future], overrideOptions: NettyFutureServerOptions): NettyFutureServer =
+case class NettyFutureServer[S <: SocketAddress](routes: Vector[FutureRoute], options: NettyFutureServerOptions)(implicit ec: ExecutionContext) {
+  def addEndpoint(se: ServerEndpoint[_, _, _, Any, Future]): NettyFutureServer[S] = addEndpoints(List(se))
+  def addEndpoint(se: ServerEndpoint[_, _, _, Any, Future], overrideOptions: NettyFutureServerOptions): NettyFutureServer[S] =
     addEndpoints(List(se), overrideOptions)
-  def addEndpoints(ses: List[ServerEndpoint[_, _, _, Any, Future]]): NettyFutureServer = addRoute(
+  def addEndpoints(ses: List[ServerEndpoint[_, _, _, Any, Future]]): NettyFutureServer[S] = addRoute(
     NettyFutureServerInterpreter(options).toRoute(ses)
   )
-  def addEndpoints(ses: List[ServerEndpoint[_, _, _, Any, Future]], overrideOptions: NettyFutureServerOptions): NettyFutureServer =
+  def addEndpoints(ses: List[ServerEndpoint[_, _, _, Any, Future]], overrideOptions: NettyFutureServerOptions): NettyFutureServer[S] =
     addRoute(
       NettyFutureServerInterpreter(overrideOptions).toRoute(ses)
     )
 
-  def addRoute(r: FutureRoute): NettyFutureServer = copy(routes = routes :+ r)
-  def addRoutes(r: Iterable[FutureRoute]): NettyFutureServer = copy(routes = routes ++ r)
+  def addRoute(r: FutureRoute): NettyFutureServer[S] = copy(routes = routes :+ r)
+  def addRoutes(r: Iterable[FutureRoute]): NettyFutureServer[S] = copy(routes = routes ++ r)
 
-  def start(): Future[NettyFutureServerBinding] = {
+  def start(): Future[NettyFutureServerBinding[S]] = {
     val eventLoopGroup = options.nettyOptions.eventLoopConfig.builder()
     implicit val monadError: MonadError[Future] = new FutureMonad()
     val route = Route.combine(routes)
@@ -40,7 +41,7 @@ case class NettyFutureServer(routes: Vector[FutureRoute], options: NettyFutureSe
 
     nettyChannelFutureToScala(channelFuture).map(ch =>
       NettyFutureServerBinding(
-        ch.localAddress().asInstanceOf[InetSocketAddress],
+        ch.localAddress().asInstanceOf[S],
         () => stop(ch, eventLoopGroup)
       )
     )
@@ -56,14 +57,14 @@ case class NettyFutureServer(routes: Vector[FutureRoute], options: NettyFutureSe
 }
 
 object NettyFutureServer {
-  def apply(serverOptions: NettyFutureServerOptions = NettyFutureServerOptions.default)(implicit ec: ExecutionContext): NettyFutureServer =
+  def apply(serverOptions: NettyFutureServerOptions = NettyFutureServerOptions.default)(implicit ec: ExecutionContext): NettyFutureServer[InetSocketAddress] =
     NettyFutureServer(Vector.empty, serverOptions)
 
-  def tcp(f: TcpOptionsBuilder => TcpOptionsBuilder = identity)(implicit ec: ExecutionContext): NettyFutureServer = {
+  def tcp(f: TcpOptionsBuilder => TcpOptionsBuilder = identity)(implicit ec: ExecutionContext): NettyFutureServer[InetSocketAddress] = {
     NettyFutureServer(Vector.empty, NettyFutureServerOptions.default.copy(nettyOptions = f(NettyOptionsBuilder.make().tcp()).build))
   }
 
-  def unixDomainSocket(f: DomainSocketOptionsBuilder => DomainSocketOptionsBuilder = identity)(implicit ec: ExecutionContext): NettyFutureServer = {
+  def unixDomainSocket(f: DomainSocketOptionsBuilder => DomainSocketOptionsBuilder = identity)(implicit ec: ExecutionContext): NettyFutureServer[DomainSocketAddress] = {
     NettyFutureServer(Vector.empty, NettyFutureServerOptions.default.copy(nettyOptions = f(NettyOptionsBuilder.make().domainSocket()).build))
   }
 }
@@ -72,7 +73,4 @@ case class NettyServerOptionsBuilder(options: NettyFutureServerOptions) {
 
 }
 
-case class NettyFutureServerBinding(localSocket: InetSocketAddress, stop: () => Future[Unit]) {
-  def host: String = localSocket.getHostString
-  def port: Int = localSocket.getPort
-}
+case class NettyFutureServerBinding[S <: SocketAddress](localSocket: S, stop: () => Future[Unit])

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServerInterpreter.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServerInterpreter.scala
@@ -4,10 +4,11 @@ import sttp.monad.FutureMonad
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.netty.internal.NettyServerInterpreter
 
+import java.net.InetSocketAddress
 import scala.concurrent.{ExecutionContext, Future}
 
 trait NettyFutureServerInterpreter {
-  def nettyServerOptions: NettyFutureServerOptions
+  def nettyServerOptions: NettyFutureServerOptions[_]
 
   def toRoute(
       ses: List[ServerEndpoint[_, _, _, Any, Future]]
@@ -18,9 +19,9 @@ trait NettyFutureServerInterpreter {
 }
 
 object NettyFutureServerInterpreter {
-  def apply(serverOptions: NettyFutureServerOptions = NettyFutureServerOptions.default): NettyFutureServerInterpreter = {
+  def apply(serverOptions: NettyFutureServerOptions[_] = NettyFutureServerOptions.default): NettyFutureServerInterpreter = {
     new NettyFutureServerInterpreter {
-      override def nettyServerOptions: NettyFutureServerOptions = serverOptions
+      override def nettyServerOptions: NettyFutureServerOptions[_] = serverOptions
     }
   }
 }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServerInterpreter.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServerInterpreter.scala
@@ -4,7 +4,6 @@ import sttp.monad.FutureMonad
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.netty.internal.NettyServerInterpreter
 
-import java.net.InetSocketAddress
 import scala.concurrent.{ExecutionContext, Future}
 
 trait NettyFutureServerInterpreter {

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServerOptions.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServerOptions.scala
@@ -9,16 +9,11 @@ import sttp.tapir.{Defaults, TapirFile}
 import scala.concurrent.{Future, blocking}
 
 case class NettyFutureServerOptions(
-    host: String,
-    port: Int,
     interceptors: List[Interceptor[Future]],
     createFile: ServerRequest => Future[TapirFile],
     deleteFile: TapirFile => Future[Unit],
     nettyOptions: NettyOptions
 ) {
-  def host(s: String): NettyFutureServerOptions = copy(host = s)
-  def port(p: Int): NettyFutureServerOptions = copy(port = p)
-  def randomPort: NettyFutureServerOptions = port(0)
   def prependInterceptor(i: Interceptor[Future]): NettyFutureServerOptions = copy(interceptors = i :: interceptors)
   def appendInterceptor(i: Interceptor[Future]): NettyFutureServerOptions = copy(interceptors = interceptors :+ i)
   def nettyOptions(o: NettyOptions): NettyFutureServerOptions = copy(nettyOptions = o)
@@ -28,8 +23,6 @@ object NettyFutureServerOptions {
   val default: NettyFutureServerOptions = customInterceptors.options
 
   def default(interceptors: List[Interceptor[Future]]): NettyFutureServerOptions = NettyFutureServerOptions(
-    NettyDefaults.DefaultHost,
-    NettyDefaults.DefaultPort,
     interceptors,
     _ => {
       import scala.concurrent.ExecutionContext.Implicits.global
@@ -39,7 +32,7 @@ object NettyFutureServerOptions {
       import scala.concurrent.ExecutionContext.Implicits.global
       Future(blocking(Defaults.deleteFile()(file)))
     },
-    NettyOptions.default
+    NettyOptionsBuilder.default.build
   )
 
   def customInterceptors: CustomInterceptors[Future, Logger => Future[Unit], NettyFutureServerOptions] = {

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptions.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptions.scala
@@ -9,8 +9,8 @@ import sttp.tapir.server.netty.NettyOptions.EventLoopConfig
 
 import java.net.SocketAddress
 
-case class NettyOptions(
-    socketAddress: SocketAddress,
+case class NettyOptions[S <: SocketAddress](
+    socketAddress: S,
     eventLoopConfig: EventLoopConfig,
     shutdownEventLoopGroupOnClose: Boolean,
     initPipeline: (ChannelPipeline, ChannelHandler) => Unit

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptions.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptions.scala
@@ -1,52 +1,36 @@
 package sttp.tapir.server.netty
 
-import io.netty.channel.epoll.{Epoll, EpollEventLoopGroup, EpollServerSocketChannel}
-import io.netty.channel.kqueue.{KQueue, KQueueEventLoopGroup, KQueueServerSocketChannel}
+import io.netty.channel.epoll.{Epoll, EpollEventLoopGroup, EpollServerDomainSocketChannel, EpollServerSocketChannel}
+import io.netty.channel.kqueue.{KQueue, KQueueEventLoopGroup, KQueueServerDomainSocketChannel, KQueueServerSocketChannel}
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.nio.NioServerSocketChannel
 import io.netty.channel.{ChannelHandler, ChannelPipeline, EventLoopGroup, ServerChannel}
-import io.netty.handler.codec.http.{HttpObjectAggregator, HttpServerCodec}
-import io.netty.handler.logging.LoggingHandler
 import sttp.tapir.server.netty.NettyOptions.EventLoopConfig
 
+import java.net.SocketAddress
+
 case class NettyOptions(
-    eventLoopConfig: NettyOptions.EventLoopConfig,
+    socketAddress: SocketAddress,
+    eventLoopConfig: EventLoopConfig,
     shutdownEventLoopGroupOnClose: Boolean,
     initPipeline: (ChannelPipeline, ChannelHandler) => Unit
-) {
-  def shutdownEventLoopGroupOnClose(shutdown: Boolean): NettyOptions = copy(shutdownEventLoopGroupOnClose = shutdown)
-  def eventLoopConfig(g: () => EventLoopGroup, clz: Class[_ <: ServerChannel]): NettyOptions =
-    copy(eventLoopConfig = EventLoopConfig(g, clz), shutdownEventLoopGroupOnClose = false)
-  def eventLoopGroup(g: EventLoopGroup): NettyOptions = {
-    g match {
-      case _: NioEventLoopGroup    => eventLoopConfig(() => g, classOf[NioServerSocketChannel])
-      case _: EpollEventLoopGroup  => eventLoopConfig(() => g, classOf[EpollServerSocketChannel])
-      case _: KQueueEventLoopGroup => eventLoopConfig(() => g, classOf[KQueueServerSocketChannel])
-      case other                   => throw new Exception(s"Unexpected EventLoopGroup of class ${other.getClass} provided")
-    }
-  }
-  def eventLoopConfig(cfg: EventLoopConfig): NettyOptions = copy(eventLoopConfig = cfg)
-}
+)
 
 object NettyOptions {
-  def default: NettyOptions = NettyOptions(
-    EventLoopConfig.auto,
-    shutdownEventLoopGroupOnClose = true,
-    (pipeline, handler) => {
-      pipeline.addLast(new HttpServerCodec())
-      pipeline.addLast(new HttpObjectAggregator(Integer.MAX_VALUE))
-      pipeline.addLast(handler)
-      pipeline.addLast(new LoggingHandler()) // TODO
-      ()
-    }
-  )
-
   case class EventLoopConfig(builder: () => EventLoopGroup, serverChannel: Class[_ <: ServerChannel])
 
   object EventLoopConfig {
-    def nio: EventLoopConfig = EventLoopConfig(() => new NioEventLoopGroup(), classOf[NioServerSocketChannel])
-    def epoll: EventLoopConfig = EventLoopConfig(() => new EpollEventLoopGroup(), classOf[EpollServerSocketChannel])
-    def kqueue: EventLoopConfig = EventLoopConfig(() => new KQueueEventLoopGroup(), classOf[KQueueServerSocketChannel])
+    def unixDomainSocket: EventLoopConfig = if (Epoll.isAvailable) {
+      EventLoopConfig(() => new EpollEventLoopGroup(), classOf[EpollServerDomainSocketChannel])
+    } else if (KQueue.isAvailable) {
+      EventLoopConfig(() => new KQueueEventLoopGroup(), classOf[KQueueServerDomainSocketChannel])
+    } else {
+      throw new Exception("UnixDomainSocket request, but neither Epoll nor KQueue is available")
+    }
+
+    val nio: EventLoopConfig = EventLoopConfig(() => new NioEventLoopGroup(), classOf[NioServerSocketChannel])
+    val epoll: EventLoopConfig = EventLoopConfig(() => new EpollEventLoopGroup(), classOf[EpollServerSocketChannel])
+    val kqueue: EventLoopConfig = EventLoopConfig(() => new KQueueEventLoopGroup(), classOf[KQueueServerSocketChannel])
 
     def auto: EventLoopConfig = {
       if (Epoll.isAvailable) {
@@ -55,6 +39,15 @@ object NettyOptions {
         kqueue
       } else {
         nio
+      }
+    }
+
+    def useExisting(g: EventLoopGroup): EventLoopConfig = {
+      g match {
+        case _: NioEventLoopGroup    => EventLoopConfig(() => g, classOf[NioServerSocketChannel])
+        case _: EpollEventLoopGroup  => EventLoopConfig(() => g, classOf[EpollServerSocketChannel])
+        case _: KQueueEventLoopGroup => EventLoopConfig(() => g, classOf[KQueueServerSocketChannel])
+        case other                   => throw new Exception(s"Unexpected EventLoopGroup of class ${other.getClass} provided")
       }
     }
   }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptions.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptions.scala
@@ -1,23 +1,36 @@
 package sttp.tapir.server.netty
 
+import io.netty.channel.epoll.{Epoll, EpollEventLoopGroup, EpollServerSocketChannel}
+import io.netty.channel.kqueue.{KQueue, KQueueEventLoopGroup, KQueueServerSocketChannel}
 import io.netty.channel.nio.NioEventLoopGroup
-import io.netty.channel.{ChannelHandler, ChannelPipeline, EventLoopGroup}
+import io.netty.channel.socket.nio.NioServerSocketChannel
+import io.netty.channel.{ChannelHandler, ChannelPipeline, EventLoopGroup, ServerChannel}
 import io.netty.handler.codec.http.{HttpObjectAggregator, HttpServerCodec}
 import io.netty.handler.logging.LoggingHandler
+import sttp.tapir.server.netty.NettyOptions.EventLoopConfig
 
 case class NettyOptions(
-    eventLoopGroup: () => EventLoopGroup,
+    eventLoopConfig: NettyOptions.EventLoopConfig,
     shutdownEventLoopGroupOnClose: Boolean,
     initPipeline: (ChannelPipeline, ChannelHandler) => Unit
 ) {
   def shutdownEventLoopGroupOnClose(shutdown: Boolean): NettyOptions = copy(shutdownEventLoopGroupOnClose = shutdown)
-  def eventLoopGroup(g: EventLoopGroup): NettyOptions = copy(eventLoopGroup = () => g, shutdownEventLoopGroupOnClose = false)
-  def eventLoopGroup(g: () => EventLoopGroup): NettyOptions = copy(eventLoopGroup = g)
+  def eventLoopConfig(g: EventLoopGroup, clz: Class[_ <: ServerChannel]): NettyOptions =
+    copy(eventLoopConfig = EventLoopConfig(() => g, clz), shutdownEventLoopGroupOnClose = false)
+  def eventLoopGroup(g: EventLoopGroup): NettyOptions = {
+    g match {
+      case _: NioEventLoopGroup    => eventLoopConfig(g, classOf[NioServerSocketChannel])
+      case _: EpollEventLoopGroup  => eventLoopConfig(g, classOf[EpollServerSocketChannel])
+      case _: KQueueEventLoopGroup => eventLoopConfig(g, classOf[KQueueServerSocketChannel])
+      case other                   => throw new Exception(s"Unexpected EventLoopGroup of class ${other.getClass} provided")
+    }
+  }
+  def eventLoopConfig(cfg: EventLoopConfig): NettyOptions = copy(eventLoopConfig = cfg)
 }
 
 object NettyOptions {
   def default: NettyOptions = NettyOptions(
-    () => new NioEventLoopGroup(),
+    EventLoopConfig.auto,
     shutdownEventLoopGroupOnClose = true,
     (pipeline, handler) => {
       pipeline.addLast(new HttpServerCodec())
@@ -27,4 +40,23 @@ object NettyOptions {
       ()
     }
   )
+
+  case class EventLoopConfig(builder: () => EventLoopGroup, serverChannel: Class[_ <: ServerChannel])
+
+  object EventLoopConfig {
+    def nio: EventLoopConfig = EventLoopConfig(() => new NioEventLoopGroup(), classOf[NioServerSocketChannel])
+    def epoll: EventLoopConfig = EventLoopConfig(() => new EpollEventLoopGroup(), classOf[EpollServerSocketChannel])
+    def kqueue: EventLoopConfig = EventLoopConfig(() => new KQueueEventLoopGroup(), classOf[KQueueServerSocketChannel])
+
+    def auto: EventLoopConfig = {
+      if (Epoll.isAvailable) {
+        epoll
+      } else if (KQueue.isAvailable) {
+        kqueue
+      } else {
+        nio
+      }
+    }
+  }
+
 }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptions.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptions.scala
@@ -15,13 +15,13 @@ case class NettyOptions(
     initPipeline: (ChannelPipeline, ChannelHandler) => Unit
 ) {
   def shutdownEventLoopGroupOnClose(shutdown: Boolean): NettyOptions = copy(shutdownEventLoopGroupOnClose = shutdown)
-  def eventLoopConfig(g: EventLoopGroup, clz: Class[_ <: ServerChannel]): NettyOptions =
-    copy(eventLoopConfig = EventLoopConfig(() => g, clz), shutdownEventLoopGroupOnClose = false)
+  def eventLoopConfig(g: () => EventLoopGroup, clz: Class[_ <: ServerChannel]): NettyOptions =
+    copy(eventLoopConfig = EventLoopConfig(g, clz), shutdownEventLoopGroupOnClose = false)
   def eventLoopGroup(g: EventLoopGroup): NettyOptions = {
     g match {
-      case _: NioEventLoopGroup    => eventLoopConfig(g, classOf[NioServerSocketChannel])
-      case _: EpollEventLoopGroup  => eventLoopConfig(g, classOf[EpollServerSocketChannel])
-      case _: KQueueEventLoopGroup => eventLoopConfig(g, classOf[KQueueServerSocketChannel])
+      case _: NioEventLoopGroup    => eventLoopConfig(() => g, classOf[NioServerSocketChannel])
+      case _: EpollEventLoopGroup  => eventLoopConfig(() => g, classOf[EpollServerSocketChannel])
+      case _: KQueueEventLoopGroup => eventLoopConfig(() => g, classOf[KQueueServerSocketChannel])
       case other                   => throw new Exception(s"Unexpected EventLoopGroup of class ${other.getClass} provided")
     }
   }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptionsBuilder.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptionsBuilder.scala
@@ -42,7 +42,7 @@ object NettyOptionsBuilder {
     def eventLoopGroup(g: EventLoopGroup): DomainSocketOptionsBuilder =
       copy(eventLoopConfig = EventLoopConfig.useExisting(g), shutdownOnClose = true)
     def noShutdownOnClose: DomainSocketOptionsBuilder = copy(shutdownOnClose = false)
-    def build: NettyOptions = NettyOptions(
+    def build: NettyOptions[DomainSocketAddress] = NettyOptions(
       new DomainSocketAddress(path.toFile),
       EventLoopConfig.unixDomainSocket,
       shutdownOnClose,
@@ -63,7 +63,7 @@ object NettyOptionsBuilder {
     def noShutdownOnClose: TcpOptionsBuilder = copy(shutdownOnClose = false)
     def eventLoopGroup(g: EventLoopGroup): TcpOptionsBuilder =
       copy(eventLoopConfig = EventLoopConfig.useExisting(g), shutdownOnClose = true)
-    def build: NettyOptions = NettyOptions(
+    def build: NettyOptions[InetSocketAddress] = NettyOptions(
       new InetSocketAddress(host, port),
       eventLoopConfig,
       shutdownOnClose,

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptionsBuilder.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptionsBuilder.scala
@@ -1,0 +1,68 @@
+package sttp.tapir.server.netty
+
+import io.netty.channel.unix.DomainSocketAddress
+import io.netty.channel.{ChannelHandler, ChannelPipeline, EventLoopGroup}
+import io.netty.handler.codec.http.{HttpObjectAggregator, HttpServerCodec}
+import io.netty.handler.logging.LoggingHandler
+import sttp.tapir.server.netty.NettyOptions.EventLoopConfig
+import sttp.tapir.server.netty.NettyOptionsBuilder.{DomainSocketOptionsBuilder, TcpOptionsBuilder}
+
+import java.net.InetSocketAddress
+import java.nio.file.Path
+
+case class NettyOptionsBuilder(initPipeline: (ChannelPipeline, ChannelHandler) => Unit) {
+  def tcp(): TcpOptionsBuilder = TcpOptionsBuilder(this, NettyDefaults.DefaultHost, NettyDefaults.DefaultPort)
+  def domainSocket(path: Path): DomainSocketOptionsBuilder = DomainSocketOptionsBuilder(this, path)
+}
+
+object NettyOptionsBuilder {
+  private val defaultInitPipeline: (ChannelPipeline, ChannelHandler) => Unit = (pipeline, handler) => {
+    pipeline.addLast(new HttpServerCodec())
+    pipeline.addLast(new HttpObjectAggregator(Integer.MAX_VALUE))
+    pipeline.addLast(handler)
+    pipeline.addLast(new LoggingHandler()) // TODO
+    ()
+  }
+  def make(): NettyOptionsBuilder = NettyOptionsBuilder(defaultInitPipeline)
+
+  def default: TcpOptionsBuilder = make().tcp()
+
+  case class DomainSocketOptionsBuilder(
+      netty: NettyOptionsBuilder,
+      path: Path,
+      shutdownOnClose: Boolean = true,
+      eventLoopConfig: EventLoopConfig = EventLoopConfig.unixDomainSocket
+  ) {
+    def eventLoopGroup(g: EventLoopGroup): DomainSocketOptionsBuilder =
+      copy(eventLoopConfig = EventLoopConfig.useExisting(g), shutdownOnClose = true)
+    def noShutdownOnClose: DomainSocketOptionsBuilder = copy(shutdownOnClose = false)
+    def build: NettyOptions = NettyOptions(
+      new DomainSocketAddress(path.toFile),
+      EventLoopConfig.unixDomainSocket,
+      shutdownOnClose,
+      netty.initPipeline
+    )
+  }
+
+  case class TcpOptionsBuilder(
+      netty: NettyOptionsBuilder,
+      host: String,
+      port: Int,
+      shutdownOnClose: Boolean = true,
+      eventLoopConfig: EventLoopConfig = EventLoopConfig.auto
+  ) {
+    def host(host: String): TcpOptionsBuilder = copy(host = host)
+    def port(port: Int): TcpOptionsBuilder = copy(port = port)
+    def randomPort: TcpOptionsBuilder = copy(port = 0)
+    def noShutdownOnClose: TcpOptionsBuilder = copy(shutdownOnClose = false)
+    def eventLoopGroup(g: EventLoopGroup): TcpOptionsBuilder =
+      copy(eventLoopConfig = EventLoopConfig.useExisting(g), shutdownOnClose = true)
+    def build: NettyOptions = NettyOptions(
+      new InetSocketAddress(host, port),
+      eventLoopConfig,
+      shutdownOnClose,
+      netty.initPipeline
+    )
+  }
+
+}

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptionsBuilder.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyOptionsBuilder.scala
@@ -8,11 +8,16 @@ import sttp.tapir.server.netty.NettyOptions.EventLoopConfig
 import sttp.tapir.server.netty.NettyOptionsBuilder.{DomainSocketOptionsBuilder, TcpOptionsBuilder}
 
 import java.net.InetSocketAddress
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
+import java.util.UUID
 
 case class NettyOptionsBuilder(initPipeline: (ChannelPipeline, ChannelHandler) => Unit) {
   def tcp(): TcpOptionsBuilder = TcpOptionsBuilder(this, NettyDefaults.DefaultHost, NettyDefaults.DefaultPort)
-  def domainSocket(path: Path): DomainSocketOptionsBuilder = DomainSocketOptionsBuilder(this, path)
+  def domainSocket(): DomainSocketOptionsBuilder = DomainSocketOptionsBuilder(this, tempFile)
+
+  private def tempFile = {
+    Paths.get(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString)
+  }
 }
 
 object NettyOptionsBuilder {
@@ -33,6 +38,7 @@ object NettyOptionsBuilder {
       shutdownOnClose: Boolean = true,
       eventLoopConfig: EventLoopConfig = EventLoopConfig.unixDomainSocket
   ) {
+    def path(path: Path) = copy(path = path)
     def eventLoopGroup(g: EventLoopGroup): DomainSocketOptionsBuilder =
       copy(eventLoopConfig = EventLoopConfig.useExisting(g), shutdownOnClose = true)
     def noShutdownOnClose: DomainSocketOptionsBuilder = copy(shutdownOnClose = false)

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyBootstrap.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyBootstrap.scala
@@ -8,7 +8,7 @@ import java.net.SocketAddress
 
 object NettyBootstrap {
   def apply[F[_]](
-      nettyOptions: NettyOptions,
+      nettyOptions: NettyOptions[_],
       handler: => NettyServerHandler[F],
       eventLoopGroup: EventLoopGroup,
       serverChannel: Class[_ <: ServerChannel],

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyBootstrap.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyBootstrap.scala
@@ -1,8 +1,7 @@
 package sttp.tapir.server.netty.internal
 
 import io.netty.bootstrap.ServerBootstrap
-import io.netty.channel.{Channel, ChannelFuture, ChannelInitializer, ChannelOption, EventLoopGroup}
-import io.netty.channel.socket.nio.NioServerSocketChannel
+import io.netty.channel._
 import sttp.tapir.server.netty.NettyOptions
 
 object NettyBootstrap {
@@ -10,6 +9,7 @@ object NettyBootstrap {
       nettyOptions: NettyOptions,
       handler: => NettyServerHandler[F],
       eventLoopGroup: EventLoopGroup,
+      serverChannel: Class[_ <: ServerChannel],
       host: String,
       port: Int
   ): ChannelFuture = {
@@ -17,7 +17,7 @@ object NettyBootstrap {
 
     httpBootstrap
       .group(eventLoopGroup)
-      .channel(classOf[NioServerSocketChannel])
+      .channel(serverChannel)
       .childHandler(new ChannelInitializer[Channel] {
         override def initChannel(ch: Channel): Unit = nettyOptions.initPipeline(ch.pipeline(), handler)
       })

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyBootstrap.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyBootstrap.scala
@@ -4,14 +4,15 @@ import io.netty.bootstrap.ServerBootstrap
 import io.netty.channel._
 import sttp.tapir.server.netty.NettyOptions
 
+import java.net.SocketAddress
+
 object NettyBootstrap {
   def apply[F[_]](
       nettyOptions: NettyOptions,
       handler: => NettyServerHandler[F],
       eventLoopGroup: EventLoopGroup,
       serverChannel: Class[_ <: ServerChannel],
-      host: String,
-      port: Int
+      socketAddress: SocketAddress
   ): ChannelFuture = {
     val httpBootstrap = new ServerBootstrap()
 
@@ -24,6 +25,6 @@ object NettyBootstrap {
       .option[java.lang.Integer](ChannelOption.SO_BACKLOG, 128) //https://github.com/netty/netty/issues/1692
       .childOption[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, true) // https://github.com/netty/netty/issues/1692
 
-    httpBootstrap.bind(host, port)
+    httpBootstrap.bind(socketAddress)
   }
 }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/package.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/package.scala
@@ -1,13 +1,10 @@
 package sttp.tapir.server.netty
 
-import scala.collection.JavaConverters._
-import scala.collection.immutable.Seq
-import scala.concurrent.{CancellationException, Future, Promise}
-import scala.util.{Failure, Success}
-
-import io.netty.channel.{Channel, ChannelFuture}
 import io.netty.handler.codec.http.HttpHeaders
 import sttp.model.Header
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
 
 package object internal {
   implicit class RichNettyHttpHeaders(underlying: HttpHeaders) {

--- a/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyCatsTestServerInterpreter.scala
+++ b/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyCatsTestServerInterpreter.scala
@@ -12,6 +12,7 @@ import sttp.tapir.server.netty.NettyOptions.EventLoopConfig
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 
+import java.net.InetSocketAddress
 import scala.reflect.ClassTag
 
 class NettyCatsTestServerInterpreter(eventLoopGroup: NioEventLoopGroup, dispatcher: Dispatcher[IO])
@@ -22,7 +23,7 @@ class NettyCatsTestServerInterpreter(eventLoopGroup: NioEventLoopGroup, dispatch
       decodeFailureHandler: Option[DecodeFailureHandler] = None,
       metricsInterceptor: Option[MetricsRequestInterceptor[IO]] = None
   ): Route[IO] = {
-    val serverOptions: NettyCatsServerOptions[IO] = NettyCatsServerOptions
+    val serverOptions: NettyCatsServerOptions[IO, InetSocketAddress] = NettyCatsServerOptions
       .customInterceptors[IO](dispatcher)
       .metricsInterceptor(metricsInterceptor)
       .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.handler))

--- a/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyCatsTestServerInterpreter.scala
+++ b/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyCatsTestServerInterpreter.scala
@@ -41,7 +41,9 @@ class NettyCatsTestServerInterpreter(eventLoopGroup: NioEventLoopGroup, dispatch
 
   override def server(routes: NonEmptyList[Route[IO]]): Resource[IO, Port] = {
     val options =
-      NettyCatsServerOptions.default[IO](dispatcher).nettyOptions(NettyOptionsBuilder.make().tcp().eventLoopGroup(eventLoopGroup).randomPort.noShutdownOnClose.build)
+      NettyCatsServerOptions
+        .default[IO](dispatcher)
+        .nettyOptions(NettyOptionsBuilder.make().tcp().eventLoopGroup(eventLoopGroup).randomPort.noShutdownOnClose.build)
     val bind = NettyCatsServer(options).addRoutes(routes.toList).start()
 
     Resource

--- a/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyCatsTestServerInterpreter.scala
+++ b/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyCatsTestServerInterpreter.scala
@@ -8,6 +8,7 @@ import sttp.tapir.Endpoint
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
 import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
+import sttp.tapir.server.netty.NettyOptions.EventLoopConfig
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 
@@ -40,7 +41,7 @@ class NettyCatsTestServerInterpreter(eventLoopGroup: NioEventLoopGroup, dispatch
 
   override def server(routes: NonEmptyList[Route[IO]]): Resource[IO, Port] = {
     val options =
-      NettyCatsServerOptions.default[IO](dispatcher).nettyOptions(NettyOptions.default.eventLoopGroup(eventLoopGroup)).randomPort
+      NettyCatsServerOptions.default[IO](dispatcher).nettyOptions(NettyOptionsBuilder.make().tcp().eventLoopGroup(eventLoopGroup).randomPort.noShutdownOnClose.build)
     val bind = NettyCatsServer(options).addRoutes(routes.toList).start()
 
     Resource

--- a/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyFutureTestServerInterpreter.scala
+++ b/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyFutureTestServerInterpreter.scala
@@ -45,6 +45,6 @@ class NettyFutureTestServerInterpreter(eventLoopGroup: NioEventLoopGroup)(implic
 
     Resource
       .make(bind)(binding => IO.fromFuture(IO.delay(binding.stop())))
-      .map(_.port)
+      .map(b => b.localSocket.getPort)
   }
 }

--- a/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyFutureTestServerInterpreter.scala
+++ b/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyFutureTestServerInterpreter.scala
@@ -40,7 +40,7 @@ class NettyFutureTestServerInterpreter(eventLoopGroup: NioEventLoopGroup)(implic
   }
 
   override def server(routes: NonEmptyList[FutureRoute]): Resource[IO, Port] = {
-    val options = NettyFutureServerOptions.default.nettyOptions(NettyOptions.default.eventLoopGroup(eventLoopGroup)).randomPort
+    val options = NettyFutureServerOptions.default.nettyOptions(NettyOptionsBuilder.make().tcp().eventLoopGroup(eventLoopGroup).randomPort.noShutdownOnClose.build)
     val bind = IO.fromFuture(IO.delay(NettyFutureServer(options).addRoutes(routes.toList).start()))
 
     Resource


### PR DESCRIPTION
Hello, this is an attempt to add support for:
- native netty transport
- unix domain sockets transport

Both of these have proven extremely useful at my employment when it comes to performance in certain applications (in our benchmarks they decimated anything big time (netty with unix domain sockets websocket managed 14000 requests/s while akka only 4000)

I felt the need to decouple builders of netty options from the case class itself. One concern is that (from my limited knowledge of this project) it seems that most of the tests rely on publishing port, which of course doesn't make sense for domain sockets. So unfortunately it will be hard to test this bit.

What do you think?