### PR TITLE
Set content type header in Part when using PlayServerInterpreter

### DIFF
--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
@@ -6,7 +6,7 @@ import akka.util.ByteString
 import play.api.mvc.Request
 import play.core.parsers.Multipart
 import sttp.capabilities.akka.AkkaStreams
-import sttp.model.Part
+import sttp.model.{Header, MediaType, Part}
 import sttp.tapir.internal._
 import sttp.tapir.server.interpreter.{RawValue, RequestBody}
 import sttp.tapir.{FileRange, RawBodyType, RawPart}
@@ -84,7 +84,12 @@ private[play] class PlayRequestBody(request: Request[Source[ByteString, Any]], s
             () => FileIO.fromPath(f.ref.path),
             Some(f.ref.toFile)
           ).map(body =>
-            Part(f.key, body.value, Map(f.key -> f.dispositionType, Part.FileNameDispositionParam -> f.filename), Nil)
+            Part(
+              f.key,
+              body.value,
+              Map(f.key -> f.dispositionType, Part.FileNameDispositionParam -> f.filename),
+              f.contentType.flatMap(MediaType.parse(_).toOption).map(Header.contentType).toList
+            )
               .asInstanceOf[RawPart]
           )
         })

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
@@ -27,6 +27,8 @@ class PlayServerTest extends TestSuite {
         invulnerableToUnsanitizedHeaders = false
       ).tests() ++
         new ServerMultipartTests(createServerTest, multipartInlineHeaderSupport = false).tests() ++
+        // play interpreter only supports the content-type header, which is tested in multipartInlineHeaderTests
+        new ServerMultipartTests(createServerTest, multipartInlineHeaderSupport = false).multipartInlineHeaderTests() ++
         new AllServerTests(createServerTest, interpreter, backend, basic = false, multipart = false, reject = false).tests() ++
         new ServerStreamingTests(createServerTest, AkkaStreams).tests() ++
         new PlayServerWithContextTest(backend).tests()


### PR DESCRIPTION
Closes #1583

Play doesn't expose headers, but it exposes `contentType` which can be set as a header so that it is accessible on tapir side.