### PR TITLE
Fixed typo

### DIFF
--- a/doc/endpoint/basics.md
+++ b/doc/endpoint/basics.md
@@ -1,6 +1,6 @@
 # Basics
 
-An endpoint is represented as a value of type `Endpoint[A, I, E, O, S]`, where:
+An endpoint is represented as a value of type `Endpoint[A, I, E, O, R]`, where:
 
 * `A` is the type of security input parameters
 * `I` is the type of input parameters


### PR DESCRIPTION
Found what looks like a little typo. `S` is not described in the section below, but `R` is.