### PR TITLE
Omit boundary when decoding fixed content-type header

### DIFF
--- a/core/src/main/scala/sttp/tapir/server/interpreter/DecodeBasicInputs.scala
+++ b/core/src/main/scala/sttp/tapir/server/interpreter/DecodeBasicInputs.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.server.interpreter
 
 import sttp.model.headers.Cookie
-import sttp.model.{HeaderNames, Method, QueryParams}
+import sttp.model.{HeaderNames, MediaType, Method, QueryParams}
 import sttp.tapir.internal._
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.{DecodeResult, EndpointIO, EndpointInput, StreamBodyIO}
@@ -227,10 +227,16 @@ object DecodeBasicInputs {
         if (m == ctx.method) (codec.decode(()), ctx)
         else (DecodeResult.Mismatch(m.method, ctx.method.method), ctx)
 
-      case EndpointIO.FixedHeader(sttp.model.Header(n, v), codec, _) =>
+      case EndpointIO.FixedHeader(h @ sttp.model.Header(n, v), codec, _) =>
         if (ctx.header(n) == Nil) (DecodeResult.Missing, ctx)
         else if (List(v) == ctx.header(n)) (codec.decode(()), ctx)
-        else (DecodeResult.Mismatch(List(v).mkString, ctx.header(n).mkString), ctx)
+        else if (h.is(HeaderNames.ContentType)) {
+          // do not compare Content-Type 'boundary' directive
+          val inMedia = MediaType.parse(ctx.header(n).head).map(_.copy(otherParameters = Map.empty))
+          val reqMedia = MediaType.parse(v).map(_.copy(otherParameters = Map.empty))
+          if (inMedia == reqMedia) (codec.decode(()), ctx)
+          else (DecodeResult.Mismatch(reqMedia.toString, inMedia.toString), ctx)
+        } else (DecodeResult.Mismatch(List(v).mkString, ctx.header(n).mkString), ctx)
 
       case EndpointInput.Query(name, codec, _) =>
         (codec.decode(ctx.queryParameter(name).toList), ctx)

--- a/core/src/test/scala/sttp/tapir/server/interpreter/DecodeBasicInputsResultTest.scala
+++ b/core/src/test/scala/sttp/tapir/server/interpreter/DecodeBasicInputsResultTest.scala
@@ -1,0 +1,46 @@
+package sttp.tapir.server.interpreter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.model.Uri._
+import sttp.model._
+import sttp.tapir.model._
+import sttp.tapir._
+
+import scala.collection.immutable
+
+class DecodeBasicInputsResultTest extends AnyFlatSpec with Matchers {
+
+  def testRequest(testHeader: Header): ServerRequest = {
+    new ServerRequest {
+      override def protocol: String = ""
+      override def connectionInfo: ConnectionInfo = ConnectionInfo(None, None, None)
+      override def underlying: Any = ()
+      override def pathSegments: List[String] = Nil
+      override def queryParameters: QueryParams = QueryParams.fromSeq(Nil)
+      override def method: Method = Method.GET
+      override def uri: Uri = uri"http://example.com"
+      override def headers: immutable.Seq[Header] = List(testHeader)
+    }
+  }
+
+  val testData = List(
+    ("multipart/form-data", "multipart/form-data", true),
+    ("multipart/form-data", "multipart/form-data; boundary=xyz", true),
+    ("text/plain", "text/plain; charset=utf-8", false),
+    ("text/plain; charset=utf-8", "text/plain; charset=utf-8", true)
+  )
+
+  for ((endpointContentType, inputContentType, expectDecodeSuccess) <- testData) {
+    val expectedStatus = if (expectDecodeSuccess) "succeed" else "fail"
+    s"decoding endpoint with fixed content-type $endpointContentType and input content-type $inputContentType" should expectedStatus in {
+      val testEp = endpoint.get.in(header(Header(HeaderNames.ContentType, endpointContentType)))
+      val request = testRequest(Header(HeaderNames.ContentType, inputContentType))
+      val decodeResult = DecodeBasicInputs.apply(testEp.input, request)
+
+      if (expectDecodeSuccess)
+        decodeResult shouldBe a[DecodeBasicInputsResult.Values]
+      else
+        decodeResult shouldBe a[DecodeBasicInputsResult.Failure]
+    }
+  }
+}

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -323,6 +323,15 @@ class ServerBasicTests[F[_], ROUTE](
     testServer(in_query_with_default_out_string)(in => pureResult(in.asRight[Unit])) { (backend, baseUri) =>
       basicRequest.get(uri"$baseUri?p1=x").send(backend).map(_.body shouldBe Right("x")) >>
         basicRequest.get(uri"$baseUri").send(backend).map(_.body shouldBe Right("DEFAULT"))
+    },
+    testServer(in_fixed_content_type_header_out_string, "fixed multipart/form-data header input should ignore boundary directive")(_ =>
+      pureResult("x".asRight[Unit])
+    ) { (backend, baseUri) =>
+      basicRequest
+        .get(uri"$baseUri/api")
+        .headers(Header(HeaderNames.ContentType, "multipart/form-data; boundary=abc"))
+        .send(backend)
+        .map(_.body shouldBe Right("x"))
     }
   )
 

--- a/tests/src/main/scala/sttp/tapir/tests/Basic.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/Basic.scala
@@ -36,6 +36,9 @@ object Basic {
   val in_fixed_header_out_string: PublicEndpoint[Unit, Unit, String, Any] =
     endpoint.in("secret").in(header("location", "secret")).out(stringBody)
 
+  val in_fixed_content_type_header_out_string: PublicEndpoint[Unit, Unit, String, Any] =
+    endpoint.in("api").in(header(Header.contentType(MediaType.MultipartFormData))).out(stringBody)
+
   val in_header_before_path: PublicEndpoint[(String, Int), Unit, (Int, String), Any] = endpoint
     .in(header[String]("SomeHeader"))
     .in(path[Int])


### PR DESCRIPTION
fixes #1582