### PR TITLE
Enables hiding endpoints with auth inputs if any inputs fails to decode

### DIFF
--- a/core/src/main/scala/sttp/tapir/server/interceptor/decodefailure/DecodeFailureHandler.scala
+++ b/core/src/main/scala/sttp/tapir/server/interceptor/decodefailure/DecodeFailureHandler.scala
@@ -3,6 +3,7 @@ package sttp.tapir.server.interceptor.decodefailure
 import sttp.model.{Header, HeaderNames, StatusCode}
 import sttp.tapir.DecodeResult.Error.JsonDecodeException
 import sttp.tapir.DecodeResult.{Error, InvalidValue}
+import sttp.tapir.internal.RichEndpointInput
 import sttp.tapir.server.interceptor.{DecodeFailureContext, ValuedEndpointOutput}
 import sttp.tapir.{DecodeResult, EndpointIO, EndpointInput, ValidationError, Validator, _}
 
@@ -47,6 +48,9 @@ object DefaultDecodeFailureHandler {
     * A 400 (bad request) is returned if a query, header or body input can't be decoded (for any reason), or if decoding a path capture
     * causes a validation error.
     *
+    * A 401 (unauthorized) is returned when an authentication input (created using [[Tapir.auth]]) cannot be decoded. The appropriate
+    * `WWW-Authenticate` headers are included.
+    *
     * Otherwise (e.g. if the method, a path segment, or path capture is missing, there's a mismatch or a decode error), `None` is returned,
     * which is a signal to try the next endpoint.
     *
@@ -55,11 +59,20 @@ object DefaultDecodeFailureHandler {
     *
     * This is only used for failures that occur when decoding inputs, not for exceptions that happen when the server logic is invoked.
     */
-  def handler: DefaultDecodeFailureHandler = DefaultDecodeFailureHandler(
+  val handler: DefaultDecodeFailureHandler = DefaultDecodeFailureHandler(
     respond(_, badRequestOnPathErrorIfPathShapeMatches = false, badRequestOnPathInvalidIfPathShapeMatches = true),
     FailureMessages.failureMessage,
     failureResponse
   )
+
+  /** A [[handler]] which responds with a `404 Not Found`, instead of a `401 Unauthorized` or `400 Bad Request`, in case any input fails to
+    * decode, and the endpoint contains authentication inputs (created using [[Tapir.auth]]). No `WWW-Authenticate` headers are sent.
+    *
+    * Hence, the information if the endpoint exists, but needs authentication is hidden from the client. However, the existence of the
+    * endpoint might still be revealed using timing attacks.
+    */
+  val handlerHideUnauthorized: DefaultDecodeFailureHandler =
+    handler.copy(respond = ctx => respondNotFoundIfHasAuth(ctx, handler.respond(ctx)))
 
   def failureResponse(c: StatusCode, hs: List[Header], m: String): ValuedEndpointOutput[_] =
     ValuedEndpointOutput(statusCode.and(headers).and(stringBody), (c, hs, m))
@@ -76,8 +89,6 @@ object DefaultDecodeFailureHandler {
       badRequestOnPathErrorIfPathShapeMatches: Boolean,
       badRequestOnPathInvalidIfPathShapeMatches: Boolean
   ): Option[(StatusCode, List[Header])] = {
-    def onlyStatus(status: StatusCode): (StatusCode, List[Header]) = (status, Nil)
-
     failingInput(ctx) match {
       case _: EndpointInput.Query[_]       => Some(onlyStatus(StatusCode.BadRequest))
       case _: EndpointInput.QueryParams[_] => Some(onlyStatus(StatusCode.BadRequest))
@@ -106,6 +117,19 @@ object DefaultDecodeFailureHandler {
     }
   }
 
+  def respondNotFoundIfHasAuth(
+      ctx: DecodeFailureContext,
+      response: Option[(StatusCode, List[Header])]
+  ): Option[(StatusCode, List[Header])] = response.map { r =>
+    val e = ctx.endpoint
+    if (e.securityInput.auths.nonEmpty || e.input.auths.nonEmpty) {
+      // all responses (both 400 and 401) are converted to a not-found
+      onlyStatus(StatusCode.NotFound)
+    } else r
+  }
+
+  private def onlyStatus(status: StatusCode): (StatusCode, List[Header]) = (status, Nil)
+
   private def failingInput(ctx: DecodeFailureContext) = {
     import sttp.tapir.internal.RichEndpointInput
     ctx.failure match {
@@ -118,12 +142,10 @@ object DefaultDecodeFailureHandler {
     }
   }
 
-  /** Default messages for [[DecodeResult.Failure]] s.
-    */
+  /** Default messages for [[DecodeResult.Failure]] s. */
   object FailureMessages {
 
-    /** Describes the source of the failure: in which part of the request did the failure occur.
-      */
+    /** Describes the source of the failure: in which part of the request did the failure occur. */
     @tailrec
     def failureSourceMessage(input: EndpointInput[_]): String =
       input match {

--- a/core/src/main/scala/sttp/tapir/server/interceptor/decodefailure/DecodeFailureHandler.scala
+++ b/core/src/main/scala/sttp/tapir/server/interceptor/decodefailure/DecodeFailureHandler.scala
@@ -3,7 +3,7 @@ package sttp.tapir.server.interceptor.decodefailure
 import sttp.model.{Header, HeaderNames, StatusCode}
 import sttp.tapir.DecodeResult.Error.JsonDecodeException
 import sttp.tapir.DecodeResult.{Error, InvalidValue}
-import sttp.tapir.internal.RichEndpointInput
+import sttp.tapir.internal.RichEndpoint
 import sttp.tapir.server.interceptor.{DecodeFailureContext, ValuedEndpointOutput}
 import sttp.tapir.{DecodeResult, EndpointIO, EndpointInput, ValidationError, Validator, _}
 
@@ -122,7 +122,7 @@ object DefaultDecodeFailureHandler {
       response: Option[(StatusCode, List[Header])]
   ): Option[(StatusCode, List[Header])] = response.map { r =>
     val e = ctx.endpoint
-    if (e.securityInput.auths.nonEmpty || e.input.auths.nonEmpty) {
+    if (e.auths.nonEmpty) {
       // all responses (both 400 and 401) are converted to a not-found
       onlyStatus(StatusCode.NotFound)
     } else r

--- a/doc/server/errors.md
+++ b/doc/server/errors.md
@@ -75,12 +75,15 @@ conventions, that an endpoint is uniquely identified by the method and served pa
 * an "endpoint doesn't match" result is returned if the request method or path doesn't match. The http library should
   attempt to serve this request with the next endpoint. The path doesn't match if a path segment is missing, there's
   a constant value mismatch or a decoding error (e.g. parsing a segment to an `Int` fails)
+* if an [authentication input](../endpoint/security.md) fails to decode, a `401 Unauthorized` is returned together with
+  an appropriate `WWW-Authenticate` header. See [options](options.md) documentation on how to return a `404` instead,
+  to hide the endpoint
 * otherwise, we assume that this is the correct endpoint to serve the request, but the parameters are somehow 
   malformed. A `400 Bad Request` response is returned if a query parameter, header or body causes any decode failure, 
   or if the decoding a path capture causes a validation error.
 
-The behavior described in the latter two points can be customised by providing a custom
-`sttp.tapir.server.DecodeFailureHandler` when creating the server options. This handler, basing on  the request, 
+The behavior described in the latter three points can be customised by providing a custom
+`sttp.tapir.server.DecodeFailureHandler` when creating the server options. This handler, basing on the request, 
 failing input and failure description can decide, whether to return a "no match" or a specific response.
 
 Only the first failure encountered for a specific endpoint is passed to the `DecodeFailureHandler`. Inputs are decoded 

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/SecuritySchemesForEndpoints.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/SecuritySchemesForEndpoints.scala
@@ -8,7 +8,7 @@ import scala.annotation.tailrec
 
 private[docs] object SecuritySchemesForEndpoints {
   def apply(es: Iterable[AnyEndpoint]): SecuritySchemes = {
-    val auths = es.flatMap(e => e.securityInput.auths) ++ es.flatMap(e => e.input.auths)
+    val auths = es.flatMap(e => e.auths)
     val authSecuritySchemes = auths.map(a => (a, authToSecurityScheme(a)))
     val securitySchemes = authSecuritySchemes.map { case (auth, scheme) => auth.securitySchemeName -> scheme }.toSet
     val takenNames = authSecuritySchemes.flatMap(_._1.securitySchemeName).toSet

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIDocs.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIDocs.scala
@@ -48,7 +48,7 @@ private[asyncapi] object EndpointToAsyncAPIDocs {
   }
 
   private def securityRequirements(securitySchemes: SecuritySchemes, e: AnyEndpoint): List[SecurityRequirement] = {
-    val auths = e.securityInput.auths ++ e.input.auths
+    val auths = e.auths
     val securityRequirement: SecurityRequirement = auths.flatMap {
       case auth @ EndpointInput.Auth(_, _, _, info: EndpointInput.AuthInfo.ScopedOAuth2) =>
         securitySchemes.get(auth).map(_._1).map((_, info.requiredScopes.toVector))

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIWebSocketChannel.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIWebSocketChannel.scala
@@ -6,7 +6,7 @@ import sttp.tapir.apispec.{Reference, ReferenceOr, Tag, Schema => ASchema, Schem
 import sttp.tapir.asyncapi._
 import sttp.tapir.docs.apispec.namedPathComponents
 import sttp.tapir.docs.apispec.schema.Schemas
-import sttp.tapir.internal.{IterableToListMap, RichEndpointInput}
+import sttp.tapir.internal.{IterableToListMap, RichEndpoint}
 import sttp.tapir.{AnyEndpoint, Codec, CodecFormat, EndpointIO, EndpointInput}
 
 import scala.collection.immutable.ListMap
@@ -20,7 +20,7 @@ private[asyncapi] class EndpointToAsyncAPIWebSocketChannel(
       e: AnyEndpoint,
       ws: WebSocketBodyWrapper[_, _]
   ): (String, ChannelItem) = {
-    val inputs = e.securityInput.asVectorOfBasicInputs(includeAuth = false) ++ e.input.asVectorOfBasicInputs(includeAuth = false)
+    val inputs = e.asVectorOfBasicInputs(includeAuth = false)
     val pathComponents = namedPathComponents(inputs)
     val method = e.method.getOrElse(Method.GET)
 

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIPaths.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIPaths.scala
@@ -18,7 +18,7 @@ private[openapi] class EndpointToOpenAPIPaths(schemas: Schemas, securitySchemes:
   def pathItem(e: AnyEndpoint): (String, PathItem) = {
     import Method._
 
-    val inputs = e.securityInput.asVectorOfBasicInputs(includeAuth = false) ++ e.input.asVectorOfBasicInputs(includeAuth = false)
+    val inputs = e.asVectorOfBasicInputs(includeAuth = false)
     val pathComponents = namedPathComponents(inputs)
     val method = e.method.getOrElse(Method.GET)
 
@@ -59,7 +59,7 @@ private[openapi] class EndpointToOpenAPIPaths(schemas: Schemas, securitySchemes:
   }
 
   private def operationSecurity(e: AnyEndpoint): List[SecurityRequirement] = {
-    val auths = e.securityInput.auths ++ e.input.auths
+    val auths = e.auths
     val securityRequirement: SecurityRequirement = auths.flatMap {
       case auth @ EndpointInput.Auth(_, _, _, info: EndpointInput.AuthInfo.ScopedOAuth2) =>
         securitySchemes.get(auth).map(_._1).map((_, info.requiredScopes.toVector))

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOperationResponse.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOperationResponse.scala
@@ -18,7 +18,7 @@ private[openapi] class EndpointToOperationResponse(
   def apply(e: AnyEndpoint): ListMap[ResponsesKey, ReferenceOr[Response]] = {
     // There always needs to be at least a 200 empty response
     outputToResponses(e.output, ResponsesCodeKey(200), Some(Response.Empty)) ++
-      inputToDefaultErrorResponses(e.input) ++
+      inputToDefaultErrorResponses(e.securityInput.and(e.input)) ++
       outputToResponses(e.errorOutput, ResponsesDefaultKey, None)
   }
 

--- a/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraServerInterpreter.scala
+++ b/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraServerInterpreter.scala
@@ -55,7 +55,7 @@ trait FinatraServerInterpreter extends Logging {
       }
     }
 
-    FinatraRoute(handler, httpMethod(se.endpoint), path(se.input))
+    FinatraRoute(handler, httpMethod(se.endpoint), path(se.securityInput.and(se.input)))
   }
 
   private[finatra] def path(input: EndpointInput[_]): String = {
@@ -71,14 +71,7 @@ trait FinatraServerInterpreter extends Logging {
     if (p.isEmpty) "/:*" else p
   }
 
-  private[finatra] def httpMethod(endpoint: AnyEndpoint): Method = {
-    endpoint.input
-      .asVectorOfBasicInputs()
-      .collectFirst { case FixedMethod(m, _, _) =>
-        Method(m.method)
-      }
-      .getOrElse(Method("ANY"))
-  }
+  private[finatra] def httpMethod(endpoint: AnyEndpoint): Method = endpoint.method.map(m => Method(m.method)).getOrElse(Method("ANY"))
 }
 
 object FinatraServerInterpreter {

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/CreateServerTest.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/CreateServerTest.scala
@@ -24,7 +24,7 @@ trait CreateServerTest[F[_], +R, ROUTE] {
       metricsInterceptor: Option[MetricsRequestInterceptor[F]] = None
   )(fn: I => F[Either[E, O]])(runTest: (SttpBackend[IO, Fs2Streams[IO] with WebSockets], Uri) => IO[Assertion]): Test
 
-  def testServerLogic(e: ServerEndpoint[R, F], testNameSuffix: String = "")(
+  def testServerLogic(e: ServerEndpoint[R, F], testNameSuffix: String = "", decodeFailureHandler: Option[DecodeFailureHandler] = None)(
       runTest: (SttpBackend[IO, Fs2Streams[IO] with WebSockets], Uri) => IO[Assertion]
   ): Test
 
@@ -53,12 +53,16 @@ class DefaultCreateServerTest[F[_], +R, ROUTE](
     )(runTest)
   }
 
-  override def testServerLogic(e: ServerEndpoint[R, F], testNameSuffix: String = "")(
+  override def testServerLogic(
+      e: ServerEndpoint[R, F],
+      testNameSuffix: String = "",
+      decodeFailureHandler: Option[DecodeFailureHandler] = None
+  )(
       runTest: (SttpBackend[IO, Fs2Streams[IO] with WebSockets], Uri) => IO[Assertion]
   ): Test = {
     testServer(
       e.showDetail + (if (testNameSuffix == "") "" else " " + testNameSuffix),
-      NonEmptyList.of(interpreter.route(e))
+      NonEmptyList.of(interpreter.route(e, decodeFailureHandler))
     )(runTest)
   }
 

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerSecurityTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerSecurityTests.scala
@@ -9,6 +9,7 @@ import sttp.model.{StatusCode, _}
 import sttp.monad.MonadError
 import sttp.tapir._
 import sttp.tapir.model.UsernamePassword
+import sttp.tapir.server.interceptor.decodefailure.DefaultDecodeFailureHandler
 import sttp.tapir.tests.Security.{
   in_security_apikey_header_in_amount_out_string,
   in_security_apikey_header_out_string,
@@ -91,13 +92,31 @@ class ServerSecurityTests[F[_], S, ROUTE](createServerTest: CreateServerTest[F, 
     ) { (backend, baseUri) =>
       basicStringRequest.get(uri"$baseUri/auth").auth.bearer("1234").send(backend).map(_.body shouldBe "1234")
     }
-  ) ++ missingAuthTests ++ correctAuthTests ++ badRequestWithCorrectAuthTests
+  ) ++
+    correctAuthTests ++
+    missingAuthTests ++
+    missingAuthWithEndpointHidingTests ++
+    badRequestWithCorrectAuthTests ++
+    badRequestWithCorrectAuthAndEndpointHidingTests
 
   private def missingAuthTests = endpoints.map { case (authType, endpoint, _) =>
     testServerLogic(endpoint.serverSecurityLogic(_ => result).serverLogic(_ => _ => result), s"missing $authType") { (backend, baseUri) =>
       validRequest(baseUri).send(backend).map { r =>
         r.code shouldBe StatusCode.Unauthorized
         r.header("WWW-Authenticate") shouldBe Some(expectedChallenge(authType))
+      }
+    }
+  }
+
+  private def missingAuthWithEndpointHidingTests = endpoints.map { case (authType, endpoint, _) =>
+    testServerLogic(
+      endpoint.serverSecurityLogic(_ => result).serverLogic(_ => _ => result),
+      s"missing $authType with endpoint hiding",
+      Some(DefaultDecodeFailureHandler.handlerHideUnauthorized)
+    ) { (backend, baseUri) =>
+      validRequest(baseUri).send(backend).map { r =>
+        r.code shouldBe StatusCode.NotFound
+        r.header("WWW-Authenticate") shouldBe None
       }
     }
   }
@@ -120,6 +139,16 @@ class ServerSecurityTests[F[_], S, ROUTE](createServerTest: CreateServerTest[F, 
     testServerLogic(endpoint.serverSecurityLogic(_ => result).serverLogic(_ => _ => result), s"invalid request $authType") {
       (backend, baseUri) =>
         auth(invalidRequest(baseUri)).send(backend).map(_.code shouldBe StatusCode.BadRequest)
+    }
+  }
+
+  private def badRequestWithCorrectAuthAndEndpointHidingTests = endpoints.map { case (authType, endpoint, auth) =>
+    testServerLogic(
+      endpoint.serverSecurityLogic(_ => result).serverLogic(_ => _ => result),
+      s"invalid request $authType with endpoint hiding",
+      Some(DefaultDecodeFailureHandler.handlerHideUnauthorized)
+    ) { (backend, baseUri) =>
+      auth(invalidRequest(baseUri)).send(backend).map(_.code shouldBe StatusCode.NotFound)
     }
   }
 }

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/handlers/package.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/handlers/package.scala
@@ -22,7 +22,7 @@ package object handlers {
   }
 
   private[vertx] def attachDefaultHandlers[E](e: Endpoint[_, _, E, _, _], route: Route): Route = {
-    e.input.asVectorOfBasicInputs() foreach {
+    e.asVectorOfBasicInputs() foreach {
       case body: EndpointIO.Body[_, _] =>
         body.bodyType match {
           case MultipartBody(_, _) =>

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/routing/PathMapping.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/routing/PathMapping.scala
@@ -2,7 +2,7 @@ package sttp.tapir.server.vertx.routing
 
 import io.vertx.core.http.HttpMethod
 import io.vertx.ext.web.{Route, Router}
-import sttp.tapir.{AnyEndpoint, Endpoint, EndpointInput}
+import sttp.tapir.{AnyEndpoint, EndpointInput}
 import sttp.tapir.EndpointInput.PathCapture
 import sttp.tapir.internal._
 
@@ -36,7 +36,7 @@ object PathMapping {
 
   private def extractVertxPath(endpoint: AnyEndpoint): String = {
     var idxUsed = 0
-    val path = endpoint.input
+    val path = endpoint
       .asVectorOfBasicInputs()
       .collect {
         case segment: EndpointInput.FixedPath[_] => segment.show

--- a/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/EndpointsToSamTemplate.scala
+++ b/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/EndpointsToSamTemplate.scala
@@ -47,7 +47,7 @@ private[sam] object EndpointsToSamTemplate {
   }
 
   private def endpointNameMethodAndPath(e: AnyEndpoint): (String, Option[Method], String) = {
-    val pathComponents = e.input
+    val pathComponents = e
       .asVectorOfBasicInputs()
       .foldLeft((Vector.empty[Either[String, String]], 0)) { case ((acc, c), input) =>
         input match {

--- a/serverless/aws/terraform/src/main/scala/sttp/tapir/serverless/aws/terraform/EndpointsToTerraformConfig.scala
+++ b/serverless/aws/terraform/src/main/scala/sttp/tapir/serverless/aws/terraform/EndpointsToTerraformConfig.scala
@@ -10,7 +10,7 @@ private[terraform] object EndpointsToTerraformConfig {
     val routes: Seq[AwsApiGatewayRoute] = eps.map { endpoint =>
       val method = endpoint.method.getOrElse(Method("ANY"))
 
-      val basicInputs = endpoint.input.asVectorOfBasicInputs()
+      val basicInputs = endpoint.asVectorOfBasicInputs()
 
       val pathComponents: Seq[(Either[EndpointInput.FixedPath[_], EndpointInput.PathCapture[_]], String)] = basicInputs
         .foldLeft((Seq.empty[(Either[EndpointInput.FixedPath[_], EndpointInput.PathCapture[_]], String)], 0)) { case ((acc, c), input) =>


### PR DESCRIPTION
Return 404 instead of a 401/400