### PR TITLE
use `addSegment` instead of `addPath` for http4s

### DIFF
--- a/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
+++ b/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
@@ -76,13 +76,13 @@ private[http4s] class EndpointToHttp4sClient(clientOptions: Http4sClientOptions)
 
     input match {
       case EndpointInput.FixedMethod(m, _, _) => req.withMethod(Method.fromString(m.method).right.get)
-      case EndpointInput.FixedPath(p, _, _)   => req.withUri(req.uri.addPath(p))
+      case EndpointInput.FixedPath(p, _, _)   => req.withUri(req.uri.addSegment(p))
       case EndpointInput.PathCapture(_, codec, _) =>
         val path = codec.asInstanceOf[PlainCodec[Any]].encode(value: Any)
-        req.withUri(req.uri.addPath(path))
+        req.withUri(req.uri.addSegment(path))
       case EndpointInput.PathsCapture(codec, _) =>
         val pathFragments = codec.encode(value)
-        val uri = pathFragments.foldLeft(req.uri)(_.addPath(_))
+        val uri = pathFragments.foldLeft(req.uri)(_.addSegment(_))
         req.withUri(uri)
       case EndpointInput.Query(name, codec, _) =>
         codec.encode(value) match {

--- a/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
+++ b/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
@@ -8,7 +8,7 @@ import sttp.capabilities.akka.AkkaStreams
 import sttp.model.{Header, Method, ResponseMetadata}
 import sttp.tapir.Codec.PlainCodec
 import sttp.tapir.client.ClientOutputParams
-import sttp.tapir.internal.{Params, ParamsAsAny, RichEndpointInput, RichEndpointOutput, SplitParams}
+import sttp.tapir.internal.{Params, ParamsAsAny, RichEndpointOutput, SplitParams}
 import sttp.tapir.{
   Codec,
   CodecFormat,
@@ -25,6 +25,7 @@ import sttp.tapir.{
 }
 
 import java.io.{ByteArrayInputStream, InputStream}
+import java.net.URLEncoder
 import java.nio.ByteBuffer
 import java.nio.file.Files
 import java.util.function.Supplier
@@ -91,16 +92,17 @@ private[play] class EndpointToPlayClient(clientOptions: PlayClientOptions, ws: S
       req: StandaloneWSRequest
   ): StandaloneWSRequest = {
     def value: I = params.asAny.asInstanceOf[I]
+    def encodePathSegment(p: String): String = URLEncoder.encode(p, "UTF-8")
     input match {
       case EndpointInput.FixedMethod(m, _, _) => req.withMethod(m.method)
       case EndpointInput.FixedPath(p, _, _) =>
-        req.withUrl(req.url + "/" + p)
+        req.withUrl(req.url + "/" + encodePathSegment(p))
       case EndpointInput.PathCapture(_, codec, _) =>
         val v = codec.asInstanceOf[PlainCodec[Any]].encode(value: Any)
-        req.withUrl(req.url + "/" + v)
+        req.withUrl(req.url + "/" + encodePathSegment(v))
       case EndpointInput.PathsCapture(codec, _) =>
         val ps = codec.encode(value)
-        req.withUrl(req.url + ps.mkString("/", "/", ""))
+        req.withUrl(req.url + ps.map(encodePathSegment).mkString("/", "/", ""))
       case EndpointInput.Query(name, codec, _) =>
         val req2 = codec.encode(value).foldLeft(req) { case (r, v) => r.addQueryStringParameters(name -> v) }
         req2

--- a/client/tests/src/main/scala/sttp/tapir/client/tests/ClientBasicTests.scala
+++ b/client/tests/src/main/scala/sttp/tapir/client/tests/ClientBasicTests.scala
@@ -29,6 +29,12 @@ trait ClientBasicTests { this: ClientTests[Any] =>
     testClient(in_query_query_out_string, (), ("apple", Some(10)), Right("fruit: apple 10"))
     testClient(in_header_out_string, (), "Admin", Right("Role: Admin"))
     testClient(in_path_path_out_string, (), ("apple", 10), Right("apple 10 None"))
+    testClient(
+      in_path_path_out_string.name("special characters in path"),
+      (),
+      ("orange/grapefruit", 10),
+      Right("orange/grapefruit 10 None")
+    )
     testClient(in_string_out_string, (), "delicious", Right("delicious"))
     testClient(in_json_out_json, (), FruitAmount("orange", 11), Right(FruitAmount("orange", 11)))
     testClient(in_byte_array_out_byte_array, (), "banana kiwi".getBytes(), Right("banana kiwi".getBytes()))


### PR DESCRIPTION
When building a http4s request, currently `addPath` is used to append segments to the path. Which results in the string being split by `/` and added as multiple segments (URL-encoding them).

So right now it's impossible to have a path segment that contains a `/` symbol (an edge case, but still):
* if you pre-url-encode it – http4s will encode it again, and you get the double encoded `/`: `/` -> `%2f` -> `%252f`
* if you don't url-encode it – it ends up "unencoded" in the resulting URI, causing a segment split

In either case, you can't get the desired `%2f` encoding.