### PR TITLE
Add toRoutesSuccess method that doesn't use an Either

### DIFF
--- a/core/src/main/scala/sttp/tapir/Endpoint.scala
+++ b/core/src/main/scala/sttp/tapir/Endpoint.scala
@@ -261,6 +261,9 @@ trait EndpointServerLogicOps[I, E, O, -R] { outer: Endpoint[I, E, O, R] =>
     */
   def serverLogic[F[_]](f: I => F[Either[E, O]]): ServerEndpoint[I, E, O, R, F] = ServerEndpoint(this, _ => f)
 
+  def serverLogicSuccess[F[_]](f: I => F[O]): ServerEndpoint[I, E, O, R, F] =
+    ServerEndpoint(this, me => in => me.map(f(in))(Right[E, O]))
+
   /** Same as [[serverLogic]], but requires `E` to be a throwable, and coverts failed effects of type `E` to endpoint
     * errors.
     */

--- a/core/src/main/scala/sttp/tapir/Endpoint.scala
+++ b/core/src/main/scala/sttp/tapir/Endpoint.scala
@@ -261,6 +261,8 @@ trait EndpointServerLogicOps[I, E, O, -R] { outer: Endpoint[I, E, O, R] =>
     */
   def serverLogic[F[_]](f: I => F[Either[E, O]]): ServerEndpoint[I, E, O, R, F] = ServerEndpoint(this, _ => f)
 
+  /** Same as [[serverLogic]], but accepts a function that can't fail, and converts to an `Either`.
+    */
   def serverLogicSuccess[F[_]](f: I => F[O]): ServerEndpoint[I, E, O, R, F] =
     ServerEndpoint(this, me => in => me.map(f(in))(Right[E, O]))
 


### PR DESCRIPTION
I thought this might be useful. I tried to add a similar method to `EndpointServerLogicOps`, but I realized that `F` is just a vanilla type constructor with no `Functor` context bounds. LMK if there's anything else I need to d