### PR TITLE
Rename DecodeSuccessContext parameters

### DIFF
--- a/core/src/main/scala/sttp/tapir/server/interceptor/DecodeSuccessContext.scala
+++ b/core/src/main/scala/sttp/tapir/server/interceptor/DecodeSuccessContext.scala
@@ -6,8 +6,8 @@ import sttp.tapir.server.ServerEndpoint
 
 case class DecodeSuccessContext[F[_], U, I](
     serverEndpoint: ServerEndpoint.Full[_, U, I, _, _, _, F],
-    u: U,
-    i: I,
+    securityLogicResult: U,
+    decodedInput: I,
     request: ServerRequest
 ) {
   def endpoint: Endpoint[_, I, _, _, _] = serverEndpoint.endpoint

--- a/core/src/main/scala/sttp/tapir/server/interpreter/ServerInterpreter.scala
+++ b/core/src/main/scala/sttp/tapir/server/interpreter/ServerInterpreter.scala
@@ -160,7 +160,7 @@ class ServerInterpreter[R, F[_], B, S](
           ctx: DecodeSuccessContext[F, U, I]
       )(implicit monad: MonadError[F], bodyListener: BodyListener[F, B]): F[ServerResponse[B]] =
         ctx.serverEndpoint
-          .logic(implicitly)(ctx.u)(ctx.i)
+          .logic(implicitly)(ctx.securityLogicResult)(ctx.decodedInput)
           .flatMap {
             case Right(result) => responder(defaultSuccessStatusCode)(ctx.request, ValuedEndpointOutput(ctx.serverEndpoint.output, result))
             case Left(err)     => responder(defaultErrorStatusCode)(ctx.request, ValuedEndpointOutput(ctx.serverEndpoint.errorOutput, err))


### PR DESCRIPTION
As discussed on gitter, the current name are not really expressing what those parameters represents.