### PR TITLE
Point to softwaremill/magnolia

### DIFF
--- a/doc/endpoint/schemas.md
+++ b/doc/endpoint/schemas.md
@@ -4,7 +4,7 @@ Implicit schemas for basic types (`String`, `Int`, etc.), and their collections 
 defined out-of-the box. They don't contain any meta-data, such as descriptions or example values.
 
 For case classes, `Schema[_]` values can be derived automatically using
-[Magnolia](https://propensive.com/opensource/magnolia/), given that schemas are defined for all the case class's fields.
+[Magnolia](https://github.com/softwaremill/magnolia), given that schemas are defined for all the case class's fields.
 
 There are two policies of custom type derivation are available:
 

--- a/generated-doc/out/endpoint/schemas.md
+++ b/generated-doc/out/endpoint/schemas.md
@@ -4,7 +4,7 @@ Implicit schemas for basic types (`String`, `Int`, etc.), and their collections 
 defined out-of-the box. They don't contain any meta-data, such as descriptions or example values.
 
 For case classes, `Schema[_]` values can be derived automatically using
-[Magnolia](https://propensive.com/opensource/magnolia/), given that schemas are defined for all the case class's fields.
+[Magnolia](https://github.com/softwaremill/magnolia), given that schemas are defined for all the case class's fields.
 
 There are two policies of custom type derivation are available:
 


### PR DESCRIPTION
https://tapir.softwaremill.com/en/latest/endpoint/schemas.html is pointing to https://propensive.com/opensource/magnolia/ which is giving a 404. The project migrated to https://github.com/softwaremill/magnolia

I wasn't sure if I should touch files in `generated-doc` directory. I erred on the side of doing it, happy to amend if it should be excluded.

