### PR TITLE
fixed mapSecurityInTo

### DIFF
--- a/core/src/main/scala-2/sttp/tapir/macros/EndpointMacros.scala
+++ b/core/src/main/scala-2/sttp/tapir/macros/EndpointMacros.scala
@@ -5,7 +5,7 @@ import sttp.tapir.{EndpointErrorOutputsOps, EndpointInputsOps, EndpointOutputsOp
 
 trait EndpointSecurityInputsMacros[A, I, E, O, -R] { this: EndpointSecurityInputsOps[A, I, E, O, R] =>
   def mapSecurityInTo[CASE_CLASS]: EndpointType[CASE_CLASS, I, E, O, R] =
-    macro MapToMacro.generateMapSecurityInTo[EndpointType[CASE_CLASS, I, E, O, R], I, CASE_CLASS]
+    macro MapToMacro.generateMapSecurityInTo[EndpointType[CASE_CLASS, I, E, O, R], A, CASE_CLASS]
 }
 
 trait EndpointInputsMacros[A, I, E, O, -R] { this: EndpointInputsOps[A, I, E, O, R] =>

--- a/core/src/test/scala/sttp/tapir/EndpointTest.scala
+++ b/core/src/test/scala/sttp/tapir/EndpointTest.scala
@@ -33,6 +33,11 @@ class EndpointTest extends AnyFlatSpec with EndpointTestExtensions with Matchers
     endpoint.securityIn(stringBody).securityIn(path[Int]): Endpoint[(String, Int), Unit, Unit, Unit, Any]
   }
 
+  it should "compile map security into case class" in {
+    case class Foo(a: String, b: String)
+    endpoint.securityIn(auth.bearer[String]()).securityIn(path[String]("foo")).mapSecurityInTo[Foo]
+  }
+
   trait TestStreams extends Streams[TestStreams] {
     override type BinaryStream = Vector[Byte]
     override type Pipe[X, Y] = Nothing
@@ -287,8 +292,10 @@ class EndpointTest extends AnyFlatSpec with EndpointTestExtensions with Matchers
 
   it should "map input and output" in {
     case class Wrapper(s: String)
+    case class Wrapper2(s1: String, s2: String)
 
     endpoint.in(query[String]("q1")).mapInTo[Wrapper]: PublicEndpoint[Wrapper, Unit, Unit, Any]
+    endpoint.in(query[String]("q1")).in(query[String]("q2")).mapInTo[Wrapper2]: PublicEndpoint[Wrapper2, Unit, Unit, Any]
     endpoint.out(stringBody).mapOutTo[Wrapper]: PublicEndpoint[Unit, Unit, Wrapper, Any]
     endpoint.errorOut(stringBody).mapErrorOutTo[Wrapper]: PublicEndpoint[Unit, Wrapper, Unit, Any]
   }


### PR DESCRIPTION
fixed passing A (security) instead of I (input) parameter for mapSecurityInTo