### PR TITLE
Scala 2.13 partial unification comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Add the following dependency:
 "com.softwaremill.sttp.tapir" %% "tapir-core" % "0.20.0-M4"
 ```
 
-You'll need partial unification enabled in the compiler (alternatively, you'll need to manually provide type arguments in some cases):
+Partial unification is now enabled by default from Scala 2.13. However, if you're using Scala 2.12 or older, then 
+you'll need partial unification enabled in the compiler (alternatively, you'll need to manually provide type 
+arguments in some cases):
 
 ```sbt
 scalacOptions += "-Ypartial-unification"

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -16,8 +16,9 @@ you import the main package entirely, i.e.:
 import sttp.tapir._
 ```
 
-If you don't have it already, you'll also need partial unification enabled in the compiler (alternatively, you'll need 
-to manually provide type arguments in some cases). In sbt, this is:
+Partial unification is now enabled by default from Scala 2.13. However, if you're using Scala 2.12 or older, and don't 
+have it already, you'll want to to enable partial unification in the compiler (alternatively, you'll need to manually 
+provide type arguments in some cases). In sbt, this is:
 
 ```scala
 scalacOptions += "-Ypartial-unification"


### PR DESCRIPTION
-Ypartial-unification is now on by default in Scala 2.13, and actually gives an error (Error: scalac: bad option).