### PR TITLE
require value class parameters list to not be empty

### DIFF
--- a/core/src/main/scala-2/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
+++ b/core/src/main/scala-2/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
@@ -17,6 +17,7 @@ trait SchemaMagnoliaDerivation {
     withCache(ctx.typeName, ctx.annotations) {
       val result =
         if (ctx.isValueClass) {
+          require(ctx.parameters.nonEmpty, s"Cannot derive schema for generic value class: ${ctx.typeName.owner}")
           val valueSchema = ctx.parameters.head.typeclass
           Schema[T](schemaType = valueSchema.schemaType.asInstanceOf[SchemaType[T]], format = valueSchema.format)
         } else {

--- a/core/src/main/scala-3/sttp/tapir/internal/SchemaMagnoliaDerivation.scala
+++ b/core/src/main/scala-3/sttp/tapir/internal/SchemaMagnoliaDerivation.scala
@@ -20,6 +20,7 @@ trait SchemaMagnoliaDerivation {
         withCache(ctx.typeInfo, ctx.annotations) {
           val result =
             if (ctx.isValueClass) {
+              require(ctx.params.nonEmpty, s"Cannot derive schema for generic value class: ${ctx.typeInfo.owner}")
               val valueSchema = ctx.params.head.typeclass
               Schema[T](schemaType = valueSchema.schemaType.asInstanceOf[SchemaType[T]], format = valueSchema.format)
             } else {

--- a/core/src/test/scala-2/sttp/tapir/SchemaMacroTest2.scala
+++ b/core/src/test/scala-2/sttp/tapir/SchemaMacroTest2.scala
@@ -3,8 +3,8 @@ package sttp.tapir
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.tapir.Schema.SName
-import sttp.tapir.SchemaMacroTestData2.ValueClasses
 import sttp.tapir.SchemaMacroTestData2.ValueClasses.DoubleValue
+import sttp.tapir.SchemaMacroTestData2.{Type, ValueClasses}
 import sttp.tapir.SchemaType.{SArray, SProduct, SString}
 import sttp.tapir.TestUtil.field
 import sttp.tapir.generic.auto._
@@ -43,5 +43,10 @@ class SchemaMacroTest2 extends AnyFlatSpec with Matchers {
     )
 
     implicitly[Schema[ValueClasses.UserListRequest]] shouldBe expected2
+  }
+
+  it should "fail to derive schema for nested generic value class with meaningful msg" in {
+    val ex = the[IllegalArgumentException] thrownBy schemaForCaseClass[Type.MapType]
+    ex.getMessage.contains("requirement failed: Cannot derive schema for generic value class") shouldBe true
   }
 }

--- a/core/src/test/scala-2/sttp/tapir/SchemaMacroTestData2.scala
+++ b/core/src/test/scala-2/sttp/tapir/SchemaMacroTestData2.scala
@@ -9,4 +9,10 @@ object SchemaMacroTestData2 {
     case class UserList(list: List[UserName]) extends AnyVal
     case class UserListRequest(list: UserList)
   }
+
+  sealed trait Type
+  object Type {
+    final case class Num[N <: AnyVal: Numeric](n: N) extends Type
+    final case class MapType(obj: Map[String, Type]) extends Type
+  }
 }


### PR DESCRIPTION
I don't know if there is something better we can do for the reported case for scala2 (we could probably implement some macro to do the check in compile time but is it worth the effort)? I added the test in scala2 sources since for scala3 it won't compile although not mentioning the `Num` class specifically in the message.