### PR TITLE
Consistent naming of client interpreter methods, fixing docs

### DIFF
--- a/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
+++ b/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
@@ -50,7 +50,7 @@ private[http4s] class EndpointToHttp4sClient(clientOptions: Http4sClientOptions)
     (request1, responseParser)
   }
 
-  def toHttp4sRequestUnsafe[A, I, E, O, R, F[_]: Async](
+  def toHttp4sRequestThrowDecodeFailures[A, I, E, O, R, F[_]: Async](
       e: Endpoint[A, I, E, O, R],
       maybeUri: Option[Uri]
   ): A => I => (Request[F], Response[F] => F[Either[E, O]]) = { aParams => iParams =>

--- a/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/Http4sClientInterpreter.scala
+++ b/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/Http4sClientInterpreter.scala
@@ -32,11 +32,11 @@ abstract class Http4sClientInterpreter[F[_]: Async] {
     *   - an `org.http4s.Request[F]`, which can be sent using an http4s client, or run against `org.http4s.HttpRoutes[F]`;
     *   - a response parser that extracts the expected entity from the received `org.http4s.Response[F]`.
     */
-  def toRequestUnsafe[I, E, O, R](
+  def toRequestThrowDecodeFailures[I, E, O, R](
       e: PublicEndpoint[I, E, O, R],
       baseUri: Option[Uri]
   ): I => (Request[F], Response[F] => F[Either[E, O]]) =
-    new EndpointToHttp4sClient(http4sClientOptions).toHttp4sRequestUnsafe[Unit, I, E, O, R, F](e, baseUri).apply(())
+    new EndpointToHttp4sClient(http4sClientOptions).toHttp4sRequestThrowDecodeFailures[Unit, I, E, O, R, F](e, baseUri).apply(())
 
   // secure
 
@@ -62,11 +62,11 @@ abstract class Http4sClientInterpreter[F[_]: Async] {
     *   - an `org.http4s.Request[F]`, which can be sent using an http4s client, or run against `org.http4s.HttpRoutes[F]`;
     *   - a response parser that extracts the expected entity from the received `org.http4s.Response[F]`.
     */
-  def toSecureRequestUnsafe[A, I, E, O, R](
+  def toSecureRequestThrowDecodeFailures[A, I, E, O, R](
       e: Endpoint[A, I, E, O, R],
       baseUri: Option[Uri]
   ): A => I => (Request[F], Response[F] => F[Either[E, O]]) =
-    new EndpointToHttp4sClient(http4sClientOptions).toHttp4sRequestUnsafe[A, I, E, O, R, F](e, baseUri)
+    new EndpointToHttp4sClient(http4sClientOptions).toHttp4sRequestThrowDecodeFailures[A, I, E, O, R, F](e, baseUri)
 }
 
 object Http4sClientInterpreter {

--- a/client/http4s-client/src/test/scala/sttp/tapir/client/http4s/Http4sClientTests.scala
+++ b/client/http4s-client/src/test/scala/sttp/tapir/client/http4s/Http4sClientTests.scala
@@ -17,7 +17,7 @@ abstract class Http4sClientTests[R] extends ClientTests[R] {
   ): IO[Either[E, O]] = {
     val (request, parseResponse) =
       Http4sClientInterpreter[IO]()
-        .toSecureRequestUnsafe(e, Some(Uri.unsafeFromString(s"http://localhost:$port")))
+        .toSecureRequestThrowDecodeFailures(e, Some(Uri.unsafeFromString(s"http://localhost:$port")))
         .apply(securityArgs)
         .apply(args)
 

--- a/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
+++ b/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
@@ -52,15 +52,15 @@ private[play] class EndpointToPlayClient(clientOptions: PlayClientOptions, ws: S
     (req, responseParser)
   }
 
-  def toPlayRequestUnsafe[A, I, E, O, R](
+  def toPlayRequestThrowDecodeFailures[A, I, E, O, R](
       e: Endpoint[A, I, E, O, R],
       baseUri: String
   ): A => I => (StandaloneWSRequest, StandaloneWSResponse => Either[E, O]) = { aParams => iParams =>
     val (req, responseParser) = toPlayRequest(e, baseUri)(aParams)(iParams)
-    def unsafeResponseParser(response: StandaloneWSResponse): Either[E, O] = {
+    def throwingResponseParser(response: StandaloneWSResponse): Either[E, O] = {
       getOrThrow(responseParser(response))
     }
-    (req, unsafeResponseParser)
+    (req, throwingResponseParser)
   }
 
   private def parsePlayResponse[A, I, E, O, R](e: Endpoint[A, I, E, O, R]): StandaloneWSResponse => DecodeResult[Either[E, O]] = {

--- a/client/play-client/src/main/scala/sttp/tapir/client/play/PlayClientInterpreter.scala
+++ b/client/play-client/src/main/scala/sttp/tapir/client/play/PlayClientInterpreter.scala
@@ -31,10 +31,10 @@ trait PlayClientInterpreter {
     * @throws IllegalArgumentException
     *   when response parsing fails
     */
-  def toRequestUnsafe[I, E, O, R](e: PublicEndpoint[I, E, O, R], baseUri: String)(implicit
+  def toRequestThrowDecodeFailures[I, E, O, R](e: PublicEndpoint[I, E, O, R], baseUri: String)(implicit
       ws: StandaloneWSClient
   ): I => (StandaloneWSRequest, StandaloneWSResponse => Either[E, O]) =
-    new EndpointToPlayClient(playClientOptions, ws).toPlayRequestUnsafe(e, baseUri).apply(())
+    new EndpointToPlayClient(playClientOptions, ws).toPlayRequestThrowDecodeFailures(e, baseUri).apply(())
 
   // secure
 
@@ -62,10 +62,10 @@ trait PlayClientInterpreter {
     * @throws IllegalArgumentException
     *   when response parsing fails
     */
-  def toSecureRequestUnsafe[A, I, E, O, R](e: Endpoint[A, I, E, O, R], baseUri: String)(implicit
+  def toSecureRequestThrowDecodeFailures[A, I, E, O, R](e: Endpoint[A, I, E, O, R], baseUri: String)(implicit
       ws: StandaloneWSClient
   ): A => I => (StandaloneWSRequest, StandaloneWSResponse => Either[E, O]) =
-    new EndpointToPlayClient(playClientOptions, ws).toPlayRequestUnsafe(e, baseUri)
+    new EndpointToPlayClient(playClientOptions, ws).toPlayRequestThrowDecodeFailures(e, baseUri)
 }
 
 object PlayClientInterpreter {

--- a/client/play-client/src/test/scala/sttp/tapir/client/play/PlayClientTests.scala
+++ b/client/play-client/src/test/scala/sttp/tapir/client/play/PlayClientTests.scala
@@ -25,7 +25,7 @@ abstract class PlayClientTests[R] extends ClientTests[R] {
   ): IO[Either[E, O]] = {
     def response: Future[Either[E, O]] = {
       val (req, responseParser) =
-        PlayClientInterpreter().toSecureRequestUnsafe(e, s"http://localhost:$port").apply(securityArgs).apply(args)
+        PlayClientInterpreter().toSecureRequestThrowDecodeFailures(e, s"http://localhost:$port").apply(securityArgs).apply(args)
       req.execute().map(responseParser)
     }
     IO.fromFuture(IO(response))

--- a/doc/client/http4s.md
+++ b/doc/client/http4s.md
@@ -13,8 +13,8 @@ import sttp.tapir.client.http4s.Http4sClientInterpreter
 ```
 
 This objects contains four methods:
-- `toRequestUnsafe(PublicEndpoint, Option[Uri])` and `toSecureRequestUnsafe(Endpoint, Option[Uri])`: given the optional base URI, returns a function
-  which generates a request and a response parser from endpoint inputs. Response parser throws
+- `toRequestThrowDecodeFailures(PublicEndpoint, Option[Uri])` and `toSecureRequestThrowDecodeFailures(Endpoint, Option[Uri])`: 
+  given the optional base URI, returns a function which generates a request and a response parser from endpoint inputs. Response parser throws
   an exception if decoding of the result fails.
   ```scala
   I => (org.http4s.Request[F], org.http4s.Response[F] => F[Either[E, O]])

--- a/doc/client/play.md
+++ b/doc/client/play.md
@@ -13,8 +13,8 @@ import sttp.tapir.client.play.PlayClientInterpreter
 ```
 
 This objects contains four methods:
- - `toRequestUnsafe(PublicEndpoint, String)` and `toSecureRequestUnsafe(Endpoint, String)`: given the base URI returns a function,
-   which will generate a request and a response parser which might throw
+ - `toRequestThrowDecodeFailures(PublicEndpoint, String)` and `toSecureRequestThrowDecodeErrors(Endpoint, String)`: given  
+   the base URI returns a function, which will generate a request and a response parser which might throw
    an exception when decoding of the result fails
    ```scala
    I => (StandaloneWSRequest, StandaloneWSResponse => Either[E, O])
@@ -54,7 +54,7 @@ def example[I, E, O, R >: AkkaStreams](implicit wsClient: StandaloneWSClient) {
   val inputArgs: I = ???
   
   val (req, responseParser) = PlayClientInterpreter()
-      .toRequestUnsafe(e, s"http://localhost:9000")
+      .toRequestThrowDecodeFailures(e, s"http://localhost:9000")
       .apply(inputArgs)
   
   val result: Future[Either[E, O]] = req

--- a/generated-doc/out/client/play.md
+++ b/generated-doc/out/client/play.md
@@ -52,14 +52,14 @@ import play.api.libs.ws.StandaloneWSClient
 def example[I, E, O, R >: AkkaStreams](implicit wsClient: StandaloneWSClient) {
   val e: PublicEndpoint[I, E, O, R] = ???
   val inputArgs: I = ???
-  
+
   val (req, responseParser) = PlayClientInterpreter()
-      .toRequestUnsafe(e, s"http://localhost:9000")
-      .apply(inputArgs)
-  
+    .toRequestThrowDecodeFailures(e, s"http://localhost:9000")
+    .apply(inputArgs)
+
   val result: Future[Either[E, O]] = req
-      .execute()
-      .map(responseParser)
+    .execute()
+    .map(responseParser)
 }
 ```
 


### PR DESCRIPTION
Closes #1765