### PR TITLE
fix multiPart upload codec

### DIFF
--- a/client/tests/src/main/scala/sttp/tapir/client/tests/ClientMultipartTests.scala
+++ b/client/tests/src/main/scala/sttp/tapir/client/tests/ClientMultipartTests.scala
@@ -37,12 +37,10 @@ trait ClientMultipartTests { this: ClientTests[Any] =>
       in_raw_multipart_out_string,
       (),
       Seq(
-        Part("operations", "{}".getBytes, contentType = Some(MediaType.ApplicationJson)),
-        Part("map", """{ "0": ["variables.files.0"], "1":  ["variables.files.1"]}""".getBytes),
-        Part("0", """image""".getBytes, contentType = Some(MediaType.ImagePng)).fileName("a.png"),
-        Part("1", """text""".getBytes, contentType = Some(MediaType.TextPlain)).fileName("a.txt")
+        Part("fruit", "apple".getBytes, contentType = Some(MediaType.TextPlain)),
+        Part("amount", "20".getBytes, contentType = Some(MediaType.TextPlain))
       ),
-      Right("=")
+      Right("apple=20")
     )
 
   }

--- a/client/tests/src/main/scala/sttp/tapir/client/tests/ClientMultipartTests.scala
+++ b/client/tests/src/main/scala/sttp/tapir/client/tests/ClientMultipartTests.scala
@@ -1,7 +1,8 @@
 package sttp.tapir.client.tests
 
 import cats.effect.unsafe.implicits.global
-import sttp.tapir.tests.Multipart.{in_simple_multipart_out_raw_string, in_simple_multipart_out_string}
+import sttp.model.{MediaType, Part}
+import sttp.tapir.tests.Multipart.{in_raw_multipart_out_string, in_simple_multipart_out_raw_string, in_simple_multipart_out_string}
 import sttp.tapir.tests.data.{FruitAmount, FruitAmountWrapper}
 
 trait ClientMultipartTests { this: ClientTests[Any] =>
@@ -31,6 +32,19 @@ trait ClientMultipartTests { this: ClientTests[Any] =>
           afterJson should not include ("Content-Type: application/json")
         }
     }
+
+    testClient(
+      in_raw_multipart_out_string,
+      (),
+      Seq(
+        Part("operations", "{}".getBytes, contentType = Some(MediaType.ApplicationJson)),
+        Part("map", """{ "0": ["variables.files.0"], "1":  ["variables.files.1"]}""".getBytes),
+        Part("0", """image""".getBytes, contentType = Some(MediaType.ImagePng)).fileName("a.png"),
+        Part("1", """text""".getBytes, contentType = Some(MediaType.TextPlain)).fileName("a.txt")
+      ),
+      Right("=")
+    )
+
   }
 
 }

--- a/core/src/main/scala/sttp/tapir/Codec.scala
+++ b/core/src/main/scala/sttp/tapir/Codec.scala
@@ -641,8 +641,10 @@ object MultipartCodec extends MultipartCodecMacros {
   val Default: MultipartCodec[Seq[Part[Array[Byte]]]] =
     Codec
       .multipart(Map.empty, Some(PartCodec(RawBodyType.ByteArrayBody, arrayBytePartListCodec)))
-      // we know that all parts will end up as byte arrays; also, removing the by-name grouping of parts
-      .map(_.values.toSeq.flatMap(_.asInstanceOf[List[Part[Array[Byte]]]]))(l => ListMap.empty.updated("0", l))
+      // we know that all parts will end up as byte arrays; also, removing/restoring the by-name grouping of parts
+      .map(_.values.toSeq.flatMap(_.asInstanceOf[List[Part[Array[Byte]]]]))(l =>
+        ListMap(l.groupBy(_.name).toList.map { case (name, parts) => name -> parts.toList }: _*)
+      )
 }
 
 /** The raw format of the body: what do we need to know, to read it and pass to a codec for further decoding. */

--- a/core/src/main/scala/sttp/tapir/Codec.scala
+++ b/core/src/main/scala/sttp/tapir/Codec.scala
@@ -642,7 +642,7 @@ object MultipartCodec extends MultipartCodecMacros {
     Codec
       .multipart(Map.empty, Some(PartCodec(RawBodyType.ByteArrayBody, arrayBytePartListCodec)))
       // we know that all parts will end up as byte arrays; also, removing the by-name grouping of parts
-      .map(_.values.toSeq.flatMap(_.asInstanceOf[List[Part[Array[Byte]]]]))(l => ListMap(l.map(p => p.name -> p): _*))
+      .map(_.values.toSeq.flatMap(_.asInstanceOf[List[Part[Array[Byte]]]]))(l => ListMap.empty.updated("0", l))
 }
 
 /** The raw format of the body: what do we need to know, to read it and pass to a codec for further decoding. */


### PR DESCRIPTION
when I use multipart upload, it shows error like this.

```
[info] - Endpoint[echo raw parts](securityin: -, in: POST /api /echo /multipart {body as multipart/form-data}, errout: -, out: {body as text/plain (UTF-8)}) *** FAILED *** (2 milliseconds)
[info]   java.lang.ClassCastException: class sttp.model.Part cannot be cast to class scala.collection.immutable.List (sttp.model.Part is in unnamed module of loader sbt.internal.LayeredClassLoader @9cb3542; scala.collection.immutable.List is in unnamed module of loader sbt.internal.ScalaLibraryClassLoader @13aa12e4)
[info]   at sttp.tapir.Mapping$$anon$4.encode(Mapping.scala:60)
[info]   at sttp.tapir.Codec$$anon$1.encode(Codec.scala:75)
[info]   at sttp.tapir.Codec$$anon$2.encode(Codec.scala:93)
[info]   at sttp.tapir.Codec$$anon$5.$anonfun$encode$2(Codec.scala:212)
[info]   at scala.collection.immutable.List.flatMap(List.scala:293)
[info]   at sttp.tapir.Codec$$anon$5.$anonfun$encode$1(Codec.scala:211)
[info]   at scala.collection.immutable.List.flatMap(List.scala:293)
[info]   at sttp.tapir.Codec$$anon$5.encode(Codec.scala:210)
[info]   at sttp.tapir.Codec$$anon$5.encode(Codec.scala:205)
[info]   at sttp.tapir.Codec$$anon$1.encode(Codec.scala:75)
[info]   ...
```