### PR TITLE
Support ZIO 1.0 and ZIO 2.0 for sttp ws

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,6 +159,7 @@ lazy val allAggregates = core.projectRefs ++
   awsExamples.projectRefs ++
   http4sClient.projectRefs ++
   sttpClient.projectRefs ++
+  sttpClientWsZio1.projectRefs ++
   playClient.projectRefs ++
   tests.projectRefs ++
   examples.projectRefs ++
@@ -1140,7 +1141,7 @@ lazy val sttpClient: ProjectMatrix = (projectMatrix in file("client/sttp-client"
         "com.softwaremill.sttp.client3" %% "httpclient-backend-fs2" % Versions.sttp % Test,
         "com.softwaremill.sttp.client3" %% "httpclient-backend-zio" % Versions.sttp % Test,
         "com.softwaremill.sttp.shared" %% "fs2" % Versions.sttpShared % Optional,
-        "com.softwaremill.sttp.shared" %% "zio1" % Versions.sttpShared % Optional
+        "com.softwaremill.sttp.shared" %% "zio" % Versions.sttpShared % Optional
       ),
       libraryDependencies ++= {
         CrossVersion.partialVersion(scalaVersion.value) match {
@@ -1164,6 +1165,22 @@ lazy val sttpClient: ProjectMatrix = (projectMatrix in file("client/sttp-client"
     )
   )
   .dependsOn(core, clientTests % Test)
+
+lazy val sttpClientWsZio1: ProjectMatrix = (projectMatrix in file("client/sttp-client-ws-zio1"))
+  .settings(clientTestServerSettings)
+  .settings(
+    name := "tapir-sttp-client-ws-zio1"
+  )
+  .jvmPlatform(
+    scalaVersions = scala2And3Versions,
+    settings = commonJvmSettings ++ Seq(
+      libraryDependencies ++= Seq(
+        "com.softwaremill.sttp.client3" %% "httpclient-backend-zio1" % Versions.sttp % Test,
+        "com.softwaremill.sttp.shared" %% "zio1" % Versions.sttpShared
+      )
+    )
+  )
+  .dependsOn(sttpClient, clientTests % Test)
 
 lazy val playClient: ProjectMatrix = (projectMatrix in file("client/play-client"))
   .settings(clientTestServerSettings)

--- a/client/sttp-client-ws-zio1/src/main/scalajvm/sttp/tapir/client/sttp/ws/zio1/TapirSttpClientZioWebSockets.scala
+++ b/client/sttp-client-ws-zio1/src/main/scalajvm/sttp/tapir/client/sttp/ws/zio1/TapirSttpClientZioWebSockets.scala
@@ -1,0 +1,10 @@
+package sttp.tapir.client.sttp.ws.zio1
+
+import sttp.capabilities.WebSockets
+import sttp.capabilities.zio.ZioStreams
+import sttp.tapir.client.sttp.WebSocketToPipe
+
+trait TapirSttpClientZioWebSockets {
+  implicit val webSocketsSupportedForZioStreams: WebSocketToPipe[ZioStreams with WebSockets] =
+    new WebSocketToZioPipe[ZioStreams with WebSockets]
+}

--- a/client/sttp-client-ws-zio1/src/main/scalajvm/sttp/tapir/client/sttp/ws/zio1/package.scala
+++ b/client/sttp-client-ws-zio1/src/main/scalajvm/sttp/tapir/client/sttp/ws/zio1/package.scala
@@ -1,0 +1,3 @@
+package sttp.tapir.client.sttp.ws
+
+package object zio1 extends TapirSttpClientZioWebSockets

--- a/client/sttp-client-ws-zio1/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientWebSocketZioTests.scala
+++ b/client/sttp-client-ws-zio1/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientWebSocketZioTests.scala
@@ -1,0 +1,29 @@
+package sttp.tapir.client.sttp
+
+import cats.effect.IO
+import sttp.capabilities.WebSockets
+import sttp.capabilities.zio.ZioStreams
+import sttp.tapir.client.sttp.ws.zio1._
+import sttp.tapir.client.tests.ClientWebSocketTests
+import zio.stream.Stream
+
+class SttpClientWebSocketZioTests extends SttpClientZioTests[WebSockets with ZioStreams] with ClientWebSocketTests[ZioStreams] {
+  override val streams: ZioStreams = ZioStreams
+  override def wsToPipe: WebSocketToPipe[WebSockets with ZioStreams] = implicitly
+
+  override def sendAndReceiveLimited[A, B](
+      p: Stream[Throwable, A] => Stream[Throwable, B],
+      receiveCount: Port,
+      as: List[A]
+  ): IO[List[B]] = IO.fromFuture(
+    IO.delay {
+      zio.Runtime.default
+        .unsafeRunToFuture(
+          Stream(as: _*).via(p).take(receiveCount).runCollect.map(_.toList)
+        )
+        .future
+    }
+  )
+
+  webSocketTests()
+}

--- a/client/sttp-client-ws-zio1/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientZioTests.scala
+++ b/client/sttp-client-ws-zio1/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientZioTests.scala
@@ -1,0 +1,55 @@
+package sttp.tapir.client.sttp
+
+import cats.effect.IO
+import sttp.capabilities.WebSockets
+import sttp.capabilities.zio.ZioStreams
+import sttp.client3._
+import sttp.client3.httpclient.zio.HttpClientZioBackend
+import sttp.tapir.client.tests.ClientTests
+import sttp.tapir.{DecodeResult, Endpoint}
+import zio.Task
+
+abstract class SttpClientZioTests[R >: WebSockets with ZioStreams] extends ClientTests[R] {
+  val backend: SttpBackend[Task, R] = zio.Runtime.default.unsafeRun(HttpClientZioBackend())
+  def wsToPipe: WebSocketToPipe[R]
+
+  override def send[A, I, E, O](
+      e: Endpoint[A, I, E, O, R],
+      port: Port,
+      securityArgs: A,
+      args: I,
+      scheme: String = "http"
+  ): IO[Either[E, O]] =
+    IO.fromFuture(IO.delay {
+      implicit val wst: WebSocketToPipe[R] = wsToPipe
+      val send = SttpClientInterpreter()
+        .toSecureRequestThrowDecodeFailures(e, Some(uri"$scheme://localhost:$port"))
+        .apply(securityArgs)
+        .apply(args)
+        .send(backend)
+        .map(_.body)
+      zio.Runtime.default.unsafeRunToFuture(send).future
+    })
+
+  override def safeSend[A, I, E, O](
+      e: Endpoint[A, I, E, O, R],
+      port: Port,
+      securityArgs: A,
+      args: I
+  ): IO[DecodeResult[Either[E, O]]] =
+    IO.fromFuture(IO.delay {
+      implicit val wst: WebSocketToPipe[R] = wsToPipe
+      val send = SttpClientInterpreter()
+        .toSecureRequest(e, Some(uri"http://localhost:$port"))
+        .apply(securityArgs)
+        .apply(args)
+        .send(backend)
+        .map(_.body)
+      zio.Runtime.default.unsafeRunToFuture(send).future
+    })
+
+  override protected def afterAll(): Unit = {
+    zio.Runtime.default.unsafeRun(backend.close())
+    super.afterAll()
+  }
+}

--- a/client/sttp-client/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientStreamingZioTests.scala
+++ b/client/sttp-client/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientStreamingZioTests.scala
@@ -3,7 +3,7 @@ package sttp.tapir.client.sttp
 import sttp.capabilities.zio.ZioStreams
 import sttp.tapir.client.tests.ClientStreamingTests
 import zio.Chunk
-import zio.stream.{Stream, ZTransducer}
+import zio.stream.{Stream, ZPipeline}
 
 class SttpClientStreamingZioTests extends SttpClientZioTests[ZioStreams] with ClientStreamingTests[ZioStreams] {
   override def wsToPipe: WebSocketToPipe[ZioStreams] = implicitly
@@ -12,7 +12,7 @@ class SttpClientStreamingZioTests extends SttpClientZioTests[ZioStreams] with Cl
   override def mkStream(s: String): Stream[Throwable, Byte] = Stream.fromChunk(Chunk.fromArray(s.getBytes("utf-8")))
   override def rmStream(s: Stream[Throwable, Byte]): String = {
     zio.Runtime.default.unsafeRun(
-      s.transduce(ZTransducer.utf8Decode).runCollect.map(_.fold("")(_ ++ _))
+      s.via(ZPipeline.utf8Decode).runCollect.map(_.fold("")(_ ++ _))
     )
   }
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,7 +3,7 @@ object Versions {
   val catsEffect = "3.3.5"
   val circe = "0.14.1"
   val circeYaml = "0.14.1"
-  val sttp = "3.3.18"
+  val sttp = "3.4.1"
   val sttpModel = "1.4.22"
   val sttpShared = "1.3.1"
   val akkaHttp = "10.2.7"


### PR DESCRIPTION
Follow up to https://github.com/softwaremill/tapir/pull/1807#issuecomment-1027261041

Migrate `tapir-sttp-client` to ZIO 2.0 and add `tapir-sttp-client-ws-zio1` for ZIO 1.0. I used package name `zio1` to prevent the conflict.