### PR TITLE
add discriminatorMapping when deriving a schema for co-products

### DIFF
--- a/core/src/main/scala-2/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
+++ b/core/src/main/scala-2/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
@@ -50,6 +50,9 @@ trait SchemaMagnoliaDerivation {
     }
   }
 
+  private def subtypeNameToSchemaName(subtype: Subtype[Typeclass, _]): Schema.SName =
+    typeNameToSchemaName(subtype.typeName, mergeAnnotations(subtype.annotations, subtype.inheritedAnnotations))
+
   private def getEncodedName(annotations: Seq[Any]): Option[String] =
     annotations.collectFirst { case ann: Schema.annotations.encodedName => ann.name }
 
@@ -70,19 +73,15 @@ trait SchemaMagnoliaDerivation {
     withCache(ctx.typeName, annotations) {
       val subtypesByName =
         ctx.subtypes
-          .map(s =>
-            typeNameToSchemaName(s.typeName, mergeAnnotations(s.annotations, s.inheritedAnnotations)) -> s.typeclass
-              .asInstanceOf[Typeclass[T]]
-          )
+          .map(s => subtypeNameToSchemaName(s) -> s.typeclass.asInstanceOf[Typeclass[T]])
           .toListMap
-      val baseCoproduct = SCoproduct(subtypesByName.values.toList, None)((t: T) =>
-        ctx.split(t) { v => subtypesByName.get(typeNameToSchemaName(v.typeName, mergeAnnotations(v.annotations, v.inheritedAnnotations))) }
-      )
+      val baseCoproduct =
+        SCoproduct(subtypesByName.values.toList, None)((t: T) => ctx.split(t) { v => subtypesByName.get(subtypeNameToSchemaName(v)) })
       val coproduct = genericDerivationConfig.discriminator match {
         case Some(d) =>
           val discriminatorMapping: Map[String, SRef[_]] =
             ctx.subtypes.map { s =>
-              val schemaName = typeNameToSchemaName(s.typeName, s.annotations)
+              val schemaName = subtypeNameToSchemaName(s)
               genericDerivationConfig.toEncodedSubtypeName(schemaName) -> SRef(schemaName)
             }.toMap
           baseCoproduct.addDiscriminatorField(

--- a/core/src/main/scala-2/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
+++ b/core/src/main/scala-2/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
@@ -82,7 +82,7 @@ trait SchemaMagnoliaDerivation {
           val discriminatorMapping: Map[String, SRef[_]] =
             ctx.subtypes.map { s =>
               val schemaName = subtypeNameToSchemaName(s)
-              genericDerivationConfig.toEncodedSubtypeName(schemaName) -> SRef(schemaName)
+              genericDerivationConfig.toDiscriminatorValue(schemaName) -> SRef(schemaName)
             }.toMap
           baseCoproduct.addDiscriminatorField(
             FieldName(d),

--- a/core/src/main/scala-2/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
+++ b/core/src/main/scala-2/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
@@ -82,7 +82,8 @@ trait SchemaMagnoliaDerivation {
         case Some(d) =>
           val discriminatorMapping: Map[String, SRef[_]] =
             ctx.subtypes.map { s =>
-              genericDerivationConfig.toEncodedSubtypeName(s.typeName) -> SRef(typeNameToSchemaName(s.typeName, s.annotations))
+              val schemaName = typeNameToSchemaName(s.typeName, s.annotations)
+              genericDerivationConfig.toEncodedSubtypeName(schemaName) -> SRef(schemaName)
             }.toMap
           baseCoproduct.addDiscriminatorField(
             FieldName(d),

--- a/core/src/main/scala-2/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
+++ b/core/src/main/scala-2/sttp/tapir/generic/internal/SchemaMagnoliaDerivation.scala
@@ -79,8 +79,16 @@ trait SchemaMagnoliaDerivation {
         ctx.split(t) { v => subtypesByName.get(typeNameToSchemaName(v.typeName, mergeAnnotations(v.annotations, v.inheritedAnnotations))) }
       )
       val coproduct = genericDerivationConfig.discriminator match {
-        case Some(d) => baseCoproduct.addDiscriminatorField(FieldName(d))
-        case None    => baseCoproduct
+        case Some(d) =>
+          val discriminatorMapping: Map[String, SRef[_]] =
+            ctx.subtypes.map { s =>
+              genericDerivationConfig.toEncodedSubtypeName(s.typeName) -> SRef(typeNameToSchemaName(s.typeName, s.annotations))
+            }.toMap
+          baseCoproduct.addDiscriminatorField(
+            FieldName(d),
+            discriminatorMapping = discriminatorMapping
+          )
+        case None => baseCoproduct
       }
       Schema(schemaType = coproduct, name = Some(typeNameToSchemaName(ctx.typeName, annotations)))
     }

--- a/core/src/main/scala/sttp/tapir/generic/Configuration.scala
+++ b/core/src/main/scala/sttp/tapir/generic/Configuration.scala
@@ -13,15 +13,15 @@ import java.util.regex.Pattern
   *   A function which, given the name of a subtype, returns the value of the discriminator field corresponding to that subtype. Used when
   *   creating [[sttp.tapir.SchemaType.SCoproduct]] schemas.
   */
-final case class Configuration(toEncodedName: String => String, discriminator: Option[String], toEncodedSubtypeName: SName => String) {
+final case class Configuration(toEncodedName: String => String, discriminator: Option[String], toDiscriminatorValue: SName => String) {
   def withSnakeCaseMemberNames: Configuration = copy(toEncodedName = Configuration.snakeCaseTransformation)
   def withKebabCaseMemberNames: Configuration = copy(toEncodedName = Configuration.kebabCaseTransformation)
   def withDiscriminator(d: String): Configuration = copy(discriminator = Some(d))
-  def withSnakeCaseSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.shortSnakeCaseSubtypeTransformation)
-  def withKebabCaseSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.shortKebabCaseSubtypeTransformation)
-  def withFullSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.fullIdentitySubtypeTransformation)
-  def withFullSnakeCaseSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.fullSnakeCaseSubtypeTransformation)
-  def withFullKebabCaseSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.fullKebabCaseSubtypeTransformation)
+  def withSnakeCaseDiscriminatorValues: Configuration = copy(toDiscriminatorValue = Configuration.shortSnakeCaseSubtypeTransformation)
+  def withKebabCaseDiscriminatorValues: Configuration = copy(toDiscriminatorValue = Configuration.shortKebabCaseSubtypeTransformation)
+  def withFullDiscriminatorValues: Configuration = copy(toDiscriminatorValue = Configuration.fullIdentitySubtypeTransformation)
+  def withFullSnakeCaseDiscriminatorValues: Configuration = copy(toDiscriminatorValue = Configuration.fullSnakeCaseSubtypeTransformation)
+  def withFullKebabCaseDiscriminatorValues: Configuration = copy(toDiscriminatorValue = Configuration.fullKebabCaseSubtypeTransformation)
 }
 
 object Configuration {

--- a/core/src/main/scala/sttp/tapir/generic/Configuration.scala
+++ b/core/src/main/scala/sttp/tapir/generic/Configuration.scala
@@ -9,7 +9,7 @@ import java.util.regex.Pattern
   *   class.
   * @param discriminator
   *   Encoded field name, whose value should be used to choose the appropriate subtype of a [[sttp.tapir.SchemaType.SCoproduct]].
-  * @param toEncodedSubtypeName
+  * @param toDiscriminatorValue
   *   A function which, given the name of a subtype, returns the value of the discriminator field corresponding to that subtype. Used when
   *   creating [[sttp.tapir.SchemaType.SCoproduct]] schemas.
   */

--- a/core/src/main/scala/sttp/tapir/generic/Configuration.scala
+++ b/core/src/main/scala/sttp/tapir/generic/Configuration.scala
@@ -1,14 +1,18 @@
- package sttp.tapir.generic
+package sttp.tapir.generic
+
+import sttp.tapir.Schema.SName
 
 import java.util.regex.Pattern
-import magnolia.TypeName
 
-final case class Configuration(toEncodedName: String => String, discriminator: Option[String], toEncodedSubtypeName: TypeName => String) {
+final case class Configuration(toEncodedName: String => String, discriminator: Option[String], toEncodedSubtypeName: SName => String) {
   def withSnakeCaseMemberNames: Configuration = copy(toEncodedName = Configuration.snakeCaseTransformation)
   def withKebabCaseMemberNames: Configuration = copy(toEncodedName = Configuration.kebabCaseTransformation)
   def withDiscriminator(d: String): Configuration = copy(discriminator = Some(d))
-  def withSnakeCaseSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.snakeCaseSubtypeTransformation)
-  def withKebabCaseSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.kebabCaseSubtypeTransformation)
+  def withSnakeCaseSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.shortSnakeCaseSubtypeTransformation)
+  def withKebabCaseSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.shortKebabCaseSubtypeTransformation)
+  def withFullSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.fullIdentitySubtypeTransformation)
+  def withFullSnakeCaseSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.fullSnakeCaseSubtypeTransformation)
+  def withFullKebabCaseSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.fullKebabCaseSubtypeTransformation)
 }
 
 object Configuration {
@@ -26,15 +30,24 @@ object Configuration {
     swapPattern.matcher(partial).replaceAll("$1-$2").toLowerCase
   }
 
-  private val identitySubtypeTransformation: TypeName => String =
-    _.short.stripSuffix("$")
+  private val fullIdentitySubtypeTransformation: SName => String =
+    _.fullName.stripSuffix("$")
 
-  private val snakeCaseSubtypeTransformation: TypeName => String =
-    ((t: TypeName) => t.short).andThen(snakeCaseTransformation).andThen(_.stripSuffix("$"))
+  private val fullSnakeCaseSubtypeTransformation: SName => String =
+    fullIdentitySubtypeTransformation.andThen(snakeCaseTransformation)
 
-  private val kebabCaseSubtypeTransformation: TypeName => String =
-    ((t: TypeName) => t.short).andThen(snakeCaseTransformation).andThen(_.stripSuffix("$"))
+  private val fullKebabCaseSubtypeTransformation: SName => String =
+    fullIdentitySubtypeTransformation.andThen(kebabCaseTransformation)
 
-  implicit val default: Configuration = Configuration(Predef.identity, None, identitySubtypeTransformation)
+  private val shortIdentitySubtypeTransformation: SName => String =
+    _.fullName.split('.').last.stripSuffix("$")
+
+  private val shortSnakeCaseSubtypeTransformation: SName => String =
+    shortIdentitySubtypeTransformation.andThen(snakeCaseTransformation)
+
+  private val shortKebabCaseSubtypeTransformation: SName => String =
+    shortIdentitySubtypeTransformation.andThen(kebabCaseTransformation)
+
+  implicit val default: Configuration = Configuration(Predef.identity, None, shortIdentitySubtypeTransformation)
 
 }

--- a/core/src/main/scala/sttp/tapir/generic/Configuration.scala
+++ b/core/src/main/scala/sttp/tapir/generic/Configuration.scala
@@ -1,15 +1,17 @@
-package sttp.tapir.generic
+ package sttp.tapir.generic
 
 import java.util.regex.Pattern
+import magnolia.TypeName
 
-final case class Configuration(toEncodedName: String => String, discriminator: Option[String]) {
+final case class Configuration(toEncodedName: String => String, discriminator: Option[String], toEncodedSubtypeName: TypeName => String) {
   def withSnakeCaseMemberNames: Configuration = copy(toEncodedName = Configuration.snakeCaseTransformation)
   def withKebabCaseMemberNames: Configuration = copy(toEncodedName = Configuration.kebabCaseTransformation)
   def withDiscriminator(d: String): Configuration = copy(discriminator = Some(d))
+  def withSnakeCaseSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.snakeCaseSubtypeTransformation)
+  def withKebabCaseSubtypeNames: Configuration = copy(toEncodedSubtypeName = Configuration.kebabCaseSubtypeTransformation)
 }
 
 object Configuration {
-  implicit val default: Configuration = Configuration(Predef.identity, None)
 
   private val basePattern: Pattern = Pattern.compile("([A-Z]+)([A-Z][a-z])")
   private val swapPattern: Pattern = Pattern.compile("([a-z\\d])([A-Z])")
@@ -23,4 +25,16 @@ object Configuration {
     val partial = basePattern.matcher(s).replaceAll("$1-$2")
     swapPattern.matcher(partial).replaceAll("$1-$2").toLowerCase
   }
+
+  private val identitySubtypeTransformation: TypeName => String =
+    _.short.stripSuffix("$")
+
+  private val snakeCaseSubtypeTransformation: TypeName => String =
+    ((t: TypeName) => t.short).andThen(snakeCaseTransformation).andThen(_.stripSuffix("$"))
+
+  private val kebabCaseSubtypeTransformation: TypeName => String =
+    ((t: TypeName) => t.short).andThen(snakeCaseTransformation).andThen(_.stripSuffix("$"))
+
+  implicit val default: Configuration = Configuration(Predef.identity, None, identitySubtypeTransformation)
+
 }

--- a/core/src/main/scala/sttp/tapir/generic/Configuration.scala
+++ b/core/src/main/scala/sttp/tapir/generic/Configuration.scala
@@ -4,6 +4,15 @@ import sttp.tapir.Schema.SName
 
 import java.util.regex.Pattern
 
+/** @param toEncodedName
+  *   A function which, given a field name of a case class, returns the encoded field name, as in the encoded representation of the case
+  *   class.
+  * @param discriminator
+  *   Encoded field name, whose value should be used to choose the appropriate subtype of a [[sttp.tapir.SchemaType.SCoproduct]].
+  * @param toEncodedSubtypeName
+  *   A function which, given the name of a subtype, returns the value of the discriminator field corresponding to that subtype. Used when
+  *   creating [[sttp.tapir.SchemaType.SCoproduct]] schemas.
+  */
 final case class Configuration(toEncodedName: String => String, discriminator: Option[String], toEncodedSubtypeName: SName => String) {
   def withSnakeCaseMemberNames: Configuration = copy(toEncodedName = Configuration.snakeCaseTransformation)
   def withKebabCaseMemberNames: Configuration = copy(toEncodedName = Configuration.kebabCaseTransformation)

--- a/core/src/test/scala/sttp/tapir/generic/SchemaGenericAutoTest.scala
+++ b/core/src/test/scala/sttp/tapir/generic/SchemaGenericAutoTest.scala
@@ -268,7 +268,7 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
   }
 
   it should "generate one-of schema using the given discriminator (kebab case subtype names)" in {
-    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withKebabCaseSubtypeNames
+    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withKebabCaseDiscriminatorValues
     val schemaType = implicitly[Schema[Entity]].schemaType
     schemaType shouldBe a[SCoproduct[Entity]]
 
@@ -312,7 +312,7 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
   }
 
   it should "generate one-of schema using the given discriminator (snake case subtype names)" in {
-    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withSnakeCaseSubtypeNames
+    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withSnakeCaseDiscriminatorValues
     val schemaType = implicitly[Schema[Entity]].schemaType
     schemaType shouldBe a[SCoproduct[Entity]]
 
@@ -356,7 +356,7 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
   }
 
   it should "generate one-of schema using the given discriminator (full subtype names)" in {
-    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withFullSubtypeNames
+    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withFullDiscriminatorValues
     val schemaType = implicitly[Schema[Entity]].schemaType
     schemaType shouldBe a[SCoproduct[Entity]]
 
@@ -400,7 +400,7 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
   }
 
   it should "generate one-of schema using the given discriminator (full kebab case subtype names)" in {
-    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withFullKebabCaseSubtypeNames
+    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withFullKebabCaseDiscriminatorValues
     val schemaType = implicitly[Schema[Entity]].schemaType
     schemaType shouldBe a[SCoproduct[Entity]]
 
@@ -444,7 +444,7 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
   }
 
   it should "generate one-of schema using the given discriminator (full snake case subtype names)" in {
-    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withFullSnakeCaseSubtypeNames
+    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withFullSnakeCaseDiscriminatorValues
     val schemaType = implicitly[Schema[Entity]].schemaType
     schemaType shouldBe a[SCoproduct[Entity]]
 

--- a/core/src/test/scala/sttp/tapir/generic/SchemaGenericAutoTest.scala
+++ b/core/src/test/scala/sttp/tapir/generic/SchemaGenericAutoTest.scala
@@ -269,37 +269,7 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
 
   it should "generate one-of schema using the given discriminator (kebab case subtype names)" in {
     implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withKebabCaseDiscriminatorValues
-    val schemaType = implicitly[Schema[Entity]].schemaType
-    schemaType shouldBe a[SCoproduct[Entity]]
-
-    schemaType.asInstanceOf[SCoproduct[Entity]].subtypes should contain theSameElementsAs List(
-      Schema(
-        SProduct[Organization](
-          List(field(FieldName("name"), Schema(SString())), field(FieldName("who_am_i"), Schema(SString())))
-        ),
-        Some(SName("sttp.tapir.generic.Organization"))
-      ),
-      Schema(
-        SProduct[Person](
-          List(
-            field(FieldName("first"), Schema(SString())),
-            field(FieldName("age"), Schema(SInteger())),
-            field(FieldName("who_am_i"), Schema(SString()))
-          )
-        ),
-        Some(SName("sttp.tapir.generic.Person"))
-      ),
-      Schema(
-        SProduct[UnknownEntity.type](
-          List(
-            field(FieldName("who_am_i"), Schema(SString()))
-          )
-        ),
-        Some(SName("sttp.tapir.generic.UnknownEntity"))
-      )
-    )
-
-    schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
+    implicitly[Schema[Entity]].schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
       SDiscriminator(
         FieldName("who_am_i"),
         Map(
@@ -313,37 +283,7 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
 
   it should "generate one-of schema using the given discriminator (snake case subtype names)" in {
     implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withSnakeCaseDiscriminatorValues
-    val schemaType = implicitly[Schema[Entity]].schemaType
-    schemaType shouldBe a[SCoproduct[Entity]]
-
-    schemaType.asInstanceOf[SCoproduct[Entity]].subtypes should contain theSameElementsAs List(
-      Schema(
-        SProduct[Organization](
-          List(field(FieldName("name"), Schema(SString())), field(FieldName("who_am_i"), Schema(SString())))
-        ),
-        Some(SName("sttp.tapir.generic.Organization"))
-      ),
-      Schema(
-        SProduct[Person](
-          List(
-            field(FieldName("first"), Schema(SString())),
-            field(FieldName("age"), Schema(SInteger())),
-            field(FieldName("who_am_i"), Schema(SString()))
-          )
-        ),
-        Some(SName("sttp.tapir.generic.Person"))
-      ),
-      Schema(
-        SProduct[UnknownEntity.type](
-          List(
-            field(FieldName("who_am_i"), Schema(SString()))
-          )
-        ),
-        Some(SName("sttp.tapir.generic.UnknownEntity"))
-      )
-    )
-
-    schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
+    implicitly[Schema[Entity]].schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
       SDiscriminator(
         FieldName("who_am_i"),
         Map(
@@ -357,37 +297,7 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
 
   it should "generate one-of schema using the given discriminator (full subtype names)" in {
     implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withFullDiscriminatorValues
-    val schemaType = implicitly[Schema[Entity]].schemaType
-    schemaType shouldBe a[SCoproduct[Entity]]
-
-    schemaType.asInstanceOf[SCoproduct[Entity]].subtypes should contain theSameElementsAs List(
-      Schema(
-        SProduct[Organization](
-          List(field(FieldName("name"), Schema(SString())), field(FieldName("who_am_i"), Schema(SString())))
-        ),
-        Some(SName("sttp.tapir.generic.Organization"))
-      ),
-      Schema(
-        SProduct[Person](
-          List(
-            field(FieldName("first"), Schema(SString())),
-            field(FieldName("age"), Schema(SInteger())),
-            field(FieldName("who_am_i"), Schema(SString()))
-          )
-        ),
-        Some(SName("sttp.tapir.generic.Person"))
-      ),
-      Schema(
-        SProduct[UnknownEntity.type](
-          List(
-            field(FieldName("who_am_i"), Schema(SString()))
-          )
-        ),
-        Some(SName("sttp.tapir.generic.UnknownEntity"))
-      )
-    )
-
-    schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
+    implicitly[Schema[Entity]].schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
       SDiscriminator(
         FieldName("who_am_i"),
         Map(
@@ -401,37 +311,7 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
 
   it should "generate one-of schema using the given discriminator (full kebab case subtype names)" in {
     implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withFullKebabCaseDiscriminatorValues
-    val schemaType = implicitly[Schema[Entity]].schemaType
-    schemaType shouldBe a[SCoproduct[Entity]]
-
-    schemaType.asInstanceOf[SCoproduct[Entity]].subtypes should contain theSameElementsAs List(
-      Schema(
-        SProduct[Organization](
-          List(field(FieldName("name"), Schema(SString())), field(FieldName("who_am_i"), Schema(SString())))
-        ),
-        Some(SName("sttp.tapir.generic.Organization"))
-      ),
-      Schema(
-        SProduct[Person](
-          List(
-            field(FieldName("first"), Schema(SString())),
-            field(FieldName("age"), Schema(SInteger())),
-            field(FieldName("who_am_i"), Schema(SString()))
-          )
-        ),
-        Some(SName("sttp.tapir.generic.Person"))
-      ),
-      Schema(
-        SProduct[UnknownEntity.type](
-          List(
-            field(FieldName("who_am_i"), Schema(SString()))
-          )
-        ),
-        Some(SName("sttp.tapir.generic.UnknownEntity"))
-      )
-    )
-
-    schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
+    implicitly[Schema[Entity]].schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
       SDiscriminator(
         FieldName("who_am_i"),
         Map(
@@ -445,37 +325,7 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
 
   it should "generate one-of schema using the given discriminator (full snake case subtype names)" in {
     implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withFullSnakeCaseDiscriminatorValues
-    val schemaType = implicitly[Schema[Entity]].schemaType
-    schemaType shouldBe a[SCoproduct[Entity]]
-
-    schemaType.asInstanceOf[SCoproduct[Entity]].subtypes should contain theSameElementsAs List(
-      Schema(
-        SProduct[Organization](
-          List(field(FieldName("name"), Schema(SString())), field(FieldName("who_am_i"), Schema(SString())))
-        ),
-        Some(SName("sttp.tapir.generic.Organization"))
-      ),
-      Schema(
-        SProduct[Person](
-          List(
-            field(FieldName("first"), Schema(SString())),
-            field(FieldName("age"), Schema(SInteger())),
-            field(FieldName("who_am_i"), Schema(SString()))
-          )
-        ),
-        Some(SName("sttp.tapir.generic.Person"))
-      ),
-      Schema(
-        SProduct[UnknownEntity.type](
-          List(
-            field(FieldName("who_am_i"), Schema(SString()))
-          )
-        ),
-        Some(SName("sttp.tapir.generic.UnknownEntity"))
-      )
-    )
-
-    schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
+    implicitly[Schema[Entity]].schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
       SDiscriminator(
         FieldName("who_am_i"),
         Map(

--- a/core/src/test/scala/sttp/tapir/generic/SchemaGenericAutoTest.scala
+++ b/core/src/test/scala/sttp/tapir/generic/SchemaGenericAutoTest.scala
@@ -244,6 +244,14 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
           )
         ),
         Some(SName("sttp.tapir.generic.Person"))
+      ),
+      Schema(
+        SProduct[UnknownEntity.type](
+          List(
+            field(FieldName("who_am_i"), Schema(SString()))
+          )
+        ),
+        Some(SName("sttp.tapir.generic.UnknownEntity"))
       )
     )
 
@@ -252,7 +260,228 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
         FieldName("who_am_i"),
         Map(
           "Organization" -> SRef(SName("sttp.tapir.generic.Organization")),
-          "Person" -> SRef(SName("sttp.tapir.generic.Person"))
+          "Person" -> SRef(SName("sttp.tapir.generic.Person")),
+          "UnknownEntity" -> SRef(SName("sttp.tapir.generic.UnknownEntity"))
+        )
+      )
+    )
+  }
+
+  it should "generate one-of schema using the given discriminator (kebab case subtype names)" in {
+    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withKebabCaseSubtypeNames
+    val schemaType = implicitly[Schema[Entity]].schemaType
+    schemaType shouldBe a[SCoproduct[Entity]]
+
+    schemaType.asInstanceOf[SCoproduct[Entity]].subtypes should contain theSameElementsAs List(
+      Schema(
+        SProduct[Organization](
+          List(field(FieldName("name"), Schema(SString())), field(FieldName("who_am_i"), Schema(SString())))
+        ),
+        Some(SName("sttp.tapir.generic.Organization"))
+      ),
+      Schema(
+        SProduct[Person](
+          List(
+            field(FieldName("first"), Schema(SString())),
+            field(FieldName("age"), Schema(SInteger())),
+            field(FieldName("who_am_i"), Schema(SString()))
+          )
+        ),
+        Some(SName("sttp.tapir.generic.Person"))
+      ),
+      Schema(
+        SProduct[UnknownEntity.type](
+          List(
+            field(FieldName("who_am_i"), Schema(SString()))
+          )
+        ),
+        Some(SName("sttp.tapir.generic.UnknownEntity"))
+      )
+    )
+
+    schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
+      SDiscriminator(
+        FieldName("who_am_i"),
+        Map(
+          "organization" -> SRef(SName("sttp.tapir.generic.Organization")),
+          "person" -> SRef(SName("sttp.tapir.generic.Person")),
+          "unknown-entity" -> SRef(SName("sttp.tapir.generic.UnknownEntity"))
+        )
+      )
+    )
+  }
+
+  it should "generate one-of schema using the given discriminator (snake case subtype names)" in {
+    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withSnakeCaseSubtypeNames
+    val schemaType = implicitly[Schema[Entity]].schemaType
+    schemaType shouldBe a[SCoproduct[Entity]]
+
+    schemaType.asInstanceOf[SCoproduct[Entity]].subtypes should contain theSameElementsAs List(
+      Schema(
+        SProduct[Organization](
+          List(field(FieldName("name"), Schema(SString())), field(FieldName("who_am_i"), Schema(SString())))
+        ),
+        Some(SName("sttp.tapir.generic.Organization"))
+      ),
+      Schema(
+        SProduct[Person](
+          List(
+            field(FieldName("first"), Schema(SString())),
+            field(FieldName("age"), Schema(SInteger())),
+            field(FieldName("who_am_i"), Schema(SString()))
+          )
+        ),
+        Some(SName("sttp.tapir.generic.Person"))
+      ),
+      Schema(
+        SProduct[UnknownEntity.type](
+          List(
+            field(FieldName("who_am_i"), Schema(SString()))
+          )
+        ),
+        Some(SName("sttp.tapir.generic.UnknownEntity"))
+      )
+    )
+
+    schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
+      SDiscriminator(
+        FieldName("who_am_i"),
+        Map(
+          "organization" -> SRef(SName("sttp.tapir.generic.Organization")),
+          "person" -> SRef(SName("sttp.tapir.generic.Person")),
+          "unknown_entity" -> SRef(SName("sttp.tapir.generic.UnknownEntity"))
+        )
+      )
+    )
+  }
+
+  it should "generate one-of schema using the given discriminator (full subtype names)" in {
+    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withFullSubtypeNames
+    val schemaType = implicitly[Schema[Entity]].schemaType
+    schemaType shouldBe a[SCoproduct[Entity]]
+
+    schemaType.asInstanceOf[SCoproduct[Entity]].subtypes should contain theSameElementsAs List(
+      Schema(
+        SProduct[Organization](
+          List(field(FieldName("name"), Schema(SString())), field(FieldName("who_am_i"), Schema(SString())))
+        ),
+        Some(SName("sttp.tapir.generic.Organization"))
+      ),
+      Schema(
+        SProduct[Person](
+          List(
+            field(FieldName("first"), Schema(SString())),
+            field(FieldName("age"), Schema(SInteger())),
+            field(FieldName("who_am_i"), Schema(SString()))
+          )
+        ),
+        Some(SName("sttp.tapir.generic.Person"))
+      ),
+      Schema(
+        SProduct[UnknownEntity.type](
+          List(
+            field(FieldName("who_am_i"), Schema(SString()))
+          )
+        ),
+        Some(SName("sttp.tapir.generic.UnknownEntity"))
+      )
+    )
+
+    schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
+      SDiscriminator(
+        FieldName("who_am_i"),
+        Map(
+          "sttp.tapir.generic.Organization" -> SRef(SName("sttp.tapir.generic.Organization")),
+          "sttp.tapir.generic.Person" -> SRef(SName("sttp.tapir.generic.Person")),
+          "sttp.tapir.generic.UnknownEntity" -> SRef(SName("sttp.tapir.generic.UnknownEntity"))
+        )
+      )
+    )
+  }
+
+  it should "generate one-of schema using the given discriminator (full kebab case subtype names)" in {
+    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withFullKebabCaseSubtypeNames
+    val schemaType = implicitly[Schema[Entity]].schemaType
+    schemaType shouldBe a[SCoproduct[Entity]]
+
+    schemaType.asInstanceOf[SCoproduct[Entity]].subtypes should contain theSameElementsAs List(
+      Schema(
+        SProduct[Organization](
+          List(field(FieldName("name"), Schema(SString())), field(FieldName("who_am_i"), Schema(SString())))
+        ),
+        Some(SName("sttp.tapir.generic.Organization"))
+      ),
+      Schema(
+        SProduct[Person](
+          List(
+            field(FieldName("first"), Schema(SString())),
+            field(FieldName("age"), Schema(SInteger())),
+            field(FieldName("who_am_i"), Schema(SString()))
+          )
+        ),
+        Some(SName("sttp.tapir.generic.Person"))
+      ),
+      Schema(
+        SProduct[UnknownEntity.type](
+          List(
+            field(FieldName("who_am_i"), Schema(SString()))
+          )
+        ),
+        Some(SName("sttp.tapir.generic.UnknownEntity"))
+      )
+    )
+
+    schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
+      SDiscriminator(
+        FieldName("who_am_i"),
+        Map(
+          "sttp.tapir.generic.organization" -> SRef(SName("sttp.tapir.generic.Organization")),
+          "sttp.tapir.generic.person" -> SRef(SName("sttp.tapir.generic.Person")),
+          "sttp.tapir.generic.unknown-entity" -> SRef(SName("sttp.tapir.generic.UnknownEntity"))
+        )
+      )
+    )
+  }
+
+  it should "generate one-of schema using the given discriminator (full snake case subtype names)" in {
+    implicit val customConf: Configuration = Configuration.default.withDiscriminator("who_am_i").withFullSnakeCaseSubtypeNames
+    val schemaType = implicitly[Schema[Entity]].schemaType
+    schemaType shouldBe a[SCoproduct[Entity]]
+
+    schemaType.asInstanceOf[SCoproduct[Entity]].subtypes should contain theSameElementsAs List(
+      Schema(
+        SProduct[Organization](
+          List(field(FieldName("name"), Schema(SString())), field(FieldName("who_am_i"), Schema(SString())))
+        ),
+        Some(SName("sttp.tapir.generic.Organization"))
+      ),
+      Schema(
+        SProduct[Person](
+          List(
+            field(FieldName("first"), Schema(SString())),
+            field(FieldName("age"), Schema(SInteger())),
+            field(FieldName("who_am_i"), Schema(SString()))
+          )
+        ),
+        Some(SName("sttp.tapir.generic.Person"))
+      ),
+      Schema(
+        SProduct[UnknownEntity.type](
+          List(
+            field(FieldName("who_am_i"), Schema(SString()))
+          )
+        ),
+        Some(SName("sttp.tapir.generic.UnknownEntity"))
+      )
+    )
+
+    schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
+      SDiscriminator(
+        FieldName("who_am_i"),
+        Map(
+          "sttp.tapir.generic.organization" -> SRef(SName("sttp.tapir.generic.Organization")),
+          "sttp.tapir.generic.person" -> SRef(SName("sttp.tapir.generic.Person")),
+          "sttp.tapir.generic.unknown_entity" -> SRef(SName("sttp.tapir.generic.UnknownEntity"))
         )
       )
     )
@@ -387,3 +616,4 @@ case class JList(data: List[IList])
 sealed trait Entity
 case class Person(first: String, age: Int) extends Entity
 case class Organization(name: String) extends Entity
+case object UnknownEntity extends Entity

--- a/core/src/test/scala/sttp/tapir/generic/SchemaGenericAutoTest.scala
+++ b/core/src/test/scala/sttp/tapir/generic/SchemaGenericAutoTest.scala
@@ -247,7 +247,15 @@ class SchemaGenericAutoTest extends AsyncFlatSpec with Matchers {
       )
     )
 
-    schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(SDiscriminator(FieldName("who_am_i"), Map.empty))
+    schemaType.asInstanceOf[SCoproduct[Entity]].discriminator shouldBe Some(
+      SDiscriminator(
+        FieldName("who_am_i"),
+        Map(
+          "Organization" -> SRef(SName("sttp.tapir.generic.Organization")),
+          "Person" -> SRef(SName("sttp.tapir.generic.Person"))
+        )
+      )
+    )
   }
 
   it should "find schema for subtypes containing parent metadata from annotations" in {


### PR DESCRIPTION
Without `discriminatorMapping` the OpenAPI generator can't make sense of the schema and fails.

---

I'm not sure if adding fields to `Configuration` was a right call – this breaks bin-compat, but I can re-work things here to re-use `toEncodedName` (and deal with the `$` suffix on the call site).