### PR TITLE
Move task cancelation on blocking pool

### DIFF
--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/VertxCatsServerOptions.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/VertxCatsServerOptions.scala
@@ -32,7 +32,7 @@ object VertxCatsServerOptions {
       createOptions = (ci: CustomInterceptors[F, VertxCatsServerOptions[F]]) =>
         VertxCatsServerOptions(
           dispatcher,
-          Defaults.createTempFile().getParentFile.getAbsoluteFile,
+          VertxServerOptions.uploadDirectory(),
           file => Sync[F].delay(Defaults.deleteFile()(file)),
           maxQueueSizeForReadStream = 16,
           ci.interceptors

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/VertxFutureServerOptions.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/VertxFutureServerOptions.scala
@@ -36,7 +36,7 @@ object VertxFutureServerOptions {
     CustomInterceptors(
       createOptions = (ci: CustomInterceptors[Future, VertxFutureServerOptions]) =>
         VertxFutureServerOptions(
-          Defaults.createTempFile().getParentFile.getAbsoluteFile,
+          VertxServerOptions.uploadDirectory(),
           defaultDeleteFile,
           ci.interceptors,
           None

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/VertxServerOptions.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/VertxServerOptions.scala
@@ -22,4 +22,7 @@ object VertxServerOptions {
       case None     => log.info(msg, Nil: _*)
       case Some(ex) => log.info(s"$msg; exception: {}", ex)
     }
+
+  private[vertx] def uploadDirectory(): TapirFile =
+    new java.io.File(System.getProperty("java.io.tmpdir")).getAbsoluteFile
 }

--- a/server/vertx/src/main/scala/sttp/tapir/server/vertx/VertxZioServerOptions.scala
+++ b/server/vertx/src/main/scala/sttp/tapir/server/vertx/VertxZioServerOptions.scala
@@ -26,7 +26,7 @@ object VertxZioServerOptions {
     CustomInterceptors(
       createOptions = (ci: CustomInterceptors[RIO[R, *], VertxZioServerOptions[RIO[R, *]]]) =>
         VertxZioServerOptions(
-          Defaults.createTempFile().getParentFile.getAbsoluteFile,
+          VertxServerOptions.uploadDirectory(),
           file => Task[Unit](Defaults.deleteFile()(file)),
           maxQueueSizeForReadStream = 16,
           ci.interceptors


### PR DESCRIPTION
Now task cancelation is executed on main vertx pool. But task cancelation may be blocking operation. Here is such example:
```scala
import zio._
import zio.blocking.Blocking

val task =
   for {
     blocking <- ZIO.service[Blocking.Service]
     _ <- blocking.effectBlocking({
       println(Thread.currentThread().getName())
       Thread.sleep(5000)
       println("end")
     })
  } yield ()

val runtime = Runtime.default

val canceler = runtime.unsafeRunAsyncCancelable(task) { _ => () }

canceler(Fiber.Id.None) // this call is blocked by Thread.sleep(5000)
```

So interrupting of several tasks may block main vertx pool and leads to following warnings
```
Thread Thread[vert.x-eventloop-thread-1,5,zio-default-async] has been blocked for 6381 ms, time limit is 2000 ms
```

So it is better to execute this operation on blocking pool.