### PR TITLE
Simplify the extractTreeAndOptTreeFromAnnotation method

### DIFF
--- a/core/src/main/scala-2/sttp/tapir/generic/internal/EndpointAnnotationsMacro.scala
+++ b/core/src/main/scala-2/sttp/tapir/generic/internal/EndpointAnnotationsMacro.scala
@@ -142,8 +142,8 @@ abstract class EndpointAnnotationsMacro(val c: blackbox.Context) {
           .fold(i)(encodedExample => q"$i.schema(_.encodedExample($encodedExample))"),
       i =>
         util
-          .extractTreeAndOptTreeFromAnnotation(field, schemaDefaultType)
-          .fold(i)(default => q"$i.default(${default._1})"),
+          .extractFirstTreeArgFromAnnotation(field, schemaDefaultType)
+          .fold(i)(default => q"$i.default($default)"),
       i =>
         util
           .extractStringArgFromAnnotation(field, schemaFormatType)

--- a/core/src/main/scala-2/sttp/tapir/internal/CaseClassUtil.scala
+++ b/core/src/main/scala-2/sttp/tapir/internal/CaseClassUtil.scala
@@ -71,14 +71,12 @@ private[tapir] class CaseClassUtil[C <: blackbox.Context, T: C#WeakTypeTag](val 
     }
   }
 
-  def extractTreeAndOptTreeFromAnnotation(field: Symbol, annotationType: c.Type): Option[(Tree, Tree)] = {
+  def extractFirstTreeArgFromAnnotation(field: Symbol, annotationType: c.Type): Option[Tree] = {
     field.annotations.collectFirst {
       case a if a.tree.tpe <:< annotationType =>
         a.tree.children.tail match {
-          case List(t, u @ Apply(TypeApply(name @ Select(_, _), List(TypeTree())), List(_))) if name.toString.startsWith("scala.Some.apply") => (t, u)
-          case List(t, u @ Select(_, _)) if u.toString.startsWith("scala.None") => (t, u)
-          case List(t, TypeApply(Select(_, name @ TermName(_)), List(TypeTree()))) if name.decodedName.toString.startsWith("<init>$default") => (t, q"None")
-          case _       => throw new IllegalStateException(s"Cannot extract annotation argument from: ${c.universe.showRaw(a.tree)}")
+          case List(t, _*) => t
+          case _           => throw new IllegalStateException(s"Cannot extract annotation argument from: ${c.universe.showRaw(a.tree)}")
         }
     }
   }

--- a/core/src/main/scala-3/sttp/tapir/internal/AnnotationsMacros.scala
+++ b/core/src/main/scala-3/sttp/tapir/internal/AnnotationsMacros.scala
@@ -376,8 +376,8 @@ class AnnotationsMacros[T <: Product: Type](using q: Quotes) {
           .getOrElse(t),
       t =>
         field
-          .extractTreeAndOptTreeFromAnnotation(schemaDefaultAnnotationSymbol)
-          .map(d => addMetadataToAtom(field, t, '{ i => i.default(${ d._1.asExprOf[f] }) }))
+          .extractFirstTreeArgFromAnnotation(schemaDefaultAnnotationSymbol)
+          .map(d => addMetadataToAtom(field, t, '{ i => i.default(${ d.asExprOf[f] }) }))
           .getOrElse(t),
       t =>
         field

--- a/core/src/main/scala-3/sttp/tapir/internal/CaseClass.scala
+++ b/core/src/main/scala-3/sttp/tapir/internal/CaseClass.scala
@@ -87,12 +87,8 @@ class CaseClassField[Q <: Quotes, T](using val q: Q, t: Type[T])(
     case _ => report.throwError(s"Cannot extract annotation: @${annSymbol.name}, from field: ${symbol.name}, of type: ${Type.show[T]}")
   }
 
-  def extractTreeAndOptTreeFromAnnotation(annSymbol: Symbol): Option[(Tree, Tree)] = constructorField.getAnnotation(annSymbol).map {
-    case Apply(_, List(t, TypeApply(Select(_, "$lessinit$greater$default$2"), _))) => (t, '{ None }.asTerm)
-    case Apply(_, List(t, u @ Ident("None"))) => (t, u)
-    case Apply(_, List(t, NamedArg(_, u @ Ident("None")))) => (t, u)
-    case Apply(_, List(t, u @ Apply(TypeApply(name @ Select(Ident("Some"), "apply"), List(_)), List(_)))) => (t, u)
-    case Apply(_, List(t, NamedArg(_, u @ Apply(TypeApply(name @ Select(Ident("Some"), "apply"), List(_)), List(_))))) => (t, u)
+  def extractFirstTreeArgFromAnnotation(annSymbol: Symbol): Option[Tree] = constructorField.getAnnotation(annSymbol).map {
+    case Apply(_, List(t, _*)) => t
     case _ => report.throwError(s"Cannot extract annotation: @${annSymbol.name}, from field: ${symbol.name}, of type: ${Type.show[T]}")
   }
 


### PR DESCRIPTION
Replace the method with simpler pattern matching.