### PR TITLE
Allow full customization of interceptors in tests

### DIFF
--- a/server/armeria-server/cats/src/test/scala/sttp/tapir/server/armeria/cats/ArmeriaCatsTestServerInterpreter.scala
+++ b/server/armeria-server/cats/src/test/scala/sttp/tapir/server/armeria/cats/ArmeriaCatsTestServerInterpreter.scala
@@ -5,27 +5,12 @@ import cats.effect.std.Dispatcher
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.armeria.{ArmeriaTestServerInterpreter, TapirService}
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 
-class ArmeriaCatsTestServerInterpreter(dispatcher: Dispatcher[IO]) extends ArmeriaTestServerInterpreter[Fs2Streams[IO], IO] {
+class ArmeriaCatsTestServerInterpreter(dispatcher: Dispatcher[IO])
+    extends ArmeriaTestServerInterpreter[Fs2Streams[IO], IO, ArmeriaCatsServerOptions[IO]] {
 
-  override def route(
-      e: ServerEndpoint[Fs2Streams[IO], IO],
-      decodeFailureHandler: Option[DecodeFailureHandler],
-      metricsInterceptor: Option[MetricsRequestInterceptor[IO]] = None
-  ): TapirService[Fs2Streams[IO], IO] = {
-    val options: ArmeriaCatsServerOptions[IO] = {
-      ArmeriaCatsServerOptions
-        .customInterceptors[IO](dispatcher)
-        .metricsInterceptor(metricsInterceptor)
-        .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-        .options
-    }
-    ArmeriaCatsServerInterpreter(options).toService(e)
-  }
-
-  override def route(es: List[ServerEndpoint[Fs2Streams[IO], IO]]): TapirService[Fs2Streams[IO], IO] = {
-    ArmeriaCatsServerInterpreter(dispatcher).toService(es)
+  override def route(es: List[ServerEndpoint[Fs2Streams[IO], IO]], interceptors: Interceptors): TapirService[Fs2Streams[IO], IO] = {
+    val options: ArmeriaCatsServerOptions[IO] = interceptors(ArmeriaCatsServerOptions.customInterceptors[IO](dispatcher)).options
+    ArmeriaCatsServerInterpreter(options).toService(es)
   }
 }

--- a/server/armeria-server/src/test/scala/sttp/tapir/server/armeria/ArmeriaTestFutureServerInterpreter.scala
+++ b/server/armeria-server/src/test/scala/sttp/tapir/server/armeria/ArmeriaTestFutureServerInterpreter.scala
@@ -1,25 +1,14 @@
 package sttp.tapir.server.armeria
 
-import scala.concurrent.Future
 import sttp.capabilities.armeria.ArmeriaStreams
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 
-class ArmeriaTestFutureServerInterpreter extends ArmeriaTestServerInterpreter[ArmeriaStreams, Future] {
+import scala.concurrent.Future
 
-  override def route(
-      e: ServerEndpoint[ArmeriaStreams, Future],
-      decodeFailureHandler: Option[DecodeFailureHandler] = None,
-      metricsInterceptor: Option[MetricsRequestInterceptor[Future]] = None
-  ): TapirService[ArmeriaStreams, Future] = {
-    val serverOptions: ArmeriaFutureServerOptions = ArmeriaFutureServerOptions.customInterceptors
-      .metricsInterceptor(metricsInterceptor)
-      .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-      .options
-    ArmeriaFutureServerInterpreter(serverOptions).toService(e)
+class ArmeriaTestFutureServerInterpreter extends ArmeriaTestServerInterpreter[ArmeriaStreams, Future, ArmeriaFutureServerOptions] {
+
+  override def route(es: List[ServerEndpoint[ArmeriaStreams, Future]], interceptors: Interceptors): TapirService[ArmeriaStreams, Future] = {
+    val serverOptions: ArmeriaFutureServerOptions = interceptors(ArmeriaFutureServerOptions.customInterceptors).options
+    ArmeriaFutureServerInterpreter(serverOptions).toService(es)
   }
-
-  override def route(es: List[ServerEndpoint[ArmeriaStreams, Future]]): TapirService[ArmeriaStreams, Future] =
-    ArmeriaFutureServerInterpreter().toService(es)
 }

--- a/server/armeria-server/src/test/scala/sttp/tapir/server/armeria/ArmeriaTestServerInterpreter.scala
+++ b/server/armeria-server/src/test/scala/sttp/tapir/server/armeria/ArmeriaTestServerInterpreter.scala
@@ -7,7 +7,7 @@ import sttp.capabilities.Streams
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 
-trait ArmeriaTestServerInterpreter[S <: Streams[S], F[_]] extends TestServerInterpreter[F, S, TapirService[S, F]] {
+trait ArmeriaTestServerInterpreter[S <: Streams[S], F[_], OPTIONS] extends TestServerInterpreter[F, S, OPTIONS, TapirService[S, F]] {
 
   override def server(routes: NonEmptyList[TapirService[S, F]]): Resource[IO, Port] = {
     val bind = IO.fromCompletableFuture(

--- a/server/armeria-server/zio/src/test/scala/sttp/tapir/server/armeria/zio/ArmeriaZioTestServerInterpreter.scala
+++ b/server/armeria-server/zio/src/test/scala/sttp/tapir/server/armeria/zio/ArmeriaZioTestServerInterpreter.scala
@@ -4,28 +4,13 @@ import _root_.zio.{Runtime, Task}
 import sttp.capabilities.zio.ZioStreams
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.armeria.{ArmeriaTestServerInterpreter, TapirService}
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 
-class ArmeriaZioTestServerInterpreter extends ArmeriaTestServerInterpreter[ZioStreams, Task] {
+class ArmeriaZioTestServerInterpreter extends ArmeriaTestServerInterpreter[ZioStreams, Task, ArmeriaZioServerOptions[Task]] {
   import ArmeriaZioTestServerInterpreter._
 
-  override def route(
-      e: ServerEndpoint[ZioStreams, Task],
-      decodeFailureHandler: Option[DecodeFailureHandler],
-      metricsInterceptor: Option[MetricsRequestInterceptor[Task]] = None
-  ): TapirService[ZioStreams, Task] = {
-    val options: ArmeriaZioServerOptions[Task] = {
-      ArmeriaZioServerOptions.customInterceptors
-        .metricsInterceptor(metricsInterceptor)
-        .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-        .options
-    }
-    ArmeriaZioServerInterpreter(options).toService(e)
-  }
-
-  override def route(es: List[ServerEndpoint[ZioStreams, Task]]): TapirService[ZioStreams, Task] = {
-    ArmeriaZioServerInterpreter[Any]().toService(es)
+  override def route(es: List[ServerEndpoint[ZioStreams, Task]], interceptors: Interceptors): TapirService[ZioStreams, Task] = {
+    val options: ArmeriaZioServerOptions[Task] = interceptors(ArmeriaZioServerOptions.customInterceptors).options
+    ArmeriaZioServerInterpreter(options).toService(es)
   }
 }
 

--- a/server/finatra-server/finatra-server-cats/src/main/scala/sttp/tapir/server/finatra/cats/FinatraCatsServerInterpreter.scala
+++ b/server/finatra-server/finatra-server-cats/src/main/scala/sttp/tapir/server/finatra/cats/FinatraCatsServerInterpreter.scala
@@ -2,60 +2,72 @@ package sttp.tapir.server.finatra.cats
 
 import cats.effect.Async
 import cats.effect.std.Dispatcher
+import cats.~>
 import com.twitter.inject.Logging
-import com.twitter.util.{Future, Promise}
-import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.finatra.{FinatraRoute, FinatraServerInterpreter, FinatraServerOptions}
+import com.twitter.util.Future
+import sttp.monad.MonadError
 import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.finatra.FinatraServerInterpreter.FutureMonadError
+import sttp.tapir.server.finatra.cats.FinatraCatsServerInterpreter._
+import sttp.tapir.server.finatra.{FinatraRoute, FinatraServerInterpreter, FinatraServerOptions}
+import sttp.tapir.server.interceptor.{
+  DecodeFailureContext,
+  DecodeSuccessContext,
+  EndpointHandler,
+  EndpointInterceptor,
+  Interceptor,
+  RequestHandler,
+  RequestInterceptor,
+  RequestResult,
+  Responder,
+  SecurityFailureContext,
+  ServerResponseFromOutput,
+  ValuedEndpointOutput
+}
+import sttp.tapir.server.interpreter.BodyListener
+import sttp.tapir.{Endpoint, TapirFile}
 
-import scala.concurrent.{ExecutionContext, Future => ScalaFuture}
-import scala.util.{Failure, Success}
+import scala.util.Try
+
+import sttp.tapir.server.finatra.cats.conversions._
 
 trait FinatraCatsServerInterpreter[F[_]] extends Logging {
 
   implicit def fa: Async[F]
 
+  private implicit val fme: MonadError[F] = new CatsMonadError[F]
+
   def finatraCatsServerOptions: FinatraCatsServerOptions[F]
 
-  def toRoute(
-      e: ServerEndpoint[Any, F]
-  ): FinatraRoute = {
+  def toRoute(e: ServerEndpoint[Any, F]): FinatraRoute = {
+    implicit val dispatcher = finatraCatsServerOptions.dispatcher
+    val finatraCreateFile: Array[Byte] => Future[TapirFile] = bytes => finatraCatsServerOptions.createFile(bytes).asTwitterFuture
+    val finatraDeleteFile: TapirFile => Future[Unit] = file => finatraCatsServerOptions.deleteFile(file).asTwitterFuture
+    val interceptors = finatraCatsServerOptions.interceptors.map(convertInterceptor(_))
+
     FinatraServerInterpreter(
-      FinatraServerOptions(finatraCatsServerOptions.createFile, finatraCatsServerOptions.deleteFile, finatraCatsServerOptions.interceptors)
+      FinatraServerOptions(finatraCreateFile, finatraDeleteFile, interceptors)
     ).toRoute(
       e.endpoint
-        .serverSecurityLogic { a =>
-          val scalaFutureResult = finatraCatsServerOptions.dispatcher.unsafeToFuture(e.securityLogic(new CatsMonadError[F])(a))
-          scalaFutureResult.asTwitter(cats.effect.unsafe.implicits.global.compute)
-        }
+        .serverSecurityLogic(e.securityLogic(new CatsMonadError[F])(_).asTwitterFuture)
         .serverLogic { u => i =>
-          val scalaFutureResult = finatraCatsServerOptions.dispatcher.unsafeToFuture(e.logic(new CatsMonadError[F])(u)(i))
-          scalaFutureResult.asTwitter(cats.effect.unsafe.implicits.global.compute)
+          e.logic(new CatsMonadError[F])(u)(i).asTwitterFuture
         }
     )
-  }
-
-  /** Convert from a Scala Future to a Twitter Future Source: https://twitter.github.io/util/guide/util-cookbook/futures.html
-    */
-  private implicit class RichScalaFuture[A](val sf: ScalaFuture[A]) {
-    def asTwitter(implicit e: ExecutionContext): Future[A] = {
-      val promise: Promise[A] = new Promise[A]()
-      sf.onComplete {
-        case Success(value)     => promise.setValue(value)
-        case Failure(exception) => promise.setException(exception)
-      }
-      promise
-    }
   }
 }
 
 object FinatraCatsServerInterpreter {
+  private type RequestHandlerLogic[F[_], B] = EndpointInterceptor[F] => RequestHandler[F, B]
+
   def apply[F[_]](
       dispatcher: Dispatcher[F]
   )(implicit _fa: Async[F]): FinatraCatsServerInterpreter[F] = {
     new FinatraCatsServerInterpreter[F] {
       override implicit def fa: Async[F] = _fa
-      override def finatraCatsServerOptions: FinatraCatsServerOptions[F] = FinatraCatsServerOptions.default(dispatcher)
+      override def finatraCatsServerOptions: FinatraCatsServerOptions[F] = FinatraCatsServerOptions.default(dispatcher)(_fa)
     }
   }
 
@@ -63,6 +75,121 @@ object FinatraCatsServerInterpreter {
     new FinatraCatsServerInterpreter[F] {
       override implicit def fa: Async[F] = _fa
       override def finatraCatsServerOptions: FinatraCatsServerOptions[F] = serverOptions
+    }
+  }
+
+  private def convertHandler[F[_]: MonadError, G[_]: MonadError, B](
+      original: EndpointHandler[F, B],
+      fToG: F ~> G,
+      gToF: G ~> F
+  ): EndpointHandler[G, B] = {
+    def convertEndpoint[R](
+        original: ServerEndpoint[R, G]
+    ): ServerEndpoint[R, F] = {
+      new ServerEndpoint[R, F] {
+        override type SECURITY_INPUT = original.SECURITY_INPUT
+        override type PRINCIPAL = original.PRINCIPAL
+        override type INPUT = original.INPUT
+        override type ERROR_OUTPUT = original.ERROR_OUTPUT
+        override type OUTPUT = original.OUTPUT
+
+        override def logic: MonadError[F] => PRINCIPAL => INPUT => F[Either[ERROR_OUTPUT, OUTPUT]] = _ =>
+          p => i => gToF(original.logic(MonadError[G])(p)(i))
+
+        override def endpoint: Endpoint[SECURITY_INPUT, INPUT, ERROR_OUTPUT, OUTPUT, R] = original.endpoint
+
+        override def securityLogic: MonadError[F] => SECURITY_INPUT => F[Either[ERROR_OUTPUT, PRINCIPAL]] = _ =>
+          si => gToF(original.securityLogic(MonadError[G])(si))
+      }
+    }
+
+    new EndpointHandler[G, B] {
+      private implicit def bodyListenerF(implicit bodyListener: BodyListener[G, B]): BodyListener[F, B] =
+        new BodyListener[F, B] {
+          override def onComplete(body: B)(cb: Try[Unit] => F[Unit]): F[B] =
+            gToF(bodyListener.onComplete(body)(x => fToG(cb(x))))
+        }
+
+      override def onDecodeSuccess[U, I](
+          ctx: DecodeSuccessContext[G, U, I]
+      )(implicit monad: MonadError[G], bodyListener: BodyListener[G, B]): G[ServerResponseFromOutput[B]] = {
+        fToG(
+          original.onDecodeSuccess(
+            ctx.copy(serverEndpoint = convertEndpoint(ctx.serverEndpoint).asInstanceOf[ServerEndpoint.Full[_, U, I, _, _, _, F]])
+          )
+        )
+      }
+
+      override def onSecurityFailure[A](
+          ctx: SecurityFailureContext[G, A]
+      )(implicit monad: MonadError[G], bodyListener: BodyListener[G, B]): G[ServerResponseFromOutput[B]] =
+        fToG(
+          original.onSecurityFailure(
+            ctx.copy(serverEndpoint = convertEndpoint(ctx.serverEndpoint).asInstanceOf[ServerEndpoint.Full[A, _, _, _, _, _, F]])
+          )
+        )
+
+      override def onDecodeFailure(
+          ctx: DecodeFailureContext
+      )(implicit monad: MonadError[G], bodyListener: BodyListener[G, B]): G[Option[ServerResponseFromOutput[B]]] =
+        fToG(original.onDecodeFailure(ctx))
+    }
+  }
+
+  private def convertResponder[F[_]: Async, B](original: Responder[Future, B]): Responder[F, B] =
+    new Responder[F, B] {
+      override def apply[O](request: ServerRequest, output: ValuedEndpointOutput[O]): F[ServerResponseFromOutput[B]] =
+        original(request, output).asF
+    }
+
+  private def convertInterceptor[F[_]: Async: Dispatcher: MonadError](original: Interceptor[F]): Interceptor[Future] = {
+    def convertRequestInterceptor(interceptor: RequestInterceptor[F]): RequestInterceptor[Future] = new RequestInterceptor[Future] {
+      override def apply[B](
+          responder: Responder[Future, B],
+          requestHandler: RequestHandlerLogic[Future, B]
+      ): RequestHandler[Future, B] = {
+        def convertRequestHandler: RequestHandlerLogic[Future, B] => RequestHandlerLogic[F, B] =
+          original =>
+            interceptorF => {
+              new RequestHandler[F, B] {
+                override def apply(request: ServerRequest)(implicit monad: MonadError[F]): F[RequestResult[B]] =
+                  original(convertEndpointInterceptor(interceptorF))(request)(FutureMonadError).asF
+              }
+            }
+
+        val handler = interceptor(convertResponder(responder), convertRequestHandler(requestHandler))
+
+        new RequestHandler[Future, B] {
+          override def apply(request: ServerRequest)(implicit monad: MonadError[Future]): Future[RequestResult[B]] =
+            handler(request).asTwitterFuture
+        }
+      }
+    }
+
+    def convertEndpointInterceptor(interceptor: EndpointInterceptor[F]): EndpointInterceptor[Future] =
+      new EndpointInterceptor[Future] {
+        override def apply[B](
+            responder: Responder[Future, B],
+            endpointHandler: EndpointHandler[Future, B]
+        ): EndpointHandler[Future, B] = {
+          val fToFuture = new (F ~> Future) {
+            override def apply[A](f: F[A]): Future[A] = f.asTwitterFuture
+          }
+
+          val futureToF = new (Future ~> F) {
+            override def apply[A](future: Future[A]): F[A] = future.asF
+          }
+
+          val handler: EndpointHandler[F, B] =
+            interceptor(convertResponder(responder), convertHandler(endpointHandler, futureToF, fToFuture))
+
+          convertHandler(handler, fToFuture, futureToF)
+        }
+      }
+
+    original match {
+      case interceptor: RequestInterceptor[F]  => convertRequestInterceptor(interceptor)
+      case interceptor: EndpointInterceptor[F] => convertEndpointInterceptor(interceptor)
     }
   }
 }

--- a/server/finatra-server/finatra-server-cats/src/main/scala/sttp/tapir/server/finatra/cats/FinatraCatsServerOptions.scala
+++ b/server/finatra-server/finatra-server-cats/src/main/scala/sttp/tapir/server/finatra/cats/FinatraCatsServerOptions.scala
@@ -1,33 +1,43 @@
 package sttp.tapir.server.finatra.cats
 
+import cats.effect.Async
 import cats.effect.std.Dispatcher
 import com.twitter.util.Future
 import com.twitter.util.logging.Logging
 import sttp.tapir.TapirFile
 import sttp.tapir.server.finatra.FinatraServerOptions
-import sttp.tapir.server.interceptor.log.{ServerLog, ServerLogInterceptor}
+import sttp.tapir.server.interceptor.log.{DefaultServerLog, ServerLog}
 import sttp.tapir.server.interceptor.{CustomInterceptors, Interceptor}
+import sttp.tapir.server.finatra.cats.conversions._
 
 case class FinatraCatsServerOptions[F[_]](
     dispatcher: Dispatcher[F],
-    createFile: Array[Byte] => Future[TapirFile],
-    deleteFile: TapirFile => Future[Unit],
-    interceptors: List[Interceptor[Future]]
+    createFile: Array[Byte] => F[TapirFile],
+    deleteFile: TapirFile => F[Unit],
+    interceptors: List[Interceptor[F]]
 )
 
 object FinatraCatsServerOptions extends Logging {
 
   /** Allows customising the interceptors used by the server interpreter. */
-  def customInterceptors[F[_]](dispatcher: Dispatcher[F]): CustomInterceptors[Future, FinatraCatsServerOptions[F]] =
+  def customInterceptors[F[_]: Async](dispatcher: Dispatcher[F]): CustomInterceptors[F, FinatraCatsServerOptions[F]] = {
+    def finatraCatsServerLog(finatraServerLog: DefaultServerLog[Future]): ServerLog[F] = DefaultServerLog[F](
+      doLogWhenHandled = (m, e) => finatraServerLog.doLogWhenHandled(m, e).asF,
+      doLogAllDecodeFailures = (m, e) => finatraServerLog.doLogAllDecodeFailures(m, e).asF,
+      doLogExceptions = (m, e) => finatraServerLog.doLogExceptions(m, e).asF,
+      noLog = finatraServerLog.noLog.asF
+    )
+
     CustomInterceptors(
-      createOptions = (ci: CustomInterceptors[Future, FinatraCatsServerOptions[F]]) =>
+      createOptions = (ci: CustomInterceptors[F, FinatraCatsServerOptions[F]]) =>
         FinatraCatsServerOptions[F](
           dispatcher,
-          FinatraServerOptions.defaultCreateFile(FinatraServerOptions.futurePool),
-          FinatraServerOptions.defaultDeleteFile(FinatraServerOptions.futurePool),
+          FinatraServerOptions.defaultCreateFile(FinatraServerOptions.futurePool)(_).asF,
+          FinatraServerOptions.defaultDeleteFile(FinatraServerOptions.futurePool)(_).asF,
           ci.interceptors
         )
-    ).serverLog(FinatraServerOptions.defaultServerLog)
+    ).serverLog(finatraCatsServerLog(FinatraServerOptions.defaultServerLog))
+  }
 
-  def default[F[_]](dispatcher: Dispatcher[F]): FinatraCatsServerOptions[F] = customInterceptors(dispatcher).options
+  def default[F[_]: Async](dispatcher: Dispatcher[F]): FinatraCatsServerOptions[F] = customInterceptors(dispatcher).options
 }

--- a/server/finatra-server/finatra-server-cats/src/main/scala/sttp/tapir/server/finatra/cats/conversions.scala
+++ b/server/finatra-server/finatra-server-cats/src/main/scala/sttp/tapir/server/finatra/cats/conversions.scala
@@ -1,0 +1,33 @@
+package sttp.tapir.server.finatra.cats
+
+import cats.effect.Async
+import cats.effect.std.Dispatcher
+import com.twitter.util.{Future, Promise}
+
+import scala.util.{Failure, Success}
+
+object conversions {
+
+  /** Convert from a Scala Future to a Twitter Future Source: https://twitter.github.io/util/guide/util-cookbook/futures.html
+    */
+  private[cats] implicit class RichF[F[_], A](val fa: F[A]) {
+    def asTwitterFuture(implicit dispatcher: Dispatcher[F]): Future[A] = {
+      val promise: Promise[A] = new Promise[A]()
+      dispatcher
+        .unsafeToFuture(fa)
+        .onComplete {
+          case Success(value)     => promise.setValue(value)
+          case Failure(exception) => promise.setException(exception)
+        }(cats.effect.unsafe.implicits.global.compute)
+      promise
+    }
+  }
+
+  /** Convert from a Twitter Future to some F with Async capabilities. Based on https://typelevel.org/cats-effect/docs/typeclasses/async
+    */
+  private[cats] implicit class RichTwitterFuture[A](val f: Future[A]) {
+    def asF[F[_]: Async]: F[A] = Async[F].async_ { cb =>
+      f.onSuccess(f => cb(Right(f))).onFailure(e => cb(Left(e)))
+    }
+  }
+}

--- a/server/finatra-server/finatra-server-cats/src/test/scala/sttp/tapir/server/finatra/cats/FinatraCatsTestServerInterpreter.scala
+++ b/server/finatra-server/finatra-server-cats/src/test/scala/sttp/tapir/server/finatra/cats/FinatraCatsTestServerInterpreter.scala
@@ -3,34 +3,22 @@ package sttp.tapir.server.finatra.cats
 import cats.data.NonEmptyList
 import cats.effect.std.Dispatcher
 import cats.effect.{IO, Resource}
-import sttp.tapir.Endpoint
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.finatra.{FinatraRoute, FinatraTestServerInterpreter}
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 
 import scala.concurrent.ExecutionContext
-import scala.reflect.ClassTag
 
-class FinatraCatsTestServerInterpreter(dispatcher: Dispatcher[IO]) extends TestServerInterpreter[IO, Any, FinatraRoute] {
+class FinatraCatsTestServerInterpreter(dispatcher: Dispatcher[IO])
+    extends TestServerInterpreter[IO, Any, FinatraCatsServerOptions[IO], FinatraRoute] {
   implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
-  override def route(
-      e: ServerEndpoint[Any, IO],
-      decodeFailureHandler: Option[DecodeFailureHandler] = None,
-      metricsInterceptor: Option[MetricsRequestInterceptor[IO]] = None
-  ): FinatraRoute = {
-    val serverOptions: FinatraCatsServerOptions[IO] =
-      FinatraCatsServerOptions
-        .customInterceptors(dispatcher)
-        .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-        .options
-    FinatraCatsServerInterpreter[IO](serverOptions).toRoute(e)
+  override def route(es: List[ServerEndpoint[Any, IO]], interceptors: Interceptors): FinatraRoute = {
+    val serverOptions: FinatraCatsServerOptions[IO] = interceptors(FinatraCatsServerOptions.customInterceptors(dispatcher)).options
+    val interpreter = FinatraCatsServerInterpreter[IO](serverOptions)
+    es.map(interpreter.toRoute).last
   }
-
-  override def route(es: List[ServerEndpoint[Any, IO]]): FinatraRoute = ???
 
   override def server(routes: NonEmptyList[FinatraRoute]): Resource[IO, Port] = FinatraTestServerInterpreter.server(routes)
 }

--- a/server/finatra-server/finatra-server-cats/src/test/scala/sttp/tapir/server/finatra/cats/FinatraServerCatsTests.scala
+++ b/server/finatra-server/finatra-server-cats/src/test/scala/sttp/tapir/server/finatra/cats/FinatraServerCatsTests.scala
@@ -2,15 +2,7 @@ package sttp.tapir.server.finatra.cats
 
 import cats.effect.{IO, Resource}
 import sttp.client3.impl.cats.CatsMonadAsyncError
-import sttp.tapir.server.tests.{
-  AllServerTests,
-  DefaultCreateServerTest,
-  ServerSecurityTests,
-  ServerBasicTests,
-  ServerMultipartTests,
-  ServerStaticContentTests,
-  backendResource
-}
+import sttp.tapir.server.tests.{AllServerTests, DefaultCreateServerTest, ServerStaticContentTests, backendResource}
 import sttp.tapir.tests.{Test, TestSuite}
 
 class FinatraServerCatsTests extends TestSuite {

--- a/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraServerOptions.scala
+++ b/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraServerOptions.scala
@@ -40,7 +40,7 @@ object FinatraServerOptions extends Logging {
 
   private[finatra] lazy val futurePool = FuturePool.unboundedPool
 
-  lazy val defaultServerLog: ServerLog[Future] = DefaultServerLog(
+  lazy val defaultServerLog: DefaultServerLog[Future] = DefaultServerLog(
     doLogWhenHandled = debugLog,
     doLogAllDecodeFailures = debugLog,
     doLogExceptions = (msg: String, ex: Throwable) => futurePool { error(msg, ex) },

--- a/server/finatra-server/src/test/scala/sttp/tapir/server/finatra/FinatraTestServerInterpreter.scala
+++ b/server/finatra-server/src/test/scala/sttp/tapir/server/finatra/FinatraTestServerInterpreter.scala
@@ -6,28 +6,17 @@ import com.twitter.finatra.http.routing.HttpRouter
 import com.twitter.finatra.http.{Controller, EmbeddedHttpServer, HttpServer}
 import com.twitter.util.Future
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 
 import scala.concurrent.duration.DurationInt
 
-class FinatraTestServerInterpreter extends TestServerInterpreter[Future, Any, FinatraRoute] {
-  override def route(
-      e: ServerEndpoint[Any, Future],
-      decodeFailureHandler: Option[DecodeFailureHandler] = None,
-      metricsInterceptor: Option[MetricsRequestInterceptor[Future]] = None
-  ): FinatraRoute = {
-    implicit val serverOptions: FinatraServerOptions =
-      FinatraServerOptions.customInterceptors
-        .metricsInterceptor(metricsInterceptor)
-        .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-        .options
-    FinatraServerInterpreter(serverOptions).toRoute(e)
+class FinatraTestServerInterpreter extends TestServerInterpreter[Future, Any, FinatraServerOptions, FinatraRoute] {
+  override def route(es: List[ServerEndpoint[Any, Future]], interceptors: Interceptors): FinatraRoute = {
+    implicit val serverOptions: FinatraServerOptions = interceptors(FinatraServerOptions.customInterceptors).options
+    val interpreter = FinatraServerInterpreter(serverOptions)
+    es.map(interpreter.toRoute).last
   }
-
-  override def route(es: List[ServerEndpoint[Any, Future]]): FinatraRoute = ???
 
   override def server(routes: NonEmptyList[FinatraRoute]): Resource[IO, Port] = FinatraTestServerInterpreter.server(routes)
 }

--- a/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sTestServerInterpreter.scala
+++ b/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sTestServerInterpreter.scala
@@ -4,16 +4,14 @@ import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import org.http4s.blaze.server.BlazeServerBuilder
+import org.http4s.server.websocket.WebSocketBuilder2
 import org.http4s.{HttpApp, HttpRoutes}
 import sttp.capabilities.WebSockets
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
+import sttp.tapir.server.http4s.Http4sTestServerInterpreter._
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
-import Http4sTestServerInterpreter._
-import org.http4s.server.websocket.WebSocketBuilder2
 
 import scala.concurrent.ExecutionContext
 
@@ -21,24 +19,12 @@ object Http4sTestServerInterpreter {
   type Routes = WebSocketBuilder2[IO] => HttpRoutes[IO]
 }
 
-class Http4sTestServerInterpreter extends TestServerInterpreter[IO, Fs2Streams[IO] with WebSockets, Routes] {
+class Http4sTestServerInterpreter extends TestServerInterpreter[IO, Fs2Streams[IO] with WebSockets, Http4sServerOptions[IO, IO], Routes] {
   implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
-  override def route(
-      e: ServerEndpoint[Fs2Streams[IO] with WebSockets, IO],
-      decodeFailureHandler: Option[DecodeFailureHandler] = None,
-      metricsInterceptor: Option[MetricsRequestInterceptor[IO]] = None
-  ): Routes = {
-    val serverOptions: Http4sServerOptions[IO, IO] = Http4sServerOptions
-      .customInterceptors[IO, IO]
-      .metricsInterceptor(metricsInterceptor)
-      .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-      .options
-    Http4sServerInterpreter(serverOptions).toWebSocketRoutes(e)
-  }
-
-  override def route(es: List[ServerEndpoint[Fs2Streams[IO] with WebSockets, IO]]): Routes = {
-    Http4sServerInterpreter[IO]().toWebSocketRoutes(es)
+  override def route(es: List[ServerEndpoint[Fs2Streams[IO] with WebSockets, IO]], interceptors: Interceptors): Routes = {
+    val serverOptions: Http4sServerOptions[IO, IO] = interceptors(Http4sServerOptions.customInterceptors[IO, IO]).options
+    Http4sServerInterpreter(serverOptions).toWebSocketRoutes(es)
   }
 
   override def server(routes: NonEmptyList[Routes]): Resource[IO, Port] = {

--- a/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyCatsTestServerInterpreter.scala
+++ b/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyCatsTestServerInterpreter.scala
@@ -5,30 +5,16 @@ import cats.effect.std.Dispatcher
 import cats.effect.{IO, Resource}
 import io.netty.channel.nio.NioEventLoopGroup
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 
 class NettyCatsTestServerInterpreter(eventLoopGroup: NioEventLoopGroup, dispatcher: Dispatcher[IO])
-    extends TestServerInterpreter[IO, Any, Route[IO]] {
+    extends TestServerInterpreter[IO, Any, NettyCatsServerOptions[IO], Route[IO]] {
 
-  override def route(
-      e: ServerEndpoint[Any, IO],
-      decodeFailureHandler: Option[DecodeFailureHandler] = None,
-      metricsInterceptor: Option[MetricsRequestInterceptor[IO]] = None
-  ): Route[IO] = {
-    val serverOptions: NettyCatsServerOptions[IO] = NettyCatsServerOptions
-      .customInterceptors[IO](dispatcher)
-      .metricsInterceptor(metricsInterceptor)
-      .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-      .options
-
-    NettyCatsServerInterpreter(serverOptions).toRoute(List(e))
+  override def route(es: List[ServerEndpoint[Any, IO]], interceptors: Interceptors): Route[IO] = {
+    val serverOptions: NettyCatsServerOptions[IO] = interceptors(NettyCatsServerOptions.customInterceptors[IO](dispatcher)).options
+    NettyCatsServerInterpreter(serverOptions).toRoute(es)
   }
-
-  override def route(es: List[ServerEndpoint[Any, IO]]): Route[IO] =
-    NettyCatsServerInterpreter[IO](dispatcher).toRoute(es)
 
   override def server(routes: NonEmptyList[Route[IO]]): Resource[IO, Port] = {
     val options =

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/AllServerTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/AllServerTests.scala
@@ -10,9 +10,9 @@ import sttp.tapir.tests.Test
 /** All server tests in default configurations, except for streaming (which require a streams object) and web socket ones (which need to be
   * subclassed). If a custom configuration is needed, exclude the tests here, and add separately.
   */
-class AllServerTests[F[_], ROUTE](
-    createServerTest: CreateServerTest[F, Any, ROUTE],
-    serverInterpreter: TestServerInterpreter[F, Any, ROUTE],
+class AllServerTests[F[_], OPTIONS, ROUTE](
+    createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE],
+    serverInterpreter: TestServerInterpreter[F, Any, OPTIONS, ROUTE],
     backend: SttpBackend[IO, Fs2Streams[IO] with WebSockets],
     security: Boolean = true,
     basic: Boolean = true,

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/CreateServerTest.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/CreateServerTest.scala
@@ -1,6 +1,7 @@
 package sttp.tapir.server.tests
 
 import cats.data.NonEmptyList
+import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Resource}
 import cats.implicits._
 import com.typesafe.scalalogging.StrictLogging
@@ -11,20 +12,23 @@ import sttp.client3._
 import sttp.model._
 import sttp.tapir._
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.decodefailure.DecodeFailureHandler
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
+import sttp.tapir.server.interceptor.CustomInterceptors
 import sttp.tapir.tests._
-import cats.effect.unsafe.implicits.global
 
-trait CreateServerTest[F[_], +R, ROUTE] {
+trait CreateServerTest[F[_], +R, OPTIONS, ROUTE] {
+  protected type Interceptors = CustomInterceptors[F, OPTIONS] => CustomInterceptors[F, OPTIONS]
+
   def testServer[I, E, O](
       e: PublicEndpoint[I, E, O, R],
       testNameSuffix: String = "",
-      decodeFailureHandler: Option[DecodeFailureHandler] = None,
-      metricsInterceptor: Option[MetricsRequestInterceptor[F]] = None
+      interceptors: Interceptors = identity
   )(fn: I => F[Either[E, O]])(runTest: (SttpBackend[IO, Fs2Streams[IO] with WebSockets], Uri) => IO[Assertion]): Test
 
-  def testServerLogic(e: ServerEndpoint[R, F], testNameSuffix: String = "", decodeFailureHandler: Option[DecodeFailureHandler] = None)(
+  def testServerLogic(
+      e: ServerEndpoint[R, F],
+      testNameSuffix: String = "",
+      interceptors: Interceptors = identity
+  )(
       runTest: (SttpBackend[IO, Fs2Streams[IO] with WebSockets], Uri) => IO[Assertion]
   ): Test
 
@@ -33,36 +37,35 @@ trait CreateServerTest[F[_], +R, ROUTE] {
   ): Test
 }
 
-class DefaultCreateServerTest[F[_], +R, ROUTE](
+class DefaultCreateServerTest[F[_], +R, OPTIONS, ROUTE](
     backend: SttpBackend[IO, Fs2Streams[IO] with WebSockets],
-    interpreter: TestServerInterpreter[F, R, ROUTE]
-) extends CreateServerTest[F, R, ROUTE]
+    interpreter: TestServerInterpreter[F, R, OPTIONS, ROUTE]
+) extends CreateServerTest[F, R, OPTIONS, ROUTE]
     with StrictLogging {
 
   override def testServer[I, E, O](
       e: PublicEndpoint[I, E, O, R],
       testNameSuffix: String = "",
-      decodeFailureHandler: Option[DecodeFailureHandler] = None,
-      metricsInterceptor: Option[MetricsRequestInterceptor[F]] = None
+      interceptors: Interceptors = identity
   )(
       fn: I => F[Either[E, O]]
   )(runTest: (SttpBackend[IO, Fs2Streams[IO] with WebSockets], Uri) => IO[Assertion]): Test = {
     testServer(
       e.showDetail + (if (testNameSuffix == "") "" else " " + testNameSuffix),
-      NonEmptyList.of(interpreter.route(e.serverLogic(fn), decodeFailureHandler, metricsInterceptor))
+      NonEmptyList.of(interpreter.route(e.serverLogic(fn), interceptors))
     )(runTest)
   }
 
   override def testServerLogic(
       e: ServerEndpoint[R, F],
       testNameSuffix: String = "",
-      decodeFailureHandler: Option[DecodeFailureHandler] = None
+      interceptors: Interceptors = identity
   )(
       runTest: (SttpBackend[IO, Fs2Streams[IO] with WebSockets], Uri) => IO[Assertion]
   ): Test = {
     testServer(
       e.showDetail + (if (testNameSuffix == "") "" else " " + testNameSuffix),
-      NonEmptyList.of(interpreter.route(e, decodeFailureHandler))
+      NonEmptyList.of(interpreter.route(e, interceptors))
     )(runTest)
   }
 

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -21,9 +21,9 @@ import sttp.tapir.tests.data.{FruitAmount, FruitError}
 import java.io.{ByteArrayInputStream, InputStream}
 import java.nio.ByteBuffer
 
-class ServerBasicTests[F[_], ROUTE](
-    createServerTest: CreateServerTest[F, Any, ROUTE],
-    serverInterpreter: TestServerInterpreter[F, Any, ROUTE],
+class ServerBasicTests[F[_], OPTIONS, ROUTE](
+    createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE],
+    serverInterpreter: TestServerInterpreter[F, Any, OPTIONS, ROUTE],
     multipleValueHeaderSupport: Boolean = true,
     inputStreamSupport: Boolean = true,
     supportsUrlEncodedPathSegments: Boolean = true,
@@ -529,7 +529,7 @@ class ServerBasicTests[F[_], ROUTE](
     testServer(
       in_path_fixed_capture_fixed_capture,
       "Returns 400 if path 'shape' matches, but failed to parse a path parameter",
-      Some(decodeFailureHandlerBadRequestOnPathFailure)
+      _.decodeFailureHandler(decodeFailureHandlerBadRequestOnPathFailure)
     )(_ => pureResult(Either.right[Unit, Unit](()))) { (backend, baseUri) =>
       basicRequest.get(uri"$baseUri/customer/asd/orders/2").send(backend).map { response =>
         response.body shouldBe Left("Invalid value for: path parameter customer_id")
@@ -539,7 +539,7 @@ class ServerBasicTests[F[_], ROUTE](
     testServer(
       in_path_fixed_capture_fixed_capture,
       "Returns 404 if path 'shape' doesn't match",
-      Some(decodeFailureHandlerBadRequestOnPathFailure)
+      _.decodeFailureHandler(decodeFailureHandlerBadRequestOnPathFailure)
     )(_ => pureResult(Either.right[Unit, Unit](()))) { (backend, baseUri) =>
       basicRequest.get(uri"$baseUri/customer").send(backend).map(response => response.code shouldBe StatusCode.NotFound) >>
         basicRequest.get(uri"$baseUri/customer/asd").send(backend).map(response => response.code shouldBe StatusCode.NotFound) >>

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerContentNegotiationTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerContentNegotiationTests.scala
@@ -13,7 +13,7 @@ import sttp.tapir.tests.ContentNegotiation._
 import sttp.tapir.tests._
 import sttp.tapir.tests.data._
 
-class ServerContentNegotiationTests[F[_], ROUTE](createServerTest: CreateServerTest[F, Any, ROUTE])(implicit
+class ServerContentNegotiationTests[F[_], OPTIONS, ROUTE](createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE])(implicit
     m: MonadError[F]
 ) {
   import createServerTest._

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerFileTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerFileTests.scala
@@ -9,7 +9,7 @@ import sttp.tapir.tests.Test
 
 import java.io.File
 
-class ServerFileTests[F[_], ROUTE](createServerTest: CreateServerTest[F, Any, ROUTE])(implicit m: MonadError[F]) {
+class ServerFileTests[F[_], OPTIONS, ROUTE](createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE])(implicit m: MonadError[F]) {
   import createServerTest._
 
   def tests(): List[Test] =

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerMappingTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerMappingTests.scala
@@ -8,7 +8,7 @@ import sttp.tapir.tests.Mapping._
 import sttp.tapir.tests._
 import sttp.tapir.tests.data._
 
-class ServerMappingTests[F[_], ROUTE](createServerTest: CreateServerTest[F, Any, ROUTE])(implicit m: MonadError[F]) {
+class ServerMappingTests[F[_], OPTIONS, ROUTE](createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE])(implicit m: MonadError[F]) {
   import createServerTest._
 
   def tests(): List[Test] = List(

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerMultipartTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerMultipartTests.scala
@@ -19,8 +19,8 @@ import sttp.tapir.tests.{MultipleFileUpload, Test, data}
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
-class ServerMultipartTests[F[_], ROUTE](
-    createServerTest: CreateServerTest[F, Any, ROUTE],
+class ServerMultipartTests[F[_], OPTIONS, ROUTE](
+    createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE],
     partContentTypeHeaderSupport: Boolean = true,
     partOtherHeaderSupport: Boolean = true
 )(implicit m: MonadError[F]) {

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerOneOfBodyTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerOneOfBodyTests.scala
@@ -15,8 +15,8 @@ import sttp.tapir.tests.OneOfBody.{
 import sttp.tapir.tests._
 import sttp.tapir.tests.data.Fruit
 
-class ServerOneOfBodyTests[F[_], ROUTE](
-    createServerTest: CreateServerTest[F, Any, ROUTE]
+class ServerOneOfBodyTests[F[_], OPTIONS, ROUTE](
+    createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE]
 )(implicit
     m: MonadError[F]
 ) {

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerOneOfTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerOneOfTests.scala
@@ -21,8 +21,8 @@ import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe.jsonBody
 import io.circe.generic.auto._
 
-class ServerOneOfTests[F[_], ROUTE](
-    createServerTest: CreateServerTest[F, Any, ROUTE]
+class ServerOneOfTests[F[_], OPTIONS, ROUTE](
+    createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE]
 )(implicit
     m: MonadError[F]
 ) {

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerRejectTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerRejectTests.scala
@@ -7,11 +7,14 @@ import sttp.client3._
 import sttp.model._
 import sttp.monad.MonadError
 import sttp.tapir._
+import sttp.tapir.server.interceptor.{CustomInterceptors, ValuedEndpointOutput}
+import sttp.tapir.server.interceptor.reject.DefaultRejectHandler
+import sttp.tapir.server.tests.ServerRejectTests.endpoints
 import sttp.tapir.tests._
 
-class ServerRejectTests[F[_], ROUTE](
-    createServerTest: CreateServerTest[F, Any, ROUTE],
-    serverInterpreter: TestServerInterpreter[F, Any, ROUTE]
+class ServerRejectTests[F[_], OPTIONS, ROUTE](
+    createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE],
+    serverInterpreter: TestServerInterpreter[F, Any, OPTIONS, ROUTE]
 )(implicit
     m: MonadError[F]
 ) {
@@ -21,17 +24,23 @@ class ServerRejectTests[F[_], ROUTE](
   def tests(): List[Test] = List(
     testServer(
       "given a list of endpoints, should return 405 for unsupported methods",
+      NonEmptyList.of(route(endpoints))
+    ) { (backend, baseUri) =>
+      basicRequest.get(uri"$baseUri/path").send(backend).map(_.code shouldBe StatusCode.Ok) >>
+        basicRequest.delete(uri"$baseUri/path").send(backend).map(_.code shouldBe StatusCode.MethodNotAllowed)
+    },
+    testServer(
+      "given a list of endpoints and a customized reject handler, should return a custom response for unsupported methods",
       NonEmptyList.of(
         route(
-          List(
-            endpoint.get.in("path").serverLogic((_: Unit) => pureResult(().asRight[Unit])),
-            endpoint.post.in("path").serverLogic((_: Unit) => pureResult(().asRight[Unit]))
-          )
+          endpoints,
+          (ci: CustomInterceptors[F, OPTIONS]) =>
+            ci.rejectHandler(DefaultRejectHandler((_, _) => ValuedEndpointOutput(statusCode, StatusCode.BadRequest)))
         )
       )
     ) { (backend, baseUri) =>
       basicRequest.get(uri"$baseUri/path").send(backend).map(_.code shouldBe StatusCode.Ok) >>
-        basicRequest.delete(uri"$baseUri/path").send(backend).map(_.code shouldBe StatusCode.MethodNotAllowed)
+        basicRequest.delete(uri"$baseUri/path").send(backend).map(_.code shouldBe StatusCode.BadRequest)
     },
     testServer(endpoint.in("path"), "should return 404 for an unknown endpoint")((_: Unit) => pureResult(().asRight[Unit])) {
       (backend, baseUri) =>
@@ -42,5 +51,13 @@ class ServerRejectTests[F[_], ROUTE](
     ) { (backend, baseUri) =>
       basicRequest.post(uri"$baseUri/path").send(backend).map(_.code shouldBe StatusCode.NotFound)
     }
+  )
+}
+
+object ServerRejectTests {
+
+  private def endpoints[F[_]: MonadError] = List(
+    endpoint.get.in("path").serverLogic((_: Unit) => pureResult(().asRight[Unit])),
+    endpoint.post.in("path").serverLogic((_: Unit) => pureResult(().asRight[Unit]))
   )
 }

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerSecurityTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerSecurityTests.scala
@@ -19,7 +19,8 @@ import sttp.tapir.tests.Security.{
 }
 import sttp.tapir.tests.Test
 
-class ServerSecurityTests[F[_], S, ROUTE](createServerTest: CreateServerTest[F, S, ROUTE])(implicit m: MonadError[F]) extends Matchers {
+class ServerSecurityTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServerTest[F, S, OPTIONS, ROUTE])(implicit m: MonadError[F])
+    extends Matchers {
   import createServerTest._
   private val Realm = "realm"
 
@@ -112,7 +113,7 @@ class ServerSecurityTests[F[_], S, ROUTE](createServerTest: CreateServerTest[F, 
     testServerLogic(
       endpoint.serverSecurityLogic(_ => result).serverLogic(_ => _ => result),
       s"missing $authType with endpoint hiding",
-      Some(DefaultDecodeFailureHandler.hideEndpointsWithAuth)
+      _.decodeFailureHandler(DefaultDecodeFailureHandler.hideEndpointsWithAuth)
     ) { (backend, baseUri) =>
       validRequest(baseUri).send(backend).map { r =>
         r.code shouldBe StatusCode.NotFound
@@ -146,7 +147,7 @@ class ServerSecurityTests[F[_], S, ROUTE](createServerTest: CreateServerTest[F, 
     testServerLogic(
       endpoint.serverSecurityLogic(_ => result).serverLogic(_ => _ => result),
       s"invalid request $authType with endpoint hiding",
-      Some(DefaultDecodeFailureHandler.hideEndpointsWithAuth)
+      _.decodeFailureHandler(DefaultDecodeFailureHandler.hideEndpointsWithAuth)
     ) { (backend, baseUri) =>
       auth(invalidRequest(baseUri)).send(backend).map(_.code shouldBe StatusCode.NotFound)
     }

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerStreamingTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerStreamingTests.scala
@@ -9,7 +9,7 @@ import sttp.monad.MonadError
 import sttp.tapir.tests.Test
 import sttp.tapir.tests.Streaming.{in_stream_out_stream, in_stream_out_stream_with_content_length}
 
-class ServerStreamingTests[F[_], S, ROUTE](createServerTest: CreateServerTest[F, S, ROUTE], streams: Streams[S])(implicit
+class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServerTest[F, S, OPTIONS, ROUTE], streams: Streams[S])(implicit
     m: MonadError[F]
 ) {
 

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerValidationTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerValidationTests.scala
@@ -9,8 +9,8 @@ import sttp.tapir.tests.Validation._
 import sttp.tapir.tests._
 import sttp.tapir.tests.data._
 
-class ServerValidationTests[F[_], ROUTE](
-    createServerTest: CreateServerTest[F, Any, ROUTE]
+class ServerValidationTests[F[_], OPTIONS, ROUTE](
+    createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE]
 )(implicit
     m: MonadError[F]
 ) {

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/TestServerInterpreter.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/TestServerInterpreter.scala
@@ -3,16 +3,17 @@ package sttp.tapir.server.tests
 import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.decodefailure.DecodeFailureHandler
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
+import sttp.tapir.server.interceptor.CustomInterceptors
 import sttp.tapir.tests.Port
 
-trait TestServerInterpreter[F[_], +R, ROUTE] {
-  def route(
-      e: ServerEndpoint[R, F],
-      decodeFailureHandler: Option[DecodeFailureHandler] = None,
-      metricsInterceptor: Option[MetricsRequestInterceptor[F]] = None
-  ): ROUTE
-  def route(es: List[ServerEndpoint[R, F]]): ROUTE
+trait TestServerInterpreter[F[_], +R, OPTIONS, ROUTE] {
+  protected type Interceptors = CustomInterceptors[F, OPTIONS] => CustomInterceptors[F, OPTIONS]
+
+  def route(e: ServerEndpoint[R, F]): ROUTE = route(List(e), (ci: CustomInterceptors[F, OPTIONS]) => ci)
+
+  def route(e: ServerEndpoint[R, F], interceptors: Interceptors): ROUTE = route(List(e), interceptors)
+
+  def route(es: List[ServerEndpoint[R, F]], interceptors: Interceptors = identity): ROUTE
+
   def server(routes: NonEmptyList[ROUTE]): Resource[IO, Port]
 }

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxTestServerBlockingInterpreter.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxTestServerBlockingInterpreter.scala
@@ -3,21 +3,13 @@ package sttp.tapir.server.vertx
 import io.vertx.core.Vertx
 import io.vertx.ext.web.{Route, Router}
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 
 import scala.concurrent.Future
 
 class VertxTestServerBlockingInterpreter(vertx: Vertx) extends VertxTestServerInterpreter(vertx) {
-  override def route(
-      e: ServerEndpoint[Any, Future],
-      decodeFailureHandler: Option[DecodeFailureHandler],
-      metricsInterceptor: Option[MetricsRequestInterceptor[Future]] = None
-  ): Router => Route = {
-    val options: VertxFutureServerOptions = VertxFutureServerOptions.customInterceptors
-      .metricsInterceptor(metricsInterceptor)
-      .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-      .options
-    VertxFutureServerInterpreter(options).blockingRoute(e)
+  override def route(es: List[ServerEndpoint[Any, Future]], interceptors: Interceptors): Router => Route = {
+    val options: VertxFutureServerOptions = interceptors(VertxFutureServerOptions.customInterceptors).options
+    val interpreter = VertxFutureServerInterpreter(options)
+    es.map(interpreter.blockingRoute).last
   }
 }

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxTestServerInterpreter.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/VertxTestServerInterpreter.scala
@@ -4,33 +4,21 @@ import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
 import io.vertx.core.http.HttpServerOptions
 import io.vertx.core.{Vertx, Future => VFuture}
-import io.vertx.ext.web.{Route, Router, RoutingContext}
-import sttp.tapir.Endpoint
+import io.vertx.ext.web.{Route, Router}
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 
 import scala.concurrent.Future
-import scala.reflect.ClassTag
 
-class VertxTestServerInterpreter(vertx: Vertx) extends TestServerInterpreter[Future, Any, Router => Route] {
+class VertxTestServerInterpreter(vertx: Vertx) extends TestServerInterpreter[Future, Any, VertxFutureServerOptions, Router => Route] {
   import VertxTestServerInterpreter._
 
-  override def route(
-      e: ServerEndpoint[Any, Future],
-      decodeFailureHandler: Option[DecodeFailureHandler],
-      metricsInterceptor: Option[MetricsRequestInterceptor[Future]] = None
-  ): Router => Route = {
-    val options: VertxFutureServerOptions = VertxFutureServerOptions.customInterceptors
-      .metricsInterceptor(metricsInterceptor)
-      .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-      .options
-    VertxFutureServerInterpreter(options).route(e)
+  override def route(es: List[ServerEndpoint[Any, Future]], interceptors: Interceptors): Router => Route = {
+    val options: VertxFutureServerOptions = interceptors(VertxFutureServerOptions.customInterceptors).options
+    val interpreter = VertxFutureServerInterpreter(options)
+    es.map(interpreter.route).last
   }
-
-  override def route(es: List[ServerEndpoint[Any, Future]]): Router => Route = router => es.map(route(_)(router)).last
 
   override def server(routes: NonEmptyList[Router => Route]): Resource[IO, Port] = {
     val router = Router.router(vertx)

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/ZioVertxServerTest.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/ZioVertxServerTest.scala
@@ -19,7 +19,7 @@ class ZioVertxServerTest extends TestSuite {
       val interpreter = new ZioVertxTestServerInterpreter(vertx)
       val createServerTest =
         new DefaultCreateServerTest(backend, interpreter)
-          .asInstanceOf[DefaultCreateServerTest[Task, ZioStreams, Router => Route]]
+          .asInstanceOf[DefaultCreateServerTest[Task, ZioStreams, VertxZioServerOptions[Task], Router => Route]]
 
       new AllServerTests(createServerTest, interpreter, backend, multipart = false, reject = false).tests() ++
         new ServerMultipartTests(

--- a/server/vertx/src/test/scala/sttp/tapir/server/vertx/ZioVertxTestServerInterpreter.scala
+++ b/server/vertx/src/test/scala/sttp/tapir/server/vertx/ZioVertxTestServerInterpreter.scala
@@ -7,29 +7,19 @@ import io.vertx.core.http.HttpServerOptions
 import io.vertx.ext.web.{Route, Router}
 import sttp.capabilities.zio.ZioStreams
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 import zio.{Runtime, Task}
 
-class ZioVertxTestServerInterpreter(vertx: Vertx) extends TestServerInterpreter[Task, ZioStreams, Router => Route] {
+class ZioVertxTestServerInterpreter(vertx: Vertx)
+    extends TestServerInterpreter[Task, ZioStreams, VertxZioServerOptions[Task], Router => Route] {
   import ZioVertxTestServerInterpreter._
 
-  override def route(
-      e: ServerEndpoint[ZioStreams, Task],
-      decodeFailureHandler: Option[DecodeFailureHandler],
-      metricsInterceptor: Option[MetricsRequestInterceptor[Task]] = None
-  ): Router => Route = {
-    val options: VertxZioServerOptions[Task] =
-      VertxZioServerOptions.customInterceptors
-        .metricsInterceptor(metricsInterceptor)
-        .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-        .options
-    VertxZioServerInterpreter(options).route(e)
+  override def route(es: List[ServerEndpoint[ZioStreams, Task]], interceptors: Interceptors): Router => Route = {
+    val options: VertxZioServerOptions[Task] = interceptors(VertxZioServerOptions.customInterceptors).options
+    val interpreter = VertxZioServerInterpreter(options)
+    es.map(interpreter.route).last
   }
-
-  override def route(es: List[ServerEndpoint[ZioStreams, Task]]): Router => Route = router => es.map(route(_)(router)).last
 
   override def server(routes: NonEmptyList[Router => Route]): Resource[IO, Port] = {
     val router = Router.router(vertx)

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
@@ -10,7 +10,7 @@ import zio.{Task, ZIO}
 import org.scalatest.matchers.should.Matchers._
 
 class ZioHttpCompositionTest(
-    createServerTest: CreateServerTest[Task, Any, Http[Any, Throwable, zhttp.http.Request, zhttp.http.Response]]
+    createServerTest: CreateServerTest[Task, Any, ZioHttpServerOptions[Any], Http[Any, Throwable, zhttp.http.Request, zhttp.http.Response]]
 ) {
   import createServerTest._
 

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
@@ -4,8 +4,6 @@ import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
 import sttp.capabilities.zio.ZioStreams
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 import zhttp.http._
@@ -14,24 +12,12 @@ import zio._
 import zio.interop.catz._
 
 class ZioHttpTestServerInterpreter(eventLoopGroup: EventLoopGroup, channelFactory: ServerChannelFactory)
-    extends TestServerInterpreter[Task, ZioStreams, Http[Any, Throwable, Request, Response]] {
+    extends TestServerInterpreter[Task, ZioStreams, ZioHttpServerOptions[Any], Http[Any, Throwable, Request, Response]] {
 
-  override def route(
-      e: ServerEndpoint[ZioStreams, Task],
-      decodeFailureHandler: Option[DecodeFailureHandler],
-      metricsInterceptor: Option[MetricsRequestInterceptor[Task]]
-  ): Http[Any, Throwable, Request, Response] = {
-    val serverOptions: ZioHttpServerOptions[Any] = ZioHttpServerOptions.customInterceptors
-      .metricsInterceptor(metricsInterceptor)
-      .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-      .options
-    ZioHttpInterpreter(serverOptions).toHttp(e)
+  override def route(es: List[ServerEndpoint[ZioStreams, Task]], interceptors: Interceptors): Http[Any, Throwable, Request, Response] = {
+    val serverOptions: ZioHttpServerOptions[Any] = interceptors(ZioHttpServerOptions.customInterceptors).options
+    ZioHttpInterpreter(serverOptions).toHttp(es)
   }
-
-  override def route(
-      es: List[ServerEndpoint[ZioStreams, Task]]
-  ): Http[Any, Throwable, Request, Response] =
-    ZioHttpInterpreter().toHttp(es)
 
   override def server(routes: NonEmptyList[Http[Any, Throwable, Request, Response]]): Resource[IO, Port] = {
     implicit val r: Runtime[Any] = Runtime.default

--- a/server/zio-http4s-server/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sTestServerInterpreter.scala
+++ b/server/zio-http4s-server/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sTestServerInterpreter.scala
@@ -4,49 +4,33 @@ import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import org.http4s.blaze.server.BlazeServerBuilder
+import org.http4s.server.websocket.WebSocketBuilder2
 import org.http4s.{HttpApp, HttpRoutes}
 import sttp.capabilities.WebSockets
 import sttp.capabilities.zio.ZioStreams
 import sttp.tapir.server.http4s.Http4sServerOptions
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
+import sttp.tapir.server.http4s.ztapir.ZHttp4sTestServerInterpreter._
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 import sttp.tapir.ztapir.ZServerEndpoint
-import zio.RIO
-import zio.Clock
 import zio.interop.catz._
 import zio.interop.catz.implicits._
-import ZHttp4sTestServerInterpreter._
-import org.http4s.server.websocket.WebSocketBuilder2
+import zio.{Clock, RIO}
 
 import scala.concurrent.ExecutionContext
 
 object ZHttp4sTestServerInterpreter {
-  type Routes = WebSocketBuilder2[RIO[Clock, *]] => HttpRoutes[RIO[Clock, *]]
+  type F[A] = RIO[Clock, A]
+  type Routes = WebSocketBuilder2[F] => HttpRoutes[F]
+  type ServerOptions = Http4sServerOptions[F, F]
 }
 
-class ZHttp4sTestServerInterpreter extends TestServerInterpreter[RIO[Clock, *], ZioStreams with WebSockets, Routes] {
+class ZHttp4sTestServerInterpreter extends TestServerInterpreter[RIO[Clock, *], ZioStreams with WebSockets, ServerOptions, Routes] {
   implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
-  override def route(
-      e: ZServerEndpoint[Clock, ZioStreams with WebSockets],
-      decodeFailureHandler: Option[DecodeFailureHandler] = None,
-      metricsInterceptor: Option[MetricsRequestInterceptor[RIO[Clock, *]]] = None
-  ): Routes = {
-    val serverOptions: Http4sServerOptions[RIO[Clock, *], RIO[Clock, *]] = Http4sServerOptions
-      .customInterceptors[RIO[Clock, *], RIO[Clock, *]]
-      .metricsInterceptor(metricsInterceptor)
-      .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-      .options
-
-    ZHttp4sServerInterpreter(serverOptions).fromWebSocket(e).toRoutes
-  }
-
-  override def route(
-      es: List[ZServerEndpoint[Clock, ZioStreams with WebSockets]]
-  ): Routes = {
-    ZHttp4sServerInterpreter().fromWebSocket(es).toRoutes
+  override def route(es: List[ZServerEndpoint[Clock, ZioStreams with WebSockets]], interceptors: Interceptors): Routes = {
+    val serverOptions: ServerOptions = interceptors(Http4sServerOptions.customInterceptors[RIO[Clock, *], RIO[Clock, *]]).options
+    ZHttp4sServerInterpreter(serverOptions).fromWebSocket(es).toRoutes
   }
 
   override def server(routes: NonEmptyList[Routes]): Resource[IO, Port] = {

--- a/server/zio1-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
+++ b/server/zio1-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
@@ -10,7 +10,7 @@ import zio.{Task, ZIO}
 import org.scalatest.matchers.should.Matchers._
 
 class ZioHttpCompositionTest(
-    createServerTest: CreateServerTest[Task, Any, Http[Any, Throwable, zhttp.http.Request, zhttp.http.Response]]
+    createServerTest: CreateServerTest[Task, Any, ZioHttpServerOptions[Any], Http[Any, Throwable, zhttp.http.Request, zhttp.http.Response]]
 ) {
   import createServerTest._
 

--- a/server/zio1-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
+++ b/server/zio1-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
@@ -4,8 +4,6 @@ import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
 import sttp.capabilities.zio.ZioStreams
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 import zhttp.http._
@@ -14,24 +12,12 @@ import zio._
 import zio.interop.catz._
 
 class ZioHttpTestServerInterpreter(nettyDeps: EventLoopGroup with ServerChannelFactory)
-    extends TestServerInterpreter[Task, ZioStreams, Http[Any, Throwable, Request, Response]] {
+    extends TestServerInterpreter[Task, ZioStreams, ZioHttpServerOptions[Any], Http[Any, Throwable, Request, Response]] {
 
-  override def route(
-      e: ServerEndpoint[ZioStreams, Task],
-      decodeFailureHandler: Option[DecodeFailureHandler],
-      metricsInterceptor: Option[MetricsRequestInterceptor[Task]]
-  ): Http[Any, Throwable, Request, Response] = {
-    val serverOptions: ZioHttpServerOptions[Any] = ZioHttpServerOptions.customInterceptors
-      .metricsInterceptor(metricsInterceptor)
-      .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-      .options
-    ZioHttpInterpreter(serverOptions).toHttp(e)
+  override def route(es: List[ServerEndpoint[ZioStreams, Task]], interceptors: Interceptors): Http[Any, Throwable, Request, Response] = {
+    val serverOptions: ZioHttpServerOptions[Any] = interceptors(ZioHttpServerOptions.customInterceptors).options
+    ZioHttpInterpreter(serverOptions).toHttp(es)
   }
-
-  override def route(
-      es: List[ServerEndpoint[ZioStreams, Task]]
-  ): Http[Any, Throwable, Request, Response] =
-    ZioHttpInterpreter().toHttp(es)
 
   override def server(routes: NonEmptyList[Http[Any, Throwable, Request, Response]]): Resource[IO, Port] = {
     implicit val r: Runtime[Any] = Runtime.default

--- a/server/zio1-http4s-server/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sTestServerInterpreter.scala
+++ b/server/zio1-http4s-server/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sTestServerInterpreter.scala
@@ -4,12 +4,12 @@ import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import org.http4s.blaze.server.BlazeServerBuilder
+import org.http4s.server.websocket.WebSocketBuilder2
 import org.http4s.{HttpApp, HttpRoutes}
 import sttp.capabilities.WebSockets
 import sttp.capabilities.zio.ZioStreams
 import sttp.tapir.server.http4s.Http4sServerOptions
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
-import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
+import sttp.tapir.server.http4s.ztapir.ZHttp4sTestServerInterpreter._
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 import sttp.tapir.ztapir.ZServerEndpoint
@@ -18,36 +18,21 @@ import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.interop.catz._
 import zio.interop.catz.implicits._
-import ZHttp4sTestServerInterpreter._
-import org.http4s.server.websocket.WebSocketBuilder2
 
 import scala.concurrent.ExecutionContext
 
 object ZHttp4sTestServerInterpreter {
-  type Routes = WebSocketBuilder2[RIO[Clock with Blocking, *]] => HttpRoutes[RIO[Clock with Blocking, *]]
+  type F[A] = RIO[Clock with Blocking, A]
+  type Routes = WebSocketBuilder2[F] => HttpRoutes[F]
+  type ServerOptions = Http4sServerOptions[F, F]
 }
 
-class ZHttp4sTestServerInterpreter extends TestServerInterpreter[RIO[Clock with Blocking, *], ZioStreams with WebSockets, Routes] {
+class ZHttp4sTestServerInterpreter extends TestServerInterpreter[F, ZioStreams with WebSockets, ServerOptions, Routes] {
   implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
-  override def route(
-      e: ZServerEndpoint[Clock with Blocking, ZioStreams with WebSockets],
-      decodeFailureHandler: Option[DecodeFailureHandler] = None,
-      metricsInterceptor: Option[MetricsRequestInterceptor[RIO[Clock with Blocking, *]]] = None
-  ): Routes = {
-    val serverOptions: Http4sServerOptions[RIO[Clock with Blocking, *], RIO[Clock with Blocking, *]] = Http4sServerOptions
-      .customInterceptors[RIO[Clock with Blocking, *], RIO[Clock with Blocking, *]]
-      .metricsInterceptor(metricsInterceptor)
-      .decodeFailureHandler(decodeFailureHandler.getOrElse(DefaultDecodeFailureHandler.default))
-      .options
-
-    ZHttp4sServerInterpreter(serverOptions).fromWebSocket(e).toRoutes
-  }
-
-  override def route(
-      es: List[ZServerEndpoint[Clock with Blocking, ZioStreams with WebSockets]]
-  ): Routes = {
-    ZHttp4sServerInterpreter().fromWebSocket(es).toRoutes
+  override def route(es: List[ZServerEndpoint[Clock with Blocking, ZioStreams with WebSockets]], interceptors: Interceptors): Routes = {
+    val serverOptions: ServerOptions = interceptors(Http4sServerOptions.customInterceptors).options
+    ZHttp4sServerInterpreter(serverOptions).fromWebSocket(es).toRoutes
   }
 
   override def server(routes: NonEmptyList[Routes]): Resource[IO, Port] = {


### PR DESCRIPTION
## Summary of changes

`TestServerInterpreter` and `CreateServerTest` now take a function `CustomInterceptors => CustomInterceptors` instead of just `Option[DecodeFailureHandler]` and `Option[MetricsRequestInterceptor]` - so that any supported interceptors can be used in test setup.

The concrete `*TestServerInterpreter`s now only use the 
```scala
def route(es: List[ServerEndpoint[R, F]], interceptors: Interceptors = identity): ROUTE
```
version of the `route` function, i.e. the one that takes a list of `ServerEndpoint`s. The version that takes a single 
`ServerEndpoint` delegates to that one on the `TestServerInterpreter` trait level. The interpreters that so far only supported a single server endpoint were updated to support a list of endpoints and only use the last endpoint from the list.

`FinatraCatsServerOptions` use `F` instead of `Future` for `createFile`, `deleteFile` and `interceptors`. The `FinatraCatsServerInterpreter` and `FinatraCatsServerOptions` have thus been updated with the necessary two-way conversions between `Future` and `F`.