### PR TITLE
[zhttp] Add more tests for zServerLogic

### DIFF
--- a/server/zio1-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
+++ b/server/zio1-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
@@ -2,12 +2,17 @@ package sttp.tapir.server.ziohttp
 
 import cats.data.NonEmptyList
 import sttp.client3._
+import org.scalactic.source.Position.here
 import sttp.model.StatusCode
 import sttp.tapir.server.tests.CreateServerTest
 import sttp.tapir.ztapir._
 import zhttp.http._
 import zio.{Task, ZIO}
 import org.scalatest.matchers.should.Matchers._
+import sttp.tapir.tests.Test
+import io.netty.util.CharsetUtil
+import zio.UIO
+import org.scalatest.compatible.Assertion
 
 class ZioHttpCompositionTest(
     createServerTest: CreateServerTest[Task, Any, ZioHttpServerOptions[Any], Http[Any, Throwable, zhttp.http.Request, zhttp.http.Response]]
@@ -32,6 +37,19 @@ class ZioHttpCompositionTest(
       basicRequest.get(uri"$baseUri/p1").send(backend).map(_.code shouldBe StatusCode.Ok) >>
         basicRequest.get(uri"$baseUri/p2").send(backend).map(_.code shouldBe StatusCode.Ok) >>
         basicRequest.get(uri"$baseUri/p3").send(backend).map(_.code shouldBe StatusCode.BadRequest)
-    }
+    },
+    new Test(
+      "zio http can get a content",
+      () => {
+        val ep = endpoint.get.in("p1").out(stringBody).zServerLogic[Any](_ => ZIO.succeed("response"))
+        val route = ZioHttpInterpreter().toHttp(ep)
+        val test: UIO[Assertion] = route(Request(url = URL.apply(Path.apply("p1"))))
+          .flatMap(response => response.data.toByteBuf.map(_.toString(CharsetUtil.UTF_8)))
+          .map(_ shouldBe "response")
+          .catchAll(_ => ZIO.succeed(fail("Unable to extract body from Http response")))
+        zio.Runtime.default.unsafeRunToFuture(test)
+      },
+      here
+    )
   )
 }


### PR DESCRIPTION
This is related to both:

- https://github.com/softwaremill/tapir/issues/1914
- https://github.com/dream11/zio-http/pull/1118

How did we not see that before ? 
From my understanding, this only happens when decoding HttpData from a server, without involving any client, so it can only be spotted in test (most of the time). Furthermore, the status code returned by the HttpData is correct, but the body is always empty.

There is not much we can do from tapir and it's not blocking as it's only reproducible in a very limited case, but I think that having a regression test for that makes sense.

This is blocked until a fix from ZIO-Http is released.
I don't think that the location where I've added the test and the way I did it is correct, but Tapir source code is pretty complex and I couldn't find a better place. If you're interested in this test (and maybe a few more), could you point me to the correct place to add them ? 

There are a few pre-requisite:
1. They must be executed by the ZIO runtime
2. They can't involved any client (sttp or any other)

Maybe creating a new test file in `test/scala/sttp/tapir/server/ziohttp` and reference it from `ZioHttpServerTest.scala` would be the best way ? 