### PR TITLE
[BUG] oneOfUsingField fails for case object enums that inherit enumeratum EnumEntry reproducer

### DIFF
--- a/core/src/main/scala-2/sttp/tapir/generic/internal/OneOfMacro.scala
+++ b/core/src/main/scala-2/sttp/tapir/generic/internal/OneOfMacro.scala
@@ -57,7 +57,7 @@ object OneOfMacro {
             import _root_.sttp.tapir.SchemaType._
             import _root_.scala.collection.immutable.{List, Map}
             val mappingAsList = List(..$mapping)
-            val mappingAsMap = mappingAsList.toMap
+            val mappingAsMap: Map[$weakTypeV, Schema[_]] = mappingAsList.toMap
             val discriminator = SDiscriminator(
               _root_.sttp.tapir.FieldName($name, $conf.toEncodedName($name)),
               // cannot use .collect because of a bug in ScalaJS (Trying to access the this of another class ... during phase: jscode)

--- a/integrations/enumeratum/src/test/scala/sttp/tapir/codec/enumeratum/TapirCodecEnumeratumTest.scala
+++ b/integrations/enumeratum/src/test/scala/sttp/tapir/codec/enumeratum/TapirCodecEnumeratumTest.scala
@@ -1,5 +1,6 @@
 package sttp.tapir.codec.enumeratum
 
+import enumeratum.EnumEntry.Snakecase
 import enumeratum._
 import enumeratum.values._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -8,6 +9,8 @@ import sttp.tapir.Codec.PlainCodec
 import sttp.tapir.Schema.SName
 import sttp.tapir.Schema.annotations.{default, description}
 import sttp.tapir.SchemaType.{SInteger, SString}
+import sttp.tapir.generic.Derived
+import sttp.tapir.generic.auto._
 import sttp.tapir.{DecodeResult, Schema, Validator}
 
 class TapirCodecEnumeratumTest extends AnyFlatSpec with Matchers {
@@ -102,6 +105,41 @@ class TapirCodecEnumeratumTest extends AnyFlatSpec with Matchers {
   it should "find schema for enumeratum enum entries and enrich with metadata from default annotations" in {
     implicitly[Schema[TestEnumEntryWithSomeEncodedDefault]].default shouldBe Some((TestEnumEntryWithSomeEncodedDefault.Value2, Some(TestEnumEntryWithSomeEncodedDefault.Value2)))
     implicitly[Schema[TestEnumEntryWithNoEncodedDefault]].default shouldBe Some((TestEnumEntryWithNoEncodedDefault.Value2, None))
+  }
+
+  it should "create schema with custom discriminator based on enumeratum enum" in {
+    // i'm not sure if this is relevant, but our tapir and circe configuration is setup to automatically handle
+    // coproducts with a `type` discriminator, but this case is an exception where we don't want the coproduct subtype's
+    // constructor name to be used as the value in openapi docs
+    //import io.circe.generic.{extras => circe}
+    //implicit val circeConfig =
+    //  circe.Configuration.default.withSnakeCaseMemberNames.withDiscriminator("type").copy(transformConstructorNames =
+    //    transformConstructorNamesConfig)
+    import sttp.tapir.{generic => tapir}
+    implicit val tapirConfig =
+      tapir.Configuration.default.withSnakeCaseMemberNames.withSnakeCaseDiscriminatorValues.withDiscriminator("type")
+
+    sealed trait OfferType extends EnumEntry with Snakecase
+    object OfferType {
+      case object OfferOne extends OfferType
+      case object OfferTwo extends OfferType
+    }
+
+    sealed trait CreateOfferRequest {
+      def `type`: OfferType
+    }
+
+    final case class CreateOfferOneRequest(`type`: OfferType) extends CreateOfferRequest
+    final case class CreateOfferTwoRequest(`type`: OfferType) extends CreateOfferRequest
+
+    implicit lazy val createOfferRequestSchema: Schema[CreateOfferRequest] = {
+      val one = implicitly[Derived[Schema[CreateOfferOneRequest]]].value
+      val two = implicitly[Derived[Schema[CreateOfferTwoRequest]]].value
+      Schema.oneOfUsingField[CreateOfferRequest, OfferType](_.`type`, _.entryName)(
+        OfferType.OfferOne -> one,
+        OfferType.OfferTwo -> two
+      )
+    }
   }
 }
 


### PR DESCRIPTION
Similar to #1950 this example is unable to compile. I think the main distinction is the use of `enumeratum.EnumEntry` and possibly the conflicting tapir configuration that this case is trying to override with a custom mapping for the discriminator.

```
[error] /home/seglo/source/tapir/integrations/enumeratum/src/test/scala/sttp/tapir/codec/enumeratum/TapirCodecEnumeratumTest.scala:138:83: type mismatch;
[error]   ee.type|OfferType with scala.Product with java.io.Serializable
[error]       Schema.oneOfUsingField[CreateOfferRequest, OfferType](_.`type`, _.entryName)(
[error]                                                                                   ^
```