### PR TITLE
Update swagger-ui to 4.9.1

### DIFF
--- a/docs/swagger-ui-bundle/src/test/scala/sttp/tapir/swagger/bundle/SwaggerInterpreterTest.scala
+++ b/docs/swagger-ui-bundle/src/test/scala/sttp/tapir/swagger/bundle/SwaggerInterpreterTest.scala
@@ -49,10 +49,16 @@ class SwaggerInterpreterTest extends AsyncFunSuite with Matchers {
           val docsPath = (context ++ prefix).mkString("/")
 
           resp.code shouldBe StatusCode.Ok
-          resp.body should include(s"/$docsPath/docs.yaml")
-
           resp.history.head.code shouldBe StatusCode.PermanentRedirect
           resp.history.head.headers("Location").head shouldBe s"/$docsPath/"
+
+          // test getting swagger-initializer.js, which should contain replaced link to spec
+          val initializerJsResp = basicRequest
+            .response(asStringAlways)
+            .get(uri"http://localhost:$port/${context ++ prefix}/swagger-initializer.js")
+            .send(backend)
+
+          initializerJsResp.body should include(s"/$docsPath/docs.yaml")
 
           // test getting a swagger-ui resource
           val respCss: Response[String] = basicRequest

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,7 +8,7 @@ object Versions {
   val sttpShared = "1.3.2"
   val akkaHttp = "10.2.9"
   val akkaStreams = "2.6.19"
-  val swaggerUi = "4.8.1"
+  val swaggerUi = "4.9.1"
   val upickle = "1.5.0"
   val playJson = "2.9.2"
   val finatra = "22.1.0"


### PR DESCRIPTION
This update requires changes in SwaggerUI because this PR (https://github.com/swagger-api/swagger-ui/pull/7905) removes inline code from index.html where the hack with replacing petstore link was implemented. Now, petstore link lives inside swagger-initializer.js and replacing is now performed for the swagger-initializer.js file.