### PR TITLE
Make exception handler effectful

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -86,20 +86,22 @@ Custom interpreters can be provided to the stub. For example, to test custom exc
 following customised akka http options:
 
 ```scala mdoc:silent
-import sttp.tapir.server.interceptor.exception.ExceptionContext
+import sttp.tapir.server.interceptor.exception.ExceptionHandler
 import sttp.tapir.server.interceptor.CustomInterceptors
 import sttp.tapir.server.akkahttp.AkkaHttpServerOptions
 import sttp.tapir.server.model.ValuedEndpointOutput
 import sttp.model.StatusCode
 
+val exceptionHandler = ExceptionHandler.pure[Future](ctx =>
+    Some(ValuedEndpointOutput(
+      stringBody.and(statusCode),
+      (s"failed due to ${ctx.e.getMessage}", StatusCode.InternalServerError)
+    ))
+)
+
 val customOptions: CustomInterceptors[Future, AkkaHttpServerOptions] = 
   AkkaHttpServerOptions.customInterceptors
-    .exceptionHandler((ctx: ExceptionContext) =>
-      Some(ValuedEndpointOutput(
-        stringBody.and(statusCode), 
-        (s"failed due to ${ctx.e.getMessage}", StatusCode.InternalServerError))
-      )  
-    )
+    .exceptionHandler(exceptionHandler)
 ```
 
 Testing such an interceptor requires simulating an exception being thrown in the server logic:

--- a/examples/src/test/scala/sttp/tapir/examples/AkkaServerStubInterpreterExample.scala
+++ b/examples/src/test/scala/sttp/tapir/examples/AkkaServerStubInterpreterExample.scala
@@ -8,7 +8,7 @@ import sttp.model.StatusCode
 import sttp.tapir._
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.akkahttp.AkkaHttpServerOptions
-import sttp.tapir.server.interceptor.exception.ExceptionContext
+import sttp.tapir.server.interceptor.exception.ExceptionHandler
 import sttp.tapir.server.interceptor.CustomInterceptors
 import sttp.tapir.server.model.ValuedEndpointOutput
 import sttp.tapir.server.stub.TapirStubInterpreter
@@ -59,8 +59,9 @@ object UsersApi {
     )
     .serverLogic(user => _ => Future.successful(Right(s"hello $user")))
 
+  val exceptionHandler = ExceptionHandler.pure[Future](ctx =>
+    Option(ValuedEndpointOutput(stringBody.and(statusCode), (s"failed due to ${ctx.e.getMessage}", StatusCode.InternalServerError)))
+  )
   val options: CustomInterceptors[Future, AkkaHttpServerOptions] = AkkaHttpServerOptions.customInterceptors
-    .exceptionHandler((ctx: ExceptionContext) =>
-      Option(ValuedEndpointOutput(stringBody.and(statusCode), (s"failed due to ${ctx.e.getMessage}", StatusCode.InternalServerError)))
-    )
+    .exceptionHandler(exceptionHandler)
 }

--- a/metrics/opentelemetry-metrics/src/test/scala/sttp/tapir/server/metrics/opentelemetry/OpenTelemetryMetricsTest.scala
+++ b/metrics/opentelemetry-metrics/src/test/scala/sttp/tapir/server/metrics/opentelemetry/OpenTelemetryMetricsTest.scala
@@ -186,7 +186,7 @@ class OpenTelemetryMetricsTest extends AnyFlatSpec with Matchers {
       _ => List(serverEp),
       TestRequestBody,
       StringToResponseBody,
-      List(metrics.metricsInterceptor(), new ExceptionInterceptor(DefaultExceptionHandler.handler)),
+      List(metrics.metricsInterceptor(), new ExceptionInterceptor(DefaultExceptionHandler[Id])),
       _ => ()
     )
 

--- a/metrics/prometheus-metrics/src/test/scala/sttp/tapir/server/metrics/prometheus/PrometheusMetricsTest.scala
+++ b/metrics/prometheus-metrics/src/test/scala/sttp/tapir/server/metrics/prometheus/PrometheusMetricsTest.scala
@@ -232,7 +232,7 @@ class PrometheusMetricsTest extends AnyFlatSpec with Matchers {
       _ => List(serverEp),
       TestRequestBody,
       StringToResponseBody,
-      List(metrics.metricsInterceptor(), new ExceptionInterceptor(DefaultExceptionHandler.handler)),
+      List(metrics.metricsInterceptor(), new ExceptionInterceptor(DefaultExceptionHandler[Id])),
       _ => ()
     )
 

--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/CustomInterceptors.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/CustomInterceptors.scala
@@ -43,7 +43,7 @@ case class CustomInterceptors[F[_], O](
     metricsInterceptor: Option[MetricsRequestInterceptor[F]] = None,
     corsInterceptor: Option[CORSInterceptor[F]] = None,
     rejectHandler: Option[RejectHandler] = Some(DefaultRejectHandler.default),
-    exceptionHandler: Option[ExceptionHandler] = Some(DefaultExceptionHandler.handler),
+    exceptionHandler: Option[ExceptionHandler[F]] = Some(DefaultExceptionHandler[F]),
     serverLog: Option[ServerLog[F]] = None,
     unsupportedMediaTypeInterceptor: Option[UnsupportedMediaTypeInterceptor[F]] = Some(
       new UnsupportedMediaTypeInterceptor[F]()
@@ -62,8 +62,8 @@ case class CustomInterceptors[F[_], O](
   def rejectHandler(r: RejectHandler): CustomInterceptors[F, O] = copy(rejectHandler = Some(r))
   def rejectHandler(r: Option[RejectHandler]): CustomInterceptors[F, O] = copy(rejectHandler = r)
 
-  def exceptionHandler(e: ExceptionHandler): CustomInterceptors[F, O] = copy(exceptionHandler = Some(e))
-  def exceptionHandler(e: Option[ExceptionHandler]): CustomInterceptors[F, O] = copy(exceptionHandler = e)
+  def exceptionHandler(e: ExceptionHandler[F]): CustomInterceptors[F, O] = copy(exceptionHandler = Some(e))
+  def exceptionHandler(e: Option[ExceptionHandler[F]]): CustomInterceptors[F, O] = copy(exceptionHandler = e)
 
   def serverLog(log: ServerLog[F]): CustomInterceptors[F, O] = copy(serverLog = Some(log))
   def serverLog(log: Option[ServerLog[F]]): CustomInterceptors[F, O] = copy(serverLog = log)

--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/exception/ExceptionHandler.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/exception/ExceptionHandler.scala
@@ -1,19 +1,34 @@
 package sttp.tapir.server.interceptor.exception
 
 import sttp.model.StatusCode
-import sttp.tapir.{server, _}
+import sttp.monad.MonadError
 import sttp.tapir.server.model.ValuedEndpointOutput
+import sttp.tapir._
 
-trait ExceptionHandler {
-  def apply(ctx: ExceptionContext): Option[ValuedEndpointOutput[_]]
+trait ExceptionHandler[F[_]] {
+  def apply(ctx: ExceptionContext)(implicit monad: MonadError[F]): F[Option[ValuedEndpointOutput[_]]]
 }
 
-case class DefaultExceptionHandler(response: (StatusCode, String) => ValuedEndpointOutput[_]) extends ExceptionHandler {
-  override def apply(ctx: ExceptionContext): Option[ValuedEndpointOutput[_]] =
-    Some(response(StatusCode.InternalServerError, "Internal server error"))
+object ExceptionHandler {
+  def apply[F[_]](f: ExceptionContext => F[Option[ValuedEndpointOutput[_]]]): ExceptionHandler[F] =
+    new ExceptionHandler[F] {
+      override def apply(ctx: ExceptionContext)(implicit monad: MonadError[F]): F[Option[ValuedEndpointOutput[_]]] =
+        f(ctx)
+    }
+
+  def pure[F[_]](f: ExceptionContext => Option[ValuedEndpointOutput[_]]): ExceptionHandler[F] =
+    new ExceptionHandler[F] {
+      override def apply(ctx: ExceptionContext)(implicit monad: MonadError[F]): F[Option[ValuedEndpointOutput[_]]] =
+        monad.unit(f(ctx))
+    }
+}
+
+case class DefaultExceptionHandler[F[_]](response: (StatusCode, String) => ValuedEndpointOutput[_]) extends ExceptionHandler[F] {
+  override def apply(ctx: ExceptionContext)(implicit monad: MonadError[F]): F[Option[ValuedEndpointOutput[_]]] =
+    monad.unit(Some(response(StatusCode.InternalServerError, "Internal server error")))
 }
 
 object DefaultExceptionHandler {
-  val handler: DefaultExceptionHandler =
-    DefaultExceptionHandler((sc, m) => server.model.ValuedEndpointOutput(statusCode.and(stringBody), (sc, m)))
+  def apply[F[_]]: ExceptionHandler[F] =
+    DefaultExceptionHandler[F]((code: StatusCode, body: String) => ValuedEndpointOutput(statusCode.and(stringBody), (code, body)))
 }


### PR DESCRIPTION
This changes signature of `ExceptionHandler` from `ExceptionContext => Option[ValuedEndpointOutput[_]]` to `ExceptionContext => F[ValuedEndpointOutput[_]]`. It allows to handle errors effectfully - now it's requires to completely redefine `ExceptionInterceptor` to do so.

If this change makes sense I think I can also create PR to make RejectionHandler effectful too.