### PR TITLE
Generate "default" and "example" values in OpenAPI for nested optional fields

### DIFF
--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/schema.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/schema.scala
@@ -25,7 +25,9 @@ package object schema {
       element = opt.element.copy(
         description = schema.description.orElse(opt.element.description),
         format = schema.format.orElse(opt.element.format),
-        deprecated = schema.deprecated || opt.element.deprecated
+        deprecated = schema.deprecated || opt.element.deprecated,
+        encodedExample = schema.encodedExample.orElse(opt.element.encodedExample),
+        default = schema.default.flatMap { case (t, raw) => opt.toOption(t).map((_, raw)) }.orElse(opt.element.default)
       )
     )(opt.toOption)
   }

--- a/docs/openapi-docs/src/test/resources/expected_default_and_example_on_nested_option_field.yml
+++ b/docs/openapi-docs/src/test/resources/expected_default_and_example_on_nested_option_field.yml
@@ -1,0 +1,41 @@
+openapi: 3.0.3
+info:
+  title: ClassWithNestedOptionalField
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClassWithNestedOptionalField'
+              required: true
+      responses:
+        '200':
+          description: ''
+        '400':
+          description: 'Invalid value for: body'
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    ClassWithNestedOptionalField:
+      type: object
+      properties:
+        value:
+          $ref: '#/components/schemas/Nested'
+    Nested:
+      required:
+      - nestedValue
+      type: object
+      properties:
+        nestedValue:
+          type: string
+      default:
+        nestedValue: foo
+      example:
+        nestedValue: foo


### PR DESCRIPTION
Fixes #1920