### PR TITLE
docs: ✏️ Document how to hide input/output from OpenAPI

### DIFF
--- a/doc/endpoint/ios.md
+++ b/doc/endpoint/ios.md
@@ -240,6 +240,19 @@ A fixed status code can be specified using the `statusCode(code)` output.
 Unless specified otherwise, successful responses are returned with the `200 OK` status code, and errors with
 `400 Bad Request`. For exception and decode failure handling, see [error handling](../server/errors.md).
 
+## OpenAPI description
+
+### Hidden input/output
+
+It's possible to hide an input/output from the OpenAPI description using following syntax:
+
+```scala mdoc:silent:reset
+import sttp.tapir._
+
+val acceptHeader: EndpointInput[String] = header[String]("Accept").schema(_.copy(hidden = true))
+```
+
+
 ## Next
 
 Read on about [one-of mappings](oneof.md).


### PR DESCRIPTION
Closes https://github.com/softwaremill/tapir/issues/2041

I didn't find a place in the documentation that is focused on description of input/output thus put a minimal paragraph in the "Input/Output" page but I'm open to other suggestions.