### PR TITLE
remove usages of ExecutionContext.Implicits.global

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,13 @@ println(docs.toYaml)
 import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import akka.http.scaladsl.server.Route
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 def bookListingLogic(bfy: BooksFromYear,
                      limit: Limit,
                      at: AuthToken): Future[Either[String, List[Book]]] =
   Future.successful(Right(List(Book("The Sorrows of Young Werther"))))
+  
 val booksListingRoute: Route = AkkaHttpServerInterpreter()
   .toRoute(booksListing.serverLogic((bookListingLogic _).tupled))
 

--- a/build.sbt
+++ b/build.sbt
@@ -1077,7 +1077,7 @@ lazy val playServer: ProjectMatrix = (projectMatrix in file("server/play-server"
       "com.typesafe.play" %% "play-akka-http-server" % Versions.playServer,
       "com.typesafe.play" %% "play" % Versions.playServer,
       "com.softwaremill.sttp.shared" %% "akka" % Versions.sttpShared,
-      "org.scala-lang.modules" %% "scala-collection-compat" % Versions.scalaCollectionCompat,
+      "org.scala-lang.modules" %% "scala-collection-compat" % Versions.scalaCollectionCompat
     )
   )
   .jvmPlatform(scalaVersions = scala2Versions)

--- a/doc/docs/openapi.md
+++ b/doc/docs/openapi.md
@@ -20,6 +20,7 @@ import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 val myEndpoints: List[AnyEndpoint] = ???
 
@@ -285,6 +286,7 @@ import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import sttp.tapir.swagger.SwaggerUI
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 val myEndpoints: Seq[AnyEndpoint] = ???
 val docsAsYaml: String = OpenAPIDocsInterpreter().toOpenAPI(myEndpoints, "My App", "1.0").toYaml

--- a/doc/endpoint/static.md
+++ b/doc/endpoint/static.md
@@ -18,6 +18,7 @@ import sttp.tapir._
 import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 val filesRoute: Route = AkkaHttpServerInterpreter().toRoute(
   filesGetServerEndpoint[Future]("site" / "static")("/home/static/data")

--- a/doc/index.md
+++ b/doc/index.md
@@ -115,11 +115,13 @@ println(docs.toYaml)
 import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import akka.http.scaladsl.server.Route
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 def bookListingLogic(bfy: BooksFromYear,
                      limit: Limit,
                      at: AuthToken): Future[Either[String, List[Book]]] =
   Future.successful(Right(List(Book("The Sorrows of Young Werther"))))
+  
 val booksListingRoute: Route = AkkaHttpServerInterpreter()
   .toRoute(booksListing.serverLogic((bookListingLogic _).tupled))
 

--- a/doc/server/akkahttp.md
+++ b/doc/server/akkahttp.md
@@ -32,6 +32,7 @@ import sttp.tapir._
 import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import scala.concurrent.Future
 import akka.http.scaladsl.server.Route
+import scala.concurrent.ExecutionContext.Implicits.global
 
 def countCharacters(s: String): Future[Either[Unit, Int]] = 
   Future.successful(Right[Unit, Int](s.length))
@@ -60,6 +61,7 @@ import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import akka.http.scaladsl.server._
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class Special
 def metricsDirective: Directive0 = ???
@@ -106,6 +108,7 @@ import sttp.tapir._
 import sttp.tapir.server.akkahttp.{AkkaHttpServerInterpreter, serverSentEventsBody}
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 val sseEndpoint = endpoint.get.out(serverSentEventsBody)
 

--- a/doc/server/errors.md
+++ b/doc/server/errors.md
@@ -131,6 +131,7 @@ import sttp.tapir.server.akkahttp.AkkaHttpServerOptions
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import io.circe.generic.auto._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 case class MyFailure(msg: String)
 def myFailureResponse(m: String): ValuedEndpointOutput[_] =

--- a/doc/server/logic.md
+++ b/doc/server/logic.md
@@ -59,6 +59,7 @@ endpoints can be converted to an akka-http route:
 import sttp.tapir._
 import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 import akka.http.scaladsl.server.Route
 
 val endpoint1 = endpoint.in("hello").out(stringBody)

--- a/doc/server/observability.md
+++ b/doc/server/observability.md
@@ -64,6 +64,7 @@ import sttp.tapir.server.metrics.prometheus.PrometheusMetrics
 import sttp.tapir.server.akkahttp.{AkkaHttpServerInterpreter, AkkaHttpServerOptions}
 
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 // an instance with default metrics; use PrometheusMetrics[Future]() for an empty one
 val prometheusMetrics = PrometheusMetrics.default[Future]()

--- a/doc/server/options.md
+++ b/doc/server/options.md
@@ -16,6 +16,7 @@ For example, for `AkkaHttpServerOptions` and `AkkaHttpServerInterpreter`:
 import sttp.tapir.server.interceptor.decodefailure.DecodeFailureHandler
 import sttp.tapir.server.akkahttp.AkkaHttpServerOptions
 import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
+import scala.concurrent.ExecutionContext.Implicits.global
 
 val customDecodeFailureHandler: DecodeFailureHandler = ???
 
@@ -39,6 +40,7 @@ returned instead by using a different decode failure handler. For example, using
 import sttp.tapir.server.interceptor.decodefailure.DefaultDecodeFailureHandler
 import sttp.tapir.server.akkahttp.AkkaHttpServerOptions
 import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
+import scala.concurrent.ExecutionContext.Implicits.global
 
 val customServerOptions: AkkaHttpServerOptions = AkkaHttpServerOptions
   .customiseInterceptors

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -99,15 +99,18 @@ val exceptionHandler = ExceptionHandler.pure[Future](ctx =>
     ))
 )
 
-val customOptions: CustomiseInterceptors[Future, AkkaHttpServerOptions] = 
+val customOptions: CustomiseInterceptors[Future, AkkaHttpServerOptions] = {
+  import scala.concurrent.ExecutionContext.Implicits.global
   AkkaHttpServerOptions.customiseInterceptors
     .exceptionHandler(exceptionHandler)
+}    
 ```
 
 Testing such an interceptor requires simulating an exception being thrown in the server logic:
 
 ```scala mdoc:silent
 class MySpec2 extends AsyncFlatSpec with Matchers {
+
   it should "use my custom exception handler" in {
     // given
     val stub = TapirStubInterpreter(customOptions, SttpBackendStub.asynchronousFuture)

--- a/examples/src/main/scala/sttp/tapir/examples/BasicAuthenticationAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BasicAuthenticationAkkaServer.scala
@@ -14,6 +14,9 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 object BasicAuthenticationAkkaServer extends App {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
   val secret: Endpoint[UsernamePassword, Unit, Unit, String, Any] =
     endpoint.get.securityIn("secret").securityIn(auth.basic[UsernamePassword](WWWAuthenticateChallenge.basic("example"))).out(stringBody)
 
@@ -25,9 +28,6 @@ object BasicAuthenticationAkkaServer extends App {
     )
 
   // starting the server
-  implicit val actorSystem: ActorSystem = ActorSystem()
-  import actorSystem.dispatcher
-
   val bindAndCheck = Http().newServerAt("localhost", 8080).bindFlow(secretRoute).map { _ =>
     // testing
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExample.scala
@@ -138,8 +138,9 @@ object BooksExample extends App with StrictLogging {
 
     import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
-    val routes = AkkaHttpServerInterpreter().toRoute(serverEndpoints)
     implicit val actorSystem: ActorSystem = ActorSystem()
+    import actorSystem.dispatcher
+    val routes = AkkaHttpServerInterpreter().toRoute(serverEndpoints)
     Await.result(Http().newServerAt("localhost", 8080).bindFlow(routes), 1.minute)
 
     logger.info("Server started")

--- a/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/BooksExampleSemiauto.scala
@@ -144,8 +144,9 @@ object BooksExampleSemiauto extends App with StrictLogging {
 
     import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
-    val routes = AkkaHttpServerInterpreter().toRoute(serverEndpoints)
     implicit val actorSystem: ActorSystem = ActorSystem()
+    import actorSystem.dispatcher
+    val routes = AkkaHttpServerInterpreter().toRoute(serverEndpoints)
     Await.result(Http().newServerAt("localhost", 8080).bindFlow(routes), 1.minute)
 
     logger.info("Server started")

--- a/examples/src/main/scala/sttp/tapir/examples/CustomErrorsOnDecodeFailureAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/CustomErrorsOnDecodeFailureAkkaServer.scala
@@ -12,6 +12,9 @@ import sttp.client3._
 import sttp.tapir.server.interceptor.decodefailure.DefaultDecodeFailureHandler
 
 object CustomErrorsOnDecodeFailureAkkaServer extends App {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
   // corresponds to: GET /?amount=...
   val amountEndpoint: PublicEndpoint[Int, String, Unit, Any] = endpoint.get.in(query[Int]("amount")).errorOut(stringBody)
 
@@ -33,9 +36,6 @@ object CustomErrorsOnDecodeFailureAkkaServer extends App {
   val amountRoute: Route = AkkaHttpServerInterpreter().toRoute(amountEndpoint.serverLogicSuccess(_ => Future.successful(())))
 
   // starting the server
-  implicit val actorSystem: ActorSystem = ActorSystem()
-  import actorSystem.dispatcher
-
   val bindAndCheck = Http().newServerAt("localhost", 8080).bindFlow(amountRoute).map { _ =>
     // testing
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()

--- a/examples/src/main/scala/sttp/tapir/examples/ErrorOutputsAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ErrorOutputsAkkaServer.scala
@@ -14,6 +14,9 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 object ErrorOutputsAkkaServer extends App {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
   // the endpoint description
   case class Result(result: Int)
 
@@ -30,9 +33,6 @@ object ErrorOutputsAkkaServer extends App {
   })
 
   // starting the server
-  implicit val actorSystem: ActorSystem = ActorSystem()
-  import actorSystem.dispatcher
-
   val bindAndCheck = Http().newServerAt("localhost", 8080).bindFlow(errorOrJsonRoute).map { _ =>
     // testing
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()

--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldAkkaServer.scala
@@ -11,6 +11,9 @@ import scala.concurrent.duration._
 import sttp.client3._
 
 object HelloWorldAkkaServer extends App {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
   // the endpoint: single fixed path input ("hello"), single query parameter
   // corresponds to: GET /hello?name=...
   val helloWorld: PublicEndpoint[String, Unit, String, Any] =
@@ -21,9 +24,6 @@ object HelloWorldAkkaServer extends App {
     AkkaHttpServerInterpreter().toRoute(helloWorld.serverLogicSuccess(name => Future.successful(s"Hello, $name!")))
 
   // starting the server
-  implicit val actorSystem: ActorSystem = ActorSystem()
-  import actorSystem.dispatcher
-
   val bindAndCheck = Http().newServerAt("localhost", 8080).bindFlow(helloWorldRoute).map { _ =>
     // testing
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()

--- a/examples/src/main/scala/sttp/tapir/examples/MultipartFormUploadAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipartFormUploadAkkaServer.scala
@@ -13,9 +13,11 @@ import sttp.tapir.server.akkahttp.AkkaHttpServerInterpreter
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 
 object MultipartFormUploadAkkaServer extends App {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
   // the class representing the multipart data
   //
   // parts can be referenced directly; if part metadata is needed, we define the type wrapped with Part[_].
@@ -39,8 +41,6 @@ object MultipartFormUploadAkkaServer extends App {
   })
 
   // starting the server
-  implicit val actorSystem: ActorSystem = ActorSystem()
-  import actorSystem.dispatcher
   val bindAndCheck = Http().newServerAt("localhost", 8080).bindFlow(setProfileRoute).map { _ =>
     val testFile = java.io.File.createTempFile("user-123", ".jpg")
     val pw = new PrintWriter(testFile); pw.write("This is not a photo"); pw.close()

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleEndpointsDocumentationAkkaServer.scala
@@ -14,6 +14,9 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 object MultipleEndpointsDocumentationAkkaServer extends App {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
   // endpoint descriptions
   case class Author(name: String)
   case class Book(title: String, year: Int, author: Author)
@@ -57,9 +60,6 @@ object MultipleEndpointsDocumentationAkkaServer extends App {
     )
 
   // starting the server
-  implicit val actorSystem: ActorSystem = ActorSystem()
-  import actorSystem.dispatcher
-
   val routes = {
     import akka.http.scaladsl.server.Directives._
     concat(booksListingRoute, addBookRoute, swaggerUIRoute)

--- a/examples/src/main/scala/sttp/tapir/examples/MultipleServerEndpointsAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/MultipleServerEndpointsAkkaServer.scala
@@ -11,6 +11,9 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 object MultipleServerEndpointsAkkaServer extends App {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
   // endpoint descriptions, together with the server logic
   val endpoint1 = endpoint.get.in("endpoint1").out(stringBody).serverLogicSuccess { _ => Future.successful("ok1") }
   val endpoint2 =
@@ -20,9 +23,6 @@ object MultipleServerEndpointsAkkaServer extends App {
   val route: Route = AkkaHttpServerInterpreter().toRoute(List(endpoint1, endpoint2))
 
   // starting the server
-  implicit val actorSystem: ActorSystem = ActorSystem()
-  import actorSystem.dispatcher
-
   val bindAndCheck = Http().newServerAt("localhost", 8080).bindFlow(route).map { _ =>
     // testing
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()

--- a/examples/src/main/scala/sttp/tapir/examples/PrometheusMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/PrometheusMetricsExample.scala
@@ -16,6 +16,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 object PrometheusMetricsExample extends App with StrictLogging {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
 
   case class Person(name: String)
 
@@ -44,8 +46,6 @@ object PrometheusMetricsExample extends App with StrictLogging {
         prometheusMetrics.metricsEndpoint
       )
     )
-
-  implicit val actorSystem: ActorSystem = ActorSystem()
 
   Await.result(Http().newServerAt("localhost", 8080).bindFlow(routes), 1.minute)
 

--- a/examples/src/main/scala/sttp/tapir/examples/StaticContentFromFilesAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/StaticContentFromFilesAkkaServer.scala
@@ -13,6 +13,9 @@ import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 
 object StaticContentFromFilesAkkaServer extends App {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
   val content = "f1 content"
   val exampleDirectory: Path = Files.createTempDirectory("akka-static-example")
   Files.write(exampleDirectory.resolve("f1"), content.getBytes, StandardOpenOption.CREATE_NEW)
@@ -21,9 +24,6 @@ object StaticContentFromFilesAkkaServer extends App {
   val route: Route = AkkaHttpServerInterpreter().toRoute(fileEndpoints)
 
   // starting the server
-  implicit val actorSystem: ActorSystem = ActorSystem()
-  import actorSystem.dispatcher
-
   val bindAndCheck: Future[Unit] = Http().newServerAt("localhost", 8080).bindFlow(route).map { _ =>
     // testing
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()

--- a/examples/src/main/scala/sttp/tapir/examples/StaticContentFromResourcesAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/StaticContentFromResourcesAkkaServer.scala
@@ -12,6 +12,9 @@ import scala.concurrent.{Await, Future}
 import scala.io.StdIn
 
 object StaticContentFromResourcesAkkaServer extends App {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
   // we're pretending to be a SPA application, that is we serve index.html if the requested resource cannot be found
   val resourceEndpoints = resourcesGetServerEndpoint[Future](emptyInput)(
     StaticContentFromResourcesAkkaServer.getClass.getClassLoader,
@@ -21,8 +24,6 @@ object StaticContentFromResourcesAkkaServer extends App {
   val route: Route = AkkaHttpServerInterpreter().toRoute(resourceEndpoints)
 
   // starting the server
-  implicit val actorSystem: ActorSystem = ActorSystem()
-
   val bind = Http().newServerAt("localhost", 8080).bindFlow(route)
   Await.result(bind, 1.minute)
   println("Open: http://localhost:8080 and experiment with various paths.")

--- a/examples/src/main/scala/sttp/tapir/examples/StreamingAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/StreamingAkkaServer.scala
@@ -14,6 +14,9 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 object StreamingAkkaServer extends App {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
   // The endpoint: corresponds to GET /receive.
   // We need to provide both the schema of the value (for documentation), as well as the format (media type) of the
   // body. Here, the schema is a `string` and the media type is `text/plain`.
@@ -25,9 +28,6 @@ object StreamingAkkaServer extends App {
   val streamingRoute: Route = AkkaHttpServerInterpreter().toRoute(streamingEndpoint.serverLogicSuccess(_ => Future.successful(testStream)))
 
   // starting the server
-  implicit val actorSystem: ActorSystem = ActorSystem()
-  import actorSystem.dispatcher
-
   val bindAndCheck = Http().newServerAt("localhost", 8080).bindFlow(streamingRoute).map { _ =>
     // testing
     val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()

--- a/examples/src/main/scala/sttp/tapir/examples/SwaggerUIOauth2AkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/SwaggerUIOauth2AkkaServer.scala
@@ -30,6 +30,7 @@ import scala.concurrent.{Await, Future, Promise}
   */
 object SwaggerUIOauth2AkkaServer extends App with RouteConcatenation {
   implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
 
   def authLogic(token: String): Future[Either[Int, String]] = Future.successful(Right(token))
 

--- a/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/WebSocketAkkaServer.scala
@@ -30,6 +30,9 @@ object WebSocketAkkaServer extends App {
   val wsEndpoint: PublicEndpoint[Unit, Unit, Flow[String, Response, Any], AkkaStreams with WebSockets] =
     endpoint.get.in("ping").out(webSocketBody[String, CodecFormat.TextPlain, Response, CodecFormat.Json](AkkaStreams))
 
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
   // Implementation of the web socket: a flow which echoes incoming messages
   val wsRoute: Route =
     AkkaHttpServerInterpreter().toRoute(
@@ -41,9 +44,6 @@ object WebSocketAkkaServer extends App {
   println(s"Paste into https://playground.asyncapi.io/ to see the docs for this endpoint:\n$apiDocs")
 
   // Starting the server
-  implicit val actorSystem: ActorSystem = ActorSystem()
-  import actorSystem.dispatcher
-
   val bindAndCheck = Http()
     .newServerAt("localhost", 8080)
     .bindFlow(wsRoute)

--- a/examples/src/test/scala/sttp/tapir/examples/AkkaServerStubInterpreterExample.scala
+++ b/examples/src/test/scala/sttp/tapir/examples/AkkaServerStubInterpreterExample.scala
@@ -13,7 +13,7 @@ import sttp.tapir.server.interceptor.CustomiseInterceptors
 import sttp.tapir.server.model.ValuedEndpointOutput
 import sttp.tapir.server.stub.TapirStubInterpreter
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class AkkaServerStubInterpreterExample extends AsyncFlatSpec with Matchers {
 
@@ -62,6 +62,6 @@ object UsersApi {
   val exceptionHandler = ExceptionHandler.pure[Future](ctx =>
     Option(ValuedEndpointOutput(stringBody.and(statusCode), (s"failed due to ${ctx.e.getMessage}", StatusCode.InternalServerError)))
   )
-  val options: CustomiseInterceptors[Future, AkkaHttpServerOptions] = AkkaHttpServerOptions.customiseInterceptors
-    .exceptionHandler(exceptionHandler)
+  def options(implicit ec: ExecutionContext): CustomiseInterceptors[Future, AkkaHttpServerOptions] =
+    AkkaHttpServerOptions.customiseInterceptors.exceptionHandler(exceptionHandler)
 }

--- a/perf-tests/src/main/scala/sttp/tapir/perf/akka/AkkaHttp.scala
+++ b/perf-tests/src/main/scala/sttp/tapir/perf/akka/AkkaHttp.scala
@@ -25,7 +25,7 @@ object Vanilla {
 
 object Tapir {
   val router: Int => Route = (nRoutes: Int) =>
-    AkkaHttpServerInterpreter().toRoute(
+    AkkaHttpServerInterpreter()(AkkaHttp.executionContext).toRoute(
       (0 to nRoutes)
         .map((n: Int) =>
           perf.Common

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaHttpServerInterpreter.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaHttpServerInterpreter.scala
@@ -29,7 +29,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait AkkaHttpServerInterpreter {
 
-  def akkaHttpServerOptions: AkkaHttpServerOptions
+  implicit def executionContext: ExecutionContext
+
+  def akkaHttpServerOptions: AkkaHttpServerOptions = AkkaHttpServerOptions.default
 
   def toRoute(se: ServerEndpoint[AkkaStreams with WebSockets, Future]): Route = toRoute(List(se))
 
@@ -98,10 +100,16 @@ trait AkkaHttpServerInterpreter {
 }
 
 object AkkaHttpServerInterpreter {
-
-  def apply()(implicit ec: ExecutionContext): AkkaHttpServerInterpreter = apply(AkkaHttpServerOptions.default)
-  def apply(serverOptions: AkkaHttpServerOptions): AkkaHttpServerInterpreter = {
+  def apply()(implicit _ec: ExecutionContext): AkkaHttpServerInterpreter = {
     new AkkaHttpServerInterpreter {
+      override implicit def executionContext: ExecutionContext = _ec
+    }
+  }
+
+  def apply(serverOptions: AkkaHttpServerOptions)(implicit _ec: ExecutionContext): AkkaHttpServerInterpreter = {
+    new AkkaHttpServerInterpreter {
+      override implicit def executionContext: ExecutionContext = _ec
+
       override def akkaHttpServerOptions: AkkaHttpServerOptions = serverOptions
     }
   }

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaHttpServerInterpreter.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaHttpServerInterpreter.scala
@@ -25,11 +25,11 @@ import sttp.tapir.server.interceptor.reject.RejectInterceptor
 import sttp.tapir.server.interpreter.{BodyListener, FilterServerEndpoints, ServerInterpreter}
 import sttp.tapir.server.model.ServerResponse
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 trait AkkaHttpServerInterpreter {
 
-  def akkaHttpServerOptions: AkkaHttpServerOptions = AkkaHttpServerOptions.default
+  def akkaHttpServerOptions: AkkaHttpServerOptions
 
   def toRoute(se: ServerEndpoint[AkkaStreams with WebSockets, Future]): Route = toRoute(List(se))
 
@@ -99,7 +99,8 @@ trait AkkaHttpServerInterpreter {
 
 object AkkaHttpServerInterpreter {
 
-  def apply(serverOptions: AkkaHttpServerOptions = AkkaHttpServerOptions.default): AkkaHttpServerInterpreter = {
+  def apply()(implicit ec: ExecutionContext): AkkaHttpServerInterpreter = apply(AkkaHttpServerOptions.default)
+  def apply(serverOptions: AkkaHttpServerOptions): AkkaHttpServerInterpreter = {
     new AkkaHttpServerInterpreter {
       override def akkaHttpServerOptions: AkkaHttpServerOptions = serverOptions
     }

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaToResponseBody.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaToResponseBody.scala
@@ -74,9 +74,9 @@ private[akkahttp] class AkkaToResponseBody(implicit ec: ExecutionContext, m: Mat
   ): Source[ByteString, Future[IOResult]] =
     FileIO
       .fromPath(tapirFile.file.toPath, chunkSize = 8192, startPosition = start)
-      .scan(0L, ByteString.empty) { case ((bytesConsumed, _), next) =>
+      .scan((0L, ByteString.empty)) { case ((bytesConsumed, _), next) =>
         val bytesInNext = next.length
-        val bytesFromNext = Math.max(0, Math.min(bytesTotal - bytesConsumed, bytesInNext))
+        val bytesFromNext = Math.max(0, Math.min(bytesTotal - bytesConsumed, bytesInNext.toLong))
         (bytesConsumed + bytesInNext, next.take(bytesFromNext.toInt))
       }
       .takeWhile(_._1 < bytesTotal, inclusive = true)

--- a/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerStubTest.scala
+++ b/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerStubTest.scala
@@ -8,12 +8,12 @@ import sttp.monad.FutureMonad
 import sttp.tapir.server.interceptor.CustomiseInterceptors
 import sttp.tapir.server.tests.{CreateServerStubTest, ServerStubStreamingTest, ServerStubTest}
 
-import scala.concurrent.ExecutionContext.global
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 object AkkaCreateServerStubTest extends CreateServerStubTest[Future, AkkaHttpServerOptions] {
   override def customiseInterceptors: CustomiseInterceptors[Future, AkkaHttpServerOptions] = AkkaHttpServerOptions.customiseInterceptors
-  override def stub[R]: SttpBackendStub[Future, R] = SttpBackendStub(new FutureMonad()(global))
+  override def stub[R]: SttpBackendStub[Future, R] = SttpBackendStub(new FutureMonad())
   override def asFuture[A]: Future[A] => Future[A] = identity
 }
 

--- a/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpTestServerInterpreter.scala
+++ b/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpTestServerInterpreter.scala
@@ -17,6 +17,7 @@ import scala.concurrent.Future
 class AkkaHttpTestServerInterpreter(implicit actorSystem: ActorSystem)
     extends TestServerInterpreter[Future, AkkaStreams with WebSockets, AkkaHttpServerOptions, Route] {
   override def route(es: List[ServerEndpoint[AkkaStreams with WebSockets, Future]], interceptors: Interceptors): Route = {
+    import actorSystem.dispatcher
     val serverOptions: AkkaHttpServerOptions = interceptors(AkkaHttpServerOptions.customiseInterceptors).options
     AkkaHttpServerInterpreter(serverOptions).toRoute(es)
   }

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayBodyListener.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayBodyListener.scala
@@ -4,11 +4,10 @@ import akka.Done
 import play.api.http.HttpEntity
 import sttp.tapir.server.interpreter.BodyListener
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-class PlayBodyListener extends BodyListener[Future, PlayResponseBody] {
+class PlayBodyListener(implicit ec: ExecutionContext) extends BodyListener[Future, PlayResponseBody] {
   override def onComplete(body: PlayResponseBody)(cb: Try[Unit] => Future[Unit]): Future[PlayResponseBody] = {
 
     def onDone(f: Future[Done]): Unit = f.onComplete {

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerInterpreter.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerInterpreter.scala
@@ -24,13 +24,13 @@ import sttp.tapir.server.interpreter.{
 }
 import sttp.tapir.server.model.ServerResponse
 
-import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.{ExecutionContext, Future}
 
 trait PlayServerInterpreter {
 
   implicit def mat: Materializer
 
-  implicit def executionContext: ExecutionContextExecutor = mat.executionContext
+  implicit def executionContext: ExecutionContext = mat.executionContext
 
   def playServerOptions: PlayServerOptions = PlayServerOptions.default
 

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayToResponseBody.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayToResponseBody.scala
@@ -88,9 +88,9 @@ class PlayToResponseBody extends ToResponseBody[PlayResponseBody, AkkaStreams] {
   ): Source[ByteString, Future[IOResult]] =
     FileIO
       .fromPath(tapirFile.file.toPath, chunkSize = 8192, startPosition = start)
-      .scan(0L, ByteString.empty) { case ((bytesConsumed, _), next) =>
+      .scan((0L, ByteString.empty)) { case ((bytesConsumed, _), next) =>
         val bytesInNext = next.length
-        val bytesFromNext = Math.max(0, Math.min(bytesTotal - bytesConsumed, bytesInNext))
+        val bytesFromNext = Math.max(0, Math.min(bytesTotal - bytesConsumed, bytesInNext.toLong))
         (bytesConsumed + bytesInNext, next.take(bytesFromNext.toInt))
       }
       .takeWhile(_._1 < bytesTotal, inclusive = true)


### PR DESCRIPTION
Do I need to maintain backwards compatibility?