### PR TITLE
move JAVA_OPTS to .sbtopts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         target-platform: [ "JVM", "JS" ]
-    env:
-      JAVA_OPTS: "-Xmx3500M -Xss2M -Dsbt.task.timings=false"
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -72,8 +70,6 @@ jobs:
     # run on external PRs, but not on internal PRs since those will be run by push to branch
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-20.04
-    env:
-      JAVA_OPTS: "-Xmx3300M -Xss2M"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -106,8 +102,6 @@ jobs:
     needs: [ci]
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-20.04
-    env:
-      JAVA_OPTS: "-Xmx3300M -Xss2M"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,3 @@
+-J-Xmx3500M
+-J-Xss2M
+-Dsbt.task.timings=false


### PR DESCRIPTION
locally if I just launch sbt, the project never finishes loading because 1G is not enough...

```
[info] welcome to sbt 1.6.2 (Eclipse Adoptium Java 17.0.3)
[info] loading settings for project global-plugins from plugins.sbt ...
[info] loading global plugins from /home/joao/.sbt/1.0/plugins
[info] loading settings for project tapir-build from build.sbt,plugins.sbt ...
[info] loading project definition from /home/joao/git/tapir/project
[info] compiling 1 Scala source to /home/joao/git/tapir/project/target/scala-2.12/sbt-1.0/classes ...
[info] loading settings for project rootProject from build.sbt ...
[info] resolving key references (307896 settings) ...
[warn] In the last 10 seconds, 5.454 (55.5%) were spent in GC. [Heap: 0.00GB free of 1.00GB, max 1.00GB] Consider increasing the JVM heap using `-Xmx` or try a different collector, e.g. `-XX:+UseG1GC`, for better performance.
[warn] In the last 10 seconds, 23.736 (248.4%) were spent in GC. [Heap: 0.00GB free of 1.00GB, max 1.00GB] Consider increasing the JVM heap using `-Xmx` or try a different collector, e.g. `-XX:+UseG1GC`, for better performance.
[warn] In the last 10 seconds, 36.068 (374.1%) were spent in GC. [Heap: 0.00GB free of 1.00GB, max 1.00GB] Consider increasing the JVM heap using `-Xmx` or try a different collector, e.g. `-XX:+UseG1GC`, for better performance.
```