### PR TITLE
Fix zio vertx documentation

### DIFF
--- a/doc/server/vertx.md
+++ b/doc/server/vertx.md
@@ -147,7 +147,7 @@ Add the following dependency
 
 ```scala
 "com.softwaremill.sttp.tapir" %% "tapir-vertx-server" % "@VERSION@"
-"com.softwaremill.sttp.shared" %% "zio" % "LatestVersion"
+"com.softwaremill.sttp.tapir" %% "tapir-zio" % "@VERSION@"
 ```
 
 to use this interpreter with ZIO.
@@ -196,8 +196,7 @@ object Short extends ZIOAppDefault {
             .flatMap(_.asRIO)
         ) { server =>
           ZIO.attempt(server.close()).flatMap(_.asRIO).orDie
-        }
-        .forever
+        } *> ZIO.never
     )
   }
 }


### PR DESCRIPTION
fixes https://github.com/softwaremill/tapir/issues/2140

Also fixes the wrong import:
zio with vertx requires "com.softwaremill.sttp.tapir" %% "tapir-zio" % V instead of "com.softwaremill.sttp.shared" %% "zio" % V