### PR TITLE
Refined scala 3 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -511,9 +511,9 @@ lazy val refined: ProjectMatrix = (projectMatrix in file("integrations/refined")
       "io.circe" %%% "circe-refined" % Versions.circe % Test
     )
   )
-  .jvmPlatform(scalaVersions = scala2Versions)
+  .jvmPlatform(scalaVersions = scala2And3Versions)
   .jsPlatform(
-    scalaVersions = scala2Versions,
+    scalaVersions = scala2And3Versions,
     settings = commonJsSettings ++ Seq(
       libraryDependencies ++= Seq(
         "io.github.cquiroz" %%% "scala-java-time" % Versions.jsScalaJavaTime % Test

--- a/integrations/refined/src/main/scala/sttp/tapir/codec/refined/TapirCodecRefined.scala
+++ b/integrations/refined/src/main/scala/sttp/tapir/codec/refined/TapirCodecRefined.scala
@@ -7,7 +7,6 @@ import eu.timepit.refined.internal.WitnessAs
 import eu.timepit.refined.numeric.{Greater, GreaterEqual, Less, LessEqual}
 import eu.timepit.refined.refineV
 import eu.timepit.refined.string.{MatchesRegex, Uuid}
-import shapeless.Witness
 import sttp.tapir._
 
 import scala.reflect.ClassTag
@@ -48,10 +47,10 @@ trait TapirCodecRefined extends LowPriorityValidatorForPredicate {
   implicit val validatorForNonEmptyString: PrimitiveValidatorForPredicate[String, NonEmpty] =
     ValidatorForPredicate.fromPrimitiveValidator[String, NonEmpty](Validator.minLength(1))
 
-  implicit def validatorForMatchesRegexp[S <: String](implicit
-      ws: Witness.Aux[S]
+  implicit def validatorForMatchesRegexpString[S <: String](implicit
+      ws: WitnessAs[S, String]
   ): PrimitiveValidatorForPredicate[String, MatchesRegex[S]] =
-    ValidatorForPredicate.fromPrimitiveValidator(Validator.pattern(ws.value))
+    ValidatorForPredicate.fromPrimitiveValidator(Validator.pattern(ws.snd))
 
   implicit def validatorForMaxSizeOnString[T <: String, NM](implicit
       ws: WitnessAs[NM, Int]

--- a/integrations/refined/src/test/scala-2/sttp/tapir/codec/refined/TapirCodecRefinedTestScala2.scala
+++ b/integrations/refined/src/test/scala-2/sttp/tapir/codec/refined/TapirCodecRefinedTestScala2.scala
@@ -6,13 +6,15 @@ import eu.timepit.refined.collection.{MaxSize, MinSize, NonEmpty}
 import eu.timepit.refined.numeric.{Greater, GreaterEqual, Interval, Less, LessEqual, Negative, NonNegative, NonPositive, Positive}
 import eu.timepit.refined.string.{IPv4, MatchesRegex}
 import eu.timepit.refined.types.string.NonEmptyString
-import eu.timepit.refined.{W, refineMV, refineV}
+import eu.timepit.refined.W
+import eu.timepit.refined.refineMV
+import eu.timepit.refined.refineV
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.tapir.Codec.PlainCodec
 import sttp.tapir.{DecodeResult, Schema, ValidationError, Validator}
 
-class TapirCodecRefinedTest extends AnyFlatSpec with Matchers with TapirCodecRefined {
+class TapirCodecRefinedTestScala2 extends AnyFlatSpec with Matchers with TapirCodecRefined {
 
   val nonEmptyStringCodec: PlainCodec[NonEmptyString] = implicitly[PlainCodec[NonEmptyString]]
 
@@ -46,6 +48,13 @@ class TapirCodecRefinedTest extends AnyFlatSpec with Matchers with TapirCodecRef
     identifierCodec.decode("-bad") should matchPattern {
       case DecodeResult.InvalidValue(List(ValidationError(validator, "-bad", _, _))) if validator == expectedValidator =>
     }
+  }
+
+  it should "decode value matching pattern" in {
+    type VariableConstraint = MatchesRegex[W.`"[a-zA-Z][-a-zA-Z0-9_]*"`.T]
+    type VariableString = String Refined VariableConstraint
+    val identifierCodec = implicitly[PlainCodec[VariableString]]
+    identifierCodec.decode("ok") shouldBe DecodeResult.Value(refineMV[VariableConstraint]("ok"))
   }
 
   "Generated codec for MaxSize on string" should "use tapir Validator.maxLength" in {

--- a/integrations/refined/src/test/scala-3/sttp/tapir/codec/refined/TapirCodecRefinedTestScala3.scala
+++ b/integrations/refined/src/test/scala-3/sttp/tapir/codec/refined/TapirCodecRefinedTestScala3.scala
@@ -1,0 +1,236 @@
+package sttp.tapir.codec.refined
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.boolean.Or
+import eu.timepit.refined.collection.{MaxSize, MinSize, NonEmpty}
+import eu.timepit.refined.numeric.{Greater, GreaterEqual, Interval, Less, LessEqual, Negative, NonNegative, NonPositive, Positive}
+import eu.timepit.refined.string.{IPv4, MatchesRegex}
+import eu.timepit.refined.types.string.NonEmptyString
+import eu.timepit.refined.refineV
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.tapir.Codec.PlainCodec
+import sttp.tapir.{DecodeResult, Schema, ValidationError, Validator}
+
+class TapirCodecRefinedTestScala3 extends AnyFlatSpec with Matchers with TapirCodecRefined {
+
+  val nonEmptyStringCodec: PlainCodec[NonEmptyString] = implicitly[PlainCodec[NonEmptyString]]
+
+  "Generated codec" should "return DecodeResult.Invalid if subtype can't be refined with correct tapir validator if available" in {
+    val expectedValidator: Validator[String] = Validator.minLength(1)
+    nonEmptyStringCodec.decode("") should matchPattern {
+      case DecodeResult.InvalidValue(List(ValidationError(validator, "", _, _))) if validator == expectedValidator =>
+    }
+  }
+
+  it should "correctly delegate to raw parser and refine it" in {
+    refineV[NonEmpty]("vive le fromage") match {
+      case Right(nes) => nonEmptyStringCodec.decode("vive le fromage") shouldBe DecodeResult.Value(nes)
+      case Left(_)    => fail()
+    }
+  }
+
+  it should "return DecodeResult.Invalid if subtype can't be refined with derived tapir validator if non tapir validator available" in {
+    type IPString = String Refined IPv4
+    val IPStringCodec = implicitly[PlainCodec[IPString]]
+
+    val expectedMsg = refineV[IPv4]("192.168.0.1000").left.get
+    IPStringCodec.decode("192.168.0.1000") should matchPattern {
+      case DecodeResult.InvalidValue(List(ValidationError(_, "192.168.0.1000", _, Some(`expectedMsg`)))) =>
+    }
+  }
+
+  "Generated codec for MatchesRegex" should "use tapir Validator.Pattern" in {
+    type VariableConstraint = MatchesRegex["[a-zA-Z][-a-zA-Z0-9_]*"]
+    type VariableString = String Refined VariableConstraint
+    val identifierCodec = implicitly[PlainCodec[VariableString]]
+
+    val expectedValidator: Validator[String] = Validator.pattern("[a-zA-Z][-a-zA-Z0-9_]*")
+    identifierCodec.decode("-bad") should matchPattern {
+      case DecodeResult.InvalidValue(List(ValidationError(validator, "-bad", _, _))) if validator == expectedValidator =>
+    }
+  }
+
+  it should "decode value matching pattern" in {
+    type VariableConstraint = MatchesRegex["[a-zA-Z][-a-zA-Z0-9_]*"]
+    type VariableString = String Refined VariableConstraint
+    val identifierCodec = implicitly[PlainCodec[VariableString]]
+    refineV[VariableConstraint]("ok") match {
+      case Right(s) => identifierCodec.decode("ok") shouldBe DecodeResult.Value(s)
+      case Left(_)  => fail()
+    }
+  }
+
+  "Generated codec for MaxSize on string" should "use tapir Validator.maxLength" in {
+    type VariableConstraint = MaxSize[2]
+    type VariableString = String Refined VariableConstraint
+    val identifierCodec = implicitly[PlainCodec[VariableString]]
+
+    val expectedValidator: Validator[String] = Validator.maxLength(2)
+    identifierCodec.decode("bad") should matchPattern {
+      case DecodeResult.InvalidValue(List(ValidationError(validator, "bad", _, _))) if validator == expectedValidator =>
+    }
+  }
+
+  "Generated codec for MinSize on string" should "use tapir Validator.minLength" in {
+    type VariableConstraint = MinSize[42]
+    type VariableString = String Refined VariableConstraint
+    val identifierCodec = implicitly[PlainCodec[VariableString]]
+
+    val expectedValidator: Validator[String] = Validator.minLength(42)
+    identifierCodec.decode("bad") should matchPattern {
+      case DecodeResult.InvalidValue(List(ValidationError(validator, "bad", _, _))) if validator == expectedValidator =>
+    }
+  }
+
+  "Generated codec for Less" should "use tapir Validator.max" in {
+    type IntConstraint = Less[3]
+    type LimitedInt = Int Refined IntConstraint
+    val limitedIntCodec = implicitly[PlainCodec[LimitedInt]]
+
+    val expectedValidator: Validator[Int] = Validator.max(3, exclusive = true)
+    limitedIntCodec.decode("3") should matchPattern {
+      case DecodeResult.InvalidValue(List(ValidationError(validator, 3, _, _))) if validator == expectedValidator =>
+    }
+  }
+
+  "Generated codec for LessEqual" should "use tapir Validator.max" in {
+    type IntConstraint = LessEqual[3]
+    type LimitedInt = Int Refined IntConstraint
+    val limitedIntCodec = implicitly[PlainCodec[LimitedInt]]
+
+    val expectedValidator: Validator[Int] = Validator.max(3)
+    limitedIntCodec.decode("4") should matchPattern {
+      case DecodeResult.InvalidValue(List(ValidationError(validator, 4, _, _))) if validator == expectedValidator =>
+    }
+  }
+
+  "Generated codec for Greater" should "use tapir Validator.min" in {
+    type IntConstraint = Greater[3]
+    type LimitedInt = Int Refined IntConstraint
+    val limitedIntCodec = implicitly[PlainCodec[LimitedInt]]
+
+    val expectedValidator: Validator[Int] = Validator.min(3, exclusive = true)
+    limitedIntCodec.decode("3") should matchPattern {
+      case DecodeResult.InvalidValue(List(ValidationError(validator, 3, _, _))) if validator == expectedValidator =>
+    }
+  }
+
+  "Generated codec for GreaterEqual" should "use tapir Validator.min" in {
+    type IntConstraint = GreaterEqual[3]
+    type LimitedInt = Int Refined IntConstraint
+    val limitedIntCodec = implicitly[PlainCodec[LimitedInt]]
+
+    val expectedValidator: Validator[Int] = Validator.min(3)
+    limitedIntCodec.decode("2") should matchPattern {
+      case DecodeResult.InvalidValue(List(ValidationError(validator, 2, _, _))) if validator == expectedValidator =>
+    }
+  }
+
+  "Generated validator for Greater" should "use tapir Validator.min" in {
+    type IntConstraint = Greater[3]
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern { case Validator.Mapped(Validator.Min(3, true), _) =>
+    }
+  }
+
+  "Generated validator for Positive" should "use tapir Validator.min" in {
+    type IntConstraint = Positive
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern { case Validator.Mapped(Validator.Min(0, true), _) => }
+  }
+
+  "Generated validator for NonNegative" should "use tapir Validator.min" in {
+    type IntConstraint = NonNegative
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern { case Validator.Mapped(Validator.Min(0, false), _) => }
+  }
+
+  "Generated validator for NonPositive" should "use tapir Validator.max" in {
+    type IntConstraint = NonPositive
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern { case Validator.Mapped(Validator.Max(0, false), _) => }
+  }
+
+  "Generated validator for Negative" should "use tapir Validator.max" in {
+    type IntConstraint = Negative
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern { case Validator.Mapped(Validator.Max(0, true), _) => }
+  }
+
+  "Generated validator for Interval.Open" should "use tapir Validator.min and Validator.max" in {
+    type IntConstraint = Interval.Open[1, 3]
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern {
+      case Validator.Mapped(Validator.All(List(Validator.Min(1, true), Validator.Max(3, true))), _) =>
+    }
+  }
+
+  "Generated validator for Interval.Close" should "use tapir Validator.min and Validator.max" in {
+    type IntConstraint = Interval.Closed[1, 3]
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern {
+      case Validator.Mapped(Validator.All(List(Validator.Min(1, false), Validator.Max(3, false))), _) =>
+    }
+  }
+
+  "Generated validator for Interval.OpenClose" should "use tapir Validator.min and Validator.max" in {
+    type IntConstraint = Interval.OpenClosed[1, 3]
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern {
+      case Validator.Mapped(Validator.All(List(Validator.Min(1, true), Validator.Max(3, false))), _) =>
+    }
+  }
+
+  "Generated validator for Interval.ClosedOpen" should "use tapir Validator.min and Validator.max" in {
+    type IntConstraint = Interval.ClosedOpen[1, 3]
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern {
+      case Validator.Mapped(Validator.All(List(Validator.Min(1, false), Validator.Max(3, true))), _) =>
+    }
+  }
+
+  "Generate validator for Or" should "use tapir Validator.any" in {
+    type IntConstraint = Greater[3] Or Less[-3]
+    type LimitedInt = Int Refined IntConstraint
+    implicitly[Schema[LimitedInt]].validator should matchPattern {
+      case Validator.Mapped(Validator.Any(List(Validator.Min(3, true), Validator.Max(-3, true))), _) =>
+    }
+  }
+
+  "TapirCodecRefined" should "compile using implicit schema for refined types" in {
+    import io.circe.refined._
+    import sttp.tapir
+    import sttp.tapir._
+    import sttp.tapir.json.circe._
+
+    object TapirCodecRefinedDeepImplicitSearch extends TapirCodecRefined with TapirJsonCirce {
+      type StringConstraint = MatchesRegex["[^\u0000-\u001f]{1,29}"]
+      type LimitedString = String Refined StringConstraint
+
+      val refinedEndpoint: PublicEndpoint[(LimitedString, List[LimitedString]), Unit, List[Option[LimitedString]], Nothing] =
+        tapir.endpoint.post
+          .in(path[LimitedString]("ls") / jsonBody[List[LimitedString]])
+          .out(jsonBody[List[Option[LimitedString]]])
+    }
+  }
+
+  "Using refined" should "compile when using tapir endpoints" in {
+    // this used to cause a:
+    // [error] java.lang.StackOverflowError
+    // [error] scala.reflect.internal.Types$TypeRef.foldOver(Types.scala:2376)
+    // [error] scala.reflect.internal.tpe.TypeMaps$IsRelatableCollector$.apply(TypeMaps.scala:1272)
+    // [error] scala.reflect.internal.tpe.TypeMaps$IsRelatableCollector$.apply(TypeMaps.scala:1267)
+    import sttp.tapir._
+    endpoint.in("x")
+  }
+}

--- a/integrations/refined/src/test/scala/sttp/tapir/codec/refined/TapirCodecRefinedTest.scala
+++ b/integrations/refined/src/test/scala/sttp/tapir/codec/refined/TapirCodecRefinedTest.scala
@@ -1,0 +1,72 @@
+package sttp.tapir.codec.refined
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.{Negative, NonNegative, NonPositive, Positive}
+import eu.timepit.refined.string.IPv4
+import eu.timepit.refined.types.string.NonEmptyString
+import eu.timepit.refined.refineV
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.tapir.Codec.PlainCodec
+import sttp.tapir.{DecodeResult, Schema, ValidationError, Validator}
+
+class TapirCodecRefinedTest extends AnyFlatSpec with Matchers with TapirCodecRefined {
+
+  val nonEmptyStringCodec: PlainCodec[NonEmptyString] = implicitly[PlainCodec[NonEmptyString]]
+
+  "Generated codec" should "return DecodeResult.Invalid if subtype can't be refined with correct tapir validator if available" in {
+    val expectedValidator: Validator[String] = Validator.minLength(1)
+    nonEmptyStringCodec.decode("") should matchPattern {
+      case DecodeResult.InvalidValue(List(ValidationError(validator, "", _, _))) if validator == expectedValidator =>
+    }
+  }
+
+  it should "return DecodeResult.Invalid if subtype can't be refined with derived tapir validator if non tapir validator available" in {
+    type IPString = String Refined IPv4
+    val IPStringCodec = implicitly[PlainCodec[IPString]]
+
+    val expectedMsg = refineV[IPv4]("192.168.0.1000").swap.getOrElse(throw new Exception("A Left was expected but got a Right"))
+    IPStringCodec.decode("192.168.0.1000") should matchPattern {
+      case DecodeResult.InvalidValue(List(ValidationError(_, "192.168.0.1000", _, Some(`expectedMsg`)))) =>
+    }
+  }
+
+  "Generated validator for Positive" should "use tapir Validator.min" in {
+    type IntConstraint = Positive
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern { case Validator.Mapped(Validator.Min(0, true), _) => }
+  }
+
+  "Generated validator for NonNegative" should "use tapir Validator.min" in {
+    type IntConstraint = NonNegative
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern { case Validator.Mapped(Validator.Min(0, false), _) => }
+  }
+
+  "Generated validator for NonPositive" should "use tapir Validator.max" in {
+    type IntConstraint = NonPositive
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern { case Validator.Mapped(Validator.Max(0, false), _) => }
+  }
+
+  "Generated validator for Negative" should "use tapir Validator.max" in {
+    type IntConstraint = Negative
+    type LimitedInt = Int Refined IntConstraint
+
+    implicitly[Schema[LimitedInt]].validator should matchPattern { case Validator.Mapped(Validator.Max(0, true), _) => }
+  }
+
+  "Using refined" should "compile when using tapir endpoints" in {
+    // this used to cause a:
+    // [error] java.lang.StackOverflowError
+    // [error] scala.reflect.internal.Types$TypeRef.foldOver(Types.scala:2376)
+    // [error] scala.reflect.internal.tpe.TypeMaps$IsRelatableCollector$.apply(TypeMaps.scala:1272)
+    // [error] scala.reflect.internal.tpe.TypeMaps$IsRelatableCollector$.apply(TypeMaps.scala:1267)
+    import sttp.tapir._
+    endpoint.in("x")
+  }
+
+}


### PR DESCRIPTION
Hi,

This PR adds `refined` support for Scala 3.

What has been done : 
- adding scala 3 as cross version in `build.sbt`
- the initial code was compiling but the tests were failing for Scala 3, so I've split the `refined` tests sources in 2 directories `scala-2` and `scala-3` and copied the original test file in both of them.
- I removed the use of shapeless in `scala-3` tests folder and used literal instead
- unfortunately the implicit for `MatchesRegex` was not working anymore so the `Validator` was `Custom` and not `Pattern`, so I've updated the implicit in sources and used `WitnessAs[S, String]` instead of `Witness.Aux[S]`. It fixed the issue. *Check with caution, I'm a `refined` user and not a `refined` expert.*
- I've added 2 extra tests (1 per scala major version) to ensure the validation of regexes was not altered.
