### PR TITLE
Add datadog metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,13 @@
+import com.softwaremill.Publish.{ossPublishSettings, updateDocs}
 import com.softwaremill.SbtSoftwareMillBrowserTestJS._
 import com.softwaremill.SbtSoftwareMillCommon.commonSmlBuildSettings
-import com.softwaremill.Publish.{ossPublishSettings, updateDocs}
 import com.softwaremill.UpdateVersionInDocs
 import com.typesafe.tools.mima.core.{Problem, ProblemFilters}
 import sbt.Reference.display
 import sbt.internal.ProjectMatrix
-import sbtassembly.AssemblyPlugin.autoImport.assembly // explicit import to avoid clash with gatling plugin
+
+// explicit import to avoid clash with gatling plugin
+import sbtassembly.AssemblyPlugin.autoImport.assembly
 
 import java.net.URL
 import scala.concurrent.duration.DurationInt
@@ -128,6 +130,7 @@ lazy val rawAllAggregates = core.projectRefs ++
   jsoniterScala.projectRefs ++
   prometheusMetrics.projectRefs ++
   opentelemetryMetrics.projectRefs ++
+  datadogMetrics.projectRefs ++
   json4s.projectRefs ++
   playJson.projectRefs ++
   sprayJson.projectRefs ++
@@ -767,6 +770,18 @@ lazy val opentelemetryMetrics: ProjectMatrix = (projectMatrix in file("metrics/o
       "io.opentelemetry" % "opentelemetry-sdk" % Versions.openTelemetry % Test,
       "io.opentelemetry" % "opentelemetry-sdk-testing" % Versions.openTelemetry % Test,
       "io.opentelemetry" % "opentelemetry-sdk-metrics" % Versions.openTelemetry % Test,
+      scalaTest.value % Test
+    )
+  )
+  .jvmPlatform(scalaVersions = scala2And3Versions)
+  .dependsOn(serverCore % CompileAndTest)
+
+lazy val datadogMetrics: ProjectMatrix = (projectMatrix in file("metrics/datadog-metrics"))
+  .settings(commonJvmSettings)
+  .settings(
+    name := "tapir-datadog-metrics",
+    libraryDependencies ++= Seq(
+      "com.datadoghq" % "java-dogstatsd-client" % Versions.dogstatsdClient,
       scalaTest.value % Test
     )
   )
@@ -1510,6 +1525,7 @@ lazy val examples: ProjectMatrix = (projectMatrix in file("examples"))
     playJson,
     prometheusMetrics,
     opentelemetryMetrics,
+    datadogMetrics,
     sttpMockServer,
     zioJson,
     vertxServer,
@@ -1603,6 +1619,7 @@ lazy val documentation: ProjectMatrix = (projectMatrix in file("generated-doc"))
     zioJson,
     prometheusMetrics,
     opentelemetryMetrics,
+    datadogMetrics,
     sttpMockServer,
     nettyServer,
     swaggerUiBundle

--- a/doc/server/observability.md
+++ b/doc/server/observability.md
@@ -151,3 +151,68 @@ val metrics = OpenTelemetryMetrics.default[Future](meter)
 
 val metricsInterceptor = metrics.metricsInterceptor() // add to your server options
 ```
+
+## Datadog Metrics
+
+Add the following dependency:
+
+```scala
+"com.softwaremill.sttp.tapir" %% "tapir-datadog-metrics" % "@VERSION@"
+```
+
+Datadog metrics are sent as Datadog custom metrics through
+[DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/) protocol.
+
+`DatadogMetrics` uses `StatsDClient` to send the metrics, and its settings such as host, port, etc. depend on it.
+For example:
+
+```scala mdoc:compile-only
+import com.timgroup.statsd.NonBlockingStatsDClientBuilder
+import sttp.tapir.server.metrics.datadog.DatadogMetrics
+
+val statsdClient: StatsDClient = new NonBlockingStatsDClientBuilder()
+  .hostname("localhost")   // Datadog Agent's hostname
+  .port(8125)              // Datadog Agent's port (UDP)
+  .build()
+
+val metrics = DatadogMetrics.default[Future](client)
+```
+
+### Custom Metrics
+
+To create and add custom metrics:
+
+```scala mdoc:compile-only
+import com.timgroup.statsd.NonBlockingStatsDClientBuilder
+import sttp.tapir.server.metrics.datadog.DatadogMetrics
+import sttp.tapir.server.metrics.datadog.DatadogMetrics.Counter
+import sttp.tapir.server.metrics.{EndpointMetric, Metric}
+import scala.concurrent.Future
+
+val statsdClient: StatsDClient = new NonBlockingStatsDClientBuilder()
+  .hostname("localhost")
+  .port(8125)
+  .build()
+
+// Metric for counting responses labeled by path, method and status code
+val responsesTotal = Metric[Future, Counter](
+  Counter("tapir.responses_total.count")(statsdClient),
+  onRequest = (req, counter, _) =>
+    Future.successful(
+      EndpointMetric()
+        .onResponseBody { (ep, res) =>
+          Future.successful {
+            val labels = List(
+              s"path:${ep.showPathTemplate()}", 
+              s"method:${req.method.method}",
+              s"status:${res.code.toString()}"
+            )
+            counter.increment(labels)
+          }
+        }
+    )
+)
+
+val datadogMetrics = DatadogMetrics.default[Future](statsdClient)
+  .addCustom(responsesTotal)
+```

--- a/doc/server/observability.md
+++ b/doc/server/observability.md
@@ -167,15 +167,16 @@ Datadog metrics are sent as Datadog custom metrics through
 For example:
 
 ```scala mdoc:compile-only
-import com.timgroup.statsd.NonBlockingStatsDClientBuilder
+import com.timgroup.statsd.{NonBlockingStatsDClientBuilder, StatsDClient}
 import sttp.tapir.server.metrics.datadog.DatadogMetrics
+import scala.concurrent.Future
 
 val statsdClient: StatsDClient = new NonBlockingStatsDClientBuilder()
   .hostname("localhost")   // Datadog Agent's hostname
   .port(8125)              // Datadog Agent's port (UDP)
   .build()
 
-val metrics = DatadogMetrics.default[Future](client)
+val metrics = DatadogMetrics.default[Future](statsdClient)
 ```
 
 ### Custom Metrics
@@ -183,7 +184,7 @@ val metrics = DatadogMetrics.default[Future](client)
 To create and add custom metrics:
 
 ```scala mdoc:compile-only
-import com.timgroup.statsd.NonBlockingStatsDClientBuilder
+import com.timgroup.statsd.{NonBlockingStatsDClientBuilder, StatsDClient}
 import sttp.tapir.server.metrics.datadog.DatadogMetrics
 import sttp.tapir.server.metrics.datadog.DatadogMetrics.Counter
 import sttp.tapir.server.metrics.{EndpointMetric, Metric}

--- a/examples/src/main/scala/sttp/tapir/examples/observability/DatadogMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/DatadogMetricsExample.scala
@@ -1,0 +1,62 @@
+package sttp.tapir.examples.observability
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Route
+import com.timgroup.statsd.NonBlockingStatsDClientBuilder
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.generic.auto._
+import sttp.tapir._
+import sttp.tapir.generic.auto._
+import sttp.tapir.json.circe.jsonBody
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.akkahttp.{AkkaHttpServerInterpreter, AkkaHttpServerOptions}
+import sttp.tapir.server.metrics.datadog.DatadogMetrics
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+object DatadogMetricsExample extends App with StrictLogging {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
+  case class Person(name: String)
+
+  // Simple endpoint returning 200 or 400 response with string body
+  val personEndpoint: ServerEndpoint[Any, Future] =
+    endpoint.post
+      .in("person")
+      .in(jsonBody[Person])
+      .out(stringBody)
+      .errorOut(stringBody)
+      .serverLogic { p =>
+        Thread.sleep(3000)
+        Future.successful { if (p.name == "Jacob") Right("Welcome") else Left("Unauthorized") }
+      }
+
+  // Datadog Agent hostname and port
+  val hostname = "localhost"
+  val port = 8125
+
+  val client =
+    new NonBlockingStatsDClientBuilder()
+      .hostname(hostname)
+      .port(port)
+      .build()
+
+  val datadogMetrics = DatadogMetrics.default[Future](client)
+
+  val serverOptions: AkkaHttpServerOptions =
+    AkkaHttpServerOptions.customiseInterceptors
+      // Adds an interceptor which collects metrics by executing callbacks
+      .metricsInterceptor(datadogMetrics.metricsInterceptor())
+      .options
+
+  val routes: Route = AkkaHttpServerInterpreter(serverOptions).toRoute(personEndpoint)
+
+  Await.result(Http().newServerAt("localhost", 8080).bindFlow(routes), 1.minute)
+
+  logger.info(
+    s"Server started. POST persons under http://localhost:8080/person. The metrics sends to udp://$hostname:$port"
+  )
+}

--- a/metrics/datadog-metrics/src/main/scala/sttp/tapir/server/metrics/datadog/DatadogMetrics.scala
+++ b/metrics/datadog-metrics/src/main/scala/sttp/tapir/server/metrics/datadog/DatadogMetrics.scala
@@ -69,13 +69,13 @@ object DatadogMetrics {
         m.unit {
           EndpointMetric()
             .onEndpointRequest { ep =>
-              m.eval(counter.increment(toTags(labels.namesForRequest, labels.valuesForRequest(ep, req))))
+              m.eval(counter.increment(mergeTags(labels.namesForRequest, labels.valuesForRequest(ep, req))))
             }
             .onResponseBody { (ep, _) =>
-              m.eval(counter.decrement(toTags(labels.namesForRequest, labels.valuesForRequest(ep, req))))
+              m.eval(counter.decrement(mergeTags(labels.namesForRequest, labels.valuesForRequest(ep, req))))
             }
             .onException { (ep, _) =>
-              m.eval(counter.decrement(toTags(labels.namesForRequest, labels.valuesForRequest(ep, req))))
+              m.eval(counter.decrement(mergeTags(labels.namesForRequest, labels.valuesForRequest(ep, req))))
             }
         }
       }
@@ -92,7 +92,7 @@ object DatadogMetrics {
             .onResponseBody { (ep, res) =>
               m.eval {
                 counter.increment(
-                  toTags(
+                  mergeTags(
                     labels.namesForRequest ++ labels.namesForResponse,
                     labels.valuesForRequest(ep, req) ++ labels.valuesForResponse(res)
                   )
@@ -102,7 +102,7 @@ object DatadogMetrics {
             .onException { (ep, ex) =>
               m.eval {
                 counter.increment(
-                  toTags(
+                  mergeTags(
                     labels.namesForRequest ++ labels.namesForResponse,
                     labels.valuesForRequest(ep, req) ++ labels.valuesForResponse(ex)
                   )
@@ -132,7 +132,7 @@ object DatadogMetrics {
               m.eval {
                 recoder.record(
                   duration,
-                  toTags(
+                  mergeTags(
                     labels.namesForRequest ++ labels.namesForResponse ++ List(labels.forResponsePhase.name),
                     labels.valuesForRequest(ep, req) ++ labels.valuesForResponse(res) ++ List(labels.forResponsePhase.headersValue)
                   )
@@ -143,7 +143,7 @@ object DatadogMetrics {
               m.eval {
                 recoder.record(
                   duration,
-                  toTags(
+                  mergeTags(
                     labels.namesForRequest ++ labels.namesForResponse ++ List(labels.forResponsePhase.name),
                     labels.valuesForRequest(ep, req) ++ labels.valuesForResponse(res) ++ List(labels.forResponsePhase.bodyValue)
                   )
@@ -154,7 +154,7 @@ object DatadogMetrics {
               m.eval {
                 recoder.record(
                   duration,
-                  toTags(
+                  mergeTags(
                     labels.namesForRequest ++ labels.namesForResponse ++ List(labels.forResponsePhase.name),
                     labels.valuesForRequest(ep, req) ++ labels.valuesForResponse(ex)
                   )
@@ -191,7 +191,7 @@ object DatadogMetrics {
     def record(value: Double, tags: List[String]): Unit = client.recordDistributionValue(name, value, tags: _*)
   }
 
-  def toTags(names: List[String], values: List[String]): List[String] = names.zip(values).map { case (n, v) =>
+  def mergeTags(names: List[String], values: List[String]): List[String] = names.zip(values).map { case (n, v) =>
     n + ":" + v
   }
 }

--- a/metrics/datadog-metrics/src/main/scala/sttp/tapir/server/metrics/datadog/DatadogMetrics.scala
+++ b/metrics/datadog-metrics/src/main/scala/sttp/tapir/server/metrics/datadog/DatadogMetrics.scala
@@ -172,9 +172,23 @@ object DatadogMetrics {
     def decrement(tags: List[String]): Unit = client.decrementCounter(name, tags: _*)
   }
 
+  case class Gauge(name: String)(client: StatsDClient) {
+    def record(value: Long, tags: List[String]): Unit = client.recordGaugeValue(name, value, tags: _*)
+    def record(value: Double, tags: List[String]): Unit = client.recordGaugeValue(name, value, tags: _*)
+  }
+
+  case class Timer(name: String)(client: StatsDClient) {
+    def record(milliSeconds: Long, tags: List[String]): Unit = client.recordExecutionTime(name, milliSeconds, tags: _*)
+  }
+
   case class Histogram(name: String)(client: StatsDClient) {
     def record(value: Long, tags: List[String]): Unit = client.recordHistogramValue(name, value, tags: _*)
     def record(value: Double, tags: List[String]): Unit = client.recordHistogramValue(name, value, tags: _*)
+  }
+
+  case class Distribution(name: String)(client: StatsDClient) {
+    def record(value: Long, tags: List[String]): Unit = client.recordDistributionValue(name, value, tags: _*)
+    def record(value: Double, tags: List[String]): Unit = client.recordDistributionValue(name, value, tags: _*)
   }
 
   def toTags(names: List[String], values: List[String]): List[String] = names.zip(values).map { case (n, v) =>

--- a/metrics/datadog-metrics/src/main/scala/sttp/tapir/server/metrics/datadog/DatadogMetrics.scala
+++ b/metrics/datadog-metrics/src/main/scala/sttp/tapir/server/metrics/datadog/DatadogMetrics.scala
@@ -1,0 +1,183 @@
+package sttp.tapir.server.metrics.datadog
+
+import com.timgroup.statsd.StatsDClient
+import sttp.tapir._
+import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
+import sttp.tapir.server.metrics._
+
+import java.time.{Clock, Duration}
+
+case class DatadogMetrics[F[_]](
+    client: StatsDClient,
+    namespace: String = "tapir",
+    metrics: List[Metric[F, _]] = Nil
+) {
+  import DatadogMetrics._
+
+  /** Registers a `$namespace.request_active.count|c|#path, method` counter (assuming default labels). */
+  def addRequestsActive(labels: MetricLabels = MetricLabels.Default): DatadogMetrics[F] =
+    copy(metrics = metrics :+ requestActive(client, namespace, labels))
+
+  /** Registers a `$namespace.request_total.count|c|#path, method, status` counter (assuming default labels). */
+  def addRequestsTotal(labels: MetricLabels = MetricLabels.Default): DatadogMetrics[F] =
+    copy(metrics = metrics :+ requestTotal(client, namespace, labels))
+
+  /** Registers a `$namespace.request_duration_seconds.xxx|h|#path, method, status, phase` histogram (assuming default labels). */
+  def addRequestsDuration(labels: MetricLabels = MetricLabels.Default, clock: Clock = Clock.systemUTC()): DatadogMetrics[F] =
+    copy(metrics = metrics :+ requestDuration(client, namespace, labels, clock))
+
+  /** Registers a custom metric. */
+  def addCustom(m: Metric[F, _]): DatadogMetrics[F] = copy(metrics = metrics :+ m)
+
+  /** The interceptor which can be added to a server's options, to enable metrics collection. */
+  def metricsInterceptor(ignoreEndpoints: Seq[AnyEndpoint] = Seq.empty): MetricsRequestInterceptor[F] =
+    new MetricsRequestInterceptor[F](metrics, ignoreEndpoints)
+}
+
+object DatadogMetrics {
+
+  /** Using the default namespace and labels, registers the following metrics:
+    *
+    *   - `$namespace.request_active.count|c|#path, method` (counter)
+    *   - `$namespace.request_total.count|c|#path, method, status}` (counter)
+    *   - `$namespace.request_duration_seconds.xxx|h|#path, method, status, phase}` (histogram)
+    *
+    * Status is by default the status code class (1xx, 2xx, etc.), and phase can be either `headers` or `body` - request duration is
+    * measured separately up to the point where the headers are determined, and then once again when the whole response body is complete.
+    */
+  def default[F[_]](
+      client: StatsDClient,
+      namespace: String = "tapir",
+      labels: MetricLabels = MetricLabels.Default
+  ): DatadogMetrics[F] =
+    DatadogMetrics(
+      client,
+      namespace,
+      List(
+        requestActive(client, namespace, labels),
+        requestTotal(client, namespace, labels),
+        requestDuration(client, namespace, labels)
+      )
+    )
+
+  def requestActive[F[_]](client: StatsDClient, namespace: String, labels: MetricLabels): Metric[F, Counter] =
+    Metric[F, Counter](
+      Counter(
+        (if (namespace.isBlank) "" else namespace + ".") + "request_active.count"
+      )(client),
+      onRequest = (req, counter, m) => {
+        m.unit {
+          EndpointMetric()
+            .onEndpointRequest { ep =>
+              m.eval(counter.increment(toTags(labels.namesForRequest, labels.valuesForRequest(ep, req))))
+            }
+            .onResponseBody { (ep, _) =>
+              m.eval(counter.decrement(toTags(labels.namesForRequest, labels.valuesForRequest(ep, req))))
+            }
+            .onException { (ep, _) =>
+              m.eval(counter.decrement(toTags(labels.namesForRequest, labels.valuesForRequest(ep, req))))
+            }
+        }
+      }
+    )
+
+  def requestTotal[F[_]](client: StatsDClient, namespace: String, labels: MetricLabels): Metric[F, Counter] =
+    Metric[F, Counter](
+      Counter(
+        (if (namespace.isBlank) "" else namespace + ".") + "request_total.count"
+      )(client),
+      onRequest = (req, counter, m) => {
+        m.unit {
+          EndpointMetric()
+            .onResponseBody { (ep, res) =>
+              m.eval {
+                counter.increment(
+                  toTags(
+                    labels.namesForRequest ++ labels.namesForResponse,
+                    labels.valuesForRequest(ep, req) ++ labels.valuesForResponse(res)
+                  )
+                )
+              }
+            }
+            .onException { (ep, ex) =>
+              m.eval {
+                counter.increment(
+                  toTags(
+                    labels.namesForRequest ++ labels.namesForResponse,
+                    labels.valuesForRequest(ep, req) ++ labels.valuesForResponse(ex)
+                  )
+                )
+              }
+            }
+        }
+      }
+    )
+
+  def requestDuration[F[_]](
+      client: StatsDClient,
+      namespace: String,
+      labels: MetricLabels,
+      clock: Clock = Clock.systemUTC()
+  ): Metric[F, Histogram] =
+    Metric[F, Histogram](
+      Histogram(
+        (if (namespace.isBlank) "" else namespace + ".") + "request_duration_seconds"
+      )(client),
+      onRequest = (req, recoder, m) => {
+        m.eval {
+          val requestStart = clock.instant()
+          def duration = Duration.between(requestStart, clock.instant()).toMillis.toDouble / 1000.0
+          EndpointMetric()
+            .onResponseHeaders { (ep, res) =>
+              m.eval {
+                recoder.record(
+                  duration,
+                  toTags(
+                    labels.namesForRequest ++ labels.namesForResponse ++ List(labels.forResponsePhase.name),
+                    labels.valuesForRequest(ep, req) ++ labels.valuesForResponse(res) ++ List(labels.forResponsePhase.headersValue)
+                  )
+                )
+              }
+            }
+            .onResponseBody { (ep, res) =>
+              m.eval {
+                recoder.record(
+                  duration,
+                  toTags(
+                    labels.namesForRequest ++ labels.namesForResponse ++ List(labels.forResponsePhase.name),
+                    labels.valuesForRequest(ep, req) ++ labels.valuesForResponse(res) ++ List(labels.forResponsePhase.bodyValue)
+                  )
+                )
+              }
+            }
+            .onException { (ep, ex) =>
+              m.eval {
+                recoder.record(
+                  duration,
+                  toTags(
+                    labels.namesForRequest ++ labels.namesForResponse ++ List(labels.forResponsePhase.name),
+                    labels.valuesForRequest(ep, req) ++ labels.valuesForResponse(ex)
+                  )
+                )
+              }
+            }
+        }
+      }
+    )
+
+  case class Counter(name: String)(client: StatsDClient) {
+    def delta(delta: Long, tags: List[String]): Unit = client.count(name, delta, tags: _*)
+    def delta(delta: Double, tags: List[String]): Unit = client.count(name, delta, tags: _*)
+    def increment(tags: List[String]): Unit = client.incrementCounter(name, tags: _*)
+    def decrement(tags: List[String]): Unit = client.decrementCounter(name, tags: _*)
+  }
+
+  case class Histogram(name: String)(client: StatsDClient) {
+    def record(value: Long, tags: List[String]): Unit = client.recordHistogramValue(name, value, tags: _*)
+    def record(value: Double, tags: List[String]): Unit = client.recordHistogramValue(name, value, tags: _*)
+  }
+
+  def toTags(names: List[String], values: List[String]): List[String] = names.zip(values).map { case (n, v) =>
+    n + ":" + v
+  }
+}

--- a/metrics/datadog-metrics/src/test/scala/sttp/tapir/server/metrics/datadog/DatadogMetricsTest.scala
+++ b/metrics/datadog-metrics/src/test/scala/sttp/tapir/server/metrics/datadog/DatadogMetricsTest.scala
@@ -1,0 +1,295 @@
+package sttp.tapir.server.metrics.datadog
+
+import com.timgroup.statsd._
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Seconds, Span}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import sttp.tapir.TestUtil._
+import sttp.tapir.capabilities.NoStreams
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.TestUtil._
+import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureInterceptor, DefaultDecodeFailureHandler}
+import sttp.tapir.server.interceptor.exception.{DefaultExceptionHandler, ExceptionInterceptor}
+import sttp.tapir.server.interpreter.{BodyListener, ServerInterpreter}
+import sttp.tapir.server.metrics.MetricLabels
+import sttp.tapir.server.metrics.datadog.DatadogMetricsTest._
+
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.nio.channels.DatagramChannel
+import java.nio.charset.StandardCharsets
+import java.time._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.{Success, Try}
+
+class DatadogMetricsTest extends AnyFlatSpec with Matchers with BeforeAndAfter with BeforeAndAfterAll {
+
+  private val statsdServerPort = 17254
+  private val statsdServer = new MockStatsDServer(statsdServerPort)
+
+  override def beforeAll(): Unit = statsdServer.start()
+  override def afterAll(): Unit = statsdServer.close()
+
+  before {
+    statsdServer.clear()
+  }
+
+  after {
+    statsdServer.clear()
+  }
+
+  "default metrics" should "collect requests active" in {
+    // given
+    val serverEp = PersonsApi { name =>
+      Thread.sleep(2000)
+      PersonsApi.defaultLogic(name)
+    }.serverEp
+    val client =
+      new NonBlockingStatsDClientBuilder()
+        .hostname("localhost")
+        .port(statsdServerPort)
+        .build()
+
+    val metrics = DatadogMetrics[Id](client).addRequestsActive()
+    val interpreter =
+      new ServerInterpreter[Any, Id, Unit, NoStreams](
+        _ => List(serverEp),
+        TestRequestBody,
+        UnitToResponseBody,
+        List(metrics.metricsInterceptor()),
+        _ => ()
+      )
+
+    // when
+    val response = Future { interpreter.apply(PersonsApi.request("Jacob")) }
+
+    waitReceiveMessage(statsdServer)
+
+    // then
+    statsdServer.getReceivedMessages should contain("""tapir.request_active.count:1|c|#method:GET,path:/person""")
+
+    statsdServer.clear()
+
+    ScalaFutures.whenReady(response, Timeout(Span(3, Seconds))) { _ =>
+      waitReceiveMessage(statsdServer)
+      statsdServer.getReceivedMessages should contain("""tapir.request_active.count:-1|c|#method:GET,path:/person""")
+    }
+  }
+
+  "default metrics" should "collect requests total" in {
+    // given
+    val serverEp = PersonsApi().serverEp
+    val client =
+      new NonBlockingStatsDClientBuilder()
+        .hostname("localhost")
+        .port(statsdServerPort)
+        .build()
+
+    val metrics = DatadogMetrics[Id](client).addRequestsTotal()
+    val interpreter =
+      new ServerInterpreter[Any, Id, Unit, NoStreams](
+        _ => List(serverEp),
+        TestRequestBody,
+        UnitToResponseBody,
+        List(metrics.metricsInterceptor(), new DecodeFailureInterceptor(DefaultDecodeFailureHandler.default)),
+        _ => ()
+      )
+
+    // when
+    interpreter.apply(PersonsApi.request("Jacob"))
+    interpreter.apply(PersonsApi.request("Jacob"))
+    interpreter.apply(PersonsApi.request("Mike"))
+    interpreter.apply(PersonsApi.request(""))
+
+    waitReceiveMessage(statsdServer)
+
+    // then
+    statsdServer.getReceivedMessages should contain("""tapir.request_total.count:2|c|#status:2xx,method:GET,path:/person""")
+    statsdServer.getReceivedMessages should contain("""tapir.request_total.count:2|c|#status:4xx,method:GET,path:/person""")
+  }
+
+  "default metrics" should "collect requests duration" in {
+    // given
+    val clock = new TestClock()
+
+    val waitServerEp: Long => ServerEndpoint[Any, Id] = millis => {
+      PersonsApi { name =>
+        clock.forward(millis)
+        PersonsApi.defaultLogic(name)
+      }.serverEp
+    }
+    val waitBodyListener: Long => BodyListener[Id, String] = millis =>
+      new BodyListener[Id, String] {
+        override def onComplete(body: String)(cb: Try[Unit] => Id[Unit]): String = {
+          clock.forward(millis)
+          cb(Success(()))
+          body
+        }
+      }
+    val client =
+      new NonBlockingStatsDClientBuilder()
+        .hostname("localhost")
+        .port(statsdServerPort)
+        .build()
+
+    val metrics = DatadogMetrics[Id](client).addRequestsDuration(clock = clock)
+    def interpret(sleepHeaders: Long, sleepBody: Long) =
+      new ServerInterpreter[Any, Id, String, NoStreams](
+        _ => List(waitServerEp(sleepHeaders)),
+        TestRequestBody,
+        StringToResponseBody,
+        List(metrics.metricsInterceptor()),
+        _ => ()
+      )(implicitly, waitBodyListener(sleepBody)).apply(PersonsApi.request("Jacob"))
+
+    // when
+    interpret(100, 1000)
+    interpret(200, 2000)
+    interpret(300, 3000)
+
+    waitReceiveMessage(statsdServer)
+
+    // then
+    // headers
+    statsdServer.getReceivedMessages should contain(
+      """tapir.request_duration_seconds:0.1|h|#phase:headers,status:2xx,method:GET,path:/person"""
+    )
+    statsdServer.getReceivedMessages should contain(
+      """tapir.request_duration_seconds:0.2|h|#phase:headers,status:2xx,method:GET,path:/person"""
+    )
+    statsdServer.getReceivedMessages should contain(
+      """tapir.request_duration_seconds:0.3|h|#phase:headers,status:2xx,method:GET,path:/person"""
+    )
+
+    // body
+    statsdServer.getReceivedMessages should contain(
+      """tapir.request_duration_seconds:1.1|h|#phase:body,status:2xx,method:GET,path:/person"""
+    )
+    statsdServer.getReceivedMessages should contain(
+      """tapir.request_duration_seconds:2.2|h|#phase:body,status:2xx,method:GET,path:/person"""
+    )
+    statsdServer.getReceivedMessages should contain(
+      """tapir.request_duration_seconds:3.3|h|#phase:body,status:2xx,method:GET,path:/person"""
+    )
+  }
+
+  "default metrics" should "customize labels" in {
+    // given
+    val serverEp = PersonsApi().serverEp
+    val labels = MetricLabels(forRequest = List("key" -> { case (_, _) => "value" }), forResponse = Nil)
+    val client =
+      new NonBlockingStatsDClientBuilder()
+        .hostname("localhost")
+        .port(statsdServerPort)
+        .build()
+
+    val metrics = DatadogMetrics[Id](client).addRequestsTotal(labels)
+    val interpreter =
+      new ServerInterpreter[Any, Id, Unit, NoStreams](
+        _ => List(serverEp),
+        TestRequestBody,
+        UnitToResponseBody,
+        List(metrics.metricsInterceptor()),
+        _ => ()
+      )
+
+    // when
+    interpreter.apply(PersonsApi.request("Jacob"))
+
+    waitReceiveMessage(statsdServer)
+
+    // then
+    statsdServer.getReceivedMessages should contain("""tapir.request_total.count:1|c|#key:value""")
+  }
+
+  "metrics" should "be collected on exception when response from exception handler" in {
+    // given
+    val serverEp = PersonsApi { _ => throw new RuntimeException("Ups") }.serverEp
+    val client =
+      new NonBlockingStatsDClientBuilder()
+        .hostname("localhost")
+        .port(statsdServerPort)
+        .build()
+
+    val metrics = DatadogMetrics[Id](client).addRequestsTotal()
+    val interpreter = new ServerInterpreter[Any, Id, Unit, NoStreams](
+      _ => List(serverEp),
+      TestRequestBody,
+      UnitToResponseBody,
+      List(metrics.metricsInterceptor(), new ExceptionInterceptor(DefaultExceptionHandler[Id])),
+      _ => ()
+    )
+
+    // when
+    interpreter.apply(PersonsApi.request("Jacob"))
+
+    waitReceiveMessage(statsdServer)
+
+    // then
+    statsdServer.getReceivedMessages should contain("""tapir.request_total.count:1|c|#status:5xx,method:GET,path:/person""")
+  }
+}
+
+object DatadogMetricsTest {
+  private def waitReceiveMessage(statsdServer: MockStatsDServer): Unit = {
+    while (statsdServer.getReceivedMessages.count(m => !m.startsWith("datadog")) == 0) {
+      Thread.sleep(100)
+    }
+  }
+
+  class MockStatsDServer(port: Int) {
+    private var receivedMessages: List[String] = Nil
+    private val server = DatagramChannel.open()
+
+    def clear(): Unit = receivedMessages = Nil
+
+    def start(): Unit = {
+      server.bind(new InetSocketAddress(port))
+
+      val thread = new Thread(() => {
+        val packet = ByteBuffer.allocate(1500)
+
+        while (server.isOpen)
+          try {
+            packet.clear()
+            server.receive(packet)
+            packet.flip()
+
+            StandardCharsets.UTF_8.decode(packet).toString.split('\n').foreach { message =>
+              val trimmed = message.trim
+
+              if (trimmed.nonEmpty)
+                receivedMessages = receivedMessages :+ trimmed
+            }
+          } catch {
+            case _: Throwable =>
+          }
+      })
+
+      thread.setDaemon(true)
+      thread.start()
+    }
+
+    def close(): Unit =
+      try server.close()
+      catch { case _: Throwable => }
+
+    def getReceivedMessages: List[String] = receivedMessages
+  }
+
+  class TestClock(start: Long = System.currentTimeMillis()) extends Clock {
+    private var _millis = start
+
+    def forward(m: Long): Unit = {
+      _millis += m
+    }
+
+    override def getZone: ZoneId = Clock.systemUTC().getZone
+    override def withZone(zone: ZoneId): Clock = this
+    override def instant(): Instant = Instant.ofEpochMilli(_millis)
+  }
+}

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -47,4 +47,5 @@ object Versions {
   val quicklens = "1.8.8"
   val openTelemetry = "1.15.0"
   val mockServer = "5.13.2"
+  val dogstatsdClient = "4.0.0"
 }


### PR DESCRIPTION
I wanted to see the metrics in Datadog, so I implemented it with reference to `PrometheusMetrics`.
It looks like it's working:

![](https://user-images.githubusercontent.com/55990751/176463769-d3d97180-a51f-43a9-af4b-400b608124c3.png)

problem: Unit tests are very very slow.