### PR TITLE
use `and` instead of `&`

### DIFF
--- a/doc/endpoint/basics.md
+++ b/doc/endpoint/basics.md
@@ -45,7 +45,7 @@ import sttp.tapir._
 val userEndpoint: PublicEndpoint[(UUID, Int), String, User, Any] = ???
 ```
 
-You can think of an endpoint as a function, which takes input parameters of type `A` & `I` and returns a result of type 
+You can think of an endpoint as a function, which takes input parameters of type `A` and `I` and returns a result of type 
 `Either[E, O]`.
 
 ### Infallible endpoints


### PR DESCRIPTION
I found it confusing to use `&` in this place because `&` is Scala 3 syntax for intersection type, so I thought I'd change it to “and” instead.