### PR TITLE
Set the "phase" label on exception in default Prometheus duration metric

### DIFF
--- a/metrics/prometheus-metrics/src/main/scala/sttp/tapir/server/metrics/prometheus/PrometheusMetrics.scala
+++ b/metrics/prometheus-metrics/src/main/scala/sttp/tapir/server/metrics/prometheus/PrometheusMetrics.scala
@@ -160,7 +160,7 @@ object PrometheusMetrics {
             .onException { (ep, ex) =>
               m.eval(
                 histogram
-                  .labels(labels.valuesForRequest(ep, req) ++ labels.valuesForResponse(ex): _*)
+                  .labels(labels.valuesForRequest(ep, req) ++ labels.valuesForResponse(ex) ++ List(labels.forResponsePhase.bodyValue): _*)
                   .observe(duration)
               )
             }


### PR DESCRIPTION
The Prometheus Java client requires the list of labels to be declared,
and then the same number of labels to be passed when "observing" a data
point. The default requestDuration was missing the "phase" label in its
onException callback. This caused it to throw an
IllegalArgumentException at run time.

Fixes #2295.