### PR TITLE
Ignore trailing slash in stub request

### DIFF
--- a/server/sttp-stub-server/src/main/scala/sttp/tapir/server/stub/SttpRequest.scala
+++ b/server/sttp-stub-server/src/main/scala/sttp/tapir/server/stub/SttpRequest.scala
@@ -14,7 +14,7 @@ case class SttpRequest(r: Request[_, _], attributes: AttributeMap = AttributeMap
   override def protocol: String = "HTTP/1.1"
   override def connectionInfo: ConnectionInfo = ConnectionInfo(None, None, None)
   override def underlying: Any = r
-  override def pathSegments: List[String] = r.uri.pathSegments.segments.map(_.v).toList
+  override def pathSegments: List[String] = r.uri.pathSegments.segments.collect{ case x if !x.v.trim.isEmpty => x.v.trim }.toList
   override def uri: Uri = r.uri
   override def attribute[T](k: AttributeKey[T]): Option[T] = attributes.get(k)
   override def attribute[T](k: AttributeKey[T], v: T): SttpRequest = copy(attributes = attributes.put(k, v))

--- a/server/sttp-stub-server/src/main/scala/sttp/tapir/server/stub/SttpRequest.scala
+++ b/server/sttp-stub-server/src/main/scala/sttp/tapir/server/stub/SttpRequest.scala
@@ -14,7 +14,10 @@ case class SttpRequest(r: Request[_, _], attributes: AttributeMap = AttributeMap
   override def protocol: String = "HTTP/1.1"
   override def connectionInfo: ConnectionInfo = ConnectionInfo(None, None, None)
   override def underlying: Any = r
-  override def pathSegments: List[String] = r.uri.pathSegments.segments.collect{ case x if !x.v.trim.isEmpty => x.v.trim }.toList
+  override def pathSegments: List[String] = (r.uri.pathSegments.segments.map(_.v) match {
+    case other :+ "" => other
+    case s           => s
+  }).toList
   override def uri: Uri = r.uri
   override def attribute[T](k: AttributeKey[T]): Option[T] = attributes.get(k)
   override def attribute[T](k: AttributeKey[T], v: T): SttpRequest = copy(attributes = attributes.put(k, v))

--- a/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/TapirStubInterpreterTest.scala
+++ b/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/TapirStubInterpreterTest.scala
@@ -42,6 +42,20 @@ class TapirStubInterpreterTest extends AnyFlatSpec with Matchers {
     response.body shouldBe Right("computer")
   }
 
+  it should "stub endpoint logic with trailing slash with success response" in {
+    // given
+    val server = TapirStubInterpreter(options, SttpBackendStub(IdMonad))
+      .whenEndpoint(getProduct)
+      .thenRespond("computer")
+      .backend()
+
+    // when
+    val response = sttp.client3.basicRequest.get(uri"http://test.com/api/products/").send(server)
+
+    // then
+    response.body shouldBe Right("computer")
+  }
+
   it should "stub endpoint logic with error response" in {
     // given
     val server = TapirStubInterpreter[Identity, Nothing, ServerOptions](options, SttpBackendStub(IdMonad))


### PR DESCRIPTION
The PR fixes the following issue:
while testing endpoints with trailing slash like `http://test.com/api/products/` the stub server returned `Unit` rather than output value according to endpoint's server logic. 

Please see #2327 for details.