### PR TITLE
Fix Validator.Any empty validators case (also fixes Validator.reject)

### DIFF
--- a/core/src/main/scala/sttp/tapir/Validator.scala
+++ b/core/src/main/scala/sttp/tapir/Validator.scala
@@ -161,13 +161,19 @@ object Validator extends ValidatorMacros {
       val results = validators.map(_.apply(t))
       if (results.exists(_.isEmpty)) {
         List.empty
-      } else {
+      } else if (validators.nonEmpty) {
         results.flatten.toList
+      } else {
+        List(ValidationError[T](Any.EmptyValidators, t))
       }
     }
 
     override def contramap[TT](g: TT => T): Validator[TT] = if (validators.isEmpty) Any(Nil) else super.contramap(g)
     override def or(other: Validator[T]): Validator[T] = if (validators.isEmpty) other else Any(validators :+ other)
+  }
+
+  object Any {
+    private[tapir] def EmptyValidators[T]: Custom[T] = Custom(_ => ValidationResult.Invalid("Any of empty validators."))
   }
 
   //

--- a/core/src/test/scala/sttp/tapir/ValidatorTest.scala
+++ b/core/src/test/scala/sttp/tapir/ValidatorTest.scala
@@ -145,6 +145,13 @@ class ValidatorTest extends AnyFlatSpec with Matchers {
     v("abc") shouldBe empty
   }
 
+  it should "validate with reject" in {
+    val validator = Validator.reject[Int]
+    validator(4) shouldBe List(ValidationError(Validator.Any.EmptyValidators, 4))
+    validator(7) shouldBe List(ValidationError(Validator.Any.EmptyValidators, 7))
+    validator(11) shouldBe List(ValidationError(Validator.Any.EmptyValidators, 11))
+  }
+
   it should "validate with any of validators" in {
     val validator = Validator.any(Validator.max(5), Validator.max(10))
     validator(4) shouldBe empty


### PR DESCRIPTION
This PR fixes `Validator.Any` that did not account for cases when there are no validators set (e.g. as it used for the `Validator.reject`).