### PR TITLE
added description field to example class

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ If you are having doubts on the *why* or *how* something works, don't hesitate t
 [gitter](https://gitter.im/softwaremill/tapir) or via github. This probably means that the documentation, scaladocs or 
 code is unclear and be improved for the benefit of all.
 
+The `core` module needs to remain binary-compatible with earlier version. To check if your changes meet this requirement,
+you can run `core/mimaReportBinaryIssues` from the sbt console. 
+
 ### Testing locally
 
 The JS tests use [Gecko instead of Chrome](https://github.com/scala-js/scala-js-env-selenium/issues/119), although this

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If you are having doubts on the *why* or *how* something works, don't hesitate t
 [gitter](https://gitter.im/softwaremill/tapir) or via github. This probably means that the documentation, scaladocs or 
 code is unclear and be improved for the benefit of all.
 
-The `core` module needs to remain binary-compatible with earlier version. To check if your changes meet this requirement,
+The `core` module needs to remain binary-compatible with earlier versions. To check if your changes meet this requirement,
 you can run `core/mimaReportBinaryIssues` from the sbt console. 
 
 ### Testing locally

--- a/core/src/main/scala/sttp/tapir/EndpointIO.scala
+++ b/core/src/main/scala/sttp/tapir/EndpointIO.scala
@@ -530,14 +530,23 @@ object EndpointIO {
   //
 
   case class Example[+T](value: T, name: Option[String], summary: Option[String], description: Option[String]) {
-
-    def this(value: T, name: Option[String], summary: Option[String]) = {
-      this(value, name, summary, None)
-    }
+    // required for binary compatibility
+    def this(value: T, name: Option[String], summary: Option[String]) = this(value, name, summary, None)
 
     def description(description: String): Example[T] = copy(description = Some(description))
 
     def map[B](f: T => B): Example[B] = copy(value = f(value))
+
+    // required for binary compatibility
+    def copy[TT](value: TT, name: Option[String], summary: Option[String]): Example[TT] =
+      Example(value, name, summary, description)
+
+    def copy[TT](
+        value: TT = this.value,
+        name: Option[String] = this.name,
+        summary: Option[String] = this.summary,
+        description: Option[String] = this.description
+    ): Example[TT] = Example(value, name, summary, description)
   }
 
   object Example {

--- a/core/src/main/scala/sttp/tapir/EndpointIO.scala
+++ b/core/src/main/scala/sttp/tapir/EndpointIO.scala
@@ -533,6 +533,8 @@ object EndpointIO {
     // required for binary compatibility
     def this(value: T, name: Option[String], summary: Option[String]) = this(value, name, summary, None)
 
+    def name(name: String): Example[T] = copy(name = Some(name))
+    def summary(summary: String): Example[T] = copy(summary = Some(summary))
     def description(description: String): Example[T] = copy(description = Some(description))
 
     def map[B](f: T => B): Example[B] = copy(value = f(value))

--- a/core/src/main/scala/sttp/tapir/EndpointIO.scala
+++ b/core/src/main/scala/sttp/tapir/EndpointIO.scala
@@ -529,12 +529,13 @@ object EndpointIO {
 
   //
 
-  case class Example[+T](value: T, name: Option[String], summary: Option[String]) {
+  case class Example[+T](value: T, name: Option[String], summary: Option[String], description: Option[String]) {
     def map[B](f: T => B): Example[B] = copy(value = f(value))
   }
 
   object Example {
-    def of[T](value: T, name: Option[String] = None, summary: Option[String] = None): Example[T] = Example(value, name, summary)
+    def of[T](value: T, name: Option[String] = None, summary: Option[String] = None, description: Option[String] = None): Example[T] =
+      Example(value, name, summary, description)
   }
 
   case class Info[T](
@@ -555,8 +556,8 @@ object EndpointIO {
     def map[U](codec: Mapping[T, U]): Info[U] =
       Info(
         description,
-        examples.map(e => e.copy(value = codec.decode(e.value))).collect { case Example(DecodeResult.Value(ee), name, summary) =>
-          Example(ee, name, summary)
+        examples.map(e => e.copy(value = codec.decode(e.value))).collect { case Example(DecodeResult.Value(ee), name, summary, desc) =>
+          Example(ee, name, summary, desc)
         },
         deprecated,
         attributes
@@ -696,12 +697,13 @@ case class WebSocketBodyOutput[PIPE_REQ_RESP, REQ, RESP, T, S](
 
   def requestsDescription(d: String): ThisType[T] = copy(requestsInfo = requestsInfo.description(d))
   def requestsExample(e: REQ): ThisType[T] = copy(requestsInfo = requestsInfo.example(e))
-  def requestsExamples(examples: List[REQ]): ThisType[T] = copy(requestsInfo = requestsInfo.examples(examples.map(Example(_, None, None))))
+  def requestsExamples(examples: List[REQ]): ThisType[T] =
+    copy(requestsInfo = requestsInfo.examples(examples.map(Example(_, None, None, None))))
 
   def responsesDescription(d: String): ThisType[T] = copy(responsesInfo = responsesInfo.description(d))
   def responsesExample(e: RESP): ThisType[T] = copy(responsesInfo = responsesInfo.example(e))
   def responsesExamples(examples: List[RESP]): ThisType[T] =
-    copy(responsesInfo = responsesInfo.examples(examples.map(Example(_, None, None))))
+    copy(responsesInfo = responsesInfo.examples(examples.map(Example(_, None, None, None))))
 
   /** @param c
     *   If `true`, fragmented frames will be concatenated, and the data frames that the `requests` & `responses` codecs decode will always

--- a/core/src/main/scala/sttp/tapir/EndpointIO.scala
+++ b/core/src/main/scala/sttp/tapir/EndpointIO.scala
@@ -535,12 +535,19 @@ object EndpointIO {
       this(value, name, summary, None)
     }
 
+    def description(description: String): Example[T] = copy(description = Some(description))
+
     def map[B](f: T => B): Example[B] = copy(value = f(value))
   }
 
   object Example {
-    def of[T](value: T, name: Option[String] = None, summary: Option[String] = None, description: Option[String] = None): Example[T] =
-      Example(value, name, summary, description)
+
+    def apply[T](value: T, name: Option[String], summary: Option[String]): Example[T] =
+      new Example(value, name, summary)
+
+    def of[T](value: T, name: Option[String] = None, summary: Option[String] = None): Example[T] =
+      Example(value, name, summary)
+
   }
 
   case class Info[T](

--- a/core/src/main/scala/sttp/tapir/EndpointIO.scala
+++ b/core/src/main/scala/sttp/tapir/EndpointIO.scala
@@ -530,6 +530,11 @@ object EndpointIO {
   //
 
   case class Example[+T](value: T, name: Option[String], summary: Option[String], description: Option[String]) {
+
+    def this(value: T, name: Option[String], summary: Option[String]) = {
+      this(value, name, summary, None)
+    }
+
     def map[B](f: T => B): Example[B] = copy(value = f(value))
   }
 

--- a/core/src/main/scala/sttp/tapir/EndpointIO.scala
+++ b/core/src/main/scala/sttp/tapir/EndpointIO.scala
@@ -552,13 +552,9 @@ object EndpointIO {
   }
 
   object Example {
-
-    def apply[T](value: T, name: Option[String], summary: Option[String]): Example[T] =
-      new Example(value, name, summary)
-
-    def of[T](value: T, name: Option[String] = None, summary: Option[String] = None): Example[T] =
-      Example(value, name, summary)
-
+    // required for binary compatibility
+    def apply[T](value: T, name: Option[String], summary: Option[String]): Example[T] = new Example(value, name, summary)
+    def of[T](value: T, name: Option[String] = None, summary: Option[String] = None): Example[T] = Example(value, name, summary)
   }
 
   case class Info[T](

--- a/core/src/main/scala/sttp/tapir/EndpointIO.scala
+++ b/core/src/main/scala/sttp/tapir/EndpointIO.scala
@@ -554,6 +554,8 @@ object EndpointIO {
   object Example {
     // required for binary compatibility
     def apply[T](value: T, name: Option[String], summary: Option[String]): Example[T] = new Example(value, name, summary)
+
+    /** To add a description, use the [[Example.description]] method on the result. */
     def of[T](value: T, name: Option[String] = None, summary: Option[String] = None): Example[T] = Example(value, name, summary)
   }
 

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointInputToParameterConverter.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointInputToParameterConverter.scala
@@ -58,7 +58,7 @@ private[openapi] object EndpointInputToParameterConverter {
     val examples =
       if (baseExamples.multipleExamples.nonEmpty) baseExamples
       else
-        ExampleConverter.convertExamples(Codec.string, List(EndpointIO.Example(header.h.value, None, None)))
+        ExampleConverter.convertExamples(Codec.string, List(EndpointIO.Example(header.h.value, None, None, None)))
     Parameter(
       name = header.h.name,
       in = ParameterIn.Header,

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/ExampleConverter.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/ExampleConverter.scala
@@ -24,17 +24,21 @@ private[openapi] object ExampleConverter {
 
   private def convertExamples[T](examples: List[EndpointIO.Example[T]])(exampleValue: T => Option[ExampleValue]): Examples = {
     examples match {
-      case (example @ EndpointIO.Example(_, None, None)) :: Nil =>
+      case (example @ EndpointIO.Example(_, None, None, None)) :: Nil =>
         Examples(exampleValue(example.value), ListMap.empty)
-      case (example @ EndpointIO.Example(_, _, _)) :: Nil if example.name.isDefined || example.summary.isDefined =>
+      case (example @ EndpointIO.Example(_, _, _, _)) :: Nil if example.name.isDefined || example.summary.isDefined =>
         Examples(
           None,
-          ListMap(example.name.getOrElse("Example") -> Right(Example(summary = example.summary, value = exampleValue(example.value))))
+          ListMap(
+            example.name.getOrElse("Example") -> Right(
+              Example(summary = example.summary, description = example.description, value = exampleValue(example.value))
+            )
+          )
         )
       case examples =>
         val exampleValues = examples.zipWithIndex.map { case (example, i) =>
           example.name.getOrElse(s"Example$i") ->
-            Right(Example(summary = example.summary, value = exampleValue(example.value)))
+            Right(Example(summary = example.summary, description = example.description, value = exampleValue(example.value)))
         }.toListMap
         Examples(None, exampleValues)
     }

--- a/docs/openapi-docs/src/test/resources/example/expected_multiple_examples_with_names.yml
+++ b/docs/openapi-docs/src/test/resources/example/expected_multiple_examples_with_names.yml
@@ -16,6 +16,7 @@ paths:
               examples:
                 Michal:
                   summary: Some summary
+                  description: Some description
                   value:
                     Person:
                       name: michal

--- a/docs/openapi-docs/src/test/resources/example/expected_single_example_with_description.yml
+++ b/docs/openapi-docs/src/test/resources/example/expected_single_example_with_description.yml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: Users
+  version: '1.0'
+paths:
+  /users:
+    get:
+      operationId: getUsers
+      parameters:
+        - name: active
+          in: query
+          description: Filter for only active or inactive users.
+          required: false
+          schema:
+            type: boolean
+          examples:
+            Example 0:
+              description: Get only active users
+              value: true
+      responses:
+        '200':
+          description: ''
+        '400':
+          description: 'Invalid value for: query parameter active'
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlExampleTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlExampleTest.scala
@@ -44,7 +44,7 @@ class VerifyYamlExampleTest extends AnyFunSuite with Matchers {
           .out(
             jsonBody[Entity].examples(
               List(
-                Example.of(Person("michal", 40), Some("Michal"), Some("Some summary")),
+                Example.of(Person("michal", 40), Some("Michal"), Some("Some summary"), Some("Some description")),
                 Example.of(Organization("acme"), Some("Acme"))
               )
             )
@@ -78,7 +78,7 @@ class VerifyYamlExampleTest extends AnyFunSuite with Matchers {
         endpoint.post
           .out(
             jsonBody[Entity].example(
-              Example(Person("michal", 40), Some("Michal"), Some("Some summary"))
+              Example.of(Person("michal", 40), Some("Michal"), Some("Some summary"))
             )
           ),
         Info("Entities", "1.0")
@@ -180,6 +180,19 @@ class VerifyYamlExampleTest extends AnyFunSuite with Matchers {
     )
 
     val expectedYaml = load("example/expected_single_example_with_summary.yml")
+    val actualYaml = OpenAPIDocsInterpreter().toOpenAPI(e, Info("Users", "1.0")).toYaml
+
+    noIndentation(actualYaml) shouldBe expectedYaml
+  }
+
+  test("should support description for single example") {
+    val e = endpoint.in(
+      "users" / query[Option[Boolean]]("active")
+        .description("Filter for only active or inactive users.")
+        .example(Example.of(value = Some(true), description = Some("Get only active users")))
+    )
+
+    val expectedYaml = load("example/expected_single_example_with_description.yml")
     val actualYaml = OpenAPIDocsInterpreter().toOpenAPI(e, Info("Users", "1.0")).toYaml
 
     noIndentation(actualYaml) shouldBe expectedYaml

--- a/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlExampleTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlExampleTest.scala
@@ -44,7 +44,7 @@ class VerifyYamlExampleTest extends AnyFunSuite with Matchers {
           .out(
             jsonBody[Entity].examples(
               List(
-                Example.of(Person("michal", 40), Some("Michal"), Some("Some summary"), Some("Some description")),
+                Example.of(Person("michal", 40), Some("Michal"), Some("Some summary")).description("Some description"),
                 Example.of(Organization("acme"), Some("Acme"))
               )
             )
@@ -189,7 +189,7 @@ class VerifyYamlExampleTest extends AnyFunSuite with Matchers {
     val e = endpoint.in(
       "users" / query[Option[Boolean]]("active")
         .description("Filter for only active or inactive users.")
-        .example(Example.of(value = Some(true), description = Some("Get only active users")))
+        .example(Example.of(value = Some(true)).description("Get only active users"))
     )
 
     val expectedYaml = load("example/expected_single_example_with_description.yml")

--- a/integrations/cats/src/test/scala/sttp/tapir/integ/cats/ExampleFunctorLawSpec.scala
+++ b/integrations/cats/src/test/scala/sttp/tapir/integ/cats/ExampleFunctorLawSpec.scala
@@ -17,7 +17,8 @@ class ExampleFunctorLawSpec extends AnyFunSuite with FunSuiteDiscipline with Che
       t <- Arbitrary.arbitrary[T]
       name <- Arbitrary.arbitrary[Option[String]]
       summary <- Arbitrary.arbitrary[Option[String]]
-    } yield Example(t, name, summary)
+      description <- Arbitrary.arbitrary[Option[String]]
+    } yield Example(t, name, summary, description)
   }
 
   checkAll("Example.FunctorLaws", FunctorTests[Example].functor[Int, Int, String])


### PR DESCRIPTION
I have added description field for examples as it might be useful in some cases. 
From code perspective, there is already implementation for description from OpenAPI point of view. What I did is, I just added `description` field to `Example` class from `EndpointIO.scala` which is then mapped to OpenAPI standard
Examples provided both in tests and below.

OpenAPI generated code could be tested against [https://editor.swagger.io/](url)
```
openapi: 3.0.3
info:
  title: Test
  version: 0.1.0-SNAPSHOT
paths:
  /admin/health:
    get:
      tags:
      - Health Check API
      summary: Checks if application resources are up
      operationId: getAdminHealth
      responses:
        '503':
          description: ''
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/TimeoutError'
              examples:
                sample1:
                  summary: "Some summary"
                  description: "some description"
                  value:
                    code: TIMEOUT_ERROR
                    message: The server was acting as a gateway or proxy and did not receive a timely response from the upstream server
                sample2:
                  summary: "Some summary 2"
                  description: "some description 2"
                  value:
                    code: TIMEOUT_ERROR
                    message: The server was acting as a gateway or proxy and did not receive a timely response from the upstream server
components:
  schemas:
    TimeoutError:
      required:
      - code
      - message
      type: object
      properties:
        code:
          type: string
        message:
          type: string

```

