### PR TITLE
fix: increase the adopt-tapir iframe's height

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -49,7 +49,7 @@ for a more detailed description of how tapir works!
      sandbox="allow-scripts allow-same-origin allow-forms allow-downloads"
      src="https://adopt-tapir.softwaremill.com/embedded-form"
      width="100%"
-     height="450"
+     height="500"
    ></iframe>
 ```
 


### PR DESCRIPTION
So that one doesn't have scroll to see `Reset` and `Generate ZIP` buttons.