### PR TITLE
chore: adjust iFrame height to the revamped adopt-tapir UI

### DIFF
--- a/generated-doc/out/index.md
+++ b/generated-doc/out/index.md
@@ -49,7 +49,7 @@ for a more detailed description of how tapir works!
      sandbox="allow-scripts allow-same-origin allow-forms allow-downloads"
      src="https://adopt-tapir.softwaremill.com/embedded-form"
      width="100%"
-     height="500"
+     height="590"
    ></iframe>
 ```
 


### PR DESCRIPTION
Increase the height to *590* so that `Reset` and `Generate ZIP` buttons are again visible.
Note that the current height value is available in [adopt-tapir](https://github.com/softwaremill/adopt-tapir/blob/main/ui/README.md#routing--embeddedable-version).

Follow-up to: softwaremill/adopt-tapir/issues/130