### PR TITLE
Allow multiple origins in CORSConfig

### DIFF
--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/cors/CORSConfig.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/cors/CORSConfig.scala
@@ -25,14 +25,14 @@ case class CORSConfig(
   /** Allows CORS requests only from a specific origin.
     *
     * If the request `Origin` matches the given `origin`, sets the `Access-Control-Allow-Origin` response header to the given `origin`.
-    * Otherwise the `Access-Control-Allow-Origin` response header is suppressed..
+    * Otherwise the `Access-Control-Allow-Origin` response header is suppressed.
     */
   def allowOrigin(origin: Origin): CORSConfig = copy(allowedOrigin = AllowedOrigin.Single(origin))
 
   /** Allows CORS requests from origins matching predicate
     *
     * If the request `Origin` header matches the given `predicate`, sets the `Access-Control-Allow-Origin` response header to the given
-    * `origin`. Otherwise the `Access-Control-Allow-Origin` response header is suppressed..
+    * `origin`. Otherwise the `Access-Control-Allow-Origin` response header is suppressed.
     */
   def allowMatchingOrigins(predicate: String => Boolean): CORSConfig = copy(allowedOrigin = AllowedOrigin.Matching(predicate))
 

--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/cors/CORSConfig.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/cors/CORSConfig.scala
@@ -29,6 +29,13 @@ case class CORSConfig(
     */
   def allowOrigin(origin: Origin): CORSConfig = copy(allowedOrigin = AllowedOrigin.Single(origin))
 
+  /** Allows CORS requests from origins matching predicate
+    *
+    * If the request `Origin` header matches the given `predicate`, sets the `Access-Control-Allow-Origin` response header to the given
+    * `origin`. Otherwise the `Access-Control-Allow-Origin` response header is suppressed..
+    */
+  def allowMatchingOrigins(predicate: String => Boolean): CORSConfig = copy(allowedOrigin = AllowedOrigin.Matching(predicate))
+
   /** Allows credentialed requests by setting the `Access-Control-Allow-Credentials` response header to `true`
     */
   def allowCredentials: CORSConfig = copy(allowedCredentials = AllowedCredentials.Allow)
@@ -130,6 +137,7 @@ object CORSConfig {
   object AllowedOrigin {
     case object All extends AllowedOrigin
     case class Single(origin: Origin) extends AllowedOrigin
+    case class Matching(predicate: String => Boolean) extends AllowedOrigin
   }
 
   sealed trait AllowedCredentials


### PR DESCRIPTION
This PR adds support for multiple matching origins in `CORSConfig`. This functionality is already present in CORS support for `Vert.X` or `zio-http`, so it is very helpful to have it in Tapir's native `CORSInterceptor`. Config is defined as `String => Boolean` function to allow partial matching.