### PR TITLE
zio-http-server: Avoid buffering ZStream request body into memory

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,3 @@
--J-Xmx4500M
+-J-Xmx3500M
 -J-Xss2M
 -Dsbt.task.timings=false

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,3 @@
--J-Xmx3500M
+-J-Xmx4500M
 -J-Xss2M
 -Dsbt.task.timings=false

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpRequestBody.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpRequestBody.scala
@@ -31,7 +31,7 @@ class ZioHttpRequestBody[R](serverOptions: ZioHttpServerOptions[R]) extends Requ
   override def toStream(serverRequest: ServerRequest): streams.BinaryStream = stream(serverRequest).asInstanceOf[streams.BinaryStream]
 
   private def stream(serverRequest: ServerRequest): Stream[Throwable, Byte] =
-    ZStream.fromZIO(zioHttpRequest(serverRequest).body).flattenChunks
+    zioHttpRequest(serverRequest).bodyAsStream
 
   private def asByteArray(serverRequest: ServerRequest): Task[Array[Byte]] = zioHttpRequest(serverRequest).body.map(_.toArray)
 


### PR DESCRIPTION
The current implementation is calling `.body`, which is implemented [as so in zhttp 2.0.0-RC10](https://github.com/zio/zio-http/blob/v2.0.0-RC10/zio-http/src/main/scala/zhttp/http/HttpDataExtension.scala):
```scala
  final def body: Task[Chunk[Byte]] =
    bodyAsByteArray.map(Chunk.fromArray)
```

This PR changes it to call `bodyAsStream`, which is implemented as so in zhttp 2.0.0-RC10:
```scala
  final def bodyAsStream: ZStream[Any, Throwable, Byte] = data.toByteBufStream
    .mapZIO[Any, Throwable, Chunk[Byte]] { buf =>
      ZIO.attempt {
        val bytes = Chunk.fromArray(ByteBufUtil.getBytes(buf))
        buf.release(buf.refCnt())
        bytes
      }
    }
    .flattenChunks
```

We noticed major memory spikes when uploading large files which led us to investigate and discover this issue.