### PR TITLE
feat: add 'allow-popups' permission to adopt-tapir iframe

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -46,7 +46,7 @@ for a more detailed description of how tapir works!
 
    <iframe
      frameborder=0
-     sandbox="allow-scripts allow-same-origin allow-forms allow-downloads"
+     sandbox="allow-scripts allow-same-origin allow-forms allow-downloads allow-popups"
      src="https://adopt-tapir.softwaremill.com/embedded-form"
      width="100%"
      height="500"


### PR DESCRIPTION
The `Preview` button of the `adopt-tapit` functionality opens new window with the source code therefore the sandbox'ed iframe requires the 'allow-popups' permission to be set.

Follow-up to softwaremill/adopt-tapir/issues/169