### PR TITLE
2499 Use `sttp-apispec` 0.3.1 in tapir

### DIFF
--- a/doc/docs/openapi.md
+++ b/doc/docs/openapi.md
@@ -115,7 +115,7 @@ OpenAPIDocsInterpreter().toOpenAPI(List(addBook, booksListing, booksListingByGen
 The openapi case classes can then be serialised to YAML using [Circe](https://circe.github.io/circe/):
 
 ```scala mdoc:silent
-import sttp.apispec.openapi.circe.yaml.RichOpenAPI
+import sttp.apispec.openapi.circe.yaml._
 
 println(docs.toYaml)
 ```
@@ -144,7 +144,7 @@ Firstly add dependencies:
 and generate the documentation by importing valid extension methods and explicitly specifying the "3.1.0" version in the OpenAPI model:
 ```scala mdoc:compile-only
 import sttp.apispec.openapi.OpenAPI
-import sttp.apispec.openapi.circe.yaml.RichOpenAPI3_1 // for `toYaml` extension method with OpenApi 3.1.0 encoders/decoders
+import sttp.apispec.openapi.circe.yaml._ // for `toYaml3_1` extension method
 import sttp.tapir._
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
@@ -155,7 +155,7 @@ val booksListing = endpoint.in(path[String]("bookId"))
 val docs: OpenAPI = OpenAPIDocsInterpreter().toOpenAPI(booksListing, "My Bookshop", "1.0")
   .openapi("3.1.0") // "3.1.0" version explicitly specified
   
-println(docs.toYaml) // OpenApi 3.1 YAML string would be printed to the console
+println(docs.toYaml3_1) // OpenApi 3.1.0 YAML string would be printed to the console
 ```
 
 ## Exposing generated OpenAPI documentation

--- a/doc/docs/openapi.md
+++ b/doc/docs/openapi.md
@@ -115,7 +115,7 @@ OpenAPIDocsInterpreter().toOpenAPI(List(addBook, booksListing, booksListingByGen
 The openapi case classes can then be serialised to YAML using [Circe](https://circe.github.io/circe/):
 
 ```scala mdoc:silent
-import sttp.apispec.openapi.circe.yaml._
+import sttp.apispec.openapi.circe.yaml.RichOpenAPI
 
 println(docs.toYaml)
 ```
@@ -141,31 +141,21 @@ Firstly add dependencies:
 "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "..." // see https://github.com/softwaremill/sttp-apispec
 ```
 
-Create an auxiliary method for encoding OpenAPI object to OpenAPI 3.1 YAML String:
+and generate the documentation by importing valid extension methods and explicitly specifying the "3.1.0" version in the OpenAPI model:
 ```scala mdoc:compile-only
-import io.circe.syntax.EncoderOps
-import io.circe.yaml.Printer
 import sttp.apispec.openapi.OpenAPI
-import sttp.apispec.openapi.circe.SttpOpenAPI3_1CirceEncoders
-
-object Encoding extends SttpOpenAPI3_1CirceEncoders { // using `SttpOpenAPI3_1CirceEncoders` ensures that proper encoder will be selected
-  def toOpenApi3_1(openAPI: OpenAPI): String = {
-    Printer(dropNullKeys = true, preserveOrder = true).pretty(openAPI.asJson)
-  }
-}
-```
-
-Use it, explicitly specifying the "3.1.0" version in the OpenAPI model:
-```scala
+import sttp.apispec.openapi.circe.yaml.RichOpenAPI3_1 // for `toYaml` extension method with OpenApi 3.1.0 encoders/decoders
 import sttp.tapir._
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
+
+case class Book(id: Option[Long], title: Option[String])
 
 val booksListing = endpoint.in(path[String]("bookId"))
 
 val docs: OpenAPI = OpenAPIDocsInterpreter().toOpenAPI(booksListing, "My Bookshop", "1.0")
   .openapi("3.1.0") // "3.1.0" version explicitly specified
-
-println(Encoding.toOpenApi3_1(docs)) // OpenApi 3.1 YAML string would be printed to the console
+  
+println(docs.toYaml) // OpenApi 3.1 YAML string would be printed to the console
 ```
 
 ## Exposing generated OpenAPI documentation

--- a/doc/docs/openapi.md
+++ b/doc/docs/openapi.md
@@ -130,6 +130,44 @@ import sttp.apispec.openapi.circe._
 println(Printer.spaces2.print(docs.asJson))
 ```
 
+### Support for OpenAPI 3.1.0
+
+Generating OpenAPI documentation compatible with 3.1.0 specifications is a matter of using a different encoder.
+For example, generating the OpenAPI 3.1.0 YAML string can be achieved by performing the following steps:
+
+Firstly add dependencies:
+```scala
+"com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "@VERSION@"
+"com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % " // see https://github.com/softwaremill/sttp-apispec
+```
+
+Create an auxiliary method for encoding OpenAPI object to OpenAPI 3.1 YAML String:
+```scala mdoc:compile-only
+import io.circe.syntax.EncoderOps
+import io.circe.yaml.Printer
+import sttp.apispec.openapi.OpenAPI
+import sttp.apispec.openapi.circe.SttpOpenAPI3_1CirceEncoders
+
+object Encoding extends SttpOpenAPI3_1CirceEncoders { // using `SttpOpenAPI3_1CirceEncoders` ensures that proper encoder would be selected
+  def toOpenApi3_1(openAPI: OpenAPI): String = {
+    Printer(dropNullKeys = true, preserveOrder = true).pretty(openAPI.asJson)
+  }
+}
+```
+
+Use it, explicitly specifying the "3.1.0" version in the OpenAPI model:
+```scala
+import sttp.tapir._
+import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
+
+val booksListing = endpoint.in(path[String]("bookId"))
+
+val docs: OpenAPI = OpenAPIDocsInterpreter().toOpenAPI(booksListing, "My Bookshop", "1.0")
+  .openapi("3.1.0") // "3.1.0" version explicitly specified
+
+println(Encoding.toOpenApi3_1(docs)) // OpenApi 3.1 YAML string would be printed to the console
+```
+
 ## Exposing generated OpenAPI documentation
 
 Exposing the OpenAPI can be done using [Swagger UI](https://swagger.io/tools/swagger-ui/) or

--- a/doc/docs/openapi.md
+++ b/doc/docs/openapi.md
@@ -13,7 +13,7 @@ these steps can be done separately, giving you complete control over the process
 To generate OpenAPI documentation and expose it using the Swagger UI in a single step, first add the dependency:
 
 ```scala
-"com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % "1.1.2"
+"com.softwaremill.sttp.tapir" %% "tapir-swagger-ui-bundle" % "@VERSION@"
 ```
 
 Then, you can interpret a list of endpoints using `SwaggerInterpreter`. The result will be a list of file-serving 
@@ -55,7 +55,7 @@ for details.
 Similarly as above, you'll need the following dependency:
 
 ```scala
-"com.softwaremill.sttp.tapir" %% "tapir-redoc-bundle" % "1.1.2"
+"com.softwaremill.sttp.tapir" %% "tapir-redoc-bundle" % "@VERSION@"
 ```
 
 And the server endpoints can be generated using the `sttp.tapir.redoc.bundle.RedocInterpreter` class.
@@ -138,7 +138,7 @@ For example, generating the OpenAPI 3.1.0 YAML string can be achieved by perform
 Firstly add dependencies:
 ```scala
 "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "@VERSION@"
-"com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % " // see https://github.com/softwaremill/sttp-apispec
+"com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "..." // see https://github.com/softwaremill/sttp-apispec
 ```
 
 Create an auxiliary method for encoding OpenAPI object to OpenAPI 3.1 YAML String:
@@ -148,7 +148,7 @@ import io.circe.yaml.Printer
 import sttp.apispec.openapi.OpenAPI
 import sttp.apispec.openapi.circe.SttpOpenAPI3_1CirceEncoders
 
-object Encoding extends SttpOpenAPI3_1CirceEncoders { // using `SttpOpenAPI3_1CirceEncoders` ensures that proper encoder would be selected
+object Encoding extends SttpOpenAPI3_1CirceEncoders { // using `SttpOpenAPI3_1CirceEncoders` ensures that proper encoder will be selected
   def toOpenApi3_1(openAPI: OpenAPI): String = {
     Printer(dropNullKeys = true, preserveOrder = true).pretty(openAPI.asJson)
   }

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
@@ -44,8 +44,8 @@ private[schema] class TSchemaToASchema(toSchemaReference: ToSchemaReference, mar
                   case t                                                          => apply(t)
                 }
                 .sortBy {
-                  case Left(Reference(ref)) => ref
-                  case Right(schema)        => schema.`type`.map(_.value).getOrElse("") + schema.toString
+                  case Left(Reference(ref, _, _)) => ref
+                  case Right(schema)        => schema.`type`.collect{case t: BasicSchemaType => t.value}.getOrElse("") + schema.toString
                 },
               d.map(tDiscriminatorToADiscriminator)
             )
@@ -116,7 +116,7 @@ private[schema] class TSchemaToASchema(toSchemaReference: ToSchemaReference, mar
           maximum = Some(toBigDecimal(v, m.valueIsNumeric, wholeNumbers)),
           exclusiveMaximum = Option(exclusive).filter(identity)
         )
-      case Validator.Pattern(value)                  => aschema.copy(pattern = Some(value))
+      case Validator.Pattern(value)                  => aschema.copy(pattern = Some(Pattern(value)))
       case Validator.MinLength(value)                => aschema.copy(minLength = Some(value))
       case Validator.MaxLength(value)                => aschema.copy(maxLength = Some(value))
       case Validator.MinSize(value)                  => aschema.copy(minItems = Some(value))

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -9,7 +9,7 @@ object Versions {
   val sttp = "3.8.2"
   val sttpModel = "1.5.2"
   val sttpShared = "1.3.10"
-  val sttpApispec = "0.2.1"
+  val sttpApispec = "0.3.0"
   val akkaHttp = "10.2.10"
   val akkaStreams = "2.6.20"
   val swaggerUi = "4.14.2"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -9,7 +9,7 @@ object Versions {
   val sttp = "3.8.2"
   val sttpModel = "1.5.2"
   val sttpShared = "1.3.10"
-  val sttpApispec = "0.3.0"
+  val sttpApispec = "0.3.1"
   val akkaHttp = "10.2.10"
   val akkaStreams = "2.6.20"
   val swaggerUi = "4.14.2"


### PR DESCRIPTION
* Updated `sttp-apispec` version from `0.2.1` to `0.3.1`, made minor changes to `TSchemaToASchema` as models in new `sttp-apispec` have changed slightly.
* Added documentation on how to generate OpenAPI documentation compatible with 3.1.0 specifications.