### PR TITLE
avoid special characters in SAM logical ids

### DIFF
--- a/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/EndpointsToSamTemplate.scala
+++ b/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/EndpointsToSamTemplate.scala
@@ -61,7 +61,9 @@ private[sam] object EndpointsToSamTemplate {
     val method = e.method
 
     val nameComponents = if (pathComponents.isEmpty) Vector("root") else pathComponents.map(_.fold(identity, identity))
-    val name = (method.map(_.method.toLowerCase).getOrElse("any").capitalize +: nameComponents.map(_.toLowerCase.capitalize)).mkString
+    val name = (method.map(_.method.toLowerCase).getOrElse("any").capitalize +: nameComponents.map(
+      _.toLowerCase.capitalize.replaceAll("\\W", "")
+    )).mkString
 
     val idComponents = pathComponents.map {
       case Left(s)  => s"{$s}"

--- a/serverless/aws/sam/src/test/resources/code_source_template.yaml
+++ b/serverless/aws/sam/src/test/resources/code_source_template.yaml
@@ -22,6 +22,14 @@ Resources:
             TimeoutInMillis: 10000
             PayloadFormatVersion: '2.0'
           Type: HttpApi
+        GetApiCutepets:
+          Properties:
+            ApiId: !Ref 'PetApiHttpApi'
+            Method: GET
+            Path: /api/cute-pets
+            TimeoutInMillis: 10000
+            PayloadFormatVersion: '2.0'
+          Type: HttpApi
       Runtime: java11
       CodeUri: /somewhere/pet-api.jar
       Handler: pet.api.Handler::handleRequest

--- a/serverless/aws/sam/src/test/resources/image_source_template.yaml
+++ b/serverless/aws/sam/src/test/resources/image_source_template.yaml
@@ -22,6 +22,14 @@ Resources:
             TimeoutInMillis: 10000
             PayloadFormatVersion: '2.0'
           Type: HttpApi
+        GetApiCutepets:
+          Properties:
+            ApiId: !Ref 'PetApiHttpApi'
+            Method: GET
+            Path: /api/cute-pets
+            TimeoutInMillis: 10000
+            PayloadFormatVersion: '2.0'
+          Type: HttpApi
       ImageUri: image.repository:pet-api
       PackageType: Image
     Type: AWS::Serverless::Function

--- a/serverless/aws/sam/src/test/scala/sttp/tapir/serverless/aws/sam/VerifySamTemplateTest.scala
+++ b/serverless/aws/sam/src/test/scala/sttp/tapir/serverless/aws/sam/VerifySamTemplateTest.scala
@@ -21,7 +21,7 @@ class VerifySamTemplateTest extends AnyFunSuite with Matchers {
       memorySize = 1024
     )
 
-    val actualYaml = AwsSamInterpreter(samOptions).toSamTemplate(List(getPetEndpoint, addPetEndpoint)).toYaml
+    val actualYaml = AwsSamInterpreter(samOptions).toSamTemplate(List(getPetEndpoint, addPetEndpoint, getCutePetsEndpoint)).toYaml
 
     expectedYaml shouldBe noIndentation(actualYaml)
   }
@@ -35,7 +35,7 @@ class VerifySamTemplateTest extends AnyFunSuite with Matchers {
       memorySize = 1024
     )
 
-    val actualYaml = AwsSamInterpreter(samOptions).toSamTemplate(List(getPetEndpoint, addPetEndpoint)).toYaml
+    val actualYaml = AwsSamInterpreter(samOptions).toSamTemplate(List(getPetEndpoint, addPetEndpoint, getCutePetsEndpoint)).toYaml
 
     expectedYaml shouldBe noIndentation(actualYaml)
   }
@@ -53,6 +53,10 @@ object VerifySamTemplateTest {
   val addPetEndpoint: PublicEndpoint[Pet, Unit, Unit, Any] = endpoint.post
     .in("api" / "pets")
     .in(jsonBody[Pet])
+
+  val getCutePetsEndpoint: PublicEndpoint[Unit, Unit, Pet, Any] = endpoint.get
+    .in("api" / "cute-pets")
+    .out(jsonBody[Pet])
 
   def load(fileName: String): String = {
     noIndentation(Source.fromInputStream(getClass.getResourceAsStream(s"/$fileName")).getLines().mkString("\n"))


### PR DESCRIPTION
When defining an endpoint which contains a hyphen, I get

`Error: [InvalidResourceException('FooApiFunctionGetApiV1Bar-baz 'Logical ids must be alphanumeric.')] ('FooApiFunctionGetApiV1Bar-baz', 'Logical ids must be alphanumeric.')`