### PR TITLE
ZIO2 core metrics interceptor/collector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1698,6 +1698,7 @@ lazy val examples: ProjectMatrix = (projectMatrix in file("examples"))
     prometheusMetrics,
     opentelemetryMetrics,
     datadogMetrics,
+    zioMetrics,
     sttpMockServer,
     zioJson,
     vertxServer,
@@ -1793,6 +1794,7 @@ lazy val documentation: ProjectMatrix = (projectMatrix in file("generated-doc"))
     prometheusMetrics,
     opentelemetryMetrics,
     datadogMetrics,
+    zioMetrics,
     sttpMockServer,
     nettyServer,
     swaggerUiBundle

--- a/build.sbt
+++ b/build.sbt
@@ -138,6 +138,7 @@ lazy val rawAllAggregates = core.projectRefs ++
   prometheusMetrics.projectRefs ++
   opentelemetryMetrics.projectRefs ++
   datadogMetrics.projectRefs ++
+  zioMetrics.projectRefs ++
   json4s.projectRefs ++
   playJson.projectRefs ++
   sprayJson.projectRefs ++

--- a/build.sbt
+++ b/build.sbt
@@ -904,6 +904,21 @@ lazy val datadogMetrics: ProjectMatrix = (projectMatrix in file("metrics/datadog
   .jvmPlatform(scalaVersions = scala2And3Versions)
   .dependsOn(serverCore % CompileAndTest)
 
+lazy val zioMetrics: ProjectMatrix = (projectMatrix in file("metrics/zio-metrics"))
+  .settings(commonJvmSettings)
+  .settings(
+    name := "tapir-prometheus-metrics",
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio" % Versions.zio,
+      "dev.zio" %% "zio-test" % Versions.zio % Test,
+      "dev.zio" %% "zio-test-sbt" % Versions.zio % Test,
+      scalaTest.value % Test
+    )
+  )
+  .jvmPlatform(scalaVersions = scala2And3Versions)
+  .dependsOn(serverCore % CompileAndTest)
+
 // docs
 
 lazy val apispecDocs: ProjectMatrix = (projectMatrix in file("docs/apispec-docs"))

--- a/build.sbt
+++ b/build.sbt
@@ -907,13 +907,12 @@ lazy val datadogMetrics: ProjectMatrix = (projectMatrix in file("metrics/datadog
 lazy val zioMetrics: ProjectMatrix = (projectMatrix in file("metrics/zio-metrics"))
   .settings(commonJvmSettings)
   .settings(
-    name := "tapir-prometheus-metrics",
+    name := "tapir-zio-metrics",
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     libraryDependencies ++= Seq(
       "dev.zio" %% "zio" % Versions.zio,
       "dev.zio" %% "zio-test" % Versions.zio % Test,
-      "dev.zio" %% "zio-test-sbt" % Versions.zio % Test,
-      scalaTest.value % Test
+      "dev.zio" %% "zio-test-sbt" % Versions.zio % Test
     )
   )
   .jvmPlatform(scalaVersions = scala2And3Versions)

--- a/doc/server/observability.md
+++ b/doc/server/observability.md
@@ -217,3 +217,68 @@ val responsesTotal = Metric[Future, Counter](
 val datadogMetrics = DatadogMetrics.default[Future](statsdClient)
   .addCustom(responsesTotal)
 ```
+
+
+## Zio Metrics
+
+Add the following dependency:
+
+```scala
+"com.softwaremill.sttp.tapir" %% "tapir-zio-metrics" % "@VERSION@"
+```
+
+Metrics have been integrated into ZIO core in ZIO2.
+
+[Monitoring a ZIO Application Using ZIO's Built-in Metric System](https://zio.dev/guides/tutorials/monitor-a-zio-application-using-zio-built-in-metric-system/).
+
+### Collecting Metrics
+```scala mdoc:compile-only
+import sttp.tapir.server.metrics.zio.ZioMetrics
+import zio.{Task, ZIO}
+
+val metrics: ZioMetrics[Task] = ZioMetrics.default[Task]()
+val metricsInterceptor: MetricsRequestInterceptor[Task] = metrics.metricsInterceptor()
+```
+
+### Example Publishing Metrics Endpoint
+
+Zio metrics publishing functionality is provided by the zio ecosystem library [zio-metrics-connectors](https://github.com/zio/zio-metrics-connectors).  
+
+[Dependencies/Examples](https://zio.dev/guides/tutorials/monitor-a-zio-application-using-zio-built-in-metric-system/#adding-dependencies-to-the-project)
+```scala
+libraryDependencies += "dev.zio" %% "zio-metrics-connectors" % "2.0.0-RC6"
+```
+
+Example zio metrics prometheus publisher style tapir metrics endpoint.
+```scala mdoc:compile-only
+import sttp.tapir.{endpoint, stringBody}
+import zio._
+import zio.metrics.connectors.MetricsConfig
+import zio.metrics.connectors.prometheus.{PrometheusPublisher, prometheusLayer, publisherLayer}
+import zio.metrics.jvm.DefaultJvmMetrics
+
+
+object ZioEndpoint {
+  
+  /** DefaultJvmMetrics.live.orDie >+> is optional if you want JVM metrics */
+  private val layer = DefaultJvmMetrics.live.orDie >+> ZLayer.make[PrometheusPublisher](
+    ZLayer.succeed(MetricsConfig(1.seconds)),
+    prometheusLayer,
+    publisherLayer
+  )
+  
+  private val unsafeLayers = Unsafe.unsafe { implicit u =>
+    Runtime.unsafe.fromLayer(layer)
+  }
+
+  def getMetricsEffect: ZIO[Any, Nothing, String] =
+    Unsafe.unsafe { implicit u =>
+      unsafeLayers.run(ZIO
+        .serviceWithZIO[PrometheusPublisher](_.get)
+      )
+    }
+
+  val metricsEndpoint =
+    endpoint.get.in("metrics").out(stringBody).serverLogicSuccess(_ => getMetricsEffect)
+}
+```

--- a/doc/server/observability.md
+++ b/doc/server/observability.md
@@ -250,7 +250,7 @@ libraryDependencies += "dev.zio" %% "zio-metrics-connectors" % "2.0.0-RC6"
 ```
 
 Example zio metrics prometheus publisher style tapir metrics endpoint.
-```scala mdoc:compile-only
+```scala
 import sttp.tapir.{endpoint, stringBody}
 import zio._
 import zio.metrics.connectors.MetricsConfig

--- a/doc/server/observability.md
+++ b/doc/server/observability.md
@@ -234,6 +234,7 @@ Metrics have been integrated into ZIO core in ZIO2.
 ### Collecting Metrics
 ```scala mdoc:compile-only
 import sttp.tapir.server.metrics.zio.ZioMetrics
+import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 import zio.{Task, ZIO}
 
 val metrics: ZioMetrics[Task] = ZioMetrics.default[Task]()

--- a/examples/src/main/scala/sttp/tapir/examples/observability/ZioMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/ZioMetricsExample.scala
@@ -1,0 +1,48 @@
+
+import sttp.tapir._
+import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
+import sttp.tapir.server.metrics.zio.ZioMetrics
+import sttp.tapir.server.ziohttp.{ZioHttpInterpreter, ZioHttpServerOptions}
+import sttp.tapir.ztapir.ZServerEndpoint
+import zhttp.http.HttpApp
+import zhttp.service.server.ServerChannelFactory
+import zhttp.service.{EventLoopGroup, Server}
+import zio.{Task, ZIO, _}
+
+/** Based on https://adopt-tapir.softwaremill.com zio version. */
+object ZioMetricsExample extends ZIOAppDefault {
+
+  case class User(name: String) extends AnyVal
+
+  val helloEndpoint: PublicEndpoint[User, Unit, String, Any] = endpoint.get
+    .in("hello")
+    .in(query[User]("name"))
+    .out(stringBody)
+  val helloServerEndpoint: ZServerEndpoint[Any, Any] = helloEndpoint.serverLogicSuccess(user => ZIO.succeed(s"Hello ${user.name}"))
+
+  val apiEndpoints: List[ZServerEndpoint[Any, Any]] = List(helloServerEndpoint)
+
+  val all: List[ZServerEndpoint[Any, Any]] = apiEndpoints
+
+  val metrics: ZioMetrics[Task] = ZioMetrics.default[Task]()
+  val metricsInterceptor: MetricsRequestInterceptor[Task] = metrics.metricsInterceptor()
+
+  //noinspection DuplicatedCode
+  override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] = {
+    val serverOptions: ZioHttpServerOptions[Any] =
+      ZioHttpServerOptions.customiseInterceptors.metricsInterceptor(metricsInterceptor).options
+    val app: HttpApp[Any, Throwable] = ZioHttpInterpreter(serverOptions).toHttp(all)
+
+    val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
+
+    (for {
+      serverStart <- Server(app).withPort(port).make
+      _ <- Console.printLine(s"Server started at http://localhost:${serverStart.port}. Press ENTER key to exit.")
+      _ <- Console.readLine
+    } yield serverStart)
+      .provideSomeLayer(EventLoopGroup.auto(0) ++ ServerChannelFactory.auto ++ Scope.default)
+      .exitCode
+  }
+
+
+}

--- a/metrics/zio-metrics/src/main/scala/sttp/tapir/server/metrics/zio/ZioMetrics.scala
+++ b/metrics/zio-metrics/src/main/scala/sttp/tapir/server/metrics/zio/ZioMetrics.scala
@@ -1,0 +1,178 @@
+package sttp.tapir.server.metrics.zio
+
+import sttp.tapir._
+import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
+import sttp.tapir.server.metrics.{EndpointMetric, Metric, MetricLabels}
+import sttp.tapir.server.model.ServerResponse
+import zio._
+import zio.metrics.Metric._
+import zio.metrics.MetricKeyType.Histogram.Boundaries
+import zio.metrics.MetricLabel
+
+import java.time.{Clock, Duration, Instant}
+
+case class ZioMetrics[F[_]](namespace: String, metrics: List[Metric[F, _]] = List.empty) {
+  import ZioMetrics._
+
+  /** Registers a `$namespace.request_active.count|c|#path, method` counter (assuming default labels). */
+  def addRequestsActive(labels: MetricLabels = MetricLabels.Default): ZioMetrics[F] =
+    copy(metrics = metrics :+ requestActive(namespace, labels))
+
+  /** Registers a `request_total{path, method, status}` counter (assuming default labels). */
+  def addRequestsTotal(labels: MetricLabels = MetricLabels.Default): ZioMetrics[F] =
+    copy(metrics = metrics :+ requestTotal(namespace, labels))
+
+  /** Registers a `request_duration_seconds{path, method, status, phase}` histogram (assuming default labels). */
+  def addRequestsDuration(labels: MetricLabels = MetricLabels.Default): ZioMetrics[F] =
+    copy(metrics = metrics :+ requestDuration(namespace, labels))
+
+  /** Registers a custom metric. */
+  def addCustom(m: Metric[F, _]): ZioMetrics[F] = copy(metrics = metrics :+ m)
+
+
+  def metricsInterceptor(ignoreEndpoints: Seq[AnyEndpoint] = Seq.empty): MetricsRequestInterceptor[F] =
+    new MetricsRequestInterceptor[F](metrics, ignoreEndpoints)
+}
+
+object ZioMetrics {
+  val DEFAULT_NAMESPACE: String = "tapir"
+  val DURATION_BOUNDARIES: Boundaries = Boundaries.fromChunk(Chunk(.005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10, 15, 30, 45, 60))
+
+  /** ZIO Default Runtime */
+  val runtime: Runtime[Any] = Runtime.default
+
+  def getActiveRequestCounter(namespace: String): Counter[Long] = zio.metrics.Metric.counter(s"${namespace}_request_active")
+  def getRequestsTotalCounter(namespace: String): Counter[Long] = zio.metrics.Metric.counter(s"${namespace}_request_total")
+  def getRequestDurationHistogram(namespace: String): zio.metrics.Metric.Histogram[Double] = zio.metrics.Metric.histogram(s"${namespace}_request_duration_seconds", DURATION_BOUNDARIES)
+
+  /** ZIO Unsafe Run Wrapper */
+  private def unsafeRun[T](task: Task[T]): T = Unsafe.unsafe { implicit u =>
+    runtime.unsafe.run(task.orDie).getOrThrowFiberFailure()
+  }
+
+  /** Convert into zio metric labels */
+  private def asZioLabel(l: MetricLabels, ep: AnyEndpoint, req: ServerRequest): Set[MetricLabel] =
+    l.forRequest.map(label => zio.metrics.MetricLabel(label._1, label._2(ep, req))).toSet
+
+  /** Convert into zio metric labels */
+  private def asZioLabel(l: MetricLabels, res: Either[Throwable, ServerResponse[_]], phase: Option[String]): Set[MetricLabel] = {
+    l.forResponse.map(label => zio.metrics.MetricLabel(label._1, label._2(res))) ++
+      phase.map(v => MetricLabel(l.forResponsePhase.name, v))
+  }.toSet
+
+  /** Using the default namespace and labels, registers the following metrics:
+   *
+   *   - `tapir_request_active{path, method}` (gauge)
+   *   - `tapir_request_total{path, method, status}` (counter)
+   *   - `tapir_request_duration_seconds{path, method, status, phase}` (histogram)
+   *
+   * Status is by default the status code class (1xx, 2xx, etc.), and phase can be either `headers` or `body` - request duration is
+   * measured separately up to the point where the headers are determined, and then once again when the whole response body is complete.
+   */
+  def default[F[_]](namespace: String = DEFAULT_NAMESPACE,
+                    labels: MetricLabels = MetricLabels.Default
+                   ): ZioMetrics[F] = ZioMetrics(
+    namespace,
+    List(
+      requestActive(namespace, labels),
+      requestTotal(namespace, labels),
+      requestDuration(namespace, labels)
+    )
+  )
+
+
+
+  def requestActive[F[_]](namespace: String, labels: MetricLabels): Metric[F, Counter[Long]] = {
+    Metric[F, Counter[Long]](
+      getActiveRequestCounter(namespace),
+      onRequest = (req, counter, m) => {
+        m.unit {
+          EndpointMetric()
+            .onEndpointRequest { ep =>
+              m.eval {
+                unsafeRun(
+                  counter.tagged(asZioLabel(labels, ep, req)).update(1).unit
+                )
+              }
+            }
+            .onResponseBody { (ep, _) =>
+              m.eval {
+                unsafeRun(
+                  counter.tagged(asZioLabel(labels, ep, req)).update(-1).unit
+                )
+              }
+            }
+            .onException { (ep, _) =>
+              m.eval {
+                unsafeRun(
+                  counter.tagged(asZioLabel(labels, ep, req)).update(-1).unit
+                )
+              }
+            }
+        }
+      }
+    )
+  }
+
+  def requestTotal[F[_]](namespace: String, labels: MetricLabels): Metric[F, Counter[Long]] = {
+    Metric[F, Counter[Long]](
+      getRequestsTotalCounter(namespace),
+      onRequest = { (req, counter, m) =>
+        m.unit {
+          EndpointMetric()
+            .onResponseBody { (ep, res) =>
+              m.eval {
+                unsafeRun(
+                  counter.tagged(asZioLabel(labels, ep, req) ++ asZioLabel(labels, Right(res), None)).update(1).unit
+                )
+              }
+            }
+            .onException { (ep, ex) =>
+              m.eval {
+                unsafeRun(
+                  counter.tagged(asZioLabel(labels, ep, req) ++ asZioLabel(labels, Left(ex), None)).update(1).unit
+                )
+              }
+            }
+        }
+      }
+    )
+  }
+
+  def requestDuration[F[_]](namespace: String,
+                            labels: MetricLabels,
+                            clock: Clock = Clock.systemUTC()
+                           ): Metric[F, zio.metrics.Metric.Histogram[Double]] =
+    Metric[F, zio.metrics.Metric.Histogram[Double]](
+      getRequestDurationHistogram(namespace),
+      onRequest = { (req, histogram, m) =>
+        m.eval {
+          val requestStart: Instant = clock.instant()
+          def duration = Duration.between(requestStart, clock.instant()).toNanos.toDouble / (1000 * 1000 * 1000)
+          EndpointMetric()
+            .onResponseHeaders { (ep, res) =>
+              m.eval {
+                unsafeRun(
+                  histogram.tagged(asZioLabel(labels, ep, req) ++ asZioLabel(labels, Right(res), Some(labels.forResponsePhase.headersValue))).update(duration).unit
+                )
+              }
+            }
+            .onResponseBody { (ep, res) =>
+              m.eval {
+                unsafeRun(
+                  histogram.tagged(asZioLabel(labels, ep, req) ++ asZioLabel(labels, Right(res), Some(labels.forResponsePhase.bodyValue))).update(duration).unit
+                )
+              }
+            }
+            .onException { (ep: AnyEndpoint, ex: Throwable) =>
+              m.eval {
+                unsafeRun(
+                  histogram.tagged(asZioLabel(labels, ep, req) ++ asZioLabel(labels, Left(ex), None)).update(duration).unit
+                )
+              }
+            }
+        }
+      }
+    )
+}

--- a/metrics/zio-metrics/src/test/scala/sttp/tapir/server/metrics/zio/ZioMetricsTest.scala
+++ b/metrics/zio-metrics/src/test/scala/sttp/tapir/server/metrics/zio/ZioMetricsTest.scala
@@ -1,0 +1,116 @@
+package sttp.tapir.server.metrics.zio
+
+import sttp.tapir.TestUtil._
+import sttp.tapir.capabilities.NoStreams
+import sttp.tapir.server.TestUtil._
+import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureInterceptor, DefaultDecodeFailureHandler}
+import sttp.tapir.server.interpreter.ServerInterpreter
+import zio.metrics.Metric.Counter
+import zio.metrics._
+import zio.test._
+import zio._
+
+object ZioMetricsTest extends ZIOSpecDefault {
+
+  override def spec: Spec[TestEnvironment, Any] = {
+    suite("ZioMetrics")(
+      test("can collect requests active") {
+
+        val serverEp = PersonsApi { name =>
+          Thread.sleep(100)
+          PersonsApi.defaultLogic(name)
+        }.serverEp
+        val metrics = ZioMetrics[Id](ZioMetrics.DEFAULT_NAMESPACE).addRequestsActive()
+        val interpreter =
+          new ServerInterpreter[Any, Id, Unit, NoStreams](
+            _ => List(serverEp),
+            TestRequestBody,
+            UnitToResponseBody,
+            List(metrics.metricsInterceptor(), new DecodeFailureInterceptor(DefaultDecodeFailureHandler.default)),
+            _ => ()
+          )
+
+        // when
+        val active: Counter[Long] = ZioMetrics.getActiveRequestCounter("tapir").tagged(
+          Set(MetricLabel("path", "/person"), MetricLabel("method", "GET"))
+        )
+
+        for {
+          _ <- ZIO.succeed({
+            interpreter.apply(PersonsApi.request("Jacob"))
+          }).fork
+          _ <- ZIO.succeed(Thread.sleep(100))
+          state <- active.value
+          _ <- ZIO.succeed(Thread.sleep(150))
+          state2 <- active.value
+        } yield assertTrue(state == MetricState.Counter(1)) && assertTrue(state2 == MetricState.Counter(0))
+
+      } @@ TestAspect.retry(Schedule.recurs(5)),
+      test("can collect requests total") {
+
+        val serverEp = PersonsApi { name =>
+          PersonsApi.defaultLogic(name)
+        }.serverEp
+        val metrics = ZioMetrics[Id](ZioMetrics.DEFAULT_NAMESPACE).addRequestsTotal()
+        val interpreter =
+          new ServerInterpreter[Any, Id, Unit, NoStreams](
+            _ => List(serverEp),
+            TestRequestBody,
+            UnitToResponseBody,
+            List(metrics.metricsInterceptor(), new DecodeFailureInterceptor(DefaultDecodeFailureHandler.default)),
+            _ => ()
+          )
+
+        // when
+        val counter: Counter[Long] = ZioMetrics.getRequestsTotalCounter("tapir").tagged(
+          Set(MetricLabel("path", "/person"), MetricLabel("method", "GET"),MetricLabel("status", "2xx"))
+        )
+
+        val missedCounter: Counter[Long] = ZioMetrics.getRequestsTotalCounter("tapir").tagged(
+          Set(MetricLabel("path", "/person"), MetricLabel("method", "GET"), MetricLabel("status", "4xx"))
+        )
+        for {
+          _ <- ZIO.succeed({
+            interpreter.apply(PersonsApi.request("Jacob"))
+            interpreter.apply(PersonsApi.request("Jacob"))
+            interpreter.apply(PersonsApi.request("Jacob"))
+            interpreter.apply(PersonsApi.request(""))
+            interpreter.apply(PersonsApi.request("Ace"))
+          })
+          state <- counter.value
+          stateMissed <- missedCounter.value
+        } yield assertTrue(state == MetricState.Counter(3)) &&
+          assertTrue(stateMissed == MetricState.Counter(2))
+      },
+      test ("can collect requests duration") {
+        val serverEp = PersonsApi { name =>
+          PersonsApi.defaultLogic(name)
+        }.serverEp
+        val metrics = ZioMetrics[Id](ZioMetrics.DEFAULT_NAMESPACE).addRequestsDuration()
+        val interpreter =
+          new ServerInterpreter[Any, Id, Unit, NoStreams](
+            _ => List(serverEp),
+            TestRequestBody,
+            UnitToResponseBody,
+            List(metrics.metricsInterceptor(), new DecodeFailureInterceptor(DefaultDecodeFailureHandler.default)),
+            _ => ()
+          )
+
+        // when
+        val histogram: Metric[MetricKeyType.Histogram, Double, MetricState.Histogram] = ZioMetrics.getRequestDurationHistogram("tapir").tagged(
+          Set(MetricLabel("path", "/person"), MetricLabel("method", "GET"), MetricLabel("status", "2xx"), MetricLabel("phase", "headers"))
+        )
+
+        for {
+          _ <- ZIO.succeed({
+            interpreter.apply(PersonsApi.request("Jacob"))
+          })
+          state <- histogram.value
+        } yield assertTrue(state.buckets.exists(_._2 == 1)) &&
+          assertTrue(state.count == 1) &&
+          assertTrue(state.min > 0) &&
+          assertTrue(state.max > 0)
+      }
+    )
+  }
+}

--- a/metrics/zio-metrics/src/test/scala/sttp/tapir/server/metrics/zio/ZioMetricsTest.scala
+++ b/metrics/zio-metrics/src/test/scala/sttp/tapir/server/metrics/zio/ZioMetricsTest.scala
@@ -20,7 +20,7 @@ object ZioMetricsTest extends ZIOSpecDefault {
           Thread.sleep(100)
           PersonsApi.defaultLogic(name)
         }.serverEp
-        val metrics = ZioMetrics[Id](ZioMetrics.DEFAULT_NAMESPACE).addRequestsActive()
+        val metrics = ZioMetrics[Id](ZioMetrics.DefaultNamespace).addRequestsActive()
         val interpreter =
           new ServerInterpreter[Any, Id, Unit, NoStreams](
             _ => List(serverEp),
@@ -51,7 +51,7 @@ object ZioMetricsTest extends ZIOSpecDefault {
         val serverEp = PersonsApi { name =>
           PersonsApi.defaultLogic(name)
         }.serverEp
-        val metrics = ZioMetrics[Id](ZioMetrics.DEFAULT_NAMESPACE).addRequestsTotal()
+        val metrics = ZioMetrics[Id](ZioMetrics.DefaultNamespace).addRequestsTotal()
         val interpreter =
           new ServerInterpreter[Any, Id, Unit, NoStreams](
             _ => List(serverEp),
@@ -86,7 +86,7 @@ object ZioMetricsTest extends ZIOSpecDefault {
         val serverEp = PersonsApi { name =>
           PersonsApi.defaultLogic(name)
         }.serverEp
-        val metrics = ZioMetrics[Id](ZioMetrics.DEFAULT_NAMESPACE).addRequestsDuration()
+        val metrics = ZioMetrics[Id](ZioMetrics.DefaultNamespace).addRequestsDuration()
         val interpreter =
           new ServerInterpreter[Any, Id, Unit, NoStreams](
             _ => List(serverEp),


### PR DESCRIPTION
ZIO2 Integrated ZMX metrics into core with v2 adding an interceptor/collector makes sense.

* Did not include a metric endpoint as zio metrics don't define output only collection.