### PR TITLE
Added necessary widens to support multiple environments

### DIFF
--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
@@ -15,17 +15,20 @@ trait ZioHttpInterpreter[R] {
 
   def zioHttpServerOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default
 
-  def toHttp(se: ZServerEndpoint[R, ZioStreams]): Http[R, Throwable, Request, Response] =
+  def toHttp[R2](se: ZServerEndpoint[R2, ZioStreams]): Http[R & R2, Throwable, Request, Response] =
     toHttp(List(se))
 
-  def toHttp(ses: List[ZServerEndpoint[R, ZioStreams]]): Http[R, Throwable, Request, Response] = {
-    implicit val bodyListener: ZioHttpBodyListener[R] = new ZioHttpBodyListener[R]
-    implicit val monadError: MonadError[RIO[R, *]] = new RIOMonadError[R]
-    val interpreter = new ServerInterpreter[ZioStreams, RIO[R, *], ZioHttpResponseBody, ZioStreams](
-      FilterServerEndpoints(ses),
-      new ZioHttpRequestBody(zioHttpServerOptions),
+  def toHttp[R2](ses: List[ZServerEndpoint[R2, ZioStreams]]): Http[R & R2, Throwable, Request, Response] = {
+    implicit val bodyListener: ZioHttpBodyListener[R & R2] = new ZioHttpBodyListener[R & R2]
+    implicit val monadError: MonadError[RIO[R & R2, *]] = new RIOMonadError[R & R2]
+    val widenedSes = ses.map(_.widen[R & R2])
+    val widenedServerOptions = zioHttpServerOptions.widen[R & R2]
+
+    val interpreter = new ServerInterpreter[ZioStreams, RIO[R & R2, *], ZioHttpResponseBody, ZioStreams](
+      FilterServerEndpoints[ZioStreams, RIO[R & R2, *]](widenedSes),
+      new ZioHttpRequestBody(widenedServerOptions),
       new ZioHttpToResponseBody,
-      RejectInterceptor.disableWhenSingleEndpoint(zioHttpServerOptions.interceptors, ses),
+      RejectInterceptor.disableWhenSingleEndpoint(widenedServerOptions.interceptors, widenedSes),
       zioHttpServerOptions.deleteFile
     )
 

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
@@ -63,9 +63,14 @@ trait ZioHttpInterpreter[R] {
 }
 
 object ZioHttpInterpreter {
-  def apply[R](serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R]): ZioHttpInterpreter[R] = {
+  def apply[R](serverOptions: ZioHttpServerOptions[R]): ZioHttpInterpreter[R] = {
     new ZioHttpInterpreter[R] {
       override def zioHttpServerOptions: ZioHttpServerOptions[R] = serverOptions
+    }
+  }
+  def apply(): ZioHttpInterpreter[Any] = {
+    new ZioHttpInterpreter[Any] {
+      override def zioHttpServerOptions: ZioHttpServerOptions[Any] = ZioHttpServerOptions.default[Any]
     }
   }
 }

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerOptions.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerOptions.scala
@@ -15,6 +15,8 @@ case class ZioHttpServerOptions[R](
     copy(interceptors = i :: interceptors)
   def appendInterceptor(i: Interceptor[RIO[R, *]]): ZioHttpServerOptions[R] =
     copy(interceptors = interceptors :+ i)
+
+  def widen[R2 <: R]: ZioHttpServerOptions[R2] = this.asInstanceOf[ZioHttpServerOptions[R2]]
 }
 
 object ZioHttpServerOptions {

--- a/server/zio1-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
+++ b/server/zio1-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
@@ -66,9 +66,15 @@ trait ZioHttpInterpreter[R] {
 }
 
 object ZioHttpInterpreter {
-  def apply[R](serverOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default[R]): ZioHttpInterpreter[R] = {
+  def apply[R](serverOptions: ZioHttpServerOptions[R]): ZioHttpInterpreter[R] = {
     new ZioHttpInterpreter[R] {
       override def zioHttpServerOptions: ZioHttpServerOptions[R] = serverOptions
+    }
+  }
+
+  def apply(): ZioHttpInterpreter[Any] = {
+    new ZioHttpInterpreter[Any] {
+      override def zioHttpServerOptions: ZioHttpServerOptions[Any] = ZioHttpServerOptions.default[Any]
     }
   }
 }

--- a/server/zio1-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
+++ b/server/zio1-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
@@ -15,17 +15,20 @@ trait ZioHttpInterpreter[R] {
 
   def zioHttpServerOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default
 
-  def toHttp(se: ZServerEndpoint[R, ZioStreams]): Http[R, Throwable, Request, Response] =
+  def toHttp[R2](se: ZServerEndpoint[R2, ZioStreams]): Http[R & R2, Throwable, Request, Response] =
     toHttp(List(se))
 
-  def toHttp(ses: List[ZServerEndpoint[R, ZioStreams]]): Http[R, Throwable, Request, Response] = {
-    implicit val bodyListener: ZioHttpBodyListener[R] = new ZioHttpBodyListener[R]
-    implicit val monadError: MonadError[RIO[R, *]] = new RIOMonadError[R]
-    val interpreter = new ServerInterpreter[ZioStreams, RIO[R, *], ZioHttpResponseBody, ZioStreams](
-      FilterServerEndpoints(ses),
-      new ZioHttpRequestBody(zioHttpServerOptions),
+  def toHttp[R2](ses: List[ZServerEndpoint[R2, ZioStreams]]): Http[R & R2, Throwable, Request, Response] = {
+    implicit val bodyListener: ZioHttpBodyListener[R & R2] = new ZioHttpBodyListener[R & R2]
+    implicit val monadError: MonadError[RIO[R & R2, *]] = new RIOMonadError[R & R2]
+    val widenedSes = ses.map(_.widen[R & R2])
+    val widenedServerOptions = zioHttpServerOptions.widen[R & R2]
+
+    val interpreter = new ServerInterpreter[ZioStreams, RIO[R & R2, *], ZioHttpResponseBody, ZioStreams](
+      FilterServerEndpoints(widenedSes),
+      new ZioHttpRequestBody(widenedServerOptions),
       new ZioHttpToResponseBody,
-      RejectInterceptor.disableWhenSingleEndpoint(zioHttpServerOptions.interceptors, ses),
+      RejectInterceptor.disableWhenSingleEndpoint(widenedServerOptions.interceptors, widenedSes),
       zioHttpServerOptions.deleteFile
     )
 

--- a/server/zio1-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerOptions.scala
+++ b/server/zio1-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerOptions.scala
@@ -14,6 +14,8 @@ case class ZioHttpServerOptions[R](
     copy(interceptors = i :: interceptors)
   def appendInterceptor(i: Interceptor[RIO[R, *]]): ZioHttpServerOptions[R] =
     copy(interceptors = interceptors :+ i)
+
+  def widen[R2 <: R]: ZioHttpServerOptions[R2] = this.asInstanceOf[ZioHttpServerOptions[R2]]
 }
 
 object ZioHttpServerOptions {


### PR DESCRIPTION
This solves the problem when ZioHttpServerOptions are required to also have the same environment as the endpoints due to R type parameter being shared between them via the ZioHttpInterpreter trait.