### PR TITLE
Replace unsafeCompat with usafe

### DIFF
--- a/client/sttp-client/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientZioTests.scala
+++ b/client/sttp-client/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientZioTests.scala
@@ -56,11 +56,11 @@ abstract class SttpClientZioTests[R >: WebSockets with ZioStreams] extends Clien
   }
 
   def unsafeRun[T](task: Task[T]): T =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafe { implicit u =>
       runtime.run(task).getOrThrowFiberFailure()
     }
 
   def unsafeToFuture[T](task: Task[T]): CancelableFuture[T] =
-    Unsafe.unsafeCompat(implicit u => runtime.runToFuture(task))
+    Unsafe.unsafe(implicit u => runtime.runToFuture(task))
 
 }

--- a/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerStubTest.scala
+++ b/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerStubTest.scala
@@ -16,7 +16,7 @@ object ZHttp4sCreateServerStubTest extends CreateServerStubTest[Task, Http4sServ
   override def customiseInterceptors: CustomiseInterceptors[Task, Http4sServerOptions[Task]] =
     Http4sServerOptions.customiseInterceptors
   override def stub[R]: SttpBackendStub[Task, R] = SttpBackendStub(new CatsMonadError[Task])
-  override def asFuture[A]: Task[A] => Future[A] = rio => Unsafe.unsafeCompat(implicit u => Runtime.default.unsafe.runToFuture(rio))
+  override def asFuture[A]: Task[A] => Future[A] = rio => Unsafe.unsafe(implicit u => Runtime.default.unsafe.runToFuture(rio))
 }
 
 class ZHttp4sServerStubTest extends ServerStubTest(ZHttp4sCreateServerStubTest)

--- a/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sTestServerInterpreter.scala
+++ b/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sTestServerInterpreter.scala
@@ -47,9 +47,9 @@ class ZHttp4sTestServerInterpreter extends TestServerInterpreter[Task, ZioStream
     // Converting a zio.RIO-resource to an cats.IO-resource
     val runtime = implicitly[zio.Runtime[Any]]
     Resource
-      .eval(IO.fromFuture(IO(Unsafe.unsafeCompat(implicit u => Runtime.default.unsafe.runToFuture(serverResource.allocated)))))
+      .eval(IO.fromFuture(IO(Unsafe.unsafe(implicit u => Runtime.default.unsafe.runToFuture(serverResource.allocated)))))
       .flatMap { case (port, release) =>
-        Resource.make(IO.pure(port))(_ => IO.fromFuture(IO(Unsafe.unsafeCompat(implicit u => Runtime.default.unsafe.runToFuture(release)))))
+        Resource.make(IO.pure(port))(_ => IO.fromFuture(IO(Unsafe.unsafe(implicit u => Runtime.default.unsafe.runToFuture(release)))))
       }
   }
 }

--- a/server/vertx-server/zio/src/main/scala/sttp/tapir/server/vertx/zio/VertxZioServerInterpreter.scala
+++ b/server/vertx-server/zio/src/main/scala/sttp/tapir/server/vertx/zio/VertxZioServerInterpreter.scala
@@ -86,7 +86,7 @@ trait VertxZioServerInterpreter[R] extends CommonServerInterpreter {
       }
 
       val canceler: FiberId => Exit[Throwable, Any] = {
-        Unsafe.unsafeCompat(implicit u => {
+        Unsafe.unsafe(implicit u => {
           val value = runtime.unsafe.fork(result)
           (fiberId: FiberId) => runtime.unsafe.run(value.interruptAs(fiberId)).flattenExit
         })

--- a/server/vertx-server/zio/src/main/scala/sttp/tapir/server/vertx/zio/streams/zio.scala
+++ b/server/vertx-server/zio/src/main/scala/sttp/tapir/server/vertx/zio/streams/zio.scala
@@ -160,7 +160,7 @@ package object streams {
         .fold(throw _, identity)
 
     def unsafeRunSync[T](task: Task[T]): Exit[Throwable, T] =
-      Unsafe.unsafeCompat { implicit u =>
+      Unsafe.unsafe { implicit u =>
         runtime.unsafe.run(task)
       }
   }

--- a/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/VertxStubServerTest.scala
+++ b/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/VertxStubServerTest.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 object VertxZioCreateServerStubTest extends CreateServerStubTest[Task, VertxZioServerOptions[Task]] {
   override def customiseInterceptors: CustomiseInterceptors[Task, VertxZioServerOptions[Task]] = VertxZioServerOptions.customiseInterceptors
   override def stub[R]: SttpBackendStub[Task, R] = SttpBackendStub(new RIOMonadError[Any])
-  override def asFuture[A]: Task[A] => Future[A] = task => Unsafe.unsafeCompat(implicit u => Runtime.default.unsafe.runToFuture(task))
+  override def asFuture[A]: Task[A] => Future[A] = task => Unsafe.unsafe(implicit u => Runtime.default.unsafe.runToFuture(task))
 }
 
 class VertxZioServerStubTest extends ServerStubTest(VertxZioCreateServerStubTest)

--- a/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/streams/ZStreamTest.scala
+++ b/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/streams/ZStreamTest.scala
@@ -220,10 +220,10 @@ class ZStreamTest extends AsyncFlatSpec with Matchers {
   }
 
   private def unsafeRunSync[T](task: Task[T]): Exit[Throwable, T] =
-    Unsafe.unsafeCompat { implicit u =>
+    Unsafe.unsafe { implicit u =>
       runtime.unsafe.run(task)
     }
 
   private def unsafeToFuture[T](task: Task[T]): CancelableFuture[T] =
-    Unsafe.unsafeCompat(implicit u => runtime.unsafe.runToFuture(task))
+    Unsafe.unsafe(implicit u => runtime.unsafe.runToFuture(task))
 }

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerStubTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerStubTest.scala
@@ -13,7 +13,7 @@ import scala.concurrent.Future
 object ZioHttpCreateServerStubTest extends CreateServerStubTest[Task, ZioHttpServerOptions[Any]] {
   override def customiseInterceptors: CustomiseInterceptors[Task, ZioHttpServerOptions[Any]] = ZioHttpServerOptions.customiseInterceptors
   override def stub[R]: SttpBackendStub[Task, R] = SttpBackendStub(new RIOMonadError[Any])
-  override def asFuture[A]: Task[A] => Future[A] = task => Unsafe.unsafeCompat(implicit u => Runtime.default.unsafe.runToFuture(task))
+  override def asFuture[A]: Task[A] => Future[A] = task => Unsafe.unsafe(implicit u => Runtime.default.unsafe.runToFuture(task))
 }
 
 class ZioHttpServerStubTest extends ServerStubTest(ZioHttpCreateServerStubTest)

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
@@ -38,7 +38,7 @@ class ZioHttpServerTest extends TestSuite {
               .flatMap(response => response.data.toByteBuf.map(_.toString(CharsetUtil.UTF_8)))
               .map(_ shouldBe "response")
               .catchAll(_ => ZIO.succeed(fail("Unable to extract body from Http response")))
-            Unsafe.unsafeCompat(implicit u => r.unsafe.runToFuture(test))
+            Unsafe.unsafe(implicit u => r.unsafe.runToFuture(test))
           }
         )
 


### PR DESCRIPTION
It seems that unsafeCompat is deprecated in favor of unsafe
![image](https://user-images.githubusercontent.com/59844835/202659349-5036d817-c199-4632-a7b0-f539283156e9.png)
