### PR TITLE
handle the CORS configuration in SAM templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .cache
 .history
 .lib/
+.vscode/
 dist/*
 target/
 lib_managed/
@@ -12,6 +13,7 @@ project/boot/
 project/plugins/project/
 .bloop
 .metals
+metals.sbt
 template.yaml
 
 .bsp

--- a/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/AwsSamOptions.scala
+++ b/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/AwsSamOptions.scala
@@ -1,9 +1,11 @@
 package sttp.tapir.serverless.aws.sam
 
+import sttp.tapir.serverless.aws.sam.HttpApiProperties._
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 case class AwsSamOptions(
     namePrefix: String,
+    httpApi: Option[HttpApiProperties] = None,
     source: FunctionSource,
     timeout: FiniteDuration = 10.seconds,
     memorySize: Int = 256
@@ -12,3 +14,15 @@ case class AwsSamOptions(
 sealed trait FunctionSource
 case class ImageSource(imageUri: String) extends FunctionSource
 case class CodeSource(runtime: String, codeUri: String, handler: String) extends FunctionSource
+
+case class HttpApiProperties(cors: Option[Cors])
+object HttpApiProperties {
+  case class Cors(
+      allowCredentials: Option[Boolean],
+      allowedHeaders: List[String],
+      allowedMethods: List[String],
+      allowedOrigins: List[String],
+      exposeHeaders: List[String],
+      maxAge: Option[Long]
+  )
+}

--- a/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/AwsSamOptions.scala
+++ b/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/AwsSamOptions.scala
@@ -1,14 +1,16 @@
 package sttp.tapir.serverless.aws.sam
 
+import sttp.model.Method
+import sttp.model.headers.Origin
 import sttp.tapir.serverless.aws.sam.HttpApiProperties._
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
 
 case class AwsSamOptions(
     namePrefix: String,
-    httpApi: Option[HttpApiProperties] = None,
     source: FunctionSource,
     timeout: FiniteDuration = 10.seconds,
-    memorySize: Int = 256
+    memorySize: Int = 256,
+    httpApi: Option[HttpApiProperties] = None
 )
 
 sealed trait FunctionSource
@@ -18,11 +20,46 @@ case class CodeSource(runtime: String, codeUri: String, handler: String) extends
 case class HttpApiProperties(cors: Option[Cors])
 object HttpApiProperties {
   case class Cors(
-      allowCredentials: Option[Boolean],
-      allowedHeaders: List[String],
-      allowedMethods: List[String],
-      allowedOrigins: List[String],
-      exposeHeaders: List[String],
-      maxAge: Option[Long]
+      allowCredentials: Option[AllowedCredentials],
+      allowedHeaders: Option[AllowedHeaders],
+      allowedMethods: Option[AllowedMethods],
+      allowedOrigins: Option[AllowedOrigins],
+      exposeHeaders: Option[ExposedHeaders],
+      maxAge: Option[MaxAge]
   )
+
+  sealed trait AllowedCredentials
+  object AllowedCredentials {
+    case object Allow extends AllowedCredentials
+    case object Deny extends AllowedCredentials
+  }
+
+  sealed trait AllowedHeaders
+  object AllowedHeaders {
+    case object All extends AllowedHeaders
+    case class Some(headersNames: Set[String]) extends AllowedHeaders
+  }
+
+  sealed trait AllowedMethods
+  object AllowedMethods {
+    case object All extends AllowedMethods
+    case class Some(methods: Set[Method]) extends AllowedMethods
+  }
+
+  sealed trait AllowedOrigins
+  object AllowedOrigin {
+    case object All extends AllowedOrigins
+    case class Some(origins: Set[Origin]) extends AllowedOrigins
+  }
+
+  sealed trait ExposedHeaders
+  object ExposedHeaders {
+    case object All extends ExposedHeaders
+    case class Some(headerNames: Set[String]) extends ExposedHeaders
+  }
+
+  sealed trait MaxAge
+  object MaxAge {
+    case class Some(duration: Duration) extends MaxAge
+  }
 }

--- a/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/AwsSamTemplateEncoders.scala
+++ b/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/AwsSamTemplateEncoders.scala
@@ -20,6 +20,7 @@ object AwsSamTemplateEncoders {
     e => Json.fromJsonObject(encoder(e).asJson.asObject.get.add("Type", Json.fromString("HttpApi")))
   }
 
+  implicit val encoderCorsConfiguration: Encoder[CorsConfiguration] = deriveEncoder[CorsConfiguration]
   implicit val encoderHttpProperties: Encoder[HttpProperties] = deriveEncoder[HttpProperties]
   implicit val encoderFunctionImageProperties: Encoder[FunctionImageProperties] = deriveEncoder[FunctionImageProperties]
   implicit val encoderFunctionCodeProperties: Encoder[FunctionCodeProperties] = deriveEncoder[FunctionCodeProperties]

--- a/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/EndpointsToSamTemplate.scala
+++ b/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/EndpointsToSamTemplate.scala
@@ -42,12 +42,24 @@ private[sam] object EndpointsToSamTemplate {
               .flatMap(_.cors)
               .map(v =>
                 CorsConfiguration(
-                  AllowCredentials = v.allowCredentials,
-                  AllowHeaders = v.allowedHeaders,
-                  AllowMethods = v.allowedMethods,
-                  AllowOrigins = v.allowedOrigins,
-                  ExposeHeaders = if (v.exposeHeaders.isEmpty) None else Some(v.exposeHeaders),
-                  MaxAge = v.maxAge
+                  AllowCredentials = v.allowCredentials.map(_ == HttpApiProperties.AllowedCredentials.Allow),
+                  AllowHeaders = v.allowedHeaders.map {
+                    case HttpApiProperties.AllowedHeaders.All                => Set("*")
+                    case HttpApiProperties.AllowedHeaders.Some(headersNames) => headersNames
+                  },
+                  AllowMethods = v.allowedMethods.map {
+                    case HttpApiProperties.AllowedMethods.All           => Set("*")
+                    case HttpApiProperties.AllowedMethods.Some(methods) => methods.map(_.method)
+                  },
+                  AllowOrigins = v.allowedOrigins.map {
+                    case HttpApiProperties.AllowedOrigin.All           => Set("*")
+                    case HttpApiProperties.AllowedOrigin.Some(origins) => origins.map(_.toString)
+                  },
+                  ExposeHeaders = v.exposeHeaders.map {
+                    case HttpApiProperties.ExposedHeaders.All               => Set("*")
+                    case HttpApiProperties.ExposedHeaders.Some(headerNames) => headerNames
+                  },
+                  MaxAge = v.maxAge.map { case HttpApiProperties.MaxAge.Some(duration) => duration.toSeconds }
                 )
               )
           )

--- a/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/model.scala
+++ b/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/model.scala
@@ -61,9 +61,9 @@ case class Output(Description: String, Value: Map[String, String])
 
 case class CorsConfiguration(
     AllowCredentials: Option[Boolean],
-    AllowHeaders: List[String],
-    AllowMethods: List[String],
-    AllowOrigins: List[String],
-    ExposeHeaders: Option[List[String]],
+    AllowHeaders: Option[Set[String]],
+    AllowMethods: Option[Set[String]],
+    AllowOrigins: Option[Set[String]],
+    ExposeHeaders: Option[Set[String]],
     MaxAge: Option[Long]
 )

--- a/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/model.scala
+++ b/serverless/aws/sam/src/main/scala/sttp/tapir/serverless/aws/sam/model.scala
@@ -45,7 +45,7 @@ case class FunctionCodeProperties(
 ) extends Properties
     with FunctionProperties
 
-case class HttpProperties(StageName: String) extends Properties
+case class HttpProperties(StageName: String, CorsConfiguration: Option[CorsConfiguration]) extends Properties
 
 case class FunctionHttpApiEvent(Properties: FunctionHttpApiEventProperties)
 
@@ -58,3 +58,12 @@ case class FunctionHttpApiEventProperties(
 )
 
 case class Output(Description: String, Value: Map[String, String])
+
+case class CorsConfiguration(
+    AllowCredentials: Option[Boolean],
+    AllowHeaders: List[String],
+    AllowMethods: List[String],
+    AllowOrigins: List[String],
+    ExposeHeaders: Option[List[String]],
+    MaxAge: Option[Long]
+)

--- a/serverless/aws/sam/src/test/resources/http_api_template.yaml
+++ b/serverless/aws/sam/src/test/resources/http_api_template.yaml
@@ -1,0 +1,54 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Resources:
+  PetApiFunction:
+    Properties:
+      Timeout: 10
+      MemorySize: 1024
+      Events:
+        GetApiPetsId:
+          Properties:
+            ApiId: !Ref 'PetApiHttpApi'
+            Method: GET
+            Path: /api/pets/{id}
+            TimeoutInMillis: 10000
+            PayloadFormatVersion: '2.0'
+          Type: HttpApi
+        PostApiPets:
+          Properties:
+            ApiId: !Ref 'PetApiHttpApi'
+            Method: POST
+            Path: /api/pets
+            TimeoutInMillis: 10000
+            PayloadFormatVersion: '2.0'
+          Type: HttpApi
+        GetApiCutepets:
+          Properties:
+            ApiId: !Ref 'PetApiHttpApi'
+            Method: GET
+            Path: /api/cute-pets
+            TimeoutInMillis: 10000
+            PayloadFormatVersion: '2.0'
+          Type: HttpApi
+      Runtime: java11
+      CodeUri: /somewhere/pet-api.jar
+      Handler: pet.api.Handler::handleRequest
+    Type: AWS::Serverless::Function
+  PetApiHttpApi:
+    Properties:
+      StageName: $default
+      CorsConfiguration:
+        AllowCredentials: false
+        AllowHeaders:
+          - '*'
+        AllowMethods:
+          - GET
+        AllowOrigins:
+          - '*'
+        MaxAge: 0
+    Type: AWS::Serverless::HttpApi
+Outputs:
+  PetApiUrl:
+    Description: Base URL of your endpoints
+    Value:
+      Fn::Sub: https://${PetApiHttpApi}.execute-api.${AWS::Region}.${AWS::URLSuffix}

--- a/serverless/aws/sam/src/test/resources/http_api_template.yaml
+++ b/serverless/aws/sam/src/test/resources/http_api_template.yaml
@@ -43,6 +43,7 @@ Resources:
           - '*'
         AllowMethods:
           - GET
+          - POST
         AllowOrigins:
           - '*'
         MaxAge: 0

--- a/serverless/aws/sam/src/test/scala/sttp/tapir/serverless/aws/sam/VerifySamTemplateTest.scala
+++ b/serverless/aws/sam/src/test/scala/sttp/tapir/serverless/aws/sam/VerifySamTemplateTest.scala
@@ -8,7 +8,9 @@ import sttp.tapir.json.circe._
 import sttp.tapir.serverless.aws.sam.VerifySamTemplateTest._
 import sttp.tapir._
 
+import scala.concurrent.duration._
 import scala.io.Source
+import sttp.model.Method
 
 class VerifySamTemplateTest extends AnyFunSuite with Matchers {
 
@@ -49,12 +51,12 @@ class VerifySamTemplateTest extends AnyFunSuite with Matchers {
         HttpApiProperties(cors =
           Some(
             HttpApiProperties.Cors(
-              allowCredentials = Some(false),
-              allowedHeaders = List("*"),
-              allowedMethods = List("GET"),
-              allowedOrigins = List("*"),
-              exposeHeaders = Nil,
-              maxAge = Some(0)
+              allowCredentials = Some(HttpApiProperties.AllowedCredentials.Deny),
+              allowedHeaders = Some(HttpApiProperties.AllowedHeaders.All),
+              allowedMethods = Some(HttpApiProperties.AllowedMethods.Some(Set(Method.GET, Method.POST))),
+              allowedOrigins = Some(HttpApiProperties.AllowedOrigin.All),
+              exposeHeaders = None,
+              maxAge = Some(HttpApiProperties.MaxAge.Some(0.seconds))
             )
           )
         )

--- a/serverless/aws/sam/src/test/scala/sttp/tapir/serverless/aws/sam/VerifySamTemplateTest.scala
+++ b/serverless/aws/sam/src/test/scala/sttp/tapir/serverless/aws/sam/VerifySamTemplateTest.scala
@@ -40,6 +40,34 @@ class VerifySamTemplateTest extends AnyFunSuite with Matchers {
     expectedYaml shouldBe noIndentation(actualYaml)
   }
 
+  test("should match the expected yaml with HttpApi properties") {
+    val expectedYaml = load("http_api_template.yaml")
+
+    val samOptions: AwsSamOptions = AwsSamOptions(
+      "PetApi",
+      httpApi = Some(
+        HttpApiProperties(cors =
+          Some(
+            HttpApiProperties.Cors(
+              allowCredentials = Some(false),
+              allowedHeaders = List("*"),
+              allowedMethods = List("GET"),
+              allowedOrigins = List("*"),
+              exposeHeaders = Nil,
+              maxAge = Some(0)
+            )
+          )
+        )
+      ),
+      source = CodeSource(runtime = "java11", codeUri = "/somewhere/pet-api.jar", "pet.api.Handler::handleRequest"),
+      memorySize = 1024
+    )
+
+    val actualYaml = AwsSamInterpreter(samOptions).toSamTemplate(List(getPetEndpoint, addPetEndpoint, getCutePetsEndpoint)).toYaml
+
+    expectedYaml shouldBe noIndentation(actualYaml)
+  }
+
 }
 
 object VerifySamTemplateTest {


### PR DESCRIPTION
Hi,
I need to configure the CORS property in the AWS SAM templates.
I think that that the user facing APIs are backward compatible, but I am not sure.