### PR TITLE
Fix port binding in zio-http examples

### DIFF
--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldZioHttpServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldZioHttpServer.scala
@@ -10,8 +10,6 @@ import zio.http.{Server, ServerConfig}
 import zio._
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
 
-import java.net.InetSocketAddress
-
 object HelloWorldZioHttpServer extends ZIOAppDefault {
   // a simple string-only endpoint
   val helloWorld: PublicEndpoint[String, Unit, String, Any] =
@@ -40,5 +38,8 @@ object HelloWorldZioHttpServer extends ZIOAppDefault {
 
   // starting the server
   override def run =
-    Server.serve(app).provide(ServerConfig.live(ServerConfig().binding(new InetSocketAddress(8090))) >>> Server.default).exitCode
+    Server.serve(app).provide(
+      ServerConfig.live(ServerConfig.default.port(8090)),
+      Server.live,
+    ).exitCode
 }

--- a/examples/src/main/scala/sttp/tapir/examples/ZioExampleZioHttpServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioExampleZioHttpServer.scala
@@ -11,8 +11,6 @@ import zio.http.HttpApp
 import zio.http.{Server, ServerConfig}
 import zio.{ExitCode, Task, URIO, ZIO, ZIOAppDefault}
 
-import java.net.InetSocketAddress
-
 object ZioExampleZioHttpServer extends ZIOAppDefault {
   case class Pet(species: String, url: String)
 
@@ -44,5 +42,11 @@ object ZioExampleZioHttpServer extends ZIOAppDefault {
   val routes: HttpApp[Any, Throwable] = ZioHttpInterpreter().toHttp(List(petServerEndpoint) ++ swaggerEndpoints)
 
   override def run: URIO[Any, ExitCode] =
-    Server.serve(routes).provide(ServerConfig.live(ServerConfig().binding(new InetSocketAddress(8080))) >>> Server.default).exitCode
+    Server
+      .serve(routes)
+      .provide(
+        ServerConfig.live(ServerConfig.default.port(8080)),
+        Server.live,
+      )
+      .exitCode
 }

--- a/examples/src/main/scala/sttp/tapir/examples/observability/ZioMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/ZioMetricsExample.scala
@@ -7,8 +7,6 @@ import zio.http.HttpApp
 import zio.http.{Server, ServerConfig}
 import zio.{Task, ZIO, _}
 
-import java.net.InetSocketAddress
-
 /** Based on https://adopt-tapir.softwaremill.com zio version. */
 object ZioMetricsExample extends ZIOAppDefault {
 
@@ -40,7 +38,10 @@ object ZioMetricsExample extends ZIOAppDefault {
       _ <- Console.printLine(s"Server started at http://localhost:${serverPort}. Press ENTER key to exit.")
       _ <- Console.readLine
     } yield serverPort)
-      .provide(ServerConfig.live(ServerConfig().binding(new InetSocketAddress(port))) >>> Server.default)
+      .provide(
+        ServerConfig.live(ServerConfig.default.port(port)),
+        Server.live,
+      )
       .exitCode
   }
 

--- a/examples/src/main/scala/sttp/tapir/examples/openapi/RedocZioHttpServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/openapi/RedocZioHttpServer.scala
@@ -11,8 +11,6 @@ import zio.http.{Server, ServerConfig}
 import zio.Console.{printLine, readLine}
 import zio.{Task, ZIO, ZIOAppDefault}
 
-import java.net.InetSocketAddress
-
 object RedocZioHttpServer extends ZIOAppDefault {
   case class Pet(species: String, url: String)
 
@@ -32,7 +30,10 @@ object RedocZioHttpServer extends ZIOAppDefault {
       printLine("Press any key to exit ...") *>
       Server
         .serve(petRoutes ++ redocRoutes)
-        .provide(ServerConfig.live(ServerConfig().binding(new InetSocketAddress(8080))) >>> Server.default)
+        .provide(
+          ServerConfig.live(ServerConfig.default.port(8080)),
+          Server.live,
+        )
         .fork
         .flatMap { fiber =>
           readLine *> fiber.interrupt

--- a/examples/src/main/scala/sttp/tapir/examples/streaming/StreamingZioHttpServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/streaming/StreamingZioHttpServer.scala
@@ -10,7 +10,6 @@ import zio.http.{Server, ServerConfig}
 import zio.{ExitCode, Schedule, URIO, ZIO, ZIOAppDefault}
 import zio.stream._
 
-import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets
 import java.time.Duration
 
@@ -42,5 +41,11 @@ object StreamingZioHttpServer extends ZIOAppDefault {
 
   // Test using: curl http://localhost:8080/receive
   override def run: URIO[Any, ExitCode] =
-    Server.serve(routes).provide(ServerConfig.live(ServerConfig().binding(new InetSocketAddress(8080))) >>> Server.default).exitCode
+    Server
+      .serve(routes)
+      .provide(
+        ServerConfig.live(ServerConfig.default.port(8080)),
+        Server.live,
+      )
+      .exitCode
 }


### PR DESCRIPTION
Use `Server.live` instead of `Server.default`.

`Server.default` forces the default port 8080 to be used, regardless of the provided `ServerConfig` layer.