### PR TITLE
Build zio modules for ScalaJS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -567,14 +567,18 @@ lazy val zio1: ProjectMatrix = (projectMatrix in file("integrations/zio1"))
     name := "tapir-zio1",
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio" % Versions.zio1,
-      "dev.zio" %% "zio-streams" % Versions.zio1,
-      "dev.zio" %% "zio-test" % Versions.zio1 % Test,
-      "dev.zio" %% "zio-test-sbt" % Versions.zio1 % Test,
-      "com.softwaremill.sttp.shared" %% "zio1" % Versions.sttpShared
+      "dev.zio" %%% "zio" % Versions.zio1,
+      "dev.zio" %%% "zio-streams" % Versions.zio1,
+      "dev.zio" %%% "zio-test" % Versions.zio1 % Test,
+      "dev.zio" %%% "zio-test-sbt" % Versions.zio1 % Test,
+      "com.softwaremill.sttp.shared" %%% "zio1" % Versions.sttpShared
     )
   )
   .jvmPlatform(scalaVersions = scala2And3Versions)
+  .jsPlatform(
+    scalaVersions = scala2And3Versions,
+    settings = commonJsSettings
+  )
   .dependsOn(core, serverCore % Test)
 
 lazy val zio: ProjectMatrix = (projectMatrix in file("integrations/zio"))
@@ -583,14 +587,18 @@ lazy val zio: ProjectMatrix = (projectMatrix in file("integrations/zio"))
     name := "tapir-zio",
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     libraryDependencies ++= Seq(
-      "dev.zio" %% "zio" % Versions.zio,
-      "dev.zio" %% "zio-streams" % Versions.zio,
-      "dev.zio" %% "zio-test" % Versions.zio % Test,
-      "dev.zio" %% "zio-test-sbt" % Versions.zio % Test,
-      "com.softwaremill.sttp.shared" %% "zio" % Versions.sttpShared
+      "dev.zio" %%% "zio" % Versions.zio,
+      "dev.zio" %%% "zio-streams" % Versions.zio,
+      "dev.zio" %%% "zio-test" % Versions.zio % Test,
+      "dev.zio" %%% "zio-test-sbt" % Versions.zio % Test,
+      "com.softwaremill.sttp.shared" %%% "zio" % Versions.sttpShared
     )
   )
   .jvmPlatform(scalaVersions = scala2And3Versions)
+  .jsPlatform(
+    scalaVersions = scala2And3Versions,
+    settings = commonJsSettings
+  )
   .dependsOn(core, serverCore % Test)
 
 lazy val derevo: ProjectMatrix = (projectMatrix in file("integrations/derevo"))


### PR DESCRIPTION
This PR adds JS platforms in zio modules. I tested this change by running tests on zio modules. I attempted adding Scala Native as a platform but got into some compilation problems so this PR is limited to JS only.