### PR TITLE
docs: add some example of custom ServerLog

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1684,6 +1684,7 @@ lazy val examples: ProjectMatrix = (projectMatrix in file("examples"))
       "org.http4s" %% "http4s-dsl" % Versions.http4s,
       "org.http4s" %% "http4s-circe" % Versions.http4s,
       "org.http4s" %% "http4s-blaze-server" % Versions.http4sBlazeServer,
+      "org.http4s" %% "http4s-ember-server" % Versions.http4sEmberServer,
       "com.softwaremill.sttp.client3" %% "akka-http-backend" % Versions.sttp,
       "com.softwaremill.sttp.client3" %% "async-http-client-backend-fs2" % Versions.sttp,
       "com.softwaremill.sttp.client3" %% "async-http-client-backend-zio" % Versions.sttp,

--- a/examples/src/main/scala/sttp/tapir/examples/errors/LogDecodingErrorsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/errors/LogDecodingErrorsExample.scala
@@ -1,0 +1,135 @@
+package sttp.tapir.examples.errors
+
+import cats.Applicative
+import cats.effect.IO
+import cats.effect.IOApp
+import cats.effect.Sync
+import cats.syntax.all._
+import com.comcast.ip4s.Host
+import com.comcast.ip4s.Port
+import io.circe.Codec
+import io.circe.generic.semiauto._
+import org.http4s.ember.server.EmberServerBuilder
+import sttp.tapir._
+import sttp.tapir.json.circe._
+import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.http4s.Http4sServerInterpreter
+import sttp.tapir.server.http4s.Http4sServerOptions
+import sttp.tapir.server.interceptor.DecodeFailureContext
+import sttp.tapir.server.interceptor.DecodeSuccessContext
+import sttp.tapir.server.interceptor.SecurityFailureContext
+import sttp.tapir.server.interceptor.log.ExceptionContext
+import sttp.tapir.server.interceptor.log.ServerLog
+import sttp.tapir.server.model.ServerResponse
+import sttp.tapir.stringBody
+
+final case class Person(
+    name: String
+)
+object Person {
+  implicit val personC: Codec[Person] = deriveCodec
+  implicit val personS: Schema[Person] = Schema.derived[Person]
+}
+
+object LogDecodingErrorsExample extends IOApp.Simple {
+  val greetingEndpoint = endpoint.post
+    .in("greeting")
+    .in(jsonBody[Person])
+    .out(htmlBodyUtf8)
+    .errorOut(stringBody)
+    .description("greeting endpoint")
+
+  val allEndpoints: List[ServerEndpoint[Any, IO]] = List(
+    greetingEndpoint.serverLogic { case Person(name) =>
+      Right(s"Hello $name").pure[IO]
+    }
+  )
+
+  val options = Http4sServerOptions
+    .customiseInterceptors[IO]
+    .serverLog(new DecodingFailureServerLog[IO](new Log[IO]))
+    .options
+  val routes = Http4sServerInterpreter[IO](options).toRoutes(allEndpoints)
+
+  val server = EmberServerBuilder
+    .default[IO]
+    .withHostOption(Host.fromString("0.0.0.0"))
+    .withPort(Port.fromInt(8080).get)
+    .withHttpApp(routes.orNotFound)
+    .build
+
+  override def run: IO[Unit] =
+    server.use(_ => IO.never)
+}
+
+class Log[F[_]: Sync] {
+  def error(msg: String) = Sync[F].delay(println(msg))
+}
+
+/** Tapir's ServerLog implementation which logs decoding failures and does nothing else. */
+class DecodingFailureServerLog[F[_]: Applicative](log: Log[F]) extends ServerLog[F] {
+
+  override type TOKEN = Long
+
+  override def requestToken: TOKEN = 0
+
+  override def decodeFailureNotHandled(
+      ctx: DecodeFailureContext,
+      token: TOKEN
+  ): F[Unit] = logDecodeFailure(ctx)
+
+  override def decodeFailureHandled(
+      ctx: DecodeFailureContext,
+      response: ServerResponse[_],
+      token: TOKEN
+  ): F[Unit] = logDecodeFailure(ctx)
+
+  private def logDecodeFailure(
+      ctx: DecodeFailureContext
+  ): F[Unit] =
+    ctx.failure match {
+      // Lets do a custom message for DecodeResult.Error.JsonDecodeException
+      case DecodeResult.Error(
+            original,
+            DecodeResult.Error.JsonDecodeException(errors, _)
+          ) =>
+        val input = original.filterNot(char => char.isWhitespace)
+        val msg =
+          s"Request: ${ctx.request.showShort}, not handled by: ${ctx.endpoint.showShort}; decode failure for input: $input. Error: $errors"
+        log.error(msg)
+
+      // otherwise just log whatever we have
+      case error =>
+        val msg =
+          s"Request: ${ctx.request.showShort}, not handled by: ${ctx.endpoint.showShort}; decode failure: ${ctx.failure}. Error: $error"
+        log.error(msg)
+    }
+
+  /*
+    ###############
+      no-ops, we're not interested in logging different things.
+    ###############
+   */
+
+  override def requestReceived(request: ServerRequest, token: Long): F[Unit] =
+    Applicative[F].unit
+
+  override def securityFailureHandled(
+      ctx: SecurityFailureContext[F, _],
+      response: ServerResponse[_],
+      token: TOKEN
+  ): F[Unit] = Applicative[F].unit
+
+  override def requestHandled(
+      ctx: DecodeSuccessContext[F, _, _, _],
+      response: ServerResponse[_],
+      token: TOKEN
+  ): F[Unit] = Applicative[F].unit
+
+  override def exception(
+      ctx: ExceptionContext[_, _],
+      ex: Throwable,
+      token: TOKEN
+  ): F[Unit] = Applicative[F].unit
+}

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -2,6 +2,7 @@ object Versions {
   val http4s = "0.23.18"
   val http4sBlazeServer = "0.23.13"
   val http4sBlazeClient = "0.23.13"
+  val http4sEmberServer = "0.23.13"
   val catsEffect = "3.4.5"
   val circe = "0.14.3"
   val circeGenericExtras = "0.14.3"

--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/log/ServerLog.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/log/ServerLog.scala
@@ -44,13 +44,7 @@ trait ServerLog[F[_]] {
   def exception(ctx: ExceptionContext[_, _], ex: Throwable, token: TOKEN): F[Unit]
 }
 
-/** Default implementation of ServerLog which is used if user hasn't provided custom one.
-  *
-  * Be aware of using it, some of unexpected behaviors are:
-  *   - doLogAllDecodeFailures despite its name is being called only for unhandled decoding failures. If you want to log unhandled ones too
-  *     you should specify doLogWhenHandled as well. Better option might be to create your own implementation of ServerLog which has full
-  *     control of formatting arguments. See examples of how one can do that
-  */
+/** Default implementation of ServerLog which is used if user hasn't provided custom one. */
 case class DefaultServerLog[F[_]](
     doLogWhenReceived: String => F[Unit],
     doLogWhenHandled: (String, Option[Throwable]) => F[Unit],
@@ -104,8 +98,8 @@ case class DefaultServerLog[F[_]](
     else noLog
 
   override def decodeFailureHandled(ctx: DecodeFailureContext, response: ServerResponse[_], token: TOKEN): F[Unit] =
-    if (logWhenHandled)
-      doLogWhenHandled(
+    if (logAllDecodeFailures)
+      doLogAllDecodeFailures(
         s"Request: ${showRequest(ctx.request)}, handled by: ${showEndpoint(
             ctx.endpoint
           )}${took(token)}; decode failure: ${ctx.failure}, on input: ${ctx.failingInput.show}; response: ${showResponse(response)}",

--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/log/ServerLogInterceptor.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/log/ServerLogInterceptor.scala
@@ -66,8 +66,8 @@ class ServerLogEndpointInterceptor[F[_], T](serverLog: ServerLog[F] { type TOKEN
         decodeHandler
           .onDecodeFailure(ctx)
           .flatMap {
-            case r @ None =>
-              serverLog.decodeFailureNotHandled(ctx, token).map(_ => r: Option[ServerResponse[B]])
+            case None =>
+              serverLog.decodeFailureNotHandled(ctx, token).map(_ => Option.empty[ServerResponse[B]])
             case r @ Some(response) =>
               serverLog
                 .decodeFailureHandled(ctx, response, token)


### PR DESCRIPTION
Hey folks! First of all thanks for wonderful library. 

I've created this PR because it wasn't obviously clear to me how to log decoding errors, I spent couple of hours playing with `DefaultServerLog` and wondering why nothing is being logged, then I had this "aha" moment when I understood what's going on.

I think scaladoc which I added about `doLogAllDecodeFailures` should be enough explanation for future users as I realize that changing behavior of `DefaultSerLog` might break somebodys workflow. Also, I provided an example how custom ServerLog can look like. 

What do you think?