### PR TITLE
[docs] Fix broken links to sections across pages

### DIFF
--- a/doc/docs/asyncapi.md
+++ b/doc/docs/asyncapi.md
@@ -32,7 +32,7 @@ val docs: AsyncAPI = AsyncAPIInterpreter().toAsyncAPI(echoWS, "Echo web socket",
 Such a model can then be refined, by adding details which are not auto-generated. Working with a deeply nested case 
 class structure such as the `AsyncAPI` one can be made easier by using a lens library, e.g. [Quicklens](https://github.com/adamw/quicklens).
 
-The documentation is generated in a large part basing on [schemas](../endpoint/codecs.md#schemas). Schemas can be
+The documentation is generated in a large part basing on [schemas](../endpoint/codecs.html#schemas). Schemas can be
 [automatically derived and customised](../endpoint/schemas.md).
 
 Quite often, you'll need to define the servers, through which the API can be reached. Any servers provided to the 

--- a/doc/endpoint/schemas.md
+++ b/doc/endpoint/schemas.md
@@ -38,7 +38,7 @@ If you have a case class which contains some non-standard types (other than stri
 collections), you only need to provide implicit schemas for them. Using these, the rest will be derived automatically.
 
 Note that when using [datatypes integrations](integrations.md), respective schemas & codecs must also be imported to 
-enable the derivation, e.g. for [newtype](integrations.md#newtype-integration) you'll have to add
+enable the derivation, e.g. for [newtype](integrations.html#newtype-integration) you'll have to add
 `import sttp.tapir.codec.newtype._` or extend `TapirCodecNewType`.
 
 ## Semi-automatic derivation

--- a/doc/endpoint/validation.md
+++ b/doc/endpoint/validation.md
@@ -17,7 +17,7 @@ some nested component (such as a field value).
 
 If you are using automatic or semi-automatic schema derivation, validators for such schemas, and their nested 
 components, including collections and options, can be added as described in 
-[schema customisation](schemas.md#customising-derived-schemas).
+[schema customisation](schemas.html#customising-derived-schemas).
 
 ## Adding validators to inputs/outputs
 

--- a/doc/endpoint/xml.md
+++ b/doc/endpoint/xml.md
@@ -90,7 +90,7 @@ object Endpoints {
 If the generation of OpenAPI documentation is required, consider adding OpenAPI doc extension on schema providing XML
 namespace as described in the "Prefixes and Namespaces" section at [OpenAPI documentation regarding handling XML](https://swagger.io/docs/specification/data-models/representing-xml/).
 This would add `xmlns` property to example request/responses at swagger, which is required by scalaxb to properly deserialize XML.
-For more information on adding OpenAPI doc extension in tapir refer to [documentation](../docs/openapi.md#openapi-specification-extensions).
+For more information on adding OpenAPI doc extension in tapir refer to [documentation](../docs/openapi.html#openapi-specification-extensions).
 
 Adding xml namespace doc extension to `Outer`'s `Schema` example:
 ```scala

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -314,7 +314,7 @@ res.toString
 
 Note that the above takes into account only the method & the shape of the path. It does *not* take into account possible
 decoding failures: these might impact request-endpoint matching, and the exact behavior is determined by the
-[`DecodeFailureHandler`](server/errors.md#decode-failures) used.
+[`DecodeFailureHandler`](server/errors.html#decode-failures) used.
 
 ### Incorrect path at endpoint
 


### PR DESCRIPTION
This PR fixes a few broken links in the docs to sections across pages. I'm using the Spinx cross-referencing syntax and sphinx.ext.autosectionlabel extension as documented on https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html