### PR TITLE
chore: zio-http 0.0.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ val scala2_13 = "2.13.10"
 val scala3 = "3.2.1"
 
 val scala2Versions = List(scala2_12, scala2_13)
+val scala2_13and3Versions = List(scala2_13, scala3)
 val scala2And3Versions = scala2Versions ++ List(scala3)
 val codegenScalaVersions = List(scala2_12)
 val examplesScalaVersions = List(scala2_13)
@@ -1361,7 +1362,7 @@ lazy val zioHttpServer: ProjectMatrix = (projectMatrix in file("server/zio-http-
     name := "tapir-zio-http-server",
     libraryDependencies ++= Seq("dev.zio" %% "zio-interop-cats" % Versions.zioInteropCats % Test, "dev.zio" %% "zio-http" % "0.0.4")
   )
-  .jvmPlatform(scalaVersions = scala2And3Versions)
+  .jvmPlatform(scalaVersions = scala2_13and3Versions)
   .dependsOn(serverCore, zio, serverTests % Test)
 
 // serverless

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ val scala2_13 = "2.13.10"
 val scala3 = "3.2.1"
 
 val scala2Versions = List(scala2_12, scala2_13)
-val scala2_13and3Versions = List(scala2_13, scala3)
 val scala2And3Versions = scala2Versions ++ List(scala3)
 val codegenScalaVersions = List(scala2_12)
 val examplesScalaVersions = List(scala2_13)
@@ -1360,9 +1359,9 @@ lazy val zioHttpServer: ProjectMatrix = (projectMatrix in file("server/zio-http-
   .settings(commonJvmSettings)
   .settings(
     name := "tapir-zio-http-server",
-    libraryDependencies ++= Seq("dev.zio" %% "zio-interop-cats" % Versions.zioInteropCats % Test, "dev.zio" %% "zio-http" % "0.0.3")
+    libraryDependencies ++= Seq("dev.zio" %% "zio-interop-cats" % Versions.zioInteropCats % Test, "dev.zio" %% "zio-http" % "0.0.4")
   )
-  .jvmPlatform(scalaVersions = scala2_13and3Versions)
+  .jvmPlatform(scalaVersions = scala2And3Versions)
   .dependsOn(serverCore, zio, serverTests % Test)
 
 // serverless

--- a/doc/server/ziohttp.md
+++ b/doc/server/ziohttp.md
@@ -46,7 +46,7 @@ example:
 import sttp.tapir.PublicEndpoint
 import sttp.tapir.ztapir._
 import sttp.tapir.server.ziohttp.ZioHttpInterpreter
-import zio.http.{Http, Request, Response}
+import zio.http.{App, Request, Response}
 import zio._
 
 def countCharacters(s: String): ZIO[Any, Nothing, Int] =
@@ -55,8 +55,8 @@ def countCharacters(s: String): ZIO[Any, Nothing, Int] =
 val countCharactersEndpoint: PublicEndpoint[String, Unit, Int, Any] =
   endpoint.in(stringBody).out(plainBody[Int])
   
-val countCharactersHttp: Http[Any, Throwable, Request, Response] =
-  ZioHttpInterpreter().toHttp(countCharactersEndpoint.zServerLogic(countCharacters))
+val countCharactersHttp: App[Any] =
+  ZioHttpInterpreter().toApp(countCharactersEndpoint.zServerLogic(countCharacters))
 ```
 
 ## Server logic

--- a/examples/src/main/scala/sttp/tapir/examples/ZioExampleZioHttpServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioExampleZioHttpServer.scala
@@ -7,7 +7,7 @@ import sttp.tapir.json.circe._
 import sttp.tapir.server.ziohttp.ZioHttpInterpreter
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import sttp.tapir.ztapir._
-import zio.http.HttpApp
+import zio.http.App
 import zio.http.{Server, ServerConfig}
 import zio.{ExitCode, Task, URIO, ZIO, ZIOAppDefault}
 
@@ -18,8 +18,8 @@ object ZioExampleZioHttpServer extends ZIOAppDefault {
   val petEndpoint: PublicEndpoint[Int, String, Pet, Any] =
     endpoint.get.in("pet" / path[Int]("petId")).errorOut(stringBody).out(jsonBody[Pet])
 
-  val petRoutes: HttpApp[Any, Throwable] =
-    ZioHttpInterpreter().toHttp(
+  val petRoutes: App[Any] =
+    ZioHttpInterpreter().toApp(
       petEndpoint.zServerLogic(petId =>
         if (petId == 35) ZIO.succeed(Pet("Tapirus terrestris", "https://en.wikipedia.org/wiki/Tapir"))
         else ZIO.fail("Unknown pet id")
@@ -39,14 +39,14 @@ object ZioExampleZioHttpServer extends ZIOAppDefault {
   val swaggerEndpoints: List[ZServerEndpoint[Any, Any]] = SwaggerInterpreter().fromEndpoints[Task](List(petEndpoint), "Our pets", "1.0")
 
   // Starting the server
-  val routes: HttpApp[Any, Throwable] = ZioHttpInterpreter().toHttp(List(petServerEndpoint) ++ swaggerEndpoints)
+  val routes: App[Any] = ZioHttpInterpreter().toApp(List(petServerEndpoint) ++ swaggerEndpoints)
 
   override def run: URIO[Any, ExitCode] =
     Server
       .serve(routes)
       .provide(
         ServerConfig.live(ServerConfig.default.port(8080)),
-        Server.live,
+        Server.live
       )
       .exitCode
 }

--- a/examples/src/main/scala/sttp/tapir/examples/observability/ZioMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/ZioMetricsExample.scala
@@ -3,7 +3,7 @@ import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 import sttp.tapir.server.metrics.zio.ZioMetrics
 import sttp.tapir.server.ziohttp.{ZioHttpInterpreter, ZioHttpServerOptions}
 import sttp.tapir.ztapir.ZServerEndpoint
-import zio.http.HttpApp
+import zio.http.App
 import zio.http.{Server, ServerConfig}
 import zio.{Task, ZIO, _}
 
@@ -29,7 +29,7 @@ object ZioMetricsExample extends ZIOAppDefault {
   override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] = {
     val serverOptions: ZioHttpServerOptions[Any] =
       ZioHttpServerOptions.customiseInterceptors.metricsInterceptor(metricsInterceptor).options
-    val app: HttpApp[Any, Throwable] = ZioHttpInterpreter(serverOptions).toHttp(all)
+    val app: App[Any] = ZioHttpInterpreter(serverOptions).toApp(all)
 
     val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
 
@@ -40,7 +40,7 @@ object ZioMetricsExample extends ZIOAppDefault {
     } yield serverPort)
       .provide(
         ServerConfig.live(ServerConfig.default.port(port)),
-        Server.live,
+        Server.live
       )
       .exitCode
   }

--- a/examples/src/main/scala/sttp/tapir/examples/openapi/RedocZioHttpServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/openapi/RedocZioHttpServer.scala
@@ -6,7 +6,7 @@ import sttp.tapir.json.circe._
 import sttp.tapir.redoc.bundle.RedocInterpreter
 import sttp.tapir.server.ziohttp.ZioHttpInterpreter
 import sttp.tapir.ztapir._
-import zio.http.HttpApp
+import zio.http.App
 import zio.http.{Server, ServerConfig}
 import zio.Console.{printLine, readLine}
 import zio.{Task, ZIO, ZIOAppDefault}
@@ -20,10 +20,10 @@ object RedocZioHttpServer extends ZIOAppDefault {
       else ZIO.fail("Unknown pet id")
     }
 
-  val petRoutes: HttpApp[Any, Throwable] = ZioHttpInterpreter().toHttp(petEndpoint)
+  val petRoutes: App[Any] = ZioHttpInterpreter().toApp(petEndpoint)
 
-  val redocRoutes: HttpApp[Any, Throwable] =
-    ZioHttpInterpreter().toHttp(RedocInterpreter().fromServerEndpoints[Task](List(petEndpoint), "Our pets", "1.0"))
+  val redocRoutes: App[Any] =
+    ZioHttpInterpreter().toApp(RedocInterpreter().fromServerEndpoints[Task](List(petEndpoint), "Our pets", "1.0"))
 
   override def run = {
     printLine("Go to: http://localhost:8080/docs") *>
@@ -32,7 +32,7 @@ object RedocZioHttpServer extends ZIOAppDefault {
         .serve(petRoutes ++ redocRoutes)
         .provide(
           ServerConfig.live(ServerConfig.default.port(8080)),
-          Server.live,
+          Server.live
         )
         .fork
         .flatMap { fiber =>

--- a/examples/src/main/scala/sttp/tapir/examples/streaming/StreamingZioHttpServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/streaming/StreamingZioHttpServer.scala
@@ -5,7 +5,7 @@ import sttp.model.HeaderNames
 import sttp.tapir.{CodecFormat, PublicEndpoint}
 import sttp.tapir.ztapir._
 import sttp.tapir.server.ziohttp.ZioHttpInterpreter
-import zio.http.HttpApp
+import zio.http.App
 import zio.http.{Server, ServerConfig}
 import zio.{ExitCode, Schedule, URIO, ZIO, ZIOAppDefault}
 import zio.stream._
@@ -37,7 +37,7 @@ object StreamingZioHttpServer extends ZIOAppDefault {
     ZIO.succeed((size, stream))
   }
 
-  val routes: HttpApp[Any, Throwable] = ZioHttpInterpreter().toHttp(streamingServerEndpoint)
+  val routes: App[Any] = ZioHttpInterpreter().toApp(streamingServerEndpoint)
 
   // Test using: curl http://localhost:8080/receive
   override def run: URIO[Any, ExitCode] =
@@ -45,7 +45,7 @@ object StreamingZioHttpServer extends ZIOAppDefault {
       .serve(routes)
       .provide(
         ServerConfig.live(ServerConfig.default.port(8080)),
-        Server.live,
+        Server.live
       )
       .exitCode
 }

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
@@ -12,7 +12,12 @@ import zio.http.model._
 import zio.{Task, ZIO}
 
 class ZioHttpCompositionTest(
-    createServerTest: CreateServerTest[Task, Any, ZioHttpServerOptions[Any], Http[Any, Throwable, zio.http.Request, zio.http.Response]]
+    createServerTest: CreateServerTest[
+      Task,
+      Any,
+      ZioHttpServerOptions[Any],
+      Http[Any, zio.http.Response, zio.http.Request, zio.http.Response]
+    ]
 ) {
   import createServerTest._
 
@@ -22,11 +27,11 @@ class ZioHttpCompositionTest(
         val ep1 = endpoint.get.in("p1").zServerLogic[Any](_ => ZIO.unit)
         val ep3 = endpoint.get.in("p3").zServerLogic[Any](_ => ZIO.fail(new RuntimeException("boom")))
 
-        val route1: RHttpApp[Any] = ZioHttpInterpreter().toHttp(ep1)
-        val route2: RHttpApp[Any] = Http.collect { case Method.GET -> !! / "p2" =>
+        val route1: App[Any] = ZioHttpInterpreter().toApp(ep1)
+        val route2: App[Any] = Http.collect { case Method.GET -> !! / "p2" =>
           zio.http.Response.ok
         }
-        val route3: RHttpApp[Any] = ZioHttpInterpreter().toHttp(ep3)
+        val route3: App[Any] = ZioHttpInterpreter().toApp(ep3)
 
         NonEmptyList.of(route3, route1, route2)
       }

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
@@ -39,7 +39,7 @@ class ZioHttpServerTest extends TestSuite {
           // https://github.com/softwaremill/tapir/issues/1914
           Test("zio http route can be called with runZIO") {
             val ep = endpoint.get.in("p1").out(stringBody).zServerLogic[Any](_ => ZIO.succeed("response"))
-            val route = ZioHttpInterpreter().toHttp(ep)
+            val route = ZioHttpInterpreter().toApp(ep)
             val test: UIO[Assertion] = route
               .runZIO(Request.get(url = URL.apply(Path.empty / "p1")))
               .flatMap(response => response.body.asString)

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
@@ -8,12 +8,14 @@ import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 import zio._
 import zio.http.netty.server.NettyDriver
-import zio.http.service.ServerChannelFactory
 import zio.http._
 import zio.interop.catz._
 
-class ZioHttpTestServerInterpreter(eventLoopGroup: zio.http.service.EventLoopGroup, channelFactory: zio.http.service.ServerChannelFactory)(
-    implicit trace: Trace
+class ZioHttpTestServerInterpreter(
+    eventLoopGroup: ZLayer[Any, Nothing, zio.http.service.EventLoopGroup],
+    channelFactory: ZLayer[Any, Nothing, zio.http.service.ServerChannelFactory]
+)(implicit
+    trace: Trace
 ) extends TestServerInterpreter[Task, ZioStreams, ZioHttpServerOptions[Any], Http[Any, Throwable, Request, Response]] {
 
   override def route(es: List[ServerEndpoint[ZioStreams, Task]], interceptors: Interceptors): Http[Any, Throwable, Request, Response] = {
@@ -24,53 +26,18 @@ class ZioHttpTestServerInterpreter(eventLoopGroup: zio.http.service.EventLoopGro
   override def server(routes: NonEmptyList[Http[Any, Throwable, Request, Response]]): Resource[IO, Port] = {
     implicit val r: Runtime[Any] = Runtime.default
 
-    val makeNettyDriver = {
-      import zio.http.netty.server._
-      import io.netty.bootstrap.ServerBootstrap
-      import io.netty.channel._
-      import io.netty.util.ResourceLeakDetector
-      import zio._
-      import zio.http.netty._
-      import zio.http.service.ServerTime
-      import zio.http.{Driver, Http, HttpApp, Server, ServerConfig}
-
-      import java.net.InetSocketAddress
-      import java.util.concurrent.atomic.AtomicReference
-
-      type ErrorCallbackRef = AtomicReference[Option[Server.ErrorCallback]]
-      type AppRef = AtomicReference[(HttpApp[Any, Throwable], ZEnvironment[Any])]
-      type EnvRef = AtomicReference[ZEnvironment[Any]]
-
-      val app = ZLayer.succeed(
-        new AtomicReference[(HttpApp[Any, Throwable], ZEnvironment[Any])]((Http.empty, ZEnvironment.empty))
-      )
-      val ecb = ZLayer.succeed(new AtomicReference[Option[Server.ErrorCallback]](Option.empty))
-      val time = ZLayer.succeed(ServerTime.make(1000.millis))
-
-      val nettyRuntime = NettyRuntime.usingSharedThreadPool
-      val serverChannelInitializer = ServerChannelInitializer.layer
-      val serverInboundHandler = ServerInboundHandler.layer
-
-      val serverLayers = app ++
-        ZLayer.succeed(channelFactory) ++
-        (
-          (
-            (time ++ app ++ ecb) ++
-              (ZLayer.succeed(eventLoopGroup) >>> nettyRuntime) >>> serverInboundHandler
-          ) >>> serverChannelInitializer
-        ) ++
-        ecb ++
-        ZLayer.succeed(eventLoopGroup)
-
-      NettyDriver.make.provideSomeLayer[ServerConfig with Scope](serverLayers)
-    }
-
     val effect: ZIO[Scope, Throwable, Int] =
       (for {
-        driver <- makeNettyDriver
+        driver <- ZIO.service[Driver]
         port <- driver.start(trace)
-        _ <- driver.addApp[Any](routes.toList.reduce(_ ++ _), ZEnvironment())
-      } yield port).provideSome[Scope](ServerConfig.live(ServerConfig.default.port(0).objectAggregator(1000000)))
+        _ <- driver.addApp[Any](routes.toList.reduce(_ ++ _).withDefaultErrorResponse, ZEnvironment())
+      } yield port)
+        .provideSome[Scope](
+          NettyDriver.manual,
+          eventLoopGroup,
+          channelFactory,
+          ServerConfig.live(ServerConfig.default.port(0).objectAggregator(1000000))
+        )
 
     Resource.scoped[IO, Any, Int](effect)
   }

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
@@ -16,14 +16,14 @@ class ZioHttpTestServerInterpreter(
     channelFactory: ZLayer[Any, Nothing, zio.http.service.ServerChannelFactory]
 )(implicit
     trace: Trace
-) extends TestServerInterpreter[Task, ZioStreams, ZioHttpServerOptions[Any], Http[Any, Throwable, Request, Response]] {
+) extends TestServerInterpreter[Task, ZioStreams, ZioHttpServerOptions[Any], Http[Any, Response, Request, Response]] {
 
-  override def route(es: List[ServerEndpoint[ZioStreams, Task]], interceptors: Interceptors): Http[Any, Throwable, Request, Response] = {
+  override def route(es: List[ServerEndpoint[ZioStreams, Task]], interceptors: Interceptors): Http[Any, Response, Request, Response] = {
     val serverOptions: ZioHttpServerOptions[Any] = interceptors(ZioHttpServerOptions.customiseInterceptors).options
-    ZioHttpInterpreter(serverOptions).toHttp(es)
+    ZioHttpInterpreter(serverOptions).toApp(es)
   }
 
-  override def server(routes: NonEmptyList[Http[Any, Throwable, Request, Response]]): Resource[IO, Port] = {
+  override def server(routes: NonEmptyList[Http[Any, Response, Request, Response]]): Resource[IO, Port] = {
     implicit val r: Runtime[Any] = Runtime.default
 
     val effect: ZIO[Scope, Throwable, Int] =


### PR DESCRIPTION
Hey!

zio-http changed quite a bit between 0.0.4 and 0.0.3, mainly separating `Route`s from `Handler`s. The difference is basically that a `Route` is a `PartialFunction[Request, Handler[R, E, In, Out]`, i.e can choose to handle or not handle an incoming request.

It also introduces a new concept of an `App` that is what we can serve via a server. `App` is a special case of a `Handler[-R, Response, Request, Response]`, i.e the error we return needs to be a valid HTTP Response. In order to convert between the two there's a convenience function `Http#withDefaultErrorResponse` that handles errors as a `500` response.

This also re-adds 2.12 support for zio-http now that https://github.com/zio/zio-http/issues/1813 is fixed.