### PR TITLE
Fix invalid sttp-mock-server dependency

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -197,7 +197,7 @@ with [mock-server](https://www.mock-server.com/)
 Add the following dependency:
 
 ```scala
-"com.softwaremill.sttp.tapir" %% "tapir-sttp-mock-server" % "@VERSION@"
+"com.softwaremill.sttp.tapir" %% "sttp-mock-server" % "@VERSION@"
 ```
 
 Imports:


### PR DESCRIPTION
Given "tapir-sttp-mock-server" dependency does not build. Based on information from https://mvnrepository.com/artifact/com.softwaremill.sttp.tapir/sttp-mock-server the dependency should be "sttp-mock-server".