### PR TITLE
Support multiple schema modifiers

### DIFF
--- a/core/src/main/scala/sttp/tapir/Codec.scala
+++ b/core/src/main/scala/sttp/tapir/Codec.scala
@@ -113,8 +113,12 @@ trait Codec[L, H, +CF <: CodecFormat] { outer =>
       override def schema: Schema[H] = s2
       override def format: CF = outer.format
     }
-  def schema(s2: Option[Schema[H]]): Codec[L, H, CF] = s2.map(schema).getOrElse(this)
-  def schema(modify: Schema[H] => Schema[H]): Codec[L, H, CF] = schema(modify(schema))
+
+  def schema(s2: Option[Schema[H]]): Codec[L, H, CF] =
+    s2.map(schema).getOrElse(this)
+
+  def schema(modify: Schema[H] => Schema[H], modifiers: (Schema[H] => Schema[H])*): Codec[L, H, CF] =
+    schema((modify +: modifiers).reduce(_ andThen _)(schema))
 
   def format[CF2 <: CodecFormat](f: CF2): Codec[L, H, CF2] =
     new Codec[L, H, CF2] {

--- a/core/src/main/scala/sttp/tapir/EndpointIO.scala
+++ b/core/src/main/scala/sttp/tapir/EndpointIO.scala
@@ -97,9 +97,14 @@ object EndpointTransput {
 
     override def map[U](mapping: Mapping[T, U]): ThisType[U] = copyWith(codec.map(mapping), info.map(mapping))
 
-    def schema(s: Schema[T]): ThisType[T] = copyWith(codec.schema(s), info)
-    def schema(s: Option[Schema[T]]): ThisType[T] = copyWith(codec.schema(s), info)
-    def schema(modify: Schema[T] => Schema[T]): ThisType[T] = copyWith(codec.schema(modify), info)
+    def schema(s: Schema[T]): ThisType[T] =
+      copyWith(codec.schema(s), info)
+
+    def schema(s: Option[Schema[T]]): ThisType[T] =
+      copyWith(codec.schema(s), info)
+
+    def schema(modify: Schema[T] => Schema[T], modifiers: (Schema[T] => Schema[T])*): ThisType[T] =
+      copyWith(codec.schema(modify, modifiers: _*), info)
 
     /** Adds a validator which validates the option's element, if it is present.
       *

--- a/core/src/test/scala/sttp/tapir/CodecTest.scala
+++ b/core/src/test/scala/sttp/tapir/CodecTest.scala
@@ -56,6 +56,16 @@ class CodecTest extends AnyFlatSpec with Matchers with Checkers {
     codec.decode(List("y", "z")) shouldBe DecodeResult.Multiple(List("y", "z"))
   }
 
+  it should "apply multiple schema modifiers" in {
+    val codec: Codec[List[String], String, TextPlain] = implicitly[Codec[List[String], String, TextPlain]].schema(
+      _.default("X"),
+      _.hidden(true)
+    )
+
+    codec.schema.hidden shouldBe true
+    codec.schema.default shouldBe Some("X", None)
+  }
+
   it should "correctly encode and decode Date" in {
     // while Date works on Scala.js, ScalaCheck tests involving Date use java.util.Calendar which doesn't - hence here a normal test
     val codec = implicitly[Codec[String, Date, TextPlain]]


### PR DESCRIPTION
The purpose of this PR is to provide a more practical syntax when you have to apply multiple `Scheme` modifiers (`Endo[Schema[T]]`) to a `Codec`

example
```scala
case class Bar(a: String, b: String, c: String)

endpoint
  .in(
    jsonBody[Bar]
      .schema(
        _.description("Bar scheme"),
        _.modify(_.a)(_.description("Field A")),
        _.modify(_.b)(_.description("Field B")),
        _.modify(_.c)(_.description("Field C"))
      )
  )
```

