### PR TITLE
Improve the efficiency of request handling in ZIO Http & Play

### DIFF
--- a/doc/server/play.md
+++ b/doc/server/play.md
@@ -48,6 +48,16 @@ val countCharactersRoutes: Routes =
   PlayServerInterpreter().toRoutes(countCharactersEndpoint.serverLogic(countCharacters _))
 ```
 
+```eval_rst
+.. note::
+
+  A single Play application can contain both tapir-managed andPlay-managed routes. However, because of the 
+  routing implementation in Play, the shape of the paths that tapir/Play-native handlers serve should not 
+  overlap. The shape of the path includes exact path segments, single- and multi-wildcards. Otherwise, request handling 
+  will throw an exception. We don't expect users to encounter this as a problem, however the implementation here 
+  diverges a bit comparing to other interpreters.
+```
+
 ## Bind the routes
 
 ### Creating the HTTP server manually

--- a/doc/server/ziohttp.md
+++ b/doc/server/ziohttp.md
@@ -24,7 +24,7 @@ Next, instead of the usual `import sttp.tapir._`, you should import (or extend t
 import sttp.tapir.ztapir._
 ```
 
-This brings into scope all of the [basic](../endpoint/basics.md) input/output descriptions, which can be used to define an endpoint.
+This brings into scope all the [basic](../endpoint/basics.md) input/output descriptions, which can be used to define an endpoint.
 
 ```eval_rst
 .. note::
@@ -57,6 +57,16 @@ val countCharactersEndpoint: PublicEndpoint[String, Unit, Int, Any] =
   
 val countCharactersHttp: HttpApp[Any, Throwable] =
   ZioHttpInterpreter().toHttp(countCharactersEndpoint.zServerLogic(countCharacters))
+```
+
+```eval_rst
+.. note::
+
+  A single ZIO-Http application can contain both tapir-managed and ZIO-Http-managed routes. However, because of the 
+  routing implementation in ZIO Http, the shape of the paths that tapir/ZIO-Http-native handlers serve should not 
+  overlap. The shape of the path includes exact path segments, single- and multi-wildcards. Otherwise, request handling 
+  will throw an exception. We don't expect users to encounter this as a problem, however the implementation here 
+  diverges a bit comparing to other interpreters.
 ```
 
 ## Server logic

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -12,6 +12,7 @@ import sttp.monad.MonadError
 import sttp.tapir._
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
+import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
 import sttp.tapir.tests.Basic._
 import sttp.tapir.tests.TestUtil._
@@ -584,7 +585,7 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
       "two endpoints, same path prefix, one without trailing slashes, second accepting trailing slashes",
       NonEmptyList.of(
         route(
-          List(
+          List[ServerEndpoint[Any, F]](
             endpoint.get.in("p1" / "p2").in(noTrailingSlash).out(stringBody).serverLogic((_: Unit) => pureResult("e1".asRight[Unit])),
             endpoint.get.in("p1" / "p2").in(paths).out(stringBody).serverLogic((_: List[String]) => pureResult("e2".asRight[Unit]))
           )

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -583,8 +583,12 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
     testServer(
       "two endpoints, same path prefix, one without trailing slashes, second accepting trailing slashes",
       NonEmptyList.of(
-        route(endpoint.get.in("p1" / "p2").in(noTrailingSlash).out(stringBody).serverLogic((_: Unit) => pureResult("e1".asRight[Unit]))),
-        route(endpoint.get.in("p1" / "p2").in(paths).out(stringBody).serverLogic((_: List[String]) => pureResult("e2".asRight[Unit])))
+        route(
+          List(
+            endpoint.get.in("p1" / "p2").in(noTrailingSlash).out(stringBody).serverLogic((_: Unit) => pureResult("e1".asRight[Unit])),
+            endpoint.get.in("p1" / "p2").in(paths).out(stringBody).serverLogic((_: List[String]) => pureResult("e2".asRight[Unit]))
+          )
+        )
       )
     ) { (backend, baseUri) =>
       basicStringRequest.get(uri"$baseUri/p1/p2").send(backend).map(_.body shouldBe "e1") >>

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
@@ -4,19 +4,13 @@ import io.netty.handler.codec.http.HttpResponseStatus
 import sttp.capabilities.zio.ZioStreams
 import sttp.model.{HeaderNames, Header => SttpHeader}
 import sttp.monad.MonadError
-import sttp.tapir.server.interceptor.{DecodeFailureContext, RequestResult}
+import sttp.tapir.server.interceptor.RequestResult
 import sttp.tapir.server.interceptor.reject.RejectInterceptor
-import sttp.tapir.server.interpreter.{
-  DecodeBasicInputs,
-  DecodeBasicInputsResult,
-  DecodeInputsContext,
-  FilterServerEndpoints,
-  ServerInterpreter
-}
+import sttp.tapir.server.interpreter.{FilterServerEndpoints, ServerInterpreter}
 import sttp.tapir.ztapir._
-import zio.http.{Body, Handler, HttpApp, Http, Request, Response}
-import zio.http.model.{Status, Header => ZioHttpHeader, Headers => ZioHttpHeaders, HttpError}
 import zio._
+import zio.http._
+import zio.http.model.{Status, Header => ZioHttpHeader, Headers => ZioHttpHeaders}
 
 trait ZioHttpInterpreter[R] {
   def zioHttpServerOptions: ZioHttpServerOptions[R] = ZioHttpServerOptions.default
@@ -29,9 +23,10 @@ trait ZioHttpInterpreter[R] {
     implicit val monadError: MonadError[RIO[R & R2, *]] = new RIOMonadError[R & R2]
     val widenedSes = ses.map(_.widen[R & R2])
     val widenedServerOptions = zioHttpServerOptions.widen[R & R2]
+    val serverEndpointsFilter = FilterServerEndpoints[ZioStreams, RIO[R & R2, *]](widenedSes)
 
     val interpreter = new ServerInterpreter[ZioStreams, RIO[R & R2, *], ZioHttpResponseBody, ZioStreams](
-      FilterServerEndpoints[ZioStreams, RIO[R & R2, *]](widenedSes),
+      serverEndpointsFilter,
       new ZioHttpRequestBody(widenedServerOptions),
       new ZioHttpToResponseBody,
       RejectInterceptor.disableWhenSingleEndpoint(widenedServerOptions.interceptors, widenedSes),
@@ -60,25 +55,23 @@ trait ZioHttpInterpreter[R] {
                     body = resp.body.map { case (stream, _) => Body.fromStream(stream) }.getOrElse(Body.empty)
                   )
                 )
-              case RequestResult.Failure(_) => ZIO.succeed(HttpError.NotFound("Not Found").toResponse)
+              case RequestResult.Failure(_) =>
+                ZIO.fail(
+                  new RuntimeException(
+                    s"The path: ${req.path} matches the shape of some endpoint, but none of the " +
+                      s"endpoints decoded the request successfully, and the decode failure handler didn't provide a " +
+                      s"response. ZIO Http requires that if the path shape matches some endpoints, the request " +
+                      s"should be handled by tapir."
+                  )
+                )
             }
           )
       }
     }
 
     val routes = new PartialFunction[Request, Handler[R & R2, Throwable, Request, Response]] {
-      override def isDefinedAt(request: Request): Boolean = {
-        val serverRequest = ZioHttpServerRequest(request)
-        ses.exists { se =>
-          DecodeBasicInputs(se.securityInput.and(se.input), DecodeInputsContext(serverRequest)) match {
-            case (DecodeBasicInputsResult.Values(_, _), _) => true
-            case (DecodeBasicInputsResult.Failure(input, failure), _) =>
-              zioHttpServerOptions.decodeFailureHandler(DecodeFailureContext(se.endpoint, input, failure, serverRequest)).isDefined
-          }
-        }
-      }
-
-      override def apply(req: Request) = handleRequest(req)
+      override def isDefinedAt(request: Request): Boolean = serverEndpointsFilter.apply(ZioHttpServerRequest(request)).nonEmpty
+      override def apply(req: Request): Handler[R & R2, Throwable, Any, Response] = handleRequest(req)
     }
 
     Http.collectHandler[Request](routes)


### PR DESCRIPTION
The request is decoded once, and the decision whether a request should be handled by tapir is done based on the shape of the path