### PR TITLE
Bring back 2.12 support for zio-http

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ val scala2_13 = "2.13.10"
 val scala3 = "3.2.2"
 
 val scala2Versions = List(scala2_12, scala2_13)
-val scala2_13and3Versions = List(scala2_13, scala3)
 val scala2And3Versions = scala2Versions ++ List(scala3)
 val codegenScalaVersions = List(scala2_12)
 val examplesScalaVersions = List(scala2_13)
@@ -1363,7 +1362,7 @@ lazy val zioHttpServer: ProjectMatrix = (projectMatrix in file("server/zio-http-
     name := "tapir-zio-http-server",
     libraryDependencies ++= Seq("dev.zio" %% "zio-interop-cats" % Versions.zioInteropCats % Test, "dev.zio" %% "zio-http" % "0.0.4")
   )
-  .jvmPlatform(scalaVersions = scala2_13and3Versions)
+  .jvmPlatform(scalaVersions = scala2And3Versions)
   .dependsOn(serverCore, zio, serverTests % Test)
 
 // serverless

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
@@ -2,12 +2,12 @@ package sttp.tapir.server.ziohttp
 
 import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
+import io.netty.channel.{ChannelFactory, EventLoopGroup, ServerChannel}
 import sttp.capabilities.zio.ZioStreams
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
 import zio._
-import zio.http.netty.server.NettyDriver
 import zio.http._
 import zio.interop.catz._
 
@@ -33,7 +33,7 @@ class ZioHttpTestServerInterpreter(
         _ <- driver.addApp[Any](routes.toList.reduce(_ ++ _).withDefaultErrorResponse, ZEnvironment())
       } yield port)
         .provideSome[Scope](
-          NettyDriver.manual,
+          zio.test.driver,
           eventLoopGroup,
           channelFactory,
           ServerConfig.live(ServerConfig.default.port(0).objectAggregator(1000000))

--- a/server/zio-http-server/src/test/scala/zio/test/package.scala
+++ b/server/zio-http-server/src/test/scala/zio/test/package.scala
@@ -1,0 +1,11 @@
+package zio
+
+import io.netty.channel._
+import zio.http._
+import zio.http.netty.server.NettyDriver
+
+package object test {
+  // NettyDriver is private[zio] so we need to fake it (will be solved in future zio-http versions)
+  val driver: ZLayer[EventLoopGroup & ChannelFactory[ServerChannel] & ServerConfig, Nothing, Driver] =
+    NettyDriver.manual
+}


### PR DESCRIPTION
Fake using the zio package to bypass the `private[zio]` in `NettyDriver`.
This can be removed after the next zio-http upgrade, but in the meantime this lets us restore Scala 2.12 suppport.
Since it's only in tests, I think it's acceptable.