### PR TITLE
Add `WebSockets` support to `VertxFutureServerInterpreter`

### DIFF
--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/encoders/VertxToResponseBody.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/encoders/VertxToResponseBody.scala
@@ -53,14 +53,16 @@ class VertxToResponseBody[F[_], S <: Streams[S]](serverOptions: VertxServerOptio
       pipe: streams.Pipe[REQ, RESP],
       o: WebSocketBodyOutput[streams.Pipe[REQ, RESP], REQ, RESP, _, S]
   ): RoutingContext => Future[Void] = { rc =>
-    rc.request
-      .toWebSocket
+    rc.request.toWebSocket
       .flatMap({ (websocket: ServerWebSocket) =>
-        Pipe(readStreamCompatible.webSocketPipe[REQ, RESP](
-          wrapWebSocket(websocket),
-          pipe.asInstanceOf[readStreamCompatible.streams.Pipe[REQ, RESP]],
-          o.asInstanceOf[WebSocketBodyOutput[readStreamCompatible.streams.Pipe[REQ, RESP], REQ, RESP, _, S]]
-        ), websocket)
+        Pipe(
+          readStreamCompatible.webSocketPipe[REQ, RESP](
+            wrapWebSocket(websocket),
+            pipe.asInstanceOf[readStreamCompatible.streams.Pipe[REQ, RESP]],
+            o.asInstanceOf[WebSocketBodyOutput[readStreamCompatible.streams.Pipe[REQ, RESP], REQ, RESP, _, S]]
+          ),
+          websocket
+        )
         websocket.accept()
         Future.succeededFuture[Void]()
       })

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/handlers/package.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/handlers/package.scala
@@ -34,11 +34,11 @@ package object handlers {
     }
 
     mbWebsocketType.headOption.orElse(bodyType.headOption) match {
-      case Some(MultipartBody(_, _))                   => route.handler(multipartHandler)
-      case Some(_: EndpointIO.StreamBodyWrapper[_, _]) => route.handler(streamPauseHandler)
+      case Some(MultipartBody(_, _))                          => route.handler(multipartHandler)
+      case Some(_: EndpointIO.StreamBodyWrapper[_, _])        => route.handler(streamPauseHandler)
       case Some(_: EndpointOutput.WebSocketBodyWrapper[_, _]) => route.handler(streamPauseHandler)
-      case Some(_)                                     => route.handler(bodyHandler)
-      case None                                        => ()
+      case Some(_)                                            => route.handler(bodyHandler)
+      case None                                               => ()
     }
 
     route

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/Pipe.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/Pipe.scala
@@ -157,7 +157,7 @@ object Pipe {
         case Pong(payload) =>
           writeFrame(VertxWebSocketFrame.pongFrame(Buffer.buffer(payload)))
         case Close(statusCode, _) =>
-          socket.close(statusCode.toShort, { _ => ()})
+          socket.close(statusCode.toShort, { _ => () })
       }
 
       if (!socket.isClosed && socket.writeQueueFull()) {

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/Pipe.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/Pipe.scala
@@ -157,7 +157,7 @@ object Pipe {
         case Pong(payload) =>
           writeFrame(VertxWebSocketFrame.pongFrame(Buffer.buffer(payload)))
         case Close(statusCode, _) =>
-          socket.close(statusCode.toShort, ( _ => ()))
+          socket.close(statusCode.toShort, { _ => ()})
       }
 
       if (!socket.isClosed && socket.writeQueueFull()) {

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/Pipe.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/Pipe.scala
@@ -2,6 +2,7 @@ package sttp.tapir.server.vertx.streams
 
 import java.util.concurrent.atomic.AtomicReference
 
+import io.vertx.core.{AsyncResult, Handler}
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.http.{WebSocketFrame => VertxWebSocketFrame}
 import io.vertx.core.http.ServerWebSocket
@@ -156,10 +157,10 @@ object Pipe {
         case Pong(payload) =>
           writeFrame(VertxWebSocketFrame.pongFrame(Buffer.buffer(payload)))
         case Close(statusCode, _) =>
-          socket.reject(statusCode)
+          socket.close(statusCode.toShort, ( _ => ()))
       }
 
-      if (socket.writeQueueFull()) {
+      if (!socket.isClosed && socket.writeQueueFull()) {
         backpressure.updateAndGet(state => state.copy(queue = state.queue :+ Pause))
         applyBackpressureCommands(backpressure, request)
       }

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/ReadStreamCompatible.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/ReadStreamCompatible.scala
@@ -12,9 +12,9 @@ trait ReadStreamCompatible[S <: Streams[S]] {
   def fromReadStream(s: ReadStream[Buffer]): streams.BinaryStream
 
   def webSocketPipe[REQ, RESP](
-    readStream: ReadStream[WebSocketFrame],
-    pipe: streams.Pipe[REQ, RESP],
-    o: WebSocketBodyOutput[streams.Pipe[REQ, RESP], REQ, RESP, _, S]
+      readStream: ReadStream[WebSocketFrame],
+      pipe: streams.Pipe[REQ, RESP],
+      o: WebSocketBodyOutput[streams.Pipe[REQ, RESP], REQ, RESP, _, S]
   ): ReadStream[WebSocketFrame]
 }
 

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/package.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/package.scala
@@ -1,8 +1,12 @@
 package sttp.tapir.server.vertx
 
+import scala.concurrent.duration.FiniteDuration
+
+import io.vertx.core.Handler
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.streams.ReadStream
-import sttp.tapir.WebSocketBodyOutput
+import sttp.tapir.{DecodeResult, WebSocketBodyOutput}
+import sttp.tapir.model.WebSocketFrameDecodeFailure
 import sttp.ws.WebSocketFrame
 
 package object streams {
@@ -21,7 +25,68 @@ package object streams {
       readStream: ReadStream[WebSocketFrame],
       pipe: streams.Pipe[REQ, RESP],
       o: WebSocketBodyOutput[streams.Pipe[REQ, RESP], REQ, RESP, _, VertxStreams]
-    ): ReadStream[WebSocketFrame] =
-      throw new UnsupportedOperationException()
+    ): ReadStream[WebSocketFrame] = {
+      val stream0 = optionallyContatenateFrames(readStream, o.concatenateFragmentedFrames)
+      val stream1 = optionallyIgnorePong(stream0, o.ignorePong)
+      val stream2 = optionallyAutoPing(stream1, o.autoPing)
+
+      val stream3 = new ReadStreamMapping(stream2, { (frame:WebSocketFrame) =>
+        o.requests.decode(frame) match {
+          case failure: DecodeResult.Failure =>
+            throw (new WebSocketFrameDecodeFailure(frame, failure))
+          case DecodeResult.Value(v) => v
+        }
+      })
+
+      new ReadStreamMapping(pipe(stream3), o.responses.encode)
+    }
+  }
+
+  private def optionallyContatenateFrames(rs: ReadStream[WebSocketFrame], doConcatenate: Boolean): ReadStream[WebSocketFrame] = {
+    //TODO implement this
+    rs
+  }
+
+  private def optionallyIgnorePong(rs: ReadStream[WebSocketFrame], ignore: Boolean): ReadStream[WebSocketFrame] = {
+    //TODO implement this
+      rs
+    }
+
+  private def optionallyAutoPing(rs:ReadStream[WebSocketFrame], autoPing: Option[(FiniteDuration, WebSocketFrame.Ping)]): ReadStream[WebSocketFrame] = {
+    //TODO implement this
+    rs
+  }
+}
+
+/*
+ * ReadStream doesn't offer a `map` function
+ */
+class ReadStreamMapping[A, B](source: ReadStream[A], mapping: A => B) extends ReadStream[B] {
+  override def handler(handler: Handler[B]): ReadStream[B] = {
+    if (handler == null) {
+      source.handler(null)
+    } else {
+      source.handler(event => handler.handle(mapping.apply(event)))
+    }
+    this
+  }
+  override def exceptionHandler(handler: Handler[Throwable]): ReadStream[B] = {
+    source.exceptionHandler(handler)
+    this
+  }
+  override def pause(): ReadStream[B] = {
+    source.pause()
+    this
+  }
+  override def resume(): ReadStream[B] = {
+    fetch(Long.MaxValue)
+  }
+  override def  fetch(amount:Long): ReadStream[B] = {
+    source.fetch(amount)
+    this
+  }
+  override def endHandler(endHandler: Handler[Void]): ReadStream[B] = {
+    source.endHandler(endHandler)
+    this
   }
 }

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/package.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/package.scala
@@ -22,38 +22,44 @@ package object streams {
       readStream
 
     override def webSocketPipe[REQ, RESP](
-      readStream: ReadStream[WebSocketFrame],
-      pipe: streams.Pipe[REQ, RESP],
-      o: WebSocketBodyOutput[streams.Pipe[REQ, RESP], REQ, RESP, _, VertxStreams]
+        readStream: ReadStream[WebSocketFrame],
+        pipe: streams.Pipe[REQ, RESP],
+        o: WebSocketBodyOutput[streams.Pipe[REQ, RESP], REQ, RESP, _, VertxStreams]
     ): ReadStream[WebSocketFrame] = {
       val stream0 = optionallyContatenateFrames(readStream, o.concatenateFragmentedFrames)
       val stream1 = optionallyIgnorePong(stream0, o.ignorePong)
       val stream2 = optionallyAutoPing(stream1, o.autoPing)
 
-      val stream3 = new ReadStreamMapping(stream2, { (frame:WebSocketFrame) =>
-        o.requests.decode(frame) match {
-          case failure: DecodeResult.Failure =>
-            throw (new WebSocketFrameDecodeFailure(frame, failure))
-          case DecodeResult.Value(v) => v
+      val stream3 = new ReadStreamMapping(
+        stream2,
+        { (frame: WebSocketFrame) =>
+          o.requests.decode(frame) match {
+            case failure: DecodeResult.Failure =>
+              throw (new WebSocketFrameDecodeFailure(frame, failure))
+            case DecodeResult.Value(v) => v
+          }
         }
-      })
+      )
 
       new ReadStreamMapping(pipe(stream3), o.responses.encode)
     }
   }
 
   private def optionallyContatenateFrames(rs: ReadStream[WebSocketFrame], doConcatenate: Boolean): ReadStream[WebSocketFrame] = {
-    //TODO implement this
+    // TODO implement this
     rs
   }
 
   private def optionallyIgnorePong(rs: ReadStream[WebSocketFrame], ignore: Boolean): ReadStream[WebSocketFrame] = {
-    //TODO implement this
-      rs
-    }
+    // TODO implement this
+    rs
+  }
 
-  private def optionallyAutoPing(rs:ReadStream[WebSocketFrame], autoPing: Option[(FiniteDuration, WebSocketFrame.Ping)]): ReadStream[WebSocketFrame] = {
-    //TODO implement this
+  private def optionallyAutoPing(
+      rs: ReadStream[WebSocketFrame],
+      autoPing: Option[(FiniteDuration, WebSocketFrame.Ping)]
+  ): ReadStream[WebSocketFrame] = {
+    // TODO implement this
     rs
   }
 }
@@ -81,7 +87,7 @@ class ReadStreamMapping[A, B](source: ReadStream[A], mapping: A => B) extends Re
   override def resume(): ReadStream[B] = {
     fetch(Long.MaxValue)
   }
-  override def  fetch(amount:Long): ReadStream[B] = {
+  override def fetch(amount: Long): ReadStream[B] = {
     source.fetch(amount)
     this
   }

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/websocket.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/websocket.scala
@@ -7,21 +7,21 @@ object websocket {
 
   def concatenateFrames(acc: Accumulator, frame: WebSocketFrame): (Accumulator, Option[WebSocketFrame]) =
     (acc, frame) match {
-      case (None, f: WebSocketFrame.Ping)                                  =>
+      case (None, f: WebSocketFrame.Ping) =>
         (None, Some(f))
-      case (None, f: WebSocketFrame.Pong)                                  =>
+      case (None, f: WebSocketFrame.Pong) =>
         (None, Some(f))
-      case (None, f: WebSocketFrame.Close)                                 =>
+      case (None, f: WebSocketFrame.Close) =>
         (None, Some(f))
-      case (None, f: WebSocketFrame.Data[_]) if f.finalFragment            =>
+      case (None, f: WebSocketFrame.Data[_]) if f.finalFragment =>
         (None, Some(f))
-      case (Some(Left(acc)), f: WebSocketFrame.Binary) if f.finalFragment  =>
+      case (Some(Left(acc)), f: WebSocketFrame.Binary) if f.finalFragment =>
         (None, Some(f.copy(payload = acc ++ f.payload)))
       case (Some(Left(acc)), f: WebSocketFrame.Binary) if !f.finalFragment =>
         (Some(Left(acc ++ f.payload)), None)
-      case (Some(Right(acc)), f: WebSocketFrame.Text) if f.finalFragment   =>
+      case (Some(Right(acc)), f: WebSocketFrame.Text) if f.finalFragment =>
         (None, Some(f.copy(payload = acc + f.payload)))
-      case (Some(Right(acc)), f: WebSocketFrame.Text) if !f.finalFragment  =>
+      case (Some(Right(acc)), f: WebSocketFrame.Text) if !f.finalFragment =>
         (Some(Right(acc + f.payload)), None)
       case (acc, f) =>
         throw new IllegalStateException(s"Cannot accumulate web socket frames. Accumulator: $acc, frame: $f.")
@@ -30,6 +30,6 @@ object websocket {
   def isPong(frame: WebSocketFrame): Boolean =
     frame match {
       case WebSocketFrame.Pong(_) => true
-      case _ => false
+      case _                      => false
     }
 }

--- a/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxServerTest.scala
+++ b/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxServerTest.scala
@@ -1,8 +1,9 @@
 package sttp.tapir.server.vertx
 
 import cats.effect.{IO, Resource}
-import io.vertx.core.Vertx
+import io.vertx.core.{Handler, Vertx}
 import sttp.monad.FutureMonad
+import io.vertx.core.streams.ReadStream
 import sttp.tapir.server.tests._
 import sttp.tapir.server.vertx.streams.VertxStreams
 import sttp.tapir.tests.{Test, TestSuite}
@@ -25,7 +26,35 @@ class VertxServerTest extends TestSuite {
           createServerTest,
           partContentTypeHeaderSupport = false, // README: doesn't seem supported but I may be wrong
           partOtherHeaderSupport = false
-        ).tests() ++ new ServerStreamingTests(createServerTest, VertxStreams).tests()
+        ).tests() ++ new ServerStreamingTests(createServerTest, VertxStreams).tests()++
+      (new ServerWebSocketTests(createServerTest, VertxStreams) {
+        override def functionToPipe[A, B](f: A => B): VertxStreams.Pipe[A, B] = in => new ReadStreamMapping(in,f)
+        override def emptyPipe[A, B]: VertxStreams.Pipe[A, B] = _ => new EmptyReadStream()
+      }).tests()
     }
+  }
+}
+
+class EmptyReadStream[B]() extends ReadStream[B]  {
+  private var endHandler: Handler[Void] = _
+  def endHandler(handler: Handler[Void]): ReadStream[B] ={
+    endHandler = handler
+    this
+  }
+  def exceptionHandler(handler: Handler[Throwable]): ReadStream[B] ={
+    this
+  }
+  def fetch(x: Long): ReadStream[B] ={
+    endHandler.handle(null)
+    this
+  }
+  def handler(handler: io.vertx.core.Handler[B]): ReadStream[B] = {
+    this
+  }
+  def pause(): ReadStream[B] ={
+    this
+  }
+  def resume(): ReadStream[B] ={
+    this
   }
 }

--- a/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxServerTest.scala
+++ b/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxServerTest.scala
@@ -26,35 +26,35 @@ class VertxServerTest extends TestSuite {
           createServerTest,
           partContentTypeHeaderSupport = false, // README: doesn't seem supported but I may be wrong
           partOtherHeaderSupport = false
-        ).tests() ++ new ServerStreamingTests(createServerTest, VertxStreams).tests()++
-      (new ServerWebSocketTests(createServerTest, VertxStreams) {
-        override def functionToPipe[A, B](f: A => B): VertxStreams.Pipe[A, B] = in => new ReadStreamMapping(in,f)
-        override def emptyPipe[A, B]: VertxStreams.Pipe[A, B] = _ => new EmptyReadStream()
-      }).tests()
+        ).tests() ++ new ServerStreamingTests(createServerTest, VertxStreams).tests() ++
+        (new ServerWebSocketTests(createServerTest, VertxStreams) {
+          override def functionToPipe[A, B](f: A => B): VertxStreams.Pipe[A, B] = in => new ReadStreamMapping(in, f)
+          override def emptyPipe[A, B]: VertxStreams.Pipe[A, B] = _ => new EmptyReadStream()
+        }).tests()
     }
   }
 }
 
-class EmptyReadStream[B]() extends ReadStream[B]  {
+class EmptyReadStream[B]() extends ReadStream[B] {
   private var endHandler: Handler[Void] = _
-  def endHandler(handler: Handler[Void]): ReadStream[B] ={
+  def endHandler(handler: Handler[Void]): ReadStream[B] = {
     endHandler = handler
     this
   }
-  def exceptionHandler(handler: Handler[Throwable]): ReadStream[B] ={
+  def exceptionHandler(handler: Handler[Throwable]): ReadStream[B] = {
     this
   }
-  def fetch(x: Long): ReadStream[B] ={
+  def fetch(x: Long): ReadStream[B] = {
     endHandler.handle(null)
     this
   }
   def handler(handler: io.vertx.core.Handler[B]): ReadStream[B] = {
     this
   }
-  def pause(): ReadStream[B] ={
+  def pause(): ReadStream[B] = {
     this
   }
-  def resume(): ReadStream[B] ={
+  def resume(): ReadStream[B] = {
     this
   }
 }

--- a/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxTestServerBlockingInterpreter.scala
+++ b/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxTestServerBlockingInterpreter.scala
@@ -2,13 +2,14 @@ package sttp.tapir.server.vertx
 
 import io.vertx.core.Vertx
 import io.vertx.ext.web.{Route, Router}
+import sttp.capabilities.WebSockets
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.vertx.streams.VertxStreams
 
 import scala.concurrent.Future
 
 class VertxTestServerBlockingInterpreter(vertx: Vertx) extends VertxTestServerInterpreter(vertx) {
-  override def route(es: List[ServerEndpoint[VertxStreams, Future]], interceptors: Interceptors): Router => Route = { router =>
+  override def route(es: List[ServerEndpoint[VertxStreams with WebSockets, Future]], interceptors: Interceptors): Router => Route = { router =>
     val options: VertxFutureServerOptions = interceptors(VertxFutureServerOptions.customiseInterceptors).options
     val interpreter = VertxFutureServerInterpreter(options)
     es.map(interpreter.blockingRoute(_)(router)).last

--- a/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxTestServerBlockingInterpreter.scala
+++ b/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxTestServerBlockingInterpreter.scala
@@ -9,9 +9,10 @@ import sttp.tapir.server.vertx.streams.VertxStreams
 import scala.concurrent.Future
 
 class VertxTestServerBlockingInterpreter(vertx: Vertx) extends VertxTestServerInterpreter(vertx) {
-  override def route(es: List[ServerEndpoint[VertxStreams with WebSockets, Future]], interceptors: Interceptors): Router => Route = { router =>
-    val options: VertxFutureServerOptions = interceptors(VertxFutureServerOptions.customiseInterceptors).options
-    val interpreter = VertxFutureServerInterpreter(options)
-    es.map(interpreter.blockingRoute(_)(router)).last
+  override def route(es: List[ServerEndpoint[VertxStreams with WebSockets, Future]], interceptors: Interceptors): Router => Route = {
+    router =>
+      val options: VertxFutureServerOptions = interceptors(VertxFutureServerOptions.customiseInterceptors).options
+      val interpreter = VertxFutureServerInterpreter(options)
+      es.map(interpreter.blockingRoute(_)(router)).last
   }
 }

--- a/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxTestServerInterpreter.scala
+++ b/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxTestServerInterpreter.scala
@@ -5,6 +5,7 @@ import cats.effect.{IO, Resource}
 import io.vertx.core.http.HttpServerOptions
 import io.vertx.core.{Vertx, Future => VFuture}
 import io.vertx.ext.web.{Route, Router}
+import sttp.capabilities.WebSockets
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.server.vertx.streams.VertxStreams
@@ -13,10 +14,10 @@ import sttp.tapir.tests.Port
 import scala.concurrent.Future
 
 class VertxTestServerInterpreter(vertx: Vertx)
-    extends TestServerInterpreter[Future, VertxStreams, VertxFutureServerOptions, Router => Route] {
+    extends TestServerInterpreter[Future, VertxStreams with WebSockets, VertxFutureServerOptions, Router => Route] {
   import VertxTestServerInterpreter._
 
-  override def route(es: List[ServerEndpoint[VertxStreams, Future]], interceptors: Interceptors): Router => Route = { router =>
+  override def route(es: List[ServerEndpoint[VertxStreams with WebSockets, Future]], interceptors: Interceptors): Router => Route = { router =>
     val options: VertxFutureServerOptions = interceptors(VertxFutureServerOptions.customiseInterceptors).options
     val interpreter = VertxFutureServerInterpreter(options)
     es.map(interpreter.route(_)(router)).last

--- a/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxTestServerInterpreter.scala
+++ b/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxTestServerInterpreter.scala
@@ -17,10 +17,11 @@ class VertxTestServerInterpreter(vertx: Vertx)
     extends TestServerInterpreter[Future, VertxStreams with WebSockets, VertxFutureServerOptions, Router => Route] {
   import VertxTestServerInterpreter._
 
-  override def route(es: List[ServerEndpoint[VertxStreams with WebSockets, Future]], interceptors: Interceptors): Router => Route = { router =>
-    val options: VertxFutureServerOptions = interceptors(VertxFutureServerOptions.customiseInterceptors).options
-    val interpreter = VertxFutureServerInterpreter(options)
-    es.map(interpreter.route(_)(router)).last
+  override def route(es: List[ServerEndpoint[VertxStreams with WebSockets, Future]], interceptors: Interceptors): Router => Route = {
+    router =>
+      val options: VertxFutureServerOptions = interceptors(VertxFutureServerOptions.customiseInterceptors).options
+      val interpreter = VertxFutureServerInterpreter(options)
+      es.map(interpreter.route(_)(router)).last
   }
 
   override def server(routes: NonEmptyList[Router => Route]): Resource[IO, Port] = {


### PR DESCRIPTION
Hi everyone,

this PR is adding web sockets to the `VertxFutureServerInterpreter`.
 
You'll see that it misses some implementations of some configuration stuff: `ignorePong`, `autoPing`and `contatenateFrames`. 
But this is a first step and the web socket is already working, I could test it in my project.
