### PR TITLE
add ability to overwrite tags on endpoint

### DIFF
--- a/core/src/main/scala/sttp/tapir/Endpoint.scala
+++ b/core/src/main/scala/sttp/tapir/Endpoint.scala
@@ -303,11 +303,18 @@ trait EndpointInfoOps[-R] {
   def name(n: String): ThisType[R] = withInfo(info.name(n))
   def summary(s: String): ThisType[R] = withInfo(info.summary(s))
   def description(d: String): ThisType[R] = withInfo(info.description(d))
-  def tags(ts: List[String]): ThisType[R] = withInfo(info.tags(ts))
-  def tag(t: String): ThisType[R] = withInfo(info.tag(t))
   def deprecated(): ThisType[R] = withInfo(info.deprecated(true))
   def attribute[T](k: AttributeKey[T]): Option[T] = info.attribute(k)
   def attribute[T](k: AttributeKey[T], v: T): ThisType[R] = withInfo(info.attribute(k, v))
+
+  /** Append to the existing tags on the endpoint **/
+  def tags(ts: List[String]): ThisType[R] = withInfo(info.tags(ts))
+  def tag(t: String): ThisType[R] = withInfo(info.tag(t))
+
+  /** Overwrite the existing tags on the endpoint **/
+  def withTags(ts: List[String]): ThisType[R] = withInfo(info.withTags(ts))
+  def withTag(t: String): ThisType[R] = withInfo(info.withTag(t))
+  def withoutTags: ThisType[R] = withInfo(info.withoutTags)
 
   def info(i: EndpointInfo): ThisType[R] = withInfo(i)
 }
@@ -578,9 +585,16 @@ case class EndpointInfo(
   def name(n: String): EndpointInfo = this.copy(name = Some(n))
   def summary(s: String): EndpointInfo = copy(summary = Some(s))
   def description(d: String): EndpointInfo = copy(description = Some(d))
-  def tags(ts: List[String]): EndpointInfo = copy(tags = tags ++ ts)
-  def tag(t: String): EndpointInfo = copy(tags = tags :+ t)
   def deprecated(d: Boolean): EndpointInfo = copy(deprecated = d)
   def attribute[T](k: AttributeKey[T]): Option[T] = attributes.get(k)
   def attribute[T](k: AttributeKey[T], v: T): EndpointInfo = copy(attributes = attributes.put(k, v))
+
+  /** Append to the existing tags **/
+  def tags(ts: List[String]): EndpointInfo = copy(tags = tags ++ ts)
+  def tag(t: String): EndpointInfo = copy(tags = tags :+ t)
+
+  /** Overwrite the existing tags **/
+  def withTags(ts: List[String]): EndpointInfo = copy(tags = ts.toVector)
+  def withTag(t: String): EndpointInfo = copy(tags = Vector(t))
+  def withoutTags: EndpointInfo = copy(tags = Vector.empty)
 }

--- a/core/src/main/scala/sttp/tapir/Endpoint.scala
+++ b/core/src/main/scala/sttp/tapir/Endpoint.scala
@@ -307,13 +307,19 @@ trait EndpointInfoOps[-R] {
   def attribute[T](k: AttributeKey[T]): Option[T] = info.attribute(k)
   def attribute[T](k: AttributeKey[T], v: T): ThisType[R] = withInfo(info.attribute(k, v))
 
-  /** Append to the existing tags on the endpoint **/
+  /** Append `ts` to the existing tags. */
   def tags(ts: List[String]): ThisType[R] = withInfo(info.tags(ts))
+
+  /** Append `t` to the existing tags. */
   def tag(t: String): ThisType[R] = withInfo(info.tag(t))
 
-  /** Overwrite the existing tags on the endpoint **/
+  /** Overwrite the existing tags with `ts`. */
   def withTags(ts: List[String]): ThisType[R] = withInfo(info.withTags(ts))
+
+  /** Overwrite the existing tags with a single tag `t`. */
   def withTag(t: String): ThisType[R] = withInfo(info.withTag(t))
+
+  /** Remove all tags from this endpoint. */
   def withoutTags: ThisType[R] = withInfo(info.withoutTags)
 
   def info(i: EndpointInfo): ThisType[R] = withInfo(i)
@@ -589,11 +595,11 @@ case class EndpointInfo(
   def attribute[T](k: AttributeKey[T]): Option[T] = attributes.get(k)
   def attribute[T](k: AttributeKey[T], v: T): EndpointInfo = copy(attributes = attributes.put(k, v))
 
-  /** Append to the existing tags **/
+  /** Append to the existing tags * */
   def tags(ts: List[String]): EndpointInfo = copy(tags = tags ++ ts)
   def tag(t: String): EndpointInfo = copy(tags = tags :+ t)
 
-  /** Overwrite the existing tags **/
+  /** Overwrite the existing tags * */
   def withTags(ts: List[String]): EndpointInfo = copy(tags = ts.toVector)
   def withTag(t: String): EndpointInfo = copy(tags = Vector(t))
   def withoutTags: EndpointInfo = copy(tags = Vector.empty)


### PR DESCRIPTION
In my code, I often share a common base endpoint that I use to create multiple concrete endpoint. But sometimes I want to overwrite the existing tags on the base endpoint.

What I currently do:

```scala
val baseEndpoint = endpoint.in("some-base").tag("basic api")

val myEndpoint = baseEndpoint
    .info(baseEndpoint.info.copy(tags = Vector.empty)) // overwrite tag of base
    .tag("personal api")
```

Does it make sense to support this?

This PR would introduce a method `tagsEmpty` to do this:

```scala
val myEndpoint = baseEndpoint
    .withoutTags // or
    .withTag("personal api") // or
    .withTags(List("personal api"))
```
