### PR TITLE
Validator.derivedEnumeration to handle sealed sub-level traits

### DIFF
--- a/core/src/main/scala-2/sttp/tapir/internal/ValidatorEnumerationMacro.scala
+++ b/core/src/main/scala-2/sttp/tapir/internal/ValidatorEnumerationMacro.scala
@@ -21,7 +21,7 @@ private[tapir] object ValidatorEnumerationMacro {
         else if (child.isSealed)
           flatChildren(child)
         else
-          c.abort(c.enclosingPosition, "All children must be objects or enum cases, or sealed parent of such.")
+          c.abort(c.enclosingPosition, "All children must be objects or sealed parent of such.")
       }
       val subclasses = flatChildren(symbol).sortBy(_.name.encodedName.toString).distinct
       if (!subclasses.forall(_.isModuleClass)) {

--- a/core/src/main/scala-3/sttp/tapir/macros/ValidatorMacros.scala
+++ b/core/src/main/scala-3/sttp/tapir/macros/ValidatorMacros.scala
@@ -24,28 +24,31 @@ private[tapir] object ValidatorMacros {
     val symbol = tpe.typeSymbol
 
     if (!symbol.isClassDef || !(symbol.flags is Flags.Sealed)) {
-      report.throwError("Can only enumerate values of a sealed trait, class or enum.")
-    } else {
-      val children = symbol.children.toList.sortBy(_.name)
+      report.errorAndAbort("Can only enumerate values of a sealed trait, class or enum.")
+    }
 
-      if (children.exists(_.isClassDef)) {
-        report.throwError("All children must be objects or enum cases.")
-      } else {
-        val instances = children.map(x =>
-          tpe.memberType(x).asType match {
-            case '[f] => Ref(x).asExprOf[f]
-          }
-        )
-        val name = '{ Option(Schema.SName(${ Expr(symbol.fullName) })) }
+    def flatChildren(s: Symbol): List[Symbol] = s.children.toList.flatMap { c =>
+      if (c.isClassDef) {
+        if (!(c.flags is Flags.Sealed))
+          report.errorAndAbort("All children must be objects or enum cases, or sealed parent of such.")
+        else
+          flatChildren(c)
+      } else List(c)
+    }
 
-        '{
-          Validator.Enumeration[T](
-            List(${ Varargs(instances) }: _*).asInstanceOf[List[T]],
-            None,
-            ${ name }
-          )
-        }
+    val instances = flatChildren(symbol).distinct.sortBy(_.name).map(x =>
+      tpe.memberType(x).asType match {
+        case '[f] => Ref(x).asExprOf[f]
       }
+    )
+    val name = '{ Option(Schema.SName(${ Expr(symbol.fullName) })) }
+
+    '{
+      Validator.Enumeration[T](
+        List(${ Varargs(instances) }: _*).asInstanceOf[List[T]],
+        None,
+        ${ name }
+      )
     }
   }
 }

--- a/core/src/main/scala-3/sttp/tapir/macros/ValidatorMacros.scala
+++ b/core/src/main/scala-3/sttp/tapir/macros/ValidatorMacros.scala
@@ -36,11 +36,13 @@ private[tapir] object ValidatorMacros {
       } else List(c)
     }
 
-    val instances = flatChildren(symbol).distinct.sortBy(_.name).map(x =>
-      tpe.memberType(x).asType match {
-        case '[f] => Ref(x).asExprOf[f]
-      }
-    )
+    val instances = flatChildren(symbol).distinct
+      .sortBy(_.name)
+      .map(x =>
+        tpe.memberType(x).asType match {
+          case '[f] => Ref(x).asExprOf[f]
+        }
+      )
     val name = '{ Option(Schema.SName(${ Expr(symbol.fullName) })) }
 
     '{

--- a/core/src/test/scala-3/sttp/tapir/ValidatorScala3EnumTest.scala
+++ b/core/src/test/scala-3/sttp/tapir/ValidatorScala3EnumTest.scala
@@ -15,16 +15,6 @@ class ValidatorScala3EnumTest extends AnyFlatSpec with Matchers {
     """)
   }
 
-  it should "derive for branched sealed traits where all leafs are objects" in {
-    Validator.derivedEnumeration[ColorShades].possibleValues should contain theSameElementsAs Vector(
-      ColorShades.LightGrey,
-      ColorShades.DarkGrey,
-      ColorShades.White,
-      ColorShades.Black,
-      ColorShades.LightYellow,
-      ColorShades.DarkBlue
-    )
-  }
 }
 
 enum ColorEnum {
@@ -35,24 +25,4 @@ enum ColorEnum {
 enum ColorEnumWithParam {
   case Red extends ColorEnumWithParam
   case Green(s: String) extends ColorEnumWithParam
-}
-
-
-sealed trait ColorShades
-
-object ColorShades {
-
-  sealed trait BW extends ColorShades
-  sealed trait Colorful extends ColorShades
-
-  sealed trait Dark extends ColorShades
-  sealed trait Light extends ColorShades
-
-  case object LightGrey extends Light, BW
-  case object DarkGrey extends Dark, BW
-  case object White extends Light, BW
-  case object Black extends Dark, BW
-
-  case object LightYellow extends Light, Colorful
-  case object DarkBlue extends Dark, Colorful
 }

--- a/core/src/test/scala-3/sttp/tapir/ValidatorScala3EnumTest.scala
+++ b/core/src/test/scala-3/sttp/tapir/ValidatorScala3EnumTest.scala
@@ -15,6 +15,16 @@ class ValidatorScala3EnumTest extends AnyFlatSpec with Matchers {
     """)
   }
 
+  it should "derive for branched sealed traits where all leafs are objects" in {
+    Validator.derivedEnumeration[ColorShades].possibleValues should contain theSameElementsAs Vector(
+      ColorShades.LightGrey,
+      ColorShades.DarkGrey,
+      ColorShades.White,
+      ColorShades.Black,
+      ColorShades.LightYellow,
+      ColorShades.DarkBlue
+    )
+  }
 }
 
 enum ColorEnum {
@@ -25,4 +35,24 @@ enum ColorEnum {
 enum ColorEnumWithParam {
   case Red extends ColorEnumWithParam
   case Green(s: String) extends ColorEnumWithParam
+}
+
+
+sealed trait ColorShades
+
+object ColorShades {
+
+  sealed trait BW extends ColorShades
+  sealed trait Colorful extends ColorShades
+
+  sealed trait Dark extends ColorShades
+  sealed trait Light extends ColorShades
+
+  case object LightGrey extends Light, BW
+  case object DarkGrey extends Dark, BW
+  case object White extends Light, BW
+  case object Black extends Dark, BW
+
+  case object LightYellow extends Light, Colorful
+  case object DarkBlue extends Dark, Colorful
 }

--- a/core/src/test/scala/sttp/tapir/ValidatorTest.scala
+++ b/core/src/test/scala/sttp/tapir/ValidatorTest.scala
@@ -182,6 +182,17 @@ class ValidatorTest extends AnyFlatSpec with Matchers {
     Validator.derivedEnumeration[Color].possibleValues should contain theSameElementsAs List(Blue, Red)
   }
 
+  it should "derive for branched sealed traits where all leafs are objects" in {
+    Validator.derivedEnumeration[ColorShades].possibleValues should contain theSameElementsAs Vector(
+      ColorShades.LightGrey,
+      ColorShades.DarkGrey,
+      ColorShades.White,
+      ColorShades.Black,
+      ColorShades.LightYellow,
+      ColorShades.DarkBlue
+    )
+  }
+
   it should "not compile for malformed coproduct enum" in {
     assertDoesNotCompile("""
       Validator.derivedEnumeration[InvalidColorEnum]
@@ -204,4 +215,23 @@ sealed trait InvalidColorEnum
 object InvalidColorEnum {
   case object Blue extends InvalidColorEnum
   case class Red(s: String) extends InvalidColorEnum
+}
+
+sealed trait ColorShades
+
+object ColorShades {
+
+  sealed trait BW extends ColorShades
+  sealed trait Colorful extends ColorShades
+
+  sealed trait Dark extends ColorShades
+  sealed trait Light extends ColorShades
+
+  case object LightGrey extends Light with BW
+  case object DarkGrey extends Dark with BW
+  case object White extends Light with BW
+  case object Black extends Dark with BW
+
+  case object LightYellow extends Light with Colorful
+  case object DarkBlue extends Dark with Colorful
 }


### PR DESCRIPTION
Fix `Validator.derivedEnumeration` for cases like below
```scala
sealed trait EnumRoot
sealed trait ABranch extends EnumRoot
sealed trait BBranch extends EnumRoot

case object A1 extends ABranch
case object A2 extends ABranch

case object B1 extends BBranch
```

`Validator.derivedEnumeration[EnumRoot]`

**Expected**
  - Validation one of (A1, A2, B1)

**Actual**
  - compile error `All children must be objects or enum cases`
