### PR TITLE
Scala.js - map source files to https://raw.githubusercontent.com/...

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,22 @@ val commonJvmSettings: Seq[Def.Setting[_]] = commonSettings ++ Seq(
 )
 
 // run JS tests inside Gecko, due to jsdom not supporting fetch and to avoid having to install node
-val commonJsSettings = commonSettings ++ browserGeckoTestSettings
+val commonJsSettings = commonSettings ++ browserGeckoTestSettings ++ Seq(
+  Compile / scalacOptions ++= {
+    if (isSnapshot.value) Seq.empty
+    else
+      Seq {
+        val mapSourcePrefix =
+          if (ScalaArtifacts.isScala3(scalaVersion.value))
+            "-scalajs-mapSourceURI"
+          else
+            "-P:scalajs:mapSourceURI"
+        val dir = project.base.toURI.toString.replaceFirst("[^/]+/?$", "")
+        val url = "https://raw.githubusercontent.com/softwaremill/tapir"
+        s"$mapSourcePrefix:$dir->$url/v${version.value}/"
+      }
+  }
+)
 
 val commonNativeSettings = commonSettings
 


### PR DESCRIPTION
Fixes #2805
Now, scala.js build references source files on the local build machine (file:/home/runner/work/tapir/...).
It would be more convenient to have them mapped to https://raw.githubusercontent.com/softwaremill/tapir/...
Code adopted from [sttp](https://github.com/softwaremill/sttp/blob/6df8daa63755600e24c7f5b30fd5379c4bd72bb4/build.sbt#L60-L67)