### PR TITLE
Extract tapir-cats-effect module from tapir-cats

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -504,8 +504,7 @@ lazy val cats: ProjectMatrix = (projectMatrix in file("integrations/cats"))
   .settings(
     name := "tapir-cats",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-core" % "2.9.0",
-      "org.typelevel" %%% "cats-effect" % Versions.catsEffect,
+      "org.typelevel" %%% "cats-core" % Versions.catsCore,
       scalaTest.value % Test,
       scalaCheck.value % Test,
       scalaTestPlusScalaCheck.value % Test,
@@ -538,6 +537,28 @@ lazy val cats: ProjectMatrix = (projectMatrix in file("integrations/cats"))
         "io.github.cquiroz" %%% "scala-java-time" % Versions.jsScalaJavaTime % Test
       )
     )
+  )
+  .dependsOn(core)
+
+lazy val catsEffect: ProjectMatrix = (projectMatrix in file("integrations/cats-effect"))
+  .settings(commonSettings)
+  .settings(
+    name := "tapir-cats-effect",
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-core" % Versions.catsCore,
+      "org.typelevel" %%% "cats-effect" % Versions.catsEffect
+    )
+  )
+  .jvmPlatform(
+    scalaVersions = scala2And3Versions
+  )
+  .jsPlatform(
+    scalaVersions = scala2And3Versions,
+    settings = commonJsSettings
+  )
+  .nativePlatform(
+    scalaVersions = scala2And3Versions,
+    settings = commonNativeSettings
   )
   .dependsOn(core)
 
@@ -1138,7 +1159,7 @@ lazy val armeriaServerCats: ProjectMatrix =
       )
     )
     .jvmPlatform(scalaVersions = scala2And3Versions)
-    .dependsOn(armeriaServer % CompileAndTest, cats, serverTests % Test)
+    .dependsOn(armeriaServer % CompileAndTest, cats, catsEffect, serverTests % Test)
 
 lazy val armeriaServerZio: ProjectMatrix =
   (projectMatrix in file("server/armeria-server/zio"))
@@ -1185,7 +1206,7 @@ lazy val http4sServer: ProjectMatrix = (projectMatrix in file("server/http4s-ser
       Test / skip := true
     )
   )
-  .dependsOn(serverCore, cats)
+  .dependsOn(serverCore, cats, catsEffect)
 
 lazy val http4sServer2_12 = http4sServer.jvm(scala2_12).dependsOn(serverTests.jvm(scala2_12) % Test)
 lazy val http4sServer2_13 = http4sServer.jvm(scala2_13).dependsOn(serverTests.jvm(scala2_13) % Test)
@@ -1267,7 +1288,7 @@ lazy val finatraServerCats: ProjectMatrix =
     .settings(commonJvmSettings)
     .settings(name := "tapir-finatra-server-cats")
     .jvmPlatform(scalaVersions = scala2Versions)
-    .dependsOn(finatraServer % CompileAndTest, cats, serverTests % Test)
+    .dependsOn(finatraServer % CompileAndTest, cats, catsEffect, serverTests % Test)
 
 lazy val playServer: ProjectMatrix = (projectMatrix in file("server/play-server"))
   .settings(commonJvmSettings)
@@ -1296,7 +1317,7 @@ lazy val nettyServer: ProjectMatrix = (projectMatrix in file("server/netty-serve
   .jvmPlatform(scalaVersions = scala2And3Versions)
   .dependsOn(serverCore, serverTests % Test)
 
-lazy val nettyServerCats: ProjectMatrix = nettyServerProject("cats", cats)
+lazy val nettyServerCats: ProjectMatrix = nettyServerProject("cats", catsEffect)
   .settings(libraryDependencies += "com.softwaremill.sttp.shared" %% "fs2" % Versions.sttpShared)
 
 lazy val nettyServerZio: ProjectMatrix = nettyServerProject("zio", zio)
@@ -1394,7 +1415,7 @@ lazy val awsLambda: ProjectMatrix = (projectMatrix in file("serverless/aws/lambd
   )
   .jvmPlatform(scalaVersions = scala2And3Versions)
   .jsPlatform(scalaVersions = scala2Versions)
-  .dependsOn(serverCore, cats, circeJson, tests % "test")
+  .dependsOn(serverCore, cats, catsEffect, circeJson, tests % "test")
 
 // integration tests for lambda interpreter
 // it's a separate project since it needs a fat jar with lambda code which cannot be build from tests sources

--- a/integrations/cats-effect/src/main/scala/sttp/tapir/integ/cats/effect/CatsMonadError.scala
+++ b/integrations/cats-effect/src/main/scala/sttp/tapir/integ/cats/effect/CatsMonadError.scala
@@ -1,4 +1,4 @@
-package sttp.tapir.integ.cats
+package sttp.tapir.integ.cats.effect
 
 import cats.effect.Sync
 import sttp.monad.MonadError

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -2,6 +2,7 @@ object Versions {
   val http4s = "0.23.18"
   val http4sBlazeServer = "0.23.14"
   val http4sBlazeClient = "0.23.14"
+  val catsCore = "2.9.0"
   val catsEffect = "3.4.8"
   val circe = "0.14.3"
   val circeGenericExtras = "0.14.3"

--- a/server/armeria-server/cats/src/main/scala/sttp/tapir/server/armeria/cats/CatsMonadAsyncError.scala
+++ b/server/armeria-server/cats/src/main/scala/sttp/tapir/server/armeria/cats/CatsMonadAsyncError.scala
@@ -3,7 +3,7 @@ package sttp.tapir.server.armeria.cats
 import cats.effect.Async
 import cats.syntax.functor._
 import sttp.monad.{Canceler, MonadAsyncError}
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 
 // Forked from sttp.client3.impl.cats.CatsMonadAsyncError
 private class CatsMonadAsyncError[F[_]](implicit F: Async[F]) extends CatsMonadError[F] with MonadAsyncError[F] {

--- a/server/armeria-server/cats/src/test/scala/sttp/tapir/server/armeria/cats/ArmeriaCatsServerTest.scala
+++ b/server/armeria-server/cats/src/test/scala/sttp/tapir/server/armeria/cats/ArmeriaCatsServerTest.scala
@@ -2,7 +2,7 @@ package sttp.tapir.server.armeria.cats
 
 import cats.effect.{IO, Resource}
 import sttp.capabilities.fs2.Fs2Streams
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
 

--- a/server/finatra-server/cats/src/main/scala/sttp/tapir/server/finatra/cats/FinatraCatsServerInterpreter.scala
+++ b/server/finatra-server/cats/src/main/scala/sttp/tapir/server/finatra/cats/FinatraCatsServerInterpreter.scala
@@ -5,7 +5,7 @@ import cats.effect.std.Dispatcher
 import cats.~>
 import com.twitter.util.Future
 import sttp.monad.MonadError
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.finatra.FinatraServerInterpreter.FutureMonadError

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerInterpreter.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerInterpreter.scala
@@ -12,7 +12,7 @@ import org.http4s.websocket.WebSocketFrame
 import org.typelevel.ci.CIString
 import sttp.capabilities.WebSockets
 import sttp.capabilities.fs2.Fs2Streams
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.interceptor.RequestResult
 import sttp.tapir.server.interceptor.reject.RejectInterceptor

--- a/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerStubTest.scala
+++ b/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerStubTest.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3.testing.SttpBackendStub
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.interceptor.CustomiseInterceptors
 import sttp.tapir.server.tests.{CreateServerStubTest, ServerStubStreamingTest, ServerStubTest}
 

--- a/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerTest.scala
+++ b/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerTest.scala
@@ -13,7 +13,7 @@ import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3._
 import sttp.model.sse.ServerSentEvent
 import sttp.tapir._
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
 import sttp.ws.{WebSocket, WebSocketFrame}

--- a/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerStubTest.scala
+++ b/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerStubTest.scala
@@ -2,7 +2,7 @@ package sttp.tapir.server.http4s.ztapir
 
 import sttp.capabilities.zio.ZioStreams
 import sttp.client3.testing.SttpBackendStub
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.http4s.Http4sServerOptions
 import sttp.tapir.server.interceptor.CustomiseInterceptors
 import sttp.tapir.server.tests.{CreateServerStubTest, ServerStubStreamingTest, ServerStubTest}

--- a/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerTest.scala
+++ b/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerTest.scala
@@ -9,7 +9,7 @@ import sttp.client3._
 import sttp.model.sse.ServerSentEvent
 import sttp.monad.MonadError
 import sttp.tapir._
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.http4s.Http4sServerSentEvents
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}

--- a/server/http4s-server/zio1/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerStubTest.scala
+++ b/server/http4s-server/zio1/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerStubTest.scala
@@ -2,7 +2,7 @@ package sttp.tapir.server.http4s.ztapir
 
 import sttp.capabilities.zio.ZioStreams
 import sttp.client3.testing.SttpBackendStub
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.http4s.Http4sServerOptions
 import sttp.tapir.server.interceptor.CustomiseInterceptors
 import sttp.tapir.server.tests.{CreateServerStubTest, ServerStubStreamingTest, ServerStubTest}

--- a/server/http4s-server/zio1/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerTest.scala
+++ b/server/http4s-server/zio1/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerTest.scala
@@ -7,7 +7,7 @@ import sttp.client3._
 import sttp.model.sse.ServerSentEvent
 import sttp.monad.MonadError
 import sttp.tapir._
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
 import zio.{RIO, UIO}

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServer.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServer.scala
@@ -6,7 +6,7 @@ import cats.syntax.all._
 import io.netty.channel._
 import io.netty.channel.unix.DomainSocketAddress
 import sttp.monad.MonadError
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.netty.cats.internal.CatsUtil.{nettyChannelFutureToScala, nettyFutureToScala}
 import sttp.tapir.server.netty.Route

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
@@ -3,7 +3,7 @@ package sttp.tapir.server.netty.cats
 import cats.effect.Async
 import cats.effect.std.Dispatcher
 import sttp.monad.MonadError
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.netty.Route
 import sttp.tapir.server.netty.internal.{NettyServerInterpreter, RunAsync}

--- a/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsServerStubTest.scala
+++ b/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsServerStubTest.scala
@@ -4,7 +4,7 @@ import cats.effect.IO
 import cats.effect.std.Dispatcher
 import cats.effect.unsafe.implicits.global
 import sttp.client3.testing.SttpBackendStub
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.interceptor.CustomiseInterceptors
 import sttp.tapir.server.tests.{CreateServerStubTest, ServerStubTest}
 

--- a/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsServerTest.scala
+++ b/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsServerTest.scala
@@ -4,7 +4,7 @@ import cats.effect.{IO, Resource}
 import io.netty.channel.nio.NioEventLoopGroup
 import org.scalatest.EitherValues
 import sttp.monad.MonadError
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.netty.internal.FutureUtil
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}

--- a/server/vertx-server/cats/src/test/scala/sttp/tapir/server/vertx/cats/VertxStubServerTest.scala
+++ b/server/vertx-server/cats/src/test/scala/sttp/tapir/server/vertx/cats/VertxStubServerTest.scala
@@ -5,7 +5,7 @@ import cats.effect.std.Dispatcher
 import cats.effect.unsafe.implicits.global
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.client3.testing.SttpBackendStub
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.interceptor.CustomiseInterceptors
 import sttp.tapir.server.tests.{CreateServerStubTest, ServerStubStreamingTest, ServerStubTest}
 

--- a/serverless/aws/lambda-tests/src/test/scala/sttp/tapir/serverless/aws/lambda/tests/AwsLambdaCreateServerStubTest.scala
+++ b/serverless/aws/lambda-tests/src/test/scala/sttp/tapir/serverless/aws/lambda/tests/AwsLambdaCreateServerStubTest.scala
@@ -11,7 +11,7 @@ import sttp.client3.testing.SttpBackendStub
 import sttp.client3.{ByteArrayBody, ByteBufferBody, InputStreamBody, NoBody, Request, Response, StringBody, SttpBackend, _}
 import sttp.model.{Header, StatusCode, Uri}
 import sttp.tapir.PublicEndpoint
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.tests.CreateServerTest
 import sttp.tapir.serverless.aws.lambda._

--- a/serverless/aws/lambda/src/main/scala/sttp/tapir/serverless/aws/lambda/runtime/AwsLambdaRuntimeInvocation.scala
+++ b/serverless/aws/lambda/src/main/scala/sttp/tapir/serverless/aws/lambda/runtime/AwsLambdaRuntimeInvocation.scala
@@ -10,7 +10,7 @@ import io.circe.syntax._
 import sttp.client3._
 import sttp.monad.MonadError
 import sttp.monad.syntax._
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.serverless.aws.lambda.{AwsRequest, AwsResponse, Route}
 
 import scala.concurrent.duration.DurationInt

--- a/serverless/aws/lambda/src/test/scalajvm/sttp/tapir/serverless/aws/lambda/runtime/AwsLambdaRuntimeInvocationTest.scala
+++ b/serverless/aws/lambda/src/test/scalajvm/sttp/tapir/serverless/aws/lambda/runtime/AwsLambdaRuntimeInvocationTest.scala
@@ -9,7 +9,7 @@ import sttp.client3._
 import sttp.client3.testing.SttpBackendStub
 import sttp.model.{Header, StatusCode}
 import sttp.tapir._
-import sttp.tapir.integ.cats.CatsMonadError
+import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.serverless.aws.lambda.runtime.AwsLambdaRuntimeInvocationTest._
 import sttp.tapir.serverless.aws.lambda.{AwsCatsEffectServerInterpreter, AwsCatsEffectServerOptions, AwsServerOptions}
 


### PR DESCRIPTION
Fixes #2822.

In addition to making the new module `tapir-cats-effect`, I also changed the package for `CatsMonadError` to `sttp.tapir.integ.cats.effect`. It seemed like the right thing to do, but it's also a breaking change so not sure how @adamw feels about that.

I looked for docs to update, but didn't find anything. Is `CatsMonadError` typically used directly by Tapir users, or is it more of an internal thing?