### PR TITLE
Add Nix flake for the documentation dev tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,21 +174,24 @@ All suggestions welcome :)
 
 See the list of [issues](https://github.com/softwaremill/tapir/issues) and pick one! Or report your own.
 
-If you are having doubts on the *why* or *how* something works, don't hesitate to ask a question on
-[discourse](https://softwaremill.community/c/tapir) or via github. This probably means that the documentation, scaladocs or 
+If you are having doubts on the _why_ or _how_ something works, don't hesitate to ask a question on
+[discourse](https://softwaremill.community/c/tapir) or via github. This probably means that the documentation, scaladocs or
 code is unclear and be improved for the benefit of all.
-
+In order to develop the documentation, you can use the `doc/watch.sh` script, which runs Sphinx using Python.
+Use `doc/requirements.txt` to set up your Python environment with `pip`. If you're using Nix, you can just run `nix develop`
+in the `doc` directory to set up a working shell with all the dependencies.
+n
 The `core` module needs to remain binary-compatible with earlier versions. To check if your changes meet this requirement,
-you can run `core/mimaReportBinaryIssues` from the sbt console. 
+you can run `core/mimaReportBinaryIssues` from the sbt console.
 
 ### Testing locally
 
 The JS tests use [Gecko instead of Chrome](https://github.com/scala-js/scala-js-env-selenium/issues/119), although this
 causes another problem: out of memory when running JS tests for multiple modules. Work-arounds:
 
-* run only tests for a specific Scala version and platform using `testScoped 2.13 JS` (supported versions: 2.12, 2.13, 3; supported platforms: JVM, JS, Native)
-* test single JS projects
-* use CI (GitHub Actions) to test all projects - the `.github/workflows/ci.yml` enumerates them one by one
+- run only tests for a specific Scala version and platform using `testScoped 2.13 JS` (supported versions: 2.12, 2.13, 3; supported platforms: JVM, JS, Native)
+- test single JS projects
+- use CI (GitHub Actions) to test all projects - the `.github/workflows/ci.yml` enumerates them one by one
 
 You can test only server/client/doc/other projects using `testServers`, `testClients`, `testDocs` and `testOther`.
 

--- a/doc/flake.lock
+++ b/doc/flake.lock
@@ -1,0 +1,128 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "pypi-deps-db": "pypi-deps-db"
+      },
+      "locked": {
+        "lastModified": 1681814846,
+        "narHash": "sha256-IMQ1Twf/ozE53CwrunXNlYD3D31xqgz/mZyZG38Ov/Y=",
+        "owner": "davhau",
+        "repo": "mach-nix",
+        "rev": "8d903072c7b5426d90bc42a008242c76590af916",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davhau",
+        "repo": "mach-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1643805626,
+        "narHash": "sha256-AXLDVMG+UaAGsGSpOtQHPIKB+IZ0KSd9WS77aanGzgc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "554d2d8aa25b6e583575459c297ec23750adb6cb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1682453498,
+        "narHash": "sha256-WoWiAd7KZt5Eh6n+qojcivaVpnXKqBsVgpixpV2L9CE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c8018361fa1d1650ee8d4b96294783cf564e8a7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pypi-deps-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678051695,
+        "narHash": "sha256-kFFP8TN8pEKARtjK9loGdH+TU23ZbHdVLCUdNcufKPs=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "e00b22ead9d3534ba1c448e1af3076af6b234acf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "mach-nix": "mach-nix",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/doc/flake.nix
+++ b/doc/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "Python shell flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    mach-nix.url = "github:davhau/mach-nix";
+  };
+
+  outputs = { self, nixpkgs, mach-nix, flake-utils, ... }:
+    let
+      pythonVersion = "python37";
+    in
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        mach = mach-nix.lib.${system};
+
+        pythonEnv = mach.mkPython {
+          python = pythonVersion;
+          requirements = builtins.readFile ./requirements.txt;
+        };
+      in
+      {
+        devShells.default = pkgs.mkShellNoCC {
+          packages = [ pythonEnv ];
+
+          shellHook = ''
+            export PYTHONPATH="${pythonEnv}/bin/python"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
This change allows running a single command: `nix develop` to build and enter into development shell with all required python dependencies needed to work on the documentation.
- `flake.nix` defines the dev environment and refers to requirements.txt
- `flake.lock` freezes all versions of resolved packages

Using Nix for such purposes is a pretty cool experience, one does not need to worry that they will pollute the system with conflicting tools and libraries, which happens especially often with Python development.