### PR TITLE
Disable BSP if ideSkipProject

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
     (scalaVersion.value == scala3) ||
     thisProjectRef.value.project.contains("Native") ||
     thisProjectRef.value.project.contains("JS"),
+  bspEnabled := !ideSkipProject.value,
   // slow down for CI
   Test / parallelExecution := false,
   // remove false alarms about unused implicit definitions in macros


### PR DESCRIPTION
Analogous to the `ideSkipProject` setting, but for Metals. This should exclude JS/Native projects as well as Scala 2.12 / Scala 3 from builds. 