### PR TITLE
Add scalafix configuration for organizing imports

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,7 +1,3 @@
 OrganizeImports {
   groupedImports = Merge
-  groups = [
-    "*"
-    "re:(javax?|scala)\\."
-  ]
 }

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,7 @@
+OrganizeImports {
+  groupedImports = Merge
+  groups = [
+    "*"
+    "re:(javax?|scala)\\."
+  ]
+}


### PR DESCRIPTION
This configuration enables the "organize imports" action for Metals. I haven't changed the default settings too much, except setting `groupedImports` to `Merge`. This creates groups of imports if they are from the same package.