### PR TITLE
Adjust Async cancellation to CE 3.5

### DIFF
--- a/server/finatra-server/cats/src/main/scala/sttp/tapir/server/finatra/cats/conversions.scala
+++ b/server/finatra-server/cats/src/main/scala/sttp/tapir/server/finatra/cats/conversions.scala
@@ -1,6 +1,7 @@
 package sttp.tapir.server.finatra.cats
 
-import cats.effect.Async
+import cats.effect.{Async, Sync}
+import cats.syntax.all._
 import cats.effect.std.Dispatcher
 import com.twitter.util.{Future, Promise}
 
@@ -25,9 +26,10 @@ object conversions {
 
   /** Convert from a Twitter Future to some F with Async capabilities. Based on https://typelevel.org/cats-effect/docs/typeclasses/async
     */
-  private[cats] implicit class RichTwitterFuture[A](val f: Future[A]) {
-    def asF[F[_]: Async]: F[A] = Async[F].async_ { cb =>
-      f.onSuccess(f => cb(Right(f))).onFailure(e => cb(Left(e)))
+   private[cats] def fromFuture[F[_]: Async, A](f: => Future[A]): F[A] = Async[F].async { cb =>
+      Sync[F].delay {
+        val fut = f.onSuccess(f => cb(Right(f))).onFailure(e => cb(Left(e)))
+        Some(Sync[F].delay(fut.raise(new InterruptedException("Fiber canceled"))).void)
+      } 
     }
-  }
 }

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/internal/CatsUtil.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/internal/CatsUtil.scala
@@ -1,32 +1,38 @@
 package sttp.tapir.server.netty.cats.internal
 
 import cats.effect.Async
+import cats.syntax.all._
 import io.netty.channel.{Channel, ChannelFuture}
 
 import scala.concurrent.CancellationException
+import cats.effect.kernel.Sync
 
 object CatsUtil {
   def nettyChannelFutureToScala[F[_]: Async](nettyFuture: ChannelFuture): F[Channel] = {
     Async[F].async { k =>
+      Sync[F].delay {
       nettyFuture.addListener((future: ChannelFuture) =>
         if (future.isSuccess) k(Right(future.channel()))
         else if (future.isCancelled) k(Left(new CancellationException))
         else k(Left(future.cause()))
       )
 
-      Async[F].pure(None)
+      Some(Sync[F].delay(nettyFuture.cancel(true)).void)
+      }
     }
   }
 
   def nettyFutureToScala[F[_]: Async, T](f: io.netty.util.concurrent.Future[T]): F[T] = {
     Async[F].async { k =>
+      Sync[F].delay {
       f.addListener((future: io.netty.util.concurrent.Future[T]) => {
         if (future.isSuccess) k(Right(future.getNow))
         else if (future.isCancelled) k(Left(new CancellationException))
         else k(Left(f.cause()))
       })
 
-      Async[F].pure(None)
+      Some(Sync[F].delay(f.cancel(true)).void)
+      }
     }
   }
 }

--- a/server/vertx-server/cats/src/main/scala/sttp/tapir/server/vertx/cats/VertxCatsServerInterpreter.scala
+++ b/server/vertx-server/cats/src/main/scala/sttp/tapir/server/vertx/cats/VertxCatsServerInterpreter.scala
@@ -133,15 +133,17 @@ object VertxCatsServerInterpreter {
 
   implicit class VertxFutureToCatsF[A](f: => Future[A]) {
     def asF[F[_]: Async]: F[A] = {
-      Async[F].async_ { cb =>
-        f.onComplete({ handler =>
-          if (handler.succeeded()) {
-            cb(Right(handler.result()))
-          } else {
-            cb(Left(handler.cause()))
-          }
-        })
-        ()
+      Async[F].async { cb =>
+        Sync[F].delay {
+          f.onComplete({ handler =>
+            if (handler.succeeded()) {
+              cb(Right(handler.result()))
+            } else {
+              cb(Left(handler.cause()))
+            }
+          })
+          Some(().pure[F])
+        }
       }
     }
   }

--- a/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxTestServerInterpreter.scala
+++ b/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxTestServerInterpreter.scala
@@ -35,10 +35,12 @@ class VertxTestServerInterpreter(vertx: Vertx)
 
 object VertxTestServerInterpreter {
   def vertxFutureToIo[A](future: => VFuture[A]): IO[A] =
-    IO.async_[A] { cb =>
-      future
-        .onFailure { cause => cb(Left(cause)) }
-        .onSuccess { result => cb(Right(result)) }
-      ()
+    IO.async[A] { cb =>
+      IO {
+        future
+          .onFailure { cause => cb(Left(cause)) }
+          .onSuccess { result => cb(Right(result)) }
+        Some(IO.unit)
+      }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/softwaremill/tapir/issues/2892

The crucial change in CE 3.5 is that now `async_` is uncancellable, which may lead to deadlocks. It also affects `Async[F].fromFuture` which relies on it underneath, as well as `async`, which becomes uncancellable when returning a `None`.

This PR revises our usages of `async` and friends in order to add proper explicit handling for cancellation where needed.

1. `ArmeriaCatsServerOptions[F]`
Creating and deleting temp files for Armeria is now converted to `async` with an attempt to cancel the underlying Java Future.
2. Armeria's `CatsFutureConversion` now uses CE's `fromFutureCancelable`, with empty cancellation logic. The underlying Future cannot be canceled, but at least we remain consistent with previous behavior - the fiber that awaits for async callback can be canceled, preventing deadlocks.
3. Finatra Futures are now converted to `F` using `async`, plus a cancellation callback which tries to interrupt the underlying Finatra Future (`future.raise(...)`)
4. Vertx Future to F conversion is also now using `async`, with a no-op cancellation logic, but at least it should keep previous behavior and avoid deadlocks.

-------------

- [x] Implementation
- [x] Adjust docs
- [x] Adjust tests