### PR TITLE
[bugfix] Handle path decoding failures with 404 in zio-http 

### DIFF
--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
@@ -157,7 +157,7 @@ class ZioHttpServerTest extends TestSuite {
               result <- route
                 .runZIO(Request.get(url = URL(Path.empty / "test" / "123")))
                 .flatMap(response => ZIO.succeed(response.status))
-                .map(_ shouldBe zio.http.Status.NotFound)
+                .map(_ shouldBe zio.http.Status.BadRequest)
                 .catchAll(_ => ZIO.succeed(fail("Unable to extract body from Http response")))
             } yield result
 

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
@@ -132,6 +132,37 @@ class ZioHttpServerTest extends TestSuite {
 
             Unsafe.unsafe(implicit u => r.unsafe.runToFuture(test))
           },
+          // https://github.com/softwaremill/tapir/issues/2764
+          Test("decode path failures result with 404") {
+            final case class Example private (value: String)
+            object Example {
+              implicit val exampleCodec: Codec[String, Example, CodecFormat.TextPlain] = Codec.string.mapDecode(raw =>
+                Example.make(raw) match {
+                  case Left(error) =>
+                    DecodeResult.Error(raw, new IllegalArgumentException(s"Invalid Example value ($raw), failed with $error"))
+                  case Right(result) => DecodeResult.Value(result)
+                }
+              )(_.value)
+
+              def make(in: String): Either[String, Example] =
+                if (in.length > 5) Right(new Example(in))
+                else Left("Too short")
+            }
+            val ep = endpoint.get
+              .in("test" / path[Example]("testId"))
+              .out(stringBody)
+              .zServerLogic[Any](testId => ZIO.succeed(s"Hello $testId"))
+            val route = ZioHttpInterpreter().toHttp(ep)
+            val test: UIO[Assertion] = for {
+              result <- route
+                .runZIO(Request.get(url = URL(Path.empty / "test" / "123")))
+                .flatMap(response => ZIO.succeed(response.status))
+                .map(_ shouldBe zio.http.Status.NotFound)
+                .catchAll(_ => ZIO.succeed(fail("Unable to extract body from Http response")))
+            } yield result
+
+            Unsafe.unsafe(implicit u => r.unsafe.runToFuture(test))
+          },
           // https://github.com/softwaremill/tapir/issues/2849
           Test("Streaming works through the stub backend") {
             // given


### PR DESCRIPTION
Fixes https://github.com/softwaremill/tapir/issues/2764

When path decoding fails due to a custom  codec failure with `DecodeResult.Error`, and no other endpoint matches the request, the core `DecodeFailureHandler` falls into

```scala
 def respond(
      ctx: DecodeFailureContext,
      badRequestOnPathErrorIfPathShapeMatches: Boolean,
      badRequestOnPathInvalidIfPathShapeMatches: Boolean
  ): Option[(StatusCode, List[Header])] = {
    failingInput(ctx) match {

 case _: EndpointInput.Basic[_] => None // <=======================
```

which results in `ZioHttpInterpreter` failing with

```scala
             case RequestResult.Failure(_) =>
                ZIO.fail(
                  new RuntimeException(
                    s"The path: ${req.path} matches the shape of some endpoint, but none of the " +
                      s"endpoints decoded the request successfully, and the decode failure handler didn't provide a " +
                      s"response. ZIO Http requires that if the path shape matches some endpoints, the request " +
                      s"should be handled by tapir."
                  )
                )
```

causing HTTP 500 as a response. We want to be consistent with the documentation and other backends and return a HTTP 404 here.