### PR TITLE
support nullable ref in openapi schema

### DIFF
--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
@@ -69,8 +69,13 @@ private[schema] class TSchemaToASchema(toSchemaReference: ToSchemaReference, mar
       case _                      => false
     }
 
-    result
-      .map(s => if (nullable) s.copy(nullable = Some(true)) else s)
+    val resultWithNullable = result match {
+      case Left(ref) if nullable     => Right(new ASchema(nullable = Some(true), allOf = List(Left(ref))))
+      case Right(schema) if nullable => Right(schema.copy(nullable = Some(true)))
+      case other                     => other
+    }
+
+    resultWithNullable
       .map(addMetadata(_, schema))
       .map(addConstraints(_, primitiveValidators, schemaIsWholeNumber))
   }


### PR DESCRIPTION
I was missing support for nullable refs in the openapi schema. That is usually some optional case classes in the json schema.

It is inspired by this stack overflow response: https://stackoverflow.com/a/48114924
See also: https://github.com/OAI/OpenAPI-Specification/issues/1368

Related: https://github.com/softwaremill/tapir/issues/1147