### PR TITLE
Remove DecodeFailureHandler from ZioHttpServerOptions

### DIFF
--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerOptions.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerOptions.scala
@@ -3,14 +3,12 @@ package sttp.tapir.server.ziohttp
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.interceptor.log.DefaultServerLog
 import sttp.tapir.server.interceptor.{CustomiseInterceptors, Interceptor}
-import sttp.tapir.server.interceptor.decodefailure.DecodeFailureHandler
 import sttp.tapir.{Defaults, TapirFile}
 import zio.{Cause, RIO, Task, ZIO}
 
 case class ZioHttpServerOptions[R](
     createFile: ServerRequest => Task[TapirFile],
     deleteFile: TapirFile => RIO[R, Unit],
-    decodeFailureHandler: DecodeFailureHandler,
     interceptors: List[Interceptor[RIO[R, *]]]
 ) {
   def prependInterceptor(i: Interceptor[RIO[R, *]]): ZioHttpServerOptions[R] =
@@ -30,7 +28,6 @@ object ZioHttpServerOptions {
         ZioHttpServerOptions(
           defaultCreateFile,
           defaultDeleteFile,
-          ci.decodeFailureHandler,
           ci.interceptors
         )
     ).serverLog(defaultServerLog[R])


### PR DESCRIPTION
Reported in https://github.com/softwaremill/tapir/issues/2764

The `DecodeFailureHandler` should be provided only by .customiseInterceptors