### PR TITLE
Add json-schema to stability.md. Follow-up on #2904

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -27,6 +27,7 @@ input and output parameters. An endpoint specification can be interpreted as:
 * documentation. Currently supported:
   * [OpenAPI](docs/openapi.md)
   * [AsyncAPI](docs/asyncapi.md)
+  * [Json Schema](docs/json-schema.md)
 
 Depending on how you prefer to explore the library, take a look at one of the [examples](examples.md) or read on
 for a more detailed description of how tapir works!

--- a/doc/stability.md
+++ b/doc/stability.md
@@ -40,11 +40,10 @@ The modules are categorised using the following levels:
 
 ## Documentation interpreters
 
-| Module      | Level        |
-|-------------|--------------|
-| openapi     | stabilising  |
-| asyncapi    | stabilising  |
-| json-schema | experimental |
+| Module   | Level       |
+|----------|-------------|
+| openapi  | stabilising |
+| asyncapi | stabilising |
 
 ## Serverless interpreters
 

--- a/doc/stability.md
+++ b/doc/stability.md
@@ -40,10 +40,11 @@ The modules are categorised using the following levels:
 
 ## Documentation interpreters
 
-| Module   | Level       |
-|----------|-------------|
-| openapi  | stabilising |
-| asyncapi | stabilising |
+| Module      | Level        |
+|-------------|--------------|
+| openapi     | stabilising  |
+| asyncapi    | stabilising  |
+| json-schema | experimental |
 
 ## Serverless interpreters
 


### PR DESCRIPTION
Follow-up on #2904.

BTW, Json Schema documentation is not visibile in https://tapir.softwaremill.com/en/latest/ under section "DOCUMENTATION INTERPRETERS".

Do the docs need to be deployed manually?