### PR TITLE
Fixed obsolete code examples

### DIFF
--- a/doc/endpoint/contenttype.md
+++ b/doc/endpoint/contenttype.md
@@ -34,7 +34,7 @@ implicit val xmlCodecForOrganization: XmlCodec[Entity] = ???
 
 endpoint.out(
   oneOf(
-    oneOfVariant(customJsonBody[Entity]),
+    oneOfVariant(customCodecJsonBody[Entity]),
     oneOfVariant(xmlBody[Entity])
   )
 )

--- a/doc/endpoint/json.md
+++ b/doc/endpoint/json.md
@@ -21,7 +21,7 @@ better error reporting, in case one of the components required to create the jso
 
 ## Implicit json codecs
 
-If you have a custom, implicit `Codec[String, T, Json]` instance, you should use the `customJsonBody[T]` method instead. 
+If you have a custom, implicit `Codec[String, T, Json]` instance, you should use the `customCodecJsonBody[T]` method instead. 
 This description of endpoint input/output, instead of deriving a codec basing on other library-specific implicits, uses 
 the json codec that is in scope.
 


### PR DESCRIPTION
Documentation referring `customJsonBody` for Custom codec, though `customJsonBody` should be `customCodecJsonBody`, according to [migration](https://github.com/softwaremill/tapir/blob/c4ce0f5a08202998542c52b4f63c4aee7f02da7d/doc/migrating.md?plain=1#L12).