### PR TITLE
Allow ignoring logging of request handling for some endpoints

### DIFF
--- a/doc/server/debugging.md
+++ b/doc/server/debugging.md
@@ -6,21 +6,23 @@ handle a request?
 For this purpose, tapir provides optional logging. The logging options (and messages) can be customised by providing
 an instance of the `ServerLog` trait, which is part of [server options](options.md).
 
-An instance of the default implementation, `DefaultServerLog`, is available in the companion object for the 
+An instance of the default implementation, `DefaultServerLog`, is available in the companion object for the
 interpreter's options class, e.g. `Http4sServerOptions.defaultServerLog` or `NettyZioServerOptions.defaultServerLog`.
 
 This instance can be customised using the following flags:
 
 1. `logWhenReceived`: log when a request is first received (default: `false`, `DEBUG` log)
-2. `logWhenHandled`: log when a request is handled by an endpoint, or when the inputs can't be decoded, and the decode 
+2. `logWhenHandled`: log when a request is handled by an endpoint, or when the inputs can't be decoded, and the decode
    failure maps to a response (default: `true`, `DEBUG` log)
-3. `logAllDecodeFailures`: log each time when the inputs can't be decoded, and the decode failure doesn't map to a 
+3. `logAllDecodeFailures`: log each time when the inputs can't be decoded, and the decode failure doesn't map to a
    response (the next endpoint will be tried; default: `false`, `DEBUG` log)
-4. `logLogicExceptions`: log when there's an exception during evaluation of the server logic  (default: `true`, 
+4. `logLogicExceptions`: log when there's an exception during evaluation of the server logic (default: `true`,
    `ERROR` log)
 
 Logging all decode failures (3) might be helpful when debugging, but can also produce a large amount of logs, hence
 it's disabled by default.
 
-Even if logging for a particular category (as described above) is set to `true`, normal logger rules apply - if you 
+Additionally, you can customize the `DefaultServerLog` with `.ignoreEndpoints` to exclude some endpoints from logging with `logWhenHandled`, but not from logging exceptions and decoding failures.
+
+Even if logging for a particular category (as described above) is set to `true`, normal logger rules apply - if you
 don't see the logs, please verify your logging levels for the appropriate packages.

--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/log/ServerLog.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/log/ServerLog.scala
@@ -42,6 +42,10 @@ trait ServerLog[F[_]] {
 
   /** Invoked when an exception has been thrown when running the server logic or handling decode failures. */
   def exception(ctx: ExceptionContext[_, _], ex: Throwable, token: TOKEN): F[Unit]
+
+  /** Allows defining a list of endpoints which should not log requestHandled. Exceptions, decode failures and security failures will still be logged.
+    */
+  def ignoreEndpoints: Seq[AnyEndpoint] = Seq.empty
 }
 
 case class DefaultServerLog[F[_]](
@@ -58,7 +62,8 @@ case class DefaultServerLog[F[_]](
     showRequest: ServerRequest => String = _.showShort,
     showResponse: ServerResponse[_] => String = _.showShort,
     includeTiming: Boolean = true,
-    clock: Clock = Clock.systemUTC()
+    clock: Clock = Clock.systemUTC(),
+    override val ignoreEndpoints: Seq[AnyEndpoint] = Seq.empty
 ) extends ServerLog[F] {
 
   def doLogWhenReceived(f: String => F[Unit]): DefaultServerLog[F] = copy(doLogWhenReceived = f)
@@ -74,6 +79,7 @@ case class DefaultServerLog[F[_]](
   def showResponse(s: ServerResponse[_] => String): DefaultServerLog[F] = copy(showResponse = s)
   def includeTiming(doInclude: Boolean): DefaultServerLog[F] = copy(includeTiming = doInclude)
   def clock(c: Clock): DefaultServerLog[F] = copy(clock = c)
+  def ignoreEndpoints(es: Seq[AnyEndpoint]): DefaultServerLog[F] = copy(ignoreEndpoints = es)
 
   //
 

--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/log/ServerLog.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/log/ServerLog.scala
@@ -43,9 +43,10 @@ trait ServerLog[F[_]] {
   /** Invoked when an exception has been thrown when running the server logic or handling decode failures. */
   def exception(ctx: ExceptionContext[_, _], ex: Throwable, token: TOKEN): F[Unit]
 
-  /** Allows defining a list of endpoints which should not log requestHandled. Exceptions, decode failures and security failures will still be logged.
+  /** Allows defining a list of endpoints which should not log requestHandled. Exceptions, decode failures and security failures will still
+    * be logged.
     */
-  def ignoreEndpoints: Seq[AnyEndpoint] = Seq.empty
+  def ignoreEndpoints: Set[AnyEndpoint] = Set.empty
 }
 
 case class DefaultServerLog[F[_]](
@@ -63,7 +64,7 @@ case class DefaultServerLog[F[_]](
     showResponse: ServerResponse[_] => String = _.showShort,
     includeTiming: Boolean = true,
     clock: Clock = Clock.systemUTC(),
-    override val ignoreEndpoints: Seq[AnyEndpoint] = Seq.empty
+    override val ignoreEndpoints: Set[AnyEndpoint] = Set.empty
 ) extends ServerLog[F] {
 
   def doLogWhenReceived(f: String => F[Unit]): DefaultServerLog[F] = copy(doLogWhenReceived = f)
@@ -79,7 +80,7 @@ case class DefaultServerLog[F[_]](
   def showResponse(s: ServerResponse[_] => String): DefaultServerLog[F] = copy(showResponse = s)
   def includeTiming(doInclude: Boolean): DefaultServerLog[F] = copy(includeTiming = doInclude)
   def clock(c: Clock): DefaultServerLog[F] = copy(clock = c)
-  def ignoreEndpoints(es: Seq[AnyEndpoint]): DefaultServerLog[F] = copy(ignoreEndpoints = es)
+  def ignoreEndpoints(es: Seq[AnyEndpoint]): DefaultServerLog[F] = copy(ignoreEndpoints = es.toSet)
 
   //
 

--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/log/ServerLogInterceptor.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/log/ServerLogInterceptor.scala
@@ -7,6 +7,7 @@ import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.interceptor._
 import sttp.tapir.server.interpreter.BodyListener
 import sttp.tapir.server.model.ServerResponse
+import sttp.tapir.AnyEndpoint
 
 /** @tparam F The effect in which log messages are returned. */
 class ServerLogInterceptor[F[_]](serverLog: ServerLog[F]) extends RequestInterceptor[F] {
@@ -36,7 +37,10 @@ class ServerLogEndpointInterceptor[F[_], T](serverLog: ServerLog[F] { type TOKEN
         decodeHandler
           .onDecodeSuccess(ctx)
           .flatMap { response =>
-            serverLog.requestHandled(ctx, response, token).map(_ => response)
+            if (serverLog.ignoreEndpoints.contains(ctx.endpoint))
+              response.unit
+            else
+              serverLog.requestHandled(ctx, response, token).map(_ => response)
           }
           .handleError { case e: Throwable =>
             serverLog

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -13,7 +13,6 @@ import sttp.tapir._
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.CustomiseInterceptors
 import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
 import sttp.tapir.tests.Basic._
 import sttp.tapir.tests.TestUtil._
@@ -22,9 +21,6 @@ import sttp.tapir.tests.data.{FruitAmount, FruitError}
 
 import java.io.{ByteArrayInputStream, InputStream}
 import java.nio.ByteBuffer
-import sttp.tapir.server.interceptor.log.DefaultServerLog
-import cats.effect.kernel.Ref
-import java.util.concurrent.atomic.AtomicInteger
 
 class ServerBasicTests[F[_], OPTIONS, ROUTE](
     createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE],
@@ -656,69 +652,6 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
       ) { (backend, baseUri) =>
         basicStringRequest.get(uri"$baseUri/customer/20").send(backend).map(_.body shouldBe "e1") >>
           basicStringRequest.get(uri"$baseUri/customer/2").send(backend).map(_.body shouldBe "e2")
-      }
-    }, {
-      val logHandledCounter = new AtomicInteger(0)
-      val logErrorCounter = new AtomicInteger(0)
-      val incLogHandled: (String, Option[Throwable]) => F[Unit] = (_, _) =>
-        m.eval {
-          val _ = logHandledCounter.incrementAndGet()
-        }
-      val incLogException: (String, Throwable) => F[Unit] = (_, _) =>
-        m.eval {
-          val _ = logErrorCounter.incrementAndGet()
-        }
-      val silentEndpoint1 = endpoint.get
-        .in("silent_hello_2827")
-        .out(stringBody)
-
-      val silentEndpoint2 = endpoint.get
-        .in("silent_hello2_2827")
-        .out(stringBody)
-
-      val serverLog = DefaultServerLog(
-        doLogWhenReceived = _ => m.unit(()),
-        doLogAllDecodeFailures = (_, _) => m.unit(()),
-        noLog = m.unit(()),
-        doLogWhenHandled = incLogHandled,
-        doLogExceptions = incLogException,
-        ignoreEndpoints = Seq(silentEndpoint1, silentEndpoint2)
-      )
-      // https://github.com/softwaremill/tapir/issues/2827
-      testServer(
-        "Log events with provided functions, skipping certain endpoints",
-        NonEmptyList.of(
-          route(
-            List(
-              endpoint.get
-                .in("hello_2827")
-                .out(stringBody)
-                .serverLogic[F](_ => pureResult("result-hello".asRight[Unit])),
-              silentEndpoint1
-                .serverLogic[F](_ => pureResult("result-silent_hello".asRight[Unit])),
-              silentEndpoint2
-                .serverLogic[F](_ => m.error(new Exception("Boom!")))
-            ),
-            (_: CustomiseInterceptors[F, OPTIONS])
-              .serverLog(serverLog)
-          )
-        )
-      ) { (backend, baseUri) =>
-        basicStringRequest.get(uri"$baseUri/hello_2827").send(backend).map{ _ => 
-          logHandledCounter.get() shouldBe 1
-        } >>
-        basicStringRequest.get(uri"$baseUri/silent_hello_2827").send(backend).map { _ =>
-          logHandledCounter.get() shouldBe 1
-          logErrorCounter.get() shouldBe 0
-        } >>
-        basicStringRequest.get(uri"$baseUri/silent_hello2_2827").send(backend).map { _ =>
-          logHandledCounter.get() shouldBe 1
-          logErrorCounter.get() shouldBe 1
-        } >>
-        basicStringRequest.get(uri"$baseUri/hello_2827").send(backend).map { _ =>
-          logHandledCounter.get() shouldBe 2
-          logErrorCounter.get() shouldBe 1
-        }
       }
     }
   )

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerOptionsTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerOptionsTests.scala
@@ -8,8 +8,11 @@ import sttp.model._
 import sttp.monad.MonadError
 import sttp.tapir._
 import sttp.tapir.server.interceptor.CustomiseInterceptors
+import sttp.tapir.server.interceptor.log.DefaultServerLog
 import sttp.tapir.server.model.ValuedEndpointOutput
 import sttp.tapir.tests._
+
+import java.util.concurrent.atomic.AtomicInteger
 
 class ServerOptionsTests[F[_], OPTIONS, ROUTE](
     createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE],
@@ -38,6 +41,69 @@ class ServerOptionsTests[F[_], OPTIONS, ROUTE](
       basicRequest.get(uri"$baseUri/incorrect").send(backend).map { response =>
         response.code shouldBe StatusCode.NotFound
         response.body shouldBe Left("ERROR: Not Found")
+      }
+    }, {
+      // https://github.com/softwaremill/tapir/issues/2827
+      val logHandledCounter = new AtomicInteger(0)
+      val logErrorCounter = new AtomicInteger(0)
+      val incLogHandled: (String, Option[Throwable]) => F[Unit] = (_, _) =>
+        m.eval {
+          val _ = logHandledCounter.incrementAndGet()
+        }
+      val incLogException: (String, Throwable) => F[Unit] = (_, _) =>
+        m.eval {
+          val _ = logErrorCounter.incrementAndGet()
+        }
+      val silentEndpoint1 = endpoint.get
+        .in("silent_hello_2827")
+        .out(stringBody)
+
+      val silentEndpoint2 = endpoint.get
+        .in("silent_hello2_2827")
+        .out(stringBody)
+
+      val serverLog = DefaultServerLog(
+        doLogWhenReceived = _ => m.unit(()),
+        doLogAllDecodeFailures = (_, _) => m.unit(()),
+        noLog = m.unit(()),
+        doLogWhenHandled = incLogHandled,
+        doLogExceptions = incLogException
+      )
+        .ignoreEndpoints(Seq(silentEndpoint1, silentEndpoint2))
+      testServer(
+        "Log events with provided functions, skipping certain endpoints",
+        NonEmptyList.of(
+          route(
+            List(
+              endpoint.get
+                .in("hello_2827")
+                .out(stringBody)
+                .serverLogic[F](_ => pureResult("result-hello".asRight[Unit])),
+              silentEndpoint1
+                .serverLogic[F](_ => pureResult("result-silent_hello".asRight[Unit])),
+              silentEndpoint2
+                .serverLogic[F](_ => m.error(new Exception("Boom!")))
+            ),
+            (_: CustomiseInterceptors[F, OPTIONS])
+              .serverLog(serverLog)
+          )
+        )
+      ) { (backend, baseUri) =>
+        basicStringRequest.get(uri"$baseUri/hello_2827").send(backend).map { _ =>
+          logHandledCounter.get() shouldBe 1
+        } >>
+          basicStringRequest.get(uri"$baseUri/silent_hello_2827").send(backend).map { _ =>
+            logHandledCounter.get() shouldBe 1
+            logErrorCounter.get() shouldBe 0
+          } >>
+          basicStringRequest.get(uri"$baseUri/silent_hello2_2827").send(backend).map { _ =>
+            logHandledCounter.get() shouldBe 1
+            logErrorCounter.get() shouldBe 1
+          } >>
+          basicStringRequest.get(uri"$baseUri/hello_2827").send(backend).map { _ =>
+            logHandledCounter.get() shouldBe 2
+            logErrorCounter.get() shouldBe 1
+          }
       }
     }
   )


### PR DESCRIPTION
Implements https://github.com/softwaremill/tapir/issues/2827

This new API is similar to what we already provide in `.metricsInterceptor`, which allows setting `ignoreEndpoints: Seq[AnyEndpoint]`.
For logging, such method is now available on the `DefaultServerLog` class, allowing to specify server options like:

```scala
Http4sServerOptions
  .customiseInterceptors[IO]
  .serverLog(Http4sServerOptions.defaultServerLog.ignoreEndpoints(Seq(healthCheckEndpoint, versionEndpoint))
  .options
```

This will skip listed endpoints when logging in `requestHandled`, but still keep logging exceptions and decoding failure errors if they are enabled.