### PR TITLE
Update magnolia to 1.3.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -390,7 +390,7 @@ lazy val core: ProjectMatrix = (projectMatrix in file("core"))
     libraryDependencies ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((3, _)) =>
-          Seq("com.softwaremill.magnolia1_3" %%% "magnolia" % "1.3.1")
+          Seq("com.softwaremill.magnolia1_3" %%% "magnolia" % "1.3.2")
         case _ =>
           Seq(
             "com.softwaremill.magnolia1_2" %%% "magnolia" % "1.1.3",


### PR DESCRIPTION
This update fixes an issue with compilation warnings caused by https://github.com/softwaremill/magnolia/issues/472