### PR TITLE
 [bugfix] Add configuration parameter to customiseInterceptors in PlayServerOptions

### DIFF
--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerOptions.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerOptions.scala
@@ -37,7 +37,7 @@ object PlayServerOptions {
         PlayServerOptions(
           SingletonTemporaryFileCreator,
           defaultDeleteFile(_),
-          DefaultActionBuilder.apply(PlayBodyParsers.apply().anyContent),
+          DefaultActionBuilder.apply(PlayBodyParsers.apply(conf = conf).anyContent),
           PlayBodyParsers.apply(conf = conf),
           ci.decodeFailureHandler,
           ci.interceptors

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerOptions.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerOptions.scala
@@ -67,7 +67,7 @@ object PlayServerOptions {
 
   def default(implicit mat: Materializer, ec: ExecutionContext): PlayServerOptions = customiseInterceptors().options
 
-  lazy val conf = ConfigFactory.load
+  private lazy val conf = ConfigFactory.load
 
   lazy val defaultParserConfiguration = {
     ParserConfiguration(

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerOptions.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayServerOptions.scala
@@ -1,6 +1,8 @@
 package sttp.tapir.server.play
 
 import akka.stream.Materializer
+import com.typesafe.config.ConfigFactory
+import play.api.http.ParserConfiguration
 import play.api.Logger
 import play.api.libs.Files.{SingletonTemporaryFileCreator, TemporaryFileCreator}
 import play.api.mvc._
@@ -26,7 +28,7 @@ case class PlayServerOptions(
 object PlayServerOptions {
 
   /** Allows customising the interceptors used by the server interpreter. */
-  def customiseInterceptors(implicit
+  def customiseInterceptors(conf: ParserConfiguration = defaultParserConfiguration)(implicit
       mat: Materializer,
       ec: ExecutionContext
   ): CustomiseInterceptors[Future, PlayServerOptions] =
@@ -36,7 +38,7 @@ object PlayServerOptions {
           SingletonTemporaryFileCreator,
           defaultDeleteFile(_),
           DefaultActionBuilder.apply(PlayBodyParsers.apply().anyContent),
-          PlayBodyParsers.apply(),
+          PlayBodyParsers.apply(conf = conf),
           ci.decodeFailureHandler,
           ci.interceptors
         )
@@ -63,7 +65,16 @@ object PlayServerOptions {
     }
   }
 
-  def default(implicit mat: Materializer, ec: ExecutionContext): PlayServerOptions = customiseInterceptors.options
+  def default(implicit mat: Materializer, ec: ExecutionContext): PlayServerOptions = customiseInterceptors().options
+
+  lazy val conf = ConfigFactory.load
+
+  lazy val defaultParserConfiguration = {
+    ParserConfiguration(
+      maxMemoryBuffer = conf.getMemorySize("play.http.parser.maxMemoryBuffer").toBytes,
+      maxDiskBuffer = conf.getMemorySize("play.http.parser.maxDiskBuffer").toBytes
+    )
+  }
 
   lazy val logger: Logger = Logger(this.getClass.getPackage.getName)
 }

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerStubTest.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerStubTest.scala
@@ -18,7 +18,7 @@ class PlayCreateServerStubTest extends CreateServerStubTest[Future, PlayServerOp
 
   override def customiseInterceptors: CustomiseInterceptors[Future, PlayServerOptions] = {
     import actorSystem.dispatcher
-    PlayServerOptions.customiseInterceptors
+    PlayServerOptions.customiseInterceptors()
   }
   override def stub[R]: SttpBackendStub[Future, R] = SttpBackendStub(new FutureMonad()(ExecutionContext.global))
   override def asFuture[A]: Future[A] => Future[A] = identity

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
@@ -22,7 +22,7 @@ class PlayTestServerInterpreter(implicit actorSystem: ActorSystem)
   import actorSystem.dispatcher
 
   override def route(es: List[ServerEndpoint[AkkaStreams with WebSockets, Future]], interceptors: Interceptors): Routes = {
-    val serverOptions: PlayServerOptions = interceptors(PlayServerOptions.customiseInterceptors).options
+    val serverOptions: PlayServerOptions = interceptors(PlayServerOptions.customiseInterceptors()).options
       // increase the default maxMemoryBuffer to 10M so that tests pass
       .copy(playBodyParsers = PlayBodyParsers(conf = ParserConfiguration(maxMemoryBuffer = 1024000)))
     PlayServerInterpreter(serverOptions).toRoutes(es)


### PR DESCRIPTION
Add configuration parameter which set maxMemoryBuffer and maxDiskBuffer from application.conf by default