### PR TITLE
Changed zio metric type for active requests from Count to Gauge.

### DIFF
--- a/metrics/zio-metrics/src/test/scala/sttp/tapir/server/metrics/zio/ZioMetricsTest.scala
+++ b/metrics/zio-metrics/src/test/scala/sttp/tapir/server/metrics/zio/ZioMetricsTest.scala
@@ -6,10 +6,10 @@ import sttp.tapir.server.TestUtil._
 import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureInterceptor, DefaultDecodeFailureHandler}
 import sttp.tapir.server.interpreter.ServerInterpreter
 import sttp.tapir.server.metrics.zio.ZioMetrics.DefaultNamespace
-import zio.metrics.Metric.Counter
+import zio._
+import zio.metrics.Metric.{Counter, Gauge}
 import zio.metrics._
 import zio.test._
-import zio._
 
 object ZioMetricsTest extends ZIOSpecDefault {
 
@@ -32,8 +32,8 @@ object ZioMetricsTest extends ZIOSpecDefault {
           )
 
         // when
-        val active: Counter[Long] = ZioMetrics
-          .getActiveRequestCounter("tapir")
+        val active: Gauge[Long] = ZioMetrics
+          .getActiveRequestGauge("tapir")
           .tagged(
             Set(MetricLabel("path", "/person"), MetricLabel("method", "GET"))
           )
@@ -48,7 +48,7 @@ object ZioMetricsTest extends ZIOSpecDefault {
           state <- active.value
           _ <- ZIO.succeed(Thread.sleep(150))
           state2 <- active.value
-        } yield assertTrue(state == MetricState.Counter(1)) && assertTrue(state2 == MetricState.Counter(0))
+        } yield assertTrue(state == MetricState.Gauge(1)) && assertTrue(state2 == MetricState.Gauge(0))
 
       } @@ TestAspect.retry(Schedule.recurs(5)),
       test("can collect requests total") {


### PR DESCRIPTION
A counter is not a good way to represent requests active metrics, as many platforms handle counters differently than a gauge. It seems like keeping track of the active requests should be represented as a gauge.

According to:

Prometheus docs: https://prometheus.io/docs/concepts/metric_types/#counter
> Do not use a counter to expose a value that can decrease. For example, do not use a counter for the number of currently running processes; instead use a gauge.

Datadog docs: https://docs.datadoghq.com/metrics/types/?tab=count
> The COUNT metric submission type represents the total number of event occurrences in one time interval. A COUNT can be used to track the total number of connections made to a database or the total number of requests to an endpoint.