### PR TITLE
Netty streaming for Cats Effect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1353,7 +1353,10 @@ lazy val nettyServer: ProjectMatrix = (projectMatrix in file("server/netty-serve
   .settings(commonJvmSettings)
   .settings(
     name := "tapir-netty-server",
-    libraryDependencies ++= Seq("io.netty" % "netty-all" % Versions.nettyAll)
+    libraryDependencies ++= Seq(
+      "io.netty" % "netty-all" % Versions.nettyAll,
+      "com.typesafe.netty" % "netty-reactive-streams-http" % "2.0.8"
+    )
       ++ loggerDependencies,
     // needed because of https://github.com/coursier/coursier/issues/2016
     useCoursier := false
@@ -1362,7 +1365,10 @@ lazy val nettyServer: ProjectMatrix = (projectMatrix in file("server/netty-serve
   .dependsOn(serverCore, serverTests % Test)
 
 lazy val nettyServerCats: ProjectMatrix = nettyServerProject("cats", catsEffect)
-  .settings(libraryDependencies += "com.softwaremill.sttp.shared" %% "fs2" % Versions.sttpShared)
+  .settings(libraryDependencies ++= Seq(
+    "com.softwaremill.sttp.shared" %% "fs2" % Versions.sttpShared,
+    "co.fs2" %% "fs2-reactive-streams" % Versions.fs2
+  ))
 
 lazy val nettyServerZio: ProjectMatrix = nettyServerProject("zio", zio)
   .settings(libraryDependencies += "dev.zio" %% "zio-interop-cats" % Versions.zioInteropCats)

--- a/build.sbt
+++ b/build.sbt
@@ -1355,7 +1355,7 @@ lazy val nettyServer: ProjectMatrix = (projectMatrix in file("server/netty-serve
     name := "tapir-netty-server",
     libraryDependencies ++= Seq(
       "io.netty" % "netty-all" % Versions.nettyAll,
-      "com.typesafe.netty" % "netty-reactive-streams-http" % "2.0.8"
+      "com.typesafe.netty" % "netty-reactive-streams-http" % Versions.nettyReactiveStreams
     )
       ++ loggerDependencies,
     // needed because of https://github.com/coursier/coursier/issues/2016

--- a/doc/server/netty.md
+++ b/doc/server/netty.md
@@ -60,7 +60,7 @@ NettyFutureServer().port(9090).addEndpoints(???)
 NettyFutureServer(NettyFutureServerOptions.customiseInterceptors.serverLog(None).options)
 
 // customise Netty config
-NettyFutureServer(NettyConfig.default.socketBacklog(256))
+NettyFutureServer(NettyConfig.defaultNoStreaming.socketBacklog(256))
 ```
 
 ## Domain socket support

--- a/doc/server/netty.md
+++ b/doc/server/netty.md
@@ -16,7 +16,7 @@ To expose an endpoint using a [Netty](https://netty.io)-based server, first add 
 Then, use:
 
 - `NettyFutureServer().addEndpoints` to expose `Future`-based server endpoints.
-- `NettyCatsServer().addEndpoints` to expose `F`-based server endpoints, where `F` is any cats-effect supported effect. [Streaming](../endpoint/streaming.md) request and response body is supported with fs2.
+- `NettyCatsServer().addEndpoints` to expose `F`-based server endpoints, where `F` is any cats-effect supported effect. [Streaming](../endpoint/streaming.md) request and response bodies is supported with fs2.
 - `NettyZioServer().addEndpoints` to expose `ZIO`-based server endpoints, where `R` represents ZIO requirements supported effect.
 
 These methods require a single, or a list of `ServerEndpoint`s, which can be created by adding [server logic](logic.md)

--- a/doc/server/netty.md
+++ b/doc/server/netty.md
@@ -15,11 +15,11 @@ To expose an endpoint using a [Netty](https://netty.io)-based server, first add 
 
 Then, use:
 
-* `NettyFutureServer().addEndpoints` to expose `Future`-based server endpoints.
-* `NettyCatsServer().addEndpoints` to expose `F`-based server endpoints, where `F` is any cats-effect supported effect.
-* `NettyZioServer().addEndpoints` to expose `ZIO`-based server endpoints, where `R` represents ZIO requirements supported effect.
+- `NettyFutureServer().addEndpoints` to expose `Future`-based server endpoints.
+- `NettyCatsServer().addEndpoints` to expose `F`-based server endpoints, where `F` is any cats-effect supported effect. [Streaming](../endpoint/streaming.md) request and response body is supported with fs2.
+- `NettyZioServer().addEndpoints` to expose `ZIO`-based server endpoints, where `R` represents ZIO requirements supported effect.
 
-These methods require a single, or a list of `ServerEndpoint`s, which can be created by adding [server logic](logic.md) 
+These methods require a single, or a list of `ServerEndpoint`s, which can be created by adding [server logic](logic.md)
 to an endpoint.
 
 For example:
@@ -36,7 +36,7 @@ val helloWorld = endpoint
   .out(stringBody)
   .serverLogic(name => Future.successful[Either[Unit, String]](Right(s"Hello, $name!")))
 
-val binding: Future[NettyFutureServerBinding] = 
+val binding: Future[NettyFutureServerBinding] =
   NettyFutureServer().addEndpoint(helloWorld).start()
 ```
 

--- a/examples/src/main/scala/sttp/tapir/examples/streaming/StreamingNettyFs2Server.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/streaming/StreamingNettyFs2Server.scala
@@ -43,29 +43,31 @@ object StreamingNettyFs2Server extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = {
     // starting the server
-  NettyCatsServer
-    .io()
-    .use { server =>
+    NettyCatsServer
+      .io()
+      .use { server =>
 
-      val effect: IO[NettyCatsServerBinding[IO]] = server
-        .port(declaredPort)
-        .host(declaredHost)
-        .addEndpoint(serverEndpoint)
-        .start()
+        val startServer: IO[NettyCatsServerBinding[IO]] = server
+          .port(declaredPort)
+          .host(declaredHost)
+          .addEndpoint(serverEndpoint)
+          .start()
 
-      effect.map { binding =>
+        startServer
+          .map { binding =>
 
-        val port = binding.port
-        val host = binding.hostName
-        println(s"Server started at port = ${binding.port}")
+            val port = binding.port
+            val host = binding.hostName
+            println(s"Server started at port = ${binding.port}")
 
-        val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
-        val result: String = basicRequest.response(asStringAlways).get(uri"http://$declaredHost:$declaredPort/receive").send(backend).body
-        println("Got result: " + result)
+            val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
+            val result: String =
+              basicRequest.response(asStringAlways).get(uri"http://$declaredHost:$declaredPort/receive").send(backend).body
+            println("Got result: " + result)
 
-        assert(result == "abcd" * 25)
+            assert(result == "abcd" * 25)
+          }
+          .as(ExitCode.Success)
       }
-      .as(ExitCode.Success)
-  }
   }
 }

--- a/examples/src/main/scala/sttp/tapir/examples/streaming/StreamingNettyFs2Server.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/streaming/StreamingNettyFs2Server.scala
@@ -1,0 +1,71 @@
+package sttp.tapir.examples.streaming
+
+import cats.effect.{ExitCode, IO, IOApp}
+import cats.implicits._
+import fs2.{Chunk, Stream}
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.client3._
+import sttp.model.HeaderNames
+import sttp.tapir._
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.netty.cats.{NettyCatsServer, NettyCatsServerBinding}
+
+import java.nio.charset.StandardCharsets
+import scala.concurrent.duration._
+
+object StreamingNettyFs2Server extends IOApp {
+  // corresponds to: GET /receive?name=...
+  // We need to provide both the schema of the value (for documentation), as well as the format (media type) of the
+  // body. Here, the schema is a `string` (set by `streamTextBody`) and the media type is `text/plain`.
+  val streamingEndpoint: PublicEndpoint[Unit, Unit, (Long, Stream[IO, Byte]), Fs2Streams[IO]] =
+    endpoint.get
+      .in("receive")
+      .out(header[Long](HeaderNames.ContentLength))
+      .out(streamTextBody(Fs2Streams[IO])(CodecFormat.TextPlain(), Some(StandardCharsets.UTF_8)))
+
+  val serverEndpoint: ServerEndpoint[Fs2Streams[IO], IO] = streamingEndpoint
+    .serverLogicSuccess { _ =>
+      val size = 100L
+      Stream
+        .emit(List[Char]('a', 'b', 'c', 'd'))
+        .repeat
+        .flatMap(list => Stream.chunk(Chunk.seq(list)))
+        .metered[IO](100.millis)
+        .take(size)
+        .covary[IO]
+        .map(_.toByte)
+        .pure[IO]
+        .map(s => (size, s))
+    }
+
+  private val declaredPort = 9090
+  private val declaredHost = "localhost"
+
+  override def run(args: List[String]): IO[ExitCode] = {
+    // starting the server
+  NettyCatsServer
+    .io()
+    .use { server =>
+
+      val effect: IO[NettyCatsServerBinding[IO]] = server
+        .port(declaredPort)
+        .host(declaredHost)
+        .addEndpoint(serverEndpoint)
+        .start()
+
+      effect.map { binding =>
+
+        val port = binding.port
+        val host = binding.hostName
+        println(s"Server started at port = ${binding.port}")
+
+        val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
+        val result: String = basicRequest.response(asStringAlways).get(uri"http://$declaredHost:$declaredPort/receive").send(backend).body
+        println("Got result: " + result)
+
+        assert(result == "abcd" * 25)
+      }
+      .as(ExitCode.Success)
+  }
+  }
+}

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -19,6 +19,7 @@ object Versions {
   val finatra = "22.12.0"
   val catbird = "21.12.0"
   val json4s = "4.0.6"
+  val nettyReactiveStreams = "2.0.8"
   val sprayJson = "1.3.6"
   val scalaCheck = "1.17.0"
   val scalaTest = "3.2.16"

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServer.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServer.scala
@@ -81,9 +81,9 @@ case class NettyCatsServer[F[_]: Async](routes: Vector[Route[F]], options: Netty
 
 object NettyCatsServer {
   def apply[F[_]: Async](dispatcher: Dispatcher[F]): NettyCatsServer[F] =
-    NettyCatsServer(Vector.empty, NettyCatsServerOptions.default(dispatcher), NettyConfig.default)
+    NettyCatsServer(Vector.empty, NettyCatsServerOptions.default(dispatcher), NettyConfig.defaultWithStreaming)
   def apply[F[_]: Async](options: NettyCatsServerOptions[F]): NettyCatsServer[F] =
-    NettyCatsServer(Vector.empty, options, NettyConfig.default)
+    NettyCatsServer(Vector.empty, options, NettyConfig.defaultWithStreaming)
   def apply[F[_]: Async](dispatcher: Dispatcher[F], config: NettyConfig): NettyCatsServer[F] =
     NettyCatsServer(Vector.empty, NettyCatsServerOptions.default(dispatcher), config)
   def apply[F[_]: Async](options: NettyCatsServerOptions[F], config: NettyConfig): NettyCatsServer[F] =

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServer.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServer.scala
@@ -61,7 +61,7 @@ case class NettyCatsServer[F[_]: Async](routes: Vector[Route[F]], options: Netty
     val channelFuture =
       NettyBootstrap(
         config,
-        new NettyServerHandler(route, (f: () => F[Unit]) => options.dispatcher.unsafeToFuture(f())),
+        new NettyServerHandler(route, (f: () => F[Unit]) => options.dispatcher.unsafeToFuture(f()), config.maxContentLength),
         eventLoopGroup,
         socketOverride
       )

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServer.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServer.scala
@@ -15,15 +15,16 @@ import sttp.tapir.server.netty.{NettyConfig, Route}
 import java.net.{InetSocketAddress, SocketAddress}
 import java.nio.file.{Path, Paths}
 import java.util.UUID
+import sttp.capabilities.fs2.Fs2Streams
 
 case class NettyCatsServer[F[_]: Async](routes: Vector[Route[F]], options: NettyCatsServerOptions[F], config: NettyConfig) {
-  def addEndpoint(se: ServerEndpoint[Any, F]): NettyCatsServer[F] = addEndpoints(List(se))
-  def addEndpoint(se: ServerEndpoint[Any, F], overrideOptions: NettyCatsServerOptions[F]): NettyCatsServer[F] =
+  def addEndpoint(se: ServerEndpoint[Fs2Streams[F], F]): NettyCatsServer[F] = addEndpoints(List(se))
+  def addEndpoint(se: ServerEndpoint[Fs2Streams[F], F], overrideOptions: NettyCatsServerOptions[F]): NettyCatsServer[F] =
     addEndpoints(List(se), overrideOptions)
-  def addEndpoints(ses: List[ServerEndpoint[Any, F]]): NettyCatsServer[F] = addRoute(
+  def addEndpoints(ses: List[ServerEndpoint[Fs2Streams[F], F]]): NettyCatsServer[F] = addRoute(
     NettyCatsServerInterpreter(options).toRoute(ses)
   )
-  def addEndpoints(ses: List[ServerEndpoint[Any, F]], overrideOptions: NettyCatsServerOptions[F]): NettyCatsServer[F] = addRoute(
+  def addEndpoints(ses: List[ServerEndpoint[Fs2Streams[F], F]], overrideOptions: NettyCatsServerOptions[F]): NettyCatsServer[F] = addRoute(
     NettyCatsServerInterpreter(overrideOptions).toRoute(ses)
   )
 

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
@@ -3,27 +3,57 @@ package sttp.tapir.server.netty.cats
 import cats.effect.Async
 import cats.effect.std.Dispatcher
 import sttp.monad.MonadError
+import sttp.monad.syntax._
 import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.netty.Route
-import sttp.tapir.server.netty.internal.{NettyServerInterpreter, RunAsync}
+import sttp.tapir.server.interpreter.BodyListener
+import sttp.tapir.server.netty.internal.NettyBodyListener
+import sttp.tapir.server.netty.NettyResponse
+import sttp.tapir.server.interpreter.ServerInterpreter
+import sttp.tapir.server.interpreter.FilterServerEndpoints
+import sttp.tapir.server.netty.internal.NettyRequestBody
+import sttp.tapir.server.netty.internal.NettyToResponseBody
+import sttp.tapir.server.interceptor.reject.RejectInterceptor
+import sttp.tapir.server.netty.NettyServerRequest
+import sttp.tapir.server.interceptor.RequestResult
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.tapir.server.netty.internal.RunAsync
+import sttp.tapir.server.netty.internal._
 
 trait NettyCatsServerInterpreter[F[_]] {
   implicit def async: Async[F]
   def nettyServerOptions: NettyCatsServerOptions[F]
 
-  def toRoute(ses: List[ServerEndpoint[Any, F]]): Route[F] = {
+  def toRoute(ses: List[ServerEndpoint[Fs2Streams[F], F]]): Route[F] = {
+
     implicit val monad: MonadError[F] = new CatsMonadError[F]
     val runAsync = new RunAsync[F] {
       override def apply[T](f: => F[T]): Unit = nettyServerOptions.dispatcher.unsafeRunAndForget(f)
     }
-    NettyServerInterpreter.toRoute(
-      ses,
-      nettyServerOptions.interceptors,
-      nettyServerOptions.createFile,
-      nettyServerOptions.deleteFile,
-      runAsync
+    implicit val bodyListener: BodyListener[F, NettyResponse] = new NettyBodyListener(runAsync)
+
+    val interceptors = nettyServerOptions.interceptors
+    val createFile = nettyServerOptions.createFile
+    val deleteFile = nettyServerOptions.deleteFile
+
+    val serverInterpreter = new ServerInterpreter[Fs2Streams[F], F, NettyResponse, Fs2Streams[F]](
+      FilterServerEndpoints(ses),
+      new NettyCatsRequestBody(createFile),
+      new NettyCatsToResponseBody(nettyServerOptions.dispatcher),
+      RejectInterceptor.disableWhenSingleEndpoint(interceptors, ses),
+      deleteFile
     )
+
+    val handler: Route[F] = { (request: NettyServerRequest) =>
+      serverInterpreter(request)
+        .map {
+          case RequestResult.Response(response) => Some(response)
+          case RequestResult.Failure(_)         => None
+        }
+    }
+
+    handler
   }
 }
 

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
@@ -32,7 +32,7 @@ trait NettyCatsServerInterpreter[F[_]] {
     val serverInterpreter = new ServerInterpreter[Fs2Streams[F], F, NettyResponse, Fs2Streams[F]](
       FilterServerEndpoints(ses),
       new NettyCatsRequestBody(createFile),
-      new NettyCatsToResponseBody(nettyServerOptions.dispatcher), 
+      new NettyCatsToResponseBody(nettyServerOptions.dispatcher, delegate = new NettyToResponseBody), 
       RejectInterceptor.disableWhenSingleEndpoint(interceptors, ses),
       deleteFile
     )

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
@@ -32,7 +32,7 @@ trait NettyCatsServerInterpreter[F[_]] {
     val serverInterpreter = new ServerInterpreter[Fs2Streams[F], F, NettyResponse, Fs2Streams[F]](
       FilterServerEndpoints(ses),
       new NettyCatsRequestBody(createFile),
-      new NettyCatsToResponseBody(nettyServerOptions.dispatcher),
+      new NettyCatsToResponseBody(nettyServerOptions.dispatcher, Some(10000)), // TODO pass from NettyCatsServer?
       RejectInterceptor.disableWhenSingleEndpoint(interceptors, ses),
       deleteFile
     )

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
@@ -32,7 +32,7 @@ trait NettyCatsServerInterpreter[F[_]] {
     val serverInterpreter = new ServerInterpreter[Fs2Streams[F], F, NettyResponse, Fs2Streams[F]](
       FilterServerEndpoints(ses),
       new NettyCatsRequestBody(createFile),
-      new NettyCatsToResponseBody(nettyServerOptions.dispatcher, Some(10000)), // TODO pass from NettyCatsServer?
+      new NettyCatsToResponseBody(nettyServerOptions.dispatcher), 
       RejectInterceptor.disableWhenSingleEndpoint(interceptors, ses),
       deleteFile
     )

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
@@ -2,24 +2,16 @@ package sttp.tapir.server.netty.cats
 
 import cats.effect.Async
 import cats.effect.std.Dispatcher
+import sttp.capabilities.fs2.Fs2Streams
 import sttp.monad.MonadError
 import sttp.monad.syntax._
 import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.netty.Route
-import sttp.tapir.server.interpreter.BodyListener
-import sttp.tapir.server.netty.internal.NettyBodyListener
-import sttp.tapir.server.netty.NettyResponse
-import sttp.tapir.server.interpreter.ServerInterpreter
-import sttp.tapir.server.interpreter.FilterServerEndpoints
-import sttp.tapir.server.netty.internal.NettyRequestBody
-import sttp.tapir.server.netty.internal.NettyToResponseBody
-import sttp.tapir.server.interceptor.reject.RejectInterceptor
-import sttp.tapir.server.netty.NettyServerRequest
 import sttp.tapir.server.interceptor.RequestResult
-import sttp.capabilities.fs2.Fs2Streams
-import sttp.tapir.server.netty.internal.RunAsync
-import sttp.tapir.server.netty.internal._
+import sttp.tapir.server.interceptor.reject.RejectInterceptor
+import sttp.tapir.server.interpreter.{BodyListener, FilterServerEndpoints, ServerInterpreter}
+import sttp.tapir.server.netty.internal.{NettyBodyListener, RunAsync, _}
+import sttp.tapir.server.netty.{NettyResponse, NettyServerRequest, Route}
 
 trait NettyCatsServerInterpreter[F[_]] {
   implicit def async: Async[F]

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsRequestBody.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsRequestBody.scala
@@ -1,0 +1,48 @@
+package sttp.tapir.server.netty.internal
+
+import cats.effect.{Async, Sync}
+import cats.syntax.all._
+import io.netty.buffer.{ByteBufInputStream, ByteBufUtil}
+import io.netty.handler.codec.http.FullHttpRequest
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.tapir.{FileRange, InputStreamRange, RawBodyType, TapirFile}
+import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.interpreter.{RawValue, RequestBody}
+
+import java.nio.ByteBuffer
+import java.nio.file.Files
+
+private[netty] class NettyCatsRequestBody[F[_]](createFile: ServerRequest => F[TapirFile])(implicit val monad: Async[F])
+    extends RequestBody[F, Fs2Streams[F]] {
+
+  val streamChunkSize = 8192
+  override val streams: Fs2Streams[F] = Fs2Streams[F]
+
+  override def toRaw[R](serverRequest: ServerRequest, bodyType: RawBodyType[R]): F[RawValue[R]] = {
+
+    /** [[ByteBufUtil.getBytes(io.netty.buffer.ByteBuf)]] copies buffer without affecting reader index of the original. */
+    def requestContentAsByteArray = ByteBufUtil.getBytes(nettyRequest(serverRequest).content())
+
+    bodyType match {
+      case RawBodyType.StringBody(charset) => monad.delay(RawValue(nettyRequest(serverRequest).content().toString(charset)))
+      case RawBodyType.ByteArrayBody       => monad.delay(RawValue(requestContentAsByteArray))
+      case RawBodyType.ByteBufferBody      => monad.delay(RawValue(ByteBuffer.wrap(requestContentAsByteArray)))
+      case RawBodyType.InputStreamBody     => monad.delay(RawValue(new ByteBufInputStream(nettyRequest(serverRequest).content())))
+      case RawBodyType.InputStreamRangeBody =>
+        monad.delay(RawValue(InputStreamRange(() => new ByteBufInputStream(nettyRequest(serverRequest).content()))))
+      case RawBodyType.FileBody =>
+        createFile(serverRequest)
+          .map(file => {
+            Files.write(file.toPath, requestContentAsByteArray)
+            RawValue(FileRange(file), Seq(FileRange(file)))
+          })
+      case _: RawBodyType.MultipartBody => ???
+    }
+  }
+
+  override def toStream(serverRequest: ServerRequest): streams.BinaryStream = {
+    fs2.io.readInputStream(Sync[F].delay(new ByteBufInputStream(nettyRequest(serverRequest).content())), streamChunkSize)
+  }
+
+  private def nettyRequest(serverRequest: ServerRequest): FullHttpRequest = serverRequest.underlying.asInstanceOf[FullHttpRequest]
+}

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsRequestBody.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsRequestBody.scala
@@ -8,9 +8,15 @@ import sttp.capabilities.fs2.Fs2Streams
 import sttp.tapir.{FileRange, InputStreamRange, RawBodyType, TapirFile}
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.interpreter.{RawValue, RequestBody}
-
+import java.io.ByteArrayInputStream
 import java.nio.ByteBuffer
-import java.nio.file.Files
+import com.typesafe.netty.http.StreamedHttpRequest
+import com.typesafe.netty.http.DefaultStreamedHttpRequest
+import fs2.interop.reactivestreams.StreamSubscriber
+import io.netty.handler.codec.http.HttpContent
+import fs2.Chunk
+import fs2.io.file.Files
+import fs2.io.file.Path
 
 private[netty] class NettyCatsRequestBody[F[_]](createFile: ServerRequest => F[TapirFile])(implicit val monad: Async[F])
     extends RequestBody[F, Fs2Streams[F]] {
@@ -20,29 +26,46 @@ private[netty] class NettyCatsRequestBody[F[_]](createFile: ServerRequest => F[T
 
   override def toRaw[R](serverRequest: ServerRequest, bodyType: RawBodyType[R]): F[RawValue[R]] = {
 
-    /** [[ByteBufUtil.getBytes(io.netty.buffer.ByteBuf)]] copies buffer without affecting reader index of the original. */
-    def requestContentAsByteArray = ByteBufUtil.getBytes(nettyRequest(serverRequest).content())
-
     bodyType match {
-      case RawBodyType.StringBody(charset) => monad.delay(RawValue(nettyRequest(serverRequest).content().toString(charset)))
-      case RawBodyType.ByteArrayBody       => monad.delay(RawValue(requestContentAsByteArray))
-      case RawBodyType.ByteBufferBody      => monad.delay(RawValue(ByteBuffer.wrap(requestContentAsByteArray)))
-      case RawBodyType.InputStreamBody     => monad.delay(RawValue(new ByteBufInputStream(nettyRequest(serverRequest).content())))
+      case RawBodyType.StringBody(charset) => nettyRequestBytes(serverRequest).map(bs => RawValue(new String(bs, charset)))
+      case RawBodyType.ByteArrayBody =>
+        nettyRequestBytes(serverRequest).map(RawValue(_))
+      case RawBodyType.ByteBufferBody =>
+        nettyRequestBytes(serverRequest).map(bs => RawValue(ByteBuffer.wrap(bs)))
+      case RawBodyType.InputStreamBody =>
+        nettyRequestBytes(serverRequest).map(bs => RawValue(new ByteArrayInputStream(bs)))
       case RawBodyType.InputStreamRangeBody =>
-        monad.delay(RawValue(InputStreamRange(() => new ByteBufInputStream(nettyRequest(serverRequest).content()))))
+        nettyRequestBytes(serverRequest).map(bs => RawValue(InputStreamRange(() => new ByteArrayInputStream(bs))))
       case RawBodyType.FileBody =>
         createFile(serverRequest)
-          .map(file => {
-            Files.write(file.toPath, requestContentAsByteArray)
-            RawValue(FileRange(file), Seq(FileRange(file)))
+          .flatMap(tapirFile => {
+            toStream(serverRequest)
+              .through(
+                Files[F](Files.forAsync[F]).writeAll(Path.fromNioPath(tapirFile.toPath))
+              )
+              .compile
+              .drain
+              .map(_ => RawValue(FileRange(tapirFile), Seq(FileRange(tapirFile))))
           })
       case _: RawBodyType.MultipartBody => ???
     }
   }
 
   override def toStream(serverRequest: ServerRequest): streams.BinaryStream = {
-    fs2.io.readInputStream(Sync[F].delay(new ByteBufInputStream(nettyRequest(serverRequest).content())), streamChunkSize)
+
+    val nettyRequest = serverRequest.underlying.asInstanceOf[StreamedHttpRequest]
+
+    fs2.Stream
+      .eval(StreamSubscriber[F, HttpContent](NettyRequestBody.bufferSize))
+      .flatMap(s => s.sub.stream(Sync[F].delay(nettyRequest.subscribe(s))))
+      .flatMap(httpContent => fs2.Stream.chunk(Chunk.byteBuffer(httpContent.content.nioBuffer())))
+
+    // fs2.io.readInputStream(Sync[F].delay(new ByteBufInputStream(nettyRequest(serverRequest).content())), streamChunkSize)
   }
 
-  private def nettyRequest(serverRequest: ServerRequest): FullHttpRequest = serverRequest.underlying.asInstanceOf[FullHttpRequest]
+  private def nettyRequestBytes(serverRequest: ServerRequest): F[Array[Byte]] = serverRequest.underlying match {
+    case req: FullHttpRequest     => monad.delay(ByteBufUtil.getBytes(req.content()))
+    case req: StreamedHttpRequest => toStream(serverRequest).compile.to(Chunk).map(_.toArray[Byte])
+    case other => monad.raiseError(new UnsupportedOperationException(s"Unexpected Netty request of type ${other.getClass().getName()}"))
+  }
 }

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsRequestBody.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsRequestBody.scala
@@ -51,7 +51,7 @@ private[netty] class NettyCatsRequestBody[F[_]](createFile: ServerRequest => F[T
   override def toStream(serverRequest: ServerRequest): streams.BinaryStream = {
     val nettyRequest = serverRequest.underlying.asInstanceOf[StreamedHttpRequest]
     fs2.Stream
-      .eval(StreamSubscriber[F, HttpContent](NettyRequestBody.bufferSize))
+      .eval(StreamSubscriber[F, HttpContent](NettyRequestBody.DefaultChunkSize))
       .flatMap(s => s.sub.stream(Sync[F].delay(nettyRequest.subscribe(s))))
       .flatMap(httpContent => fs2.Stream.chunk(Chunk.byteBuffer(httpContent.content.nioBuffer())))
   }

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsRequestBody.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsRequestBody.scala
@@ -19,7 +19,6 @@ import java.nio.ByteBuffer
 private[netty] class NettyCatsRequestBody[F[_]](createFile: ServerRequest => F[TapirFile])(implicit val monad: Async[F])
     extends RequestBody[F, Fs2Streams[F]] {
 
-  val streamChunkSize = 8192
   override val streams: Fs2Streams[F] = Fs2Streams[F]
 
   override def toRaw[R](serverRequest: ServerRequest, bodyType: RawBodyType[R]): F[RawValue[R]] = {

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsToResponseBody.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsToResponseBody.scala
@@ -8,7 +8,6 @@ import fs2.io.file.{Files, Flags, Path}
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelHandlerContext
 import io.netty.handler.codec.http.{DefaultHttpContent, HttpContent}
-import io.netty.handler.stream.ChunkedStream
 import org.reactivestreams.Publisher
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.model.HasHeaders
@@ -20,12 +19,6 @@ import sttp.tapir.{CodecFormat, RawBodyType, WebSocketBodyOutput}
 import java.io.InputStream
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
-
-private[netty] class RangedChunkedStream(raw: InputStream, length: Long) extends ChunkedStream(raw) {
-
-  override def isEndOfInput(): Boolean =
-    super.isEndOfInput || transferredBytes == length
-}
 
 class NettyCatsToResponseBody[F[_]: Async](dispatcher: Dispatcher[F]) extends ToResponseBody[NettyResponse, Fs2Streams[F]] {
   override val streams: Fs2Streams[F] = Fs2Streams[F]

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsToResponseBody.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsToResponseBody.scala
@@ -15,7 +15,7 @@ import sttp.model.HasHeaders
 import sttp.tapir.server.interpreter.ToResponseBody
 import sttp.tapir.server.netty.NettyResponseContent.ByteBufNettyResponseContent
 import sttp.tapir.server.netty.{NettyResponse, NettyResponseContent}
-import sttp.tapir.{CodecFormat, InputStreamRange, RawBodyType, WebSocketBodyOutput}
+import sttp.tapir.{CodecFormat, RawBodyType, WebSocketBodyOutput}
 
 import java.io.InputStream
 import java.nio.ByteBuffer
@@ -75,13 +75,8 @@ class NettyCatsToResponseBody[F[_]: Async](dispatcher: Dispatcher[F]) extends To
       Sync[F].blocking(inputStream()),
       NettyToResponseBody.DefaultChunkSize
     )
-  private def wrap(streamRange: InputStreamRange): ChunkedStream = {
-    streamRange.range
-      .map(r => new RangedChunkedStream(streamRange.inputStreamFromRangeStart(), r.contentLength))
-      .getOrElse(new ChunkedStream(streamRange.inputStream()))
-  }
 
-  def fs2StreamToPublisher(stream: streams.BinaryStream): Publisher[HttpContent] = {
+  private def fs2StreamToPublisher(stream: streams.BinaryStream): Publisher[HttpContent] = {
     // Deprecated constructor, but the proposed one does roughly the same, forcing a dedicated
     // dispatcher, which results in a Resource[], which is hard to afford here
     StreamUnicastPublisher(

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsToResponseBody.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsToResponseBody.scala
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import fs2.Pull
 
-class NettyCatsToResponseBody[F[_]: Async](dispatcher: Dispatcher[F], maxContentLength: Option[Int])
+class NettyCatsToResponseBody[F[_]: Async](dispatcher: Dispatcher[F])
     extends ToResponseBody[NettyResponse, Fs2Streams[F]] {
   override val streams: Fs2Streams[F] = Fs2Streams[F]
 
@@ -72,12 +72,10 @@ class NettyCatsToResponseBody[F[_]: Async](dispatcher: Dispatcher[F], maxContent
     )
 
   private def fs2StreamToPublisher(stream: streams.BinaryStream): Publisher[HttpContent] = {
-    val chunkedStream = stream.chunkLimit(NettyToResponseBody.DefaultChunkSize)
-    val streamToConvert = maxContentLength.map(enforceFs2MaxBytes(chunkedStream, _)).getOrElse(chunkedStream)
     // Deprecated constructor, but the proposed one does roughly the same, forcing a dedicated
     // dispatcher, which results in a Resource[], which is hard to afford here
     StreamUnicastPublisher(
-      streamToConvert
+      stream.chunkLimit(NettyToResponseBody.DefaultChunkSize)
         .map { chunk =>
           val bytes: Chunk.ArraySlice[Byte] = chunk.compact
 
@@ -85,23 +83,6 @@ class NettyCatsToResponseBody[F[_]: Async](dispatcher: Dispatcher[F], maxContent
         },
       dispatcher
     )
-  }
-  private def enforceFs2MaxBytes(stream: fs2.Stream[F, Chunk[Byte]], maxBytes: Int): fs2.Stream[F, Chunk[Byte]] = {
-    def go(s: fs2.Stream[F, Chunk[Byte]], count: Long): Pull[F, Chunk[Byte], Unit] = {
-      s.pull.uncons.flatMap {
-        case Some((chunk, tail)) =>
-          val chunkSize = chunk.size.toLong
-          val newCount = count + chunkSize
-          if (newCount > maxBytes) {
-            Pull.raiseError[F](new IllegalArgumentException(s"Body size limit $maxBytes exceeded"))
-          } else {
-            Pull.output(chunk) >> go(tail, newCount)
-          }
-        case None =>
-          Pull.done
-      }
-    }
-    go(stream, 0L).stream
   }
 
   override def fromStreamValue(

--- a/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsServerTest.scala
+++ b/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsServerTest.scala
@@ -1,10 +1,8 @@
 package sttp.tapir.server.netty.cats
 
 import cats.effect.{IO, Resource}
-import com.typesafe.scalalogging.StrictLogging
 import io.netty.channel.nio.NioEventLoopGroup
 import org.scalatest.EitherValues
-import org.scalatest.matchers.should.Matchers
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.monad.MonadError
 import sttp.tapir.integ.cats.effect.CatsMonadError
@@ -12,7 +10,7 @@ import sttp.tapir.server.netty.internal.FutureUtil
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
 
-class NettyCatsServerTest extends TestSuite with EitherValues with StrictLogging with Matchers {
+class NettyCatsServerTest extends TestSuite with EitherValues {
   override def tests: Resource[IO, List[Test]] =
     backendResource.flatMap { backend =>
       Resource
@@ -23,7 +21,8 @@ class NettyCatsServerTest extends TestSuite with EitherValues with StrictLogging
           val interpreter = new NettyCatsTestServerInterpreter(eventLoopGroup, dispatcher)
           val createServerTest = new DefaultCreateServerTest(backend, interpreter)
 
-          val tests = new AllServerTests(createServerTest, interpreter, backend, multipart = false).tests() ++ new ServerStreamingTests(createServerTest, Fs2Streams[IO]).tests()
+          val tests = new AllServerTests(createServerTest, interpreter, backend, multipart = false)
+            .tests() ++ new ServerStreamingTests(createServerTest, Fs2Streams[IO]).tests()
 
           IO.pure((tests, eventLoopGroup))
         } { case (_, eventLoopGroup) =>

--- a/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsServerTest.scala
+++ b/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsServerTest.scala
@@ -1,15 +1,30 @@
 package sttp.tapir.server.netty.cats
 
+import cats.data.NonEmptyList
+import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Resource}
+import cats.syntax.all._
+import com.typesafe.scalalogging.StrictLogging
 import io.netty.channel.nio.NioEventLoopGroup
 import org.scalatest.EitherValues
+import org.scalatest.matchers.should.Matchers
+import sttp.capabilities.fs2.Fs2Streams
+import sttp.client3._
 import sttp.monad.MonadError
+import sttp.tapir._
 import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.netty.internal.FutureUtil
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
 
-class NettyCatsServerTest extends TestSuite with EitherValues {
+import java.nio.charset.StandardCharsets
+import scala.concurrent.duration._
+import fs2.io.file.Files
+import java.nio.file.Paths
+import fs2.io.file.Path
+import scala.util.Random
+
+class NettyCatsServerTest extends TestSuite with EitherValues with StrictLogging with Matchers {
   override def tests: Resource[IO, List[Test]] =
     backendResource.flatMap { backend =>
       Resource
@@ -20,7 +35,52 @@ class NettyCatsServerTest extends TestSuite with EitherValues {
           val interpreter = new NettyCatsTestServerInterpreter(eventLoopGroup, dispatcher)
           val createServerTest = new DefaultCreateServerTest(backend, interpreter)
 
-          val tests = new AllServerTests(createServerTest, interpreter, backend, multipart = false).tests()
+          val tests = new AllServerTests(createServerTest, interpreter, backend, multipart = false).tests() 
+          //
+          // val tests = new ServerStreamingTests(createServerTest, Fs2Streams[IO]).tests()
+
+          val s = Fs2Streams[IO]
+          val streamBody = streamTextBody(s)(CodecFormat.TextPlain(), Some(StandardCharsets.UTF_8))
+
+          val responseStr = "This is response text"
+          val responseText = responseStr.getBytes().toList
+          // val responseAsStream = Files[IO].readAll(Path.fromNioPath(Paths.get("/home/kc/LICENSE")))
+          val responseAsStream: fs2.Stream[IO, Byte] = fs2.Stream.emits(responseText).covary[IO]
+          val testRoute = endpoint.post.in("kc").in(streamBody).out(streamBody).serverLogic[IO] { (inputStream) =>
+            val sink = Files[IO].writeAll(Path.fromNioPath(Paths.get(s"./out-${Random.nextInt()}")))
+            // val s2 = inputStream.through(sink).compile
+            // s2.drain.unsafeRunSync()
+
+            IO.delay(Right(inputStream.map(_.toChar).map(_.toString).map(_.toUpperCase).map(_.head).map(_.toByte)))
+            // IO.delay(Right(fs2.Stream.emits(inputStream.getBytes().toList)))
+          }
+
+          val route = interpreter.route(testRoute)
+          val rs = NonEmptyList.one(route)
+          val resources = for {
+            port <- interpreter.server(rs).onError { case e: Exception =>
+              Resource.eval(IO(logger.error(s"Starting server failed because of ${e.getMessage}")))
+            }
+            _ <- Resource.eval(IO(logger.info(s"Bound server on port: $port")))
+          } yield port
+
+          val requestStr = "Pen pineapple apple pen streaming req text"
+          val requestBytes = requestStr.getBytes().toList
+          val requestAsStream: fs2.Stream[IO, Byte] = fs2.Stream.emits(requestBytes).covary[IO]
+          val tests2 = List(Test("work!") {
+            resources
+              .use { port =>
+                val baseUri = uri"http://localhost:$port"
+                // IO.sleep(30.seconds) >>
+                basicRequest
+                  .post(uri"$baseUri/kc")
+                  .streamBody(Fs2Streams[IO])(requestAsStream)
+                  // .body("requestStr")
+                  .send(backend)
+                  .map(_.body shouldBe Right(responseStr))
+              }
+              .unsafeToFuture()
+          })
 
           IO.pure((tests, eventLoopGroup))
         } { case (_, eventLoopGroup) =>

--- a/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsServerTest.scala
+++ b/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsServerTest.scala
@@ -11,6 +11,7 @@ import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
 
 class NettyCatsServerTest extends TestSuite with EitherValues {
+
   override def tests: Resource[IO, List[Test]] =
     backendResource.flatMap { backend =>
       Resource
@@ -21,7 +22,13 @@ class NettyCatsServerTest extends TestSuite with EitherValues {
           val interpreter = new NettyCatsTestServerInterpreter(eventLoopGroup, dispatcher)
           val createServerTest = new DefaultCreateServerTest(backend, interpreter)
 
-          val tests = new AllServerTests(createServerTest, interpreter, backend, multipart = false)
+          val tests = new AllServerTests(
+            createServerTest,
+            interpreter,
+            backend,
+            multipart = false,
+            maxContentLength = Some(NettyCatsTestServerInterpreter.maxContentLength)
+          )
             .tests() ++ new ServerStreamingTests(createServerTest, Fs2Streams[IO]).tests()
 
           IO.pure((tests, eventLoopGroup))

--- a/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsServerTest.scala
+++ b/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsServerTest.scala
@@ -1,28 +1,16 @@
 package sttp.tapir.server.netty.cats
 
-import cats.data.NonEmptyList
-import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Resource}
-import cats.syntax.all._
 import com.typesafe.scalalogging.StrictLogging
 import io.netty.channel.nio.NioEventLoopGroup
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import sttp.capabilities.fs2.Fs2Streams
-import sttp.client3._
 import sttp.monad.MonadError
-import sttp.tapir._
 import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.netty.internal.FutureUtil
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
-
-import java.nio.charset.StandardCharsets
-import scala.concurrent.duration._
-import fs2.io.file.Files
-import java.nio.file.Paths
-import fs2.io.file.Path
-import scala.util.Random
 
 class NettyCatsServerTest extends TestSuite with EitherValues with StrictLogging with Matchers {
   override def tests: Resource[IO, List[Test]] =
@@ -35,52 +23,7 @@ class NettyCatsServerTest extends TestSuite with EitherValues with StrictLogging
           val interpreter = new NettyCatsTestServerInterpreter(eventLoopGroup, dispatcher)
           val createServerTest = new DefaultCreateServerTest(backend, interpreter)
 
-          val tests = new AllServerTests(createServerTest, interpreter, backend, multipart = false).tests() 
-          //
-          // val tests = new ServerStreamingTests(createServerTest, Fs2Streams[IO]).tests()
-
-          val s = Fs2Streams[IO]
-          val streamBody = streamTextBody(s)(CodecFormat.TextPlain(), Some(StandardCharsets.UTF_8))
-
-          val responseStr = "This is response text"
-          val responseText = responseStr.getBytes().toList
-          // val responseAsStream = Files[IO].readAll(Path.fromNioPath(Paths.get("/home/kc/LICENSE")))
-          val responseAsStream: fs2.Stream[IO, Byte] = fs2.Stream.emits(responseText).covary[IO]
-          val testRoute = endpoint.post.in("kc").in(streamBody).out(streamBody).serverLogic[IO] { (inputStream) =>
-            val sink = Files[IO].writeAll(Path.fromNioPath(Paths.get(s"./out-${Random.nextInt()}")))
-            // val s2 = inputStream.through(sink).compile
-            // s2.drain.unsafeRunSync()
-
-            IO.delay(Right(inputStream.map(_.toChar).map(_.toString).map(_.toUpperCase).map(_.head).map(_.toByte)))
-            // IO.delay(Right(fs2.Stream.emits(inputStream.getBytes().toList)))
-          }
-
-          val route = interpreter.route(testRoute)
-          val rs = NonEmptyList.one(route)
-          val resources = for {
-            port <- interpreter.server(rs).onError { case e: Exception =>
-              Resource.eval(IO(logger.error(s"Starting server failed because of ${e.getMessage}")))
-            }
-            _ <- Resource.eval(IO(logger.info(s"Bound server on port: $port")))
-          } yield port
-
-          val requestStr = "Pen pineapple apple pen streaming req text"
-          val requestBytes = requestStr.getBytes().toList
-          val requestAsStream: fs2.Stream[IO, Byte] = fs2.Stream.emits(requestBytes).covary[IO]
-          val tests2 = List(Test("work!") {
-            resources
-              .use { port =>
-                val baseUri = uri"http://localhost:$port"
-                // IO.sleep(30.seconds) >>
-                basicRequest
-                  .post(uri"$baseUri/kc")
-                  .streamBody(Fs2Streams[IO])(requestAsStream)
-                  // .body("requestStr")
-                  .send(backend)
-                  .map(_.body shouldBe Right(responseStr))
-              }
-              .unsafeToFuture()
-          })
+          val tests = new AllServerTests(createServerTest, interpreter, backend, multipart = false).tests() ++ new ServerStreamingTests(createServerTest, Fs2Streams[IO]).tests()
 
           IO.pure((tests, eventLoopGroup))
         } { case (_, eventLoopGroup) =>

--- a/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsTestServerInterpreter.scala
+++ b/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsTestServerInterpreter.scala
@@ -20,7 +20,7 @@ class NettyCatsTestServerInterpreter(eventLoopGroup: NioEventLoopGroup, dispatch
   }
 
   override def server(routes: NonEmptyList[Route[IO]]): Resource[IO, Port] = {
-    val config = NettyConfig.default.eventLoopGroup(eventLoopGroup).randomPort.withDontShutdownEventLoopGroupOnClose
+    val config = NettyConfig.defaultWithStreaming.eventLoopGroup(eventLoopGroup).randomPort.withDontShutdownEventLoopGroupOnClose
     val options = NettyCatsServerOptions.default[IO](dispatcher)
     val bind: IO[NettyCatsServerBinding[IO]] = NettyCatsServer(options, config).addRoutes(routes.toList).start()
 

--- a/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsTestServerInterpreter.scala
+++ b/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsTestServerInterpreter.scala
@@ -20,7 +20,11 @@ class NettyCatsTestServerInterpreter(eventLoopGroup: NioEventLoopGroup, dispatch
   }
 
   override def server(routes: NonEmptyList[Route[IO]]): Resource[IO, Port] = {
-    val config = NettyConfig.defaultWithStreaming.eventLoopGroup(eventLoopGroup).randomPort.withDontShutdownEventLoopGroupOnClose
+    val config = NettyConfig.defaultWithStreaming
+      .eventLoopGroup(eventLoopGroup)
+      .randomPort
+      .withDontShutdownEventLoopGroupOnClose
+      .maxContentLength(NettyCatsTestServerInterpreter.maxContentLength)
     val options = NettyCatsServerOptions.default[IO](dispatcher)
     val bind: IO[NettyCatsServerBinding[IO]] = NettyCatsServer(options, config).addRoutes(routes.toList).start()
 
@@ -28,4 +32,8 @@ class NettyCatsTestServerInterpreter(eventLoopGroup: NioEventLoopGroup, dispatch
       .make(bind)(_.stop())
       .map(_.port)
   }
+}
+
+object NettyCatsTestServerInterpreter {
+  val maxContentLength = 10000
 }

--- a/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsTestServerInterpreter.scala
+++ b/server/netty-server/cats/src/test/scala/sttp/tapir/server/netty/cats/NettyCatsTestServerInterpreter.scala
@@ -8,10 +8,11 @@ import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.netty.{NettyConfig, Route}
 import sttp.tapir.server.tests.TestServerInterpreter
 import sttp.tapir.tests.Port
+import sttp.capabilities.fs2.Fs2Streams
 
 class NettyCatsTestServerInterpreter(eventLoopGroup: NioEventLoopGroup, dispatcher: Dispatcher[IO])
-    extends TestServerInterpreter[IO, Any, NettyCatsServerOptions[IO], Route[IO]] {
-  override def route(es: List[ServerEndpoint[Any, IO]], interceptors: Interceptors): Route[IO] = {
+    extends TestServerInterpreter[IO, Fs2Streams[IO], NettyCatsServerOptions[IO], Route[IO]] {
+  override def route(es: List[ServerEndpoint[Fs2Streams[IO], IO]], interceptors: Interceptors): Route[IO] = {
     val serverOptions: NettyCatsServerOptions[IO] = interceptors(
       NettyCatsServerOptions.customiseInterceptors[IO](dispatcher)
     ).options

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
@@ -14,6 +14,8 @@ import io.netty.handler.timeout.ReadTimeoutException
 import sttp.tapir.server.netty.NettyConfig.EventLoopConfig
 
 import scala.concurrent.duration._
+import com.typesafe.netty.http.HttpStreamsClientHandler
+import sttp.tapir.server.netty.internal.NettyStreamingHandler
 
 /** Netty configuration, used by [[NettyFutureServer]] and other server implementations to configure the networking layer, the Netty
   * processing pipeline, and start & stop the server.
@@ -119,10 +121,10 @@ object NettyConfig {
 
   def defaultInitPipeline(cfg: NettyConfig)(pipeline: ChannelPipeline, handler: ChannelHandler): Unit = {
     cfg.sslContext.foreach(s => pipeline.addLast(s.newHandler(pipeline.channel().alloc())))
+    println("--------------------------------------- default init pipeline")
     pipeline.addLast(new HttpServerCodec())
-    pipeline.addLast(new HttpObjectAggregator(cfg.maxContentLength))
-    pipeline.addLast(new ChunkedWriteHandler())
     pipeline.addLast("serverStreamsHandler", new HttpStreamsServerHandler())
+    pipeline.addLast(new ChunkedWriteHandler())
     pipeline.addLast(handler)
     if (cfg.addLoggingHandler) pipeline.addLast(new LoggingHandler())
     ()

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
@@ -1,5 +1,6 @@
 package sttp.tapir.server.netty
 
+import com.typesafe.netty.http.HttpStreamsServerHandler
 import io.netty.channel.epoll.{Epoll, EpollEventLoopGroup, EpollServerSocketChannel}
 import io.netty.channel.kqueue.{KQueue, KQueueEventLoopGroup, KQueueServerSocketChannel}
 import io.netty.channel.nio.NioEventLoopGroup
@@ -121,6 +122,7 @@ object NettyConfig {
     pipeline.addLast(new HttpServerCodec())
     pipeline.addLast(new HttpObjectAggregator(cfg.maxContentLength))
     pipeline.addLast(new ChunkedWriteHandler())
+    pipeline.addLast("serverStreamsHandler", new HttpStreamsServerHandler())
     pipeline.addLast(handler)
     if (cfg.addLoggingHandler) pipeline.addLast(new LoggingHandler())
     ()

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
@@ -96,7 +96,6 @@ case class NettyConfig(
   def eventLoopGroup(elg: EventLoopGroup): NettyConfig = copy(eventLoopConfig = EventLoopConfig.useExisting(elg))
 
   def initPipeline(f: NettyConfig => (ChannelPipeline, ChannelHandler) => Unit): NettyConfig = copy(initPipeline = f)
-
 }
 
 object NettyConfig {

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
@@ -55,7 +55,12 @@ case class NettyFutureServer(routes: Vector[FutureRoute], options: NettyFutureSe
     val route = Route.combine(routes)
 
     val channelFuture =
-      NettyBootstrap(config, new NettyServerHandler(route, (f: () => Future[Unit]) => f(), config.maxContentLength), eventLoopGroup, socketOverride)
+      NettyBootstrap(
+        config,
+        new NettyServerHandler(route, (f: () => Future[Unit]) => f(), config.maxContentLength),
+        eventLoopGroup,
+        socketOverride
+      )
 
     nettyChannelFutureToScala(channelFuture).map(ch => (ch.localAddress().asInstanceOf[SA], () => stop(ch, eventLoopGroup)))
   }
@@ -71,10 +76,10 @@ case class NettyFutureServer(routes: Vector[FutureRoute], options: NettyFutureSe
 
 object NettyFutureServer {
   def apply()(implicit ec: ExecutionContext): NettyFutureServer =
-    NettyFutureServer(Vector.empty, NettyFutureServerOptions.default, NettyConfig.default)
+    NettyFutureServer(Vector.empty, NettyFutureServerOptions.default, NettyConfig.defaultNoStreaming)
 
   def apply(serverOptions: NettyFutureServerOptions)(implicit ec: ExecutionContext): NettyFutureServer =
-    NettyFutureServer(Vector.empty, serverOptions, NettyConfig.default)
+    NettyFutureServer(Vector.empty, serverOptions, NettyConfig.defaultNoStreaming)
 
   def apply(config: NettyConfig)(implicit ec: ExecutionContext): NettyFutureServer =
     NettyFutureServer(Vector.empty, NettyFutureServerOptions.default, config)

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
@@ -55,7 +55,7 @@ case class NettyFutureServer(routes: Vector[FutureRoute], options: NettyFutureSe
     val route = Route.combine(routes)
 
     val channelFuture =
-      NettyBootstrap(config, new NettyServerHandler(route, (f: () => Future[Unit]) => f()), eventLoopGroup, socketOverride)
+      NettyBootstrap(config, new NettyServerHandler(route, (f: () => Future[Unit]) => f(), config.maxContentLength), eventLoopGroup, socketOverride)
 
     nettyChannelFutureToScala(channelFuture).map(ch => (ch.localAddress().asInstanceOf[SA], () => stop(ch, eventLoopGroup)))
   }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyResponseContent.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyResponseContent.scala
@@ -2,7 +2,9 @@ package sttp.tapir.server.netty
 
 import io.netty.buffer.ByteBuf
 import io.netty.channel.ChannelPromise
+import io.netty.handler.codec.http.HttpContent
 import io.netty.handler.stream.{ChunkedFile, ChunkedStream}
+import org.reactivestreams.Publisher
 
 sealed trait NettyResponseContent {
   def channelPromise: ChannelPromise
@@ -13,4 +15,5 @@ object NettyResponseContent {
   final case class ChunkedStreamNettyResponseContent(channelPromise: ChannelPromise, chunkedStream: ChunkedStream)
       extends NettyResponseContent
   final case class ChunkedFileNettyResponseContent(channelPromise: ChannelPromise, chunkedFile: ChunkedFile) extends NettyResponseContent
+  final case class ReactivePublisherNettyResponseContent(channelPromise: ChannelPromise, publisher: Publisher[HttpContent]) extends NettyResponseContent
 }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyServerRequest.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyServerRequest.scala
@@ -2,13 +2,14 @@ package sttp.tapir.server.netty
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable.Seq
-import io.netty.handler.codec.http.{FullHttpRequest, QueryStringDecoder}
+import io.netty.handler.codec.http.{HttpRequest, QueryStringDecoder}
 import sttp.model.{Header, Method, QueryParams, Uri}
 import sttp.tapir.{AttributeKey, AttributeMap}
 import sttp.tapir.model.{ConnectionInfo, ServerRequest}
 import sttp.tapir.server.netty.internal.RichNettyHttpHeaders
+import io.netty.handler.codec.http.FullHttpRequest
 
-case class NettyServerRequest(req: FullHttpRequest, attributes: AttributeMap = AttributeMap.Empty) extends ServerRequest {
+case class NettyServerRequest(req: HttpRequest, attributes: AttributeMap = AttributeMap.Empty) extends ServerRequest {
   override lazy val protocol: String = req.protocolVersion().text()
   override lazy val connectionInfo: ConnectionInfo = ConnectionInfo.NoInfo
   override lazy val underlying: Any = req
@@ -25,9 +26,12 @@ case class NettyServerRequest(req: FullHttpRequest, attributes: AttributeMap = A
   override lazy val method: Method = Method.unsafeApply(req.method().name())
   override lazy val uri: Uri = Uri.unsafeParse(req.uri())
   override lazy val pathSegments: List[String] = uri.pathSegments.segments.map(_.v).filter(_.nonEmpty).toList
-  override lazy val headers: Seq[Header] = req.headers().toHeaderSeq ::: req.trailingHeaders().toHeaderSeq
+  override lazy val headers: Seq[Header] = req.headers().toHeaderSeq ::: (req match {
+    case full: FullHttpRequest => full.trailingHeaders().toHeaderSeq
+    case _                     => List.empty
+  })
   override def attribute[T](k: AttributeKey[T]): Option[T] = attributes.get(k)
   override def attribute[T](k: AttributeKey[T], v: T): NettyServerRequest = copy(attributes = attributes.put(k, v))
   override def withUnderlying(underlying: Any): ServerRequest =
-    NettyServerRequest(req = underlying.asInstanceOf[FullHttpRequest], attributes)
+    NettyServerRequest(req = underlying.asInstanceOf[HttpRequest], attributes)
 }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyRequestBody.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyRequestBody.scala
@@ -46,6 +46,6 @@ class NettyRequestBody[F[_]](createFile: ServerRequest => F[TapirFile])(implicit
   private def nettyRequest(serverRequest: ServerRequest): FullHttpRequest = serverRequest.underlying.asInstanceOf[FullHttpRequest]
 }
 
-object NettyRequestBody {
-  private[internal] val bufferSize = 8192
+private[internal] object NettyRequestBody {
+  val DefaultChunkSize = 8192
 }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyRequestBody.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyRequestBody.scala
@@ -46,3 +46,7 @@ class NettyRequestBody[F[_]](createFile: ServerRequest => F[TapirFile])(implicit
 
   private def nettyRequest(serverRequest: ServerRequest): FullHttpRequest = serverRequest.underlying.asInstanceOf[FullHttpRequest]
 }
+
+object NettyRequestBody {
+  private[internal] val bufferSize = 8192
+}

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyRequestBody.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyRequestBody.scala
@@ -9,7 +9,6 @@ import sttp.tapir.model.ServerRequest
 import sttp.monad.syntax._
 import sttp.tapir.capabilities.NoStreams
 import sttp.tapir.server.interpreter.{RawValue, RequestBody}
-import sttp.tapir.server.netty.NettyServerRequest
 
 import java.nio.ByteBuffer
 import java.nio.file.Files

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyServerHandler.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyServerHandler.scala
@@ -133,7 +133,6 @@ class NettyServerHandler[F[_]](route: Route[F], unsafeRunAsync: (() => F[Unit]) 
           new DefaultStreamedHttpResponse(req.protocolVersion(), HttpResponseStatus.valueOf(serverResponse.code.code), publisher)
 
         res.setHeadersFrom(serverResponse)
-        res.handleContentLengthAndChunkedHeaders(None)
         res.handleCloseAndKeepAliveHeaders(req)
         ctx.writeAndFlush(res, channelPromise).closeIfNeeded(req)
 

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyServerHandler.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyServerHandler.scala
@@ -1,5 +1,6 @@
 package sttp.tapir.server.netty.internal
 
+import com.typesafe.netty.http.{DefaultStreamedHttpResponse, StreamedHttpRequest}
 import com.typesafe.scalalogging.Logger
 import io.netty.buffer.{ByteBuf, Unpooled}
 import io.netty.channel._
@@ -17,9 +18,6 @@ import sttp.tapir.server.netty.NettyResponseContent.{
 import sttp.tapir.server.netty.{NettyResponse, NettyResponseContent, NettyServerRequest, Route}
 
 import scala.collection.JavaConverters._
-import com.typesafe.netty.http.DefaultStreamedHttpResponse
-import com.typesafe.netty.http.DelegateStreamedHttpRequest
-import com.typesafe.netty.http.StreamedHttpRequest
 
 class NettyServerHandler[F[_]](route: Route[F], unsafeRunAsync: (() => F[Unit]) => Unit)(implicit me: MonadError[F])
     extends SimpleChannelInboundHandler[HttpRequest] {

--- a/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyFutureTestServerInterpreter.scala
+++ b/server/netty-server/src/test/scala/sttp/tapir/server/netty/NettyFutureTestServerInterpreter.scala
@@ -18,7 +18,7 @@ class NettyFutureTestServerInterpreter(eventLoopGroup: NioEventLoopGroup)(implic
   }
 
   override def server(routes: NonEmptyList[FutureRoute]): Resource[IO, Port] = {
-    val config = NettyConfig.default.eventLoopGroup(eventLoopGroup).randomPort.withDontShutdownEventLoopGroupOnClose
+    val config = NettyConfig.defaultNoStreaming.eventLoopGroup(eventLoopGroup).randomPort.withDontShutdownEventLoopGroupOnClose
     val options = NettyFutureServerOptions.default
     val bind = IO.fromFuture(IO.delay(NettyFutureServer(options, config).addRoutes(routes.toList).start()))
 

--- a/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/NettyZioServer.scala
+++ b/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/NettyZioServer.scala
@@ -66,7 +66,8 @@ case class NettyZioServer[R](routes: Vector[RIO[R, Route[RIO[R, *]]]], options: 
         config,
         new NettyServerHandler[RIO[R, *]](
           route,
-          (f: () => RIO[R, Unit]) => Unsafe.unsafe(implicit u => runtime.unsafe.runToFuture(f()))
+          (f: () => RIO[R, Unit]) => Unsafe.unsafe(implicit u => runtime.unsafe.runToFuture(f())),
+          config.maxContentLength
         ),
         eventLoopGroup,
         socketOverride

--- a/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/NettyZioServer.scala
+++ b/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/NettyZioServer.scala
@@ -93,8 +93,8 @@ case class NettyZioServer[R](routes: Vector[RIO[R, Route[RIO[R, *]]]], options: 
 }
 
 object NettyZioServer {
-  def apply[R](): NettyZioServer[R] = NettyZioServer(Vector.empty, NettyZioServerOptions.default[R], NettyConfig.default)
-  def apply[R](options: NettyZioServerOptions[R]): NettyZioServer[R] = NettyZioServer(Vector.empty, options, NettyConfig.default)
+  def apply[R](): NettyZioServer[R] = NettyZioServer(Vector.empty, NettyZioServerOptions.default[R], NettyConfig.defaultNoStreaming)
+  def apply[R](options: NettyZioServerOptions[R]): NettyZioServer[R] = NettyZioServer(Vector.empty, options, NettyConfig.defaultNoStreaming)
   def apply[R](config: NettyConfig): NettyZioServer[R] = NettyZioServer(Vector.empty, NettyZioServerOptions.default[R], config)
   def apply[R](options: NettyZioServerOptions[R], config: NettyConfig): NettyZioServer[R] = NettyZioServer(Vector.empty, options, config)
 }

--- a/server/netty-server/zio/src/test/scala/sttp/tapir/server/netty/zio/NettyZioTestServerInterpreter.scala
+++ b/server/netty-server/zio/src/test/scala/sttp/tapir/server/netty/zio/NettyZioTestServerInterpreter.scala
@@ -21,7 +21,7 @@ class NettyZioTestServerInterpreter[R](eventLoopGroup: NioEventLoopGroup)
   }
 
   override def server(routes: NonEmptyList[Task[Route[Task]]]): Resource[IO, Port] = {
-    val config = NettyConfig.default.eventLoopGroup(eventLoopGroup).randomPort.withDontShutdownEventLoopGroupOnClose
+    val config = NettyConfig.defaultNoStreaming.eventLoopGroup(eventLoopGroup).randomPort.withDontShutdownEventLoopGroupOnClose
     val options = NettyZioServerOptions.default[R]
 
     val runtime: Runtime[R] = Runtime.default.asInstanceOf[Runtime[R]]

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/AllServerTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/AllServerTests.scala
@@ -27,13 +27,14 @@ class AllServerTests[F[_], OPTIONS, ROUTE](
     validation: Boolean = true,
     oneOfBody: Boolean = true,
     cors: Boolean = true,
-    options: Boolean = true
+    options: Boolean = true,
+    maxContentLength: Option[Int] = None
 )(implicit
     m: MonadError[F]
 ) {
   def tests(): List[Test] =
     (if (security) new ServerSecurityTests(createServerTest).tests() else Nil) ++
-      (if (basic) new ServerBasicTests(createServerTest, serverInterpreter).tests() else Nil) ++
+      (if (basic) new ServerBasicTests(createServerTest, serverInterpreter, maxContentLength = maxContentLength).tests() else Nil) ++    
       (if (contentNegotiation) new ServerContentNegotiationTests(createServerTest).tests() else Nil) ++
       (if (file) new ServerFileTests(createServerTest).tests() else Nil) ++
       (if (mapping) new ServerMappingTests(createServerTest).tests() else Nil) ++

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/CreateServerTest.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/CreateServerTest.scala
@@ -79,6 +79,7 @@ class DefaultCreateServerTest[F[_], +R, OPTIONS, ROUTE](
       _ <- Resource.eval(IO(logger.info(s"Bound server on port: $port")))
     } yield port
 
+    import scala.concurrent.duration._
     Test(name)(
       resources
         .use { port =>

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/CreateServerTest.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/CreateServerTest.scala
@@ -79,7 +79,6 @@ class DefaultCreateServerTest[F[_], +R, OPTIONS, ROUTE](
       _ <- Resource.eval(IO(logger.info(s"Bound server on port: $port")))
     } yield port
 
-    import scala.concurrent.duration._
     Test(name)(
       resources
         .use { port =>

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -15,7 +15,7 @@ import sttp.tapir.codec.enumeratum.TapirCodecEnumeratum
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.interceptor.decodefailure.{DecodeFailureHandler, DefaultDecodeFailureHandler}
+import sttp.tapir.server.interceptor.decodefailure.DefaultDecodeFailureHandler
 import sttp.tapir.tests.Basic._
 import sttp.tapir.tests.TestUtil._
 import sttp.tapir.tests._

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerFilesTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerFilesTests.scala
@@ -218,9 +218,8 @@ class ServerFilesTests[F[_], OPTIONS, ROUTE](
       },
       Test("should return 200 status code for whole file") {
         withTestFilesDirectory { testDir =>
-          import scala.concurrent.duration._
           serveRoute(staticFilesGetServerEndpoint[F]("test")(testDir.getAbsolutePath))
-            .use { port => get(port, List("test", "f2")).timeout(10.seconds).map(_.code shouldBe StatusCode.Ok) }
+            .use { port => get(port, List("test", "f2")).map(_.code shouldBe StatusCode.Ok) }
             .unsafeToFuture()
         }
       },

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerFilesTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerFilesTests.scala
@@ -218,8 +218,9 @@ class ServerFilesTests[F[_], OPTIONS, ROUTE](
       },
       Test("should return 200 status code for whole file") {
         withTestFilesDirectory { testDir =>
+          import scala.concurrent.duration._
           serveRoute(staticFilesGetServerEndpoint[F]("test")(testDir.getAbsolutePath))
-            .use { port => get(port, List("test", "f2")).map(_.code shouldBe StatusCode.Ok) }
+            .use { port => get(port, List("test", "f2")).timeout(10.seconds).map(_.code shouldBe StatusCode.Ok) }
             .unsafeToFuture()
         }
       },

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerStreamingTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerStreamingTests.scala
@@ -4,8 +4,9 @@ import cats.syntax.all._
 import org.scalatest.matchers.should.Matchers._
 import sttp.capabilities.Streams
 import sttp.client3._
-import sttp.model.{Header, MediaType}
+import sttp.model.{Header, HeaderNames, MediaType}
 import sttp.monad.MonadError
+import sttp.tapir.tests.Test
 import sttp.tapir.tests.Streaming.{
   in_stream_out_either_json_xml_stream,
   in_stream_out_stream,
@@ -13,13 +14,8 @@ import sttp.tapir.tests.Streaming.{
   in_string_stream_out_either_stream_string,
   out_custom_content_type_stream_body
 }
-import sttp.tapir.tests.Test
 
-class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](
-    createServerTest: CreateServerTest[F, S, OPTIONS, ROUTE],
-    streams: Streams[S],
-    streamingWithContentLengthSupport: Boolean = true
-)(implicit
+class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServerTest[F, S, OPTIONS, ROUTE], streams: Streams[S])(implicit
     m: MonadError[F]
 ) {
 
@@ -27,89 +23,81 @@ class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](
     import createServerTest._
 
     val penPineapple = "pen pineapple apple pen"
-    if (streamingWithContentLengthSupport)
-      List(
-        testServer(
-          in_stream_out_stream_with_content_length(streams)
-        )((in: (Long, streams.BinaryStream)) => pureResult(in.asRight[Unit])) { (backend, baseUri) =>
-          {
-            basicRequest
-              .post(uri"$baseUri/api/echo")
-              .contentLength(penPineapple.length.toLong)
-              .body(penPineapple)
-              .send(backend)
-              .map { response =>
-                response.body shouldBe Right(penPineapple)
-                if (streamingWithContentLengthSupport) {
-                  response.contentLength shouldBe Some(penPineapple.length)
-                } else {
-                  response.contentLength shouldBe None
-                }
-              }
-          }
+
+    List(
+      testServer(in_stream_out_stream(streams))((s: streams.BinaryStream) => pureResult(s.asRight[Unit])) { (backend, baseUri) =>
+        basicRequest.post(uri"$baseUri/api/echo").body(penPineapple).send(backend).map(_.body shouldBe Right(penPineapple))
+      },
+      testServer(
+        in_stream_out_stream_with_content_length(streams)
+      )((in: (Long, streams.BinaryStream)) => pureResult(in.asRight[Unit])) { (backend, baseUri) =>
+        {
+          basicRequest
+            .post(uri"$baseUri/api/echo")
+            .contentLength(penPineapple.length.toLong)
+            .body(penPineapple)
+            .send(backend)
+            .map { response =>
+              response.body shouldBe Right(penPineapple)
+              response.contentLength shouldBe Some(penPineapple.length)
+            }
         }
-      )
-    else
-      Nil ++
-        List(
-          testServer(in_stream_out_stream(streams))((s: streams.BinaryStream) => pureResult(s.asRight[Unit])) { (backend, baseUri) =>
-            basicRequest.post(uri"$baseUri/api/echo").body(penPineapple).send(backend).map(_.body shouldBe Right(penPineapple))
-          },
-          testServer(out_custom_content_type_stream_body(streams)) { case (k, s) =>
-            pureResult((if (k < 0) (MediaType.ApplicationJson.toString(), s) else (MediaType.ApplicationXml.toString(), s)).asRight[Unit])
-          } { (backend, baseUri) =>
-            basicRequest
-              .post(uri"$baseUri?kind=-1")
-              .body(penPineapple)
-              .send(backend)
-              .map { r =>
-                r.body shouldBe Right(penPineapple)
-                r.contentType shouldBe Some(MediaType.ApplicationJson.toString())
-              } >>
-              basicRequest
-                .post(uri"$baseUri?kind=1")
-                .body(penPineapple)
-                .send(backend)
-                .map { r =>
-                  r.body shouldBe Right(penPineapple)
-                  r.contentType shouldBe Some(MediaType.ApplicationXml.toString())
-                }
-          },
-          testServer(in_string_stream_out_either_stream_string(streams)) {
-            case ("left", s) => pureResult((Left(s): Either[streams.BinaryStream, String]).asRight[Unit])
-            case _           => pureResult((Right("was not left"): Either[streams.BinaryStream, String]).asRight[Unit])
-          } { (backend, baseUri) =>
-            basicRequest
-              .post(uri"$baseUri?which=left")
-              .body(penPineapple)
-              .send(backend)
-              .map(_.body shouldBe Right(penPineapple)) >>
-              basicRequest
-                .post(uri"$baseUri?which=right")
-                .body(penPineapple)
-                .send(backend)
-                .map(_.body shouldBe Right("was not left"))
-          },
-          testServer(in_stream_out_either_json_xml_stream(streams)) { s => pureResult(s.asRight[Unit]) } { (backend, baseUri) =>
-            basicRequest
-              .post(uri"$baseUri")
-              .body(penPineapple)
-              .header(Header.accept(MediaType.ApplicationXml, MediaType.ApplicationJson))
-              .send(backend)
-              .map { r =>
-                r.contentType shouldBe Some(MediaType.ApplicationXml.toString())
-                r.body shouldBe Right(penPineapple)
-              } >>
-              basicRequest
-                .post(uri"$baseUri")
-                .body(penPineapple)
-                .header(Header.accept(MediaType.ApplicationJson, MediaType.ApplicationXml))
-                .send(backend)
-                .map { r =>
-                  r.contentType shouldBe Some(MediaType.ApplicationJson.toString())
-                  r.body shouldBe Right(penPineapple)
-                }
-          }
-        )
+      },
+      testServer(out_custom_content_type_stream_body(streams)) { case (k, s) =>
+        pureResult((if (k < 0) (MediaType.ApplicationJson.toString(), s) else (MediaType.ApplicationXml.toString(), s)).asRight[Unit])
+      } { (backend, baseUri) =>
+        basicRequest
+          .post(uri"$baseUri?kind=-1")
+          .body(penPineapple)
+          .send(backend)
+          .map { r =>
+            r.body shouldBe Right(penPineapple)
+            r.contentType shouldBe Some(MediaType.ApplicationJson.toString())
+          } >>
+          basicRequest
+            .post(uri"$baseUri?kind=1")
+            .body(penPineapple)
+            .send(backend)
+            .map { r =>
+              r.body shouldBe Right(penPineapple)
+              r.contentType shouldBe Some(MediaType.ApplicationXml.toString())
+            }
+      },
+      testServer(in_string_stream_out_either_stream_string(streams)) {
+        case ("left", s) => pureResult((Left(s): Either[streams.BinaryStream, String]).asRight[Unit])
+        case _           => pureResult((Right("was not left"): Either[streams.BinaryStream, String]).asRight[Unit])
+      } { (backend, baseUri) =>
+        basicRequest
+          .post(uri"$baseUri?which=left")
+          .body(penPineapple)
+          .send(backend)
+          .map(_.body shouldBe Right(penPineapple)) >>
+          basicRequest
+            .post(uri"$baseUri?which=right")
+            .body(penPineapple)
+            .send(backend)
+            .map(_.body shouldBe Right("was not left"))
+      },
+      testServer(in_stream_out_either_json_xml_stream(streams)) { s => pureResult(s.asRight[Unit]) } { (backend, baseUri) =>
+        basicRequest
+          .post(uri"$baseUri")
+          .body(penPineapple)
+          .header(Header.accept(MediaType.ApplicationXml, MediaType.ApplicationJson))
+          .send(backend)
+          .map { r =>
+            r.contentType shouldBe Some(MediaType.ApplicationXml.toString())
+            r.body shouldBe Right(penPineapple)
+          } >>
+          basicRequest
+            .post(uri"$baseUri")
+            .body(penPineapple)
+            .header(Header.accept(MediaType.ApplicationJson, MediaType.ApplicationXml))
+            .send(backend)
+            .map { r =>
+              r.contentType shouldBe Some(MediaType.ApplicationJson.toString())
+              r.body shouldBe Right(penPineapple)
+            }
+      }
+    )
   }
 }

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerStreamingTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerStreamingTests.scala
@@ -14,9 +14,6 @@ import sttp.tapir.tests.Streaming.{
   in_string_stream_out_either_stream_string,
   out_custom_content_type_stream_body
 }
-import scala.concurrent.duration._
-import java.io.ByteArrayInputStream
-import java.io.InputStream
 
 class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServerTest[F, S, OPTIONS, ROUTE], streams: Streams[S])(implicit
     m: MonadError[F]
@@ -36,7 +33,6 @@ class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServ
       )((in: (Long, streams.BinaryStream)) => pureResult(in.asRight[Unit])) { (backend, baseUri) =>
         {
           basicRequest
-          .readTimeout(3.seconds)
             .post(uri"$baseUri/api/echo")
             .contentLength(penPineapple.length.toLong)
             .body(penPineapple)
@@ -56,7 +52,6 @@ class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServ
       } { (backend, baseUri) =>
         basicRequest
           .post(uri"$baseUri?kind=-1")
-          .readTimeout(3.seconds)
           .body(penPineapple)
           .send(backend)
           .map { r =>
@@ -90,7 +85,6 @@ class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServ
       testServer(in_stream_out_either_json_xml_stream(streams)) { s => pureResult(s.asRight[Unit]) } { (backend, baseUri) =>
         basicRequest
           .post(uri"$baseUri")
-          .readTimeout(3.seconds)
           .body(penPineapple)
           .header(Header.accept(MediaType.ApplicationXml, MediaType.ApplicationJson))
           .send(backend)

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerStreamingTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerStreamingTests.scala
@@ -14,6 +14,9 @@ import sttp.tapir.tests.Streaming.{
   in_string_stream_out_either_stream_string,
   out_custom_content_type_stream_body
 }
+import scala.concurrent.duration._
+import java.io.ByteArrayInputStream
+import java.io.InputStream
 
 class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServerTest[F, S, OPTIONS, ROUTE], streams: Streams[S])(implicit
     m: MonadError[F]
@@ -33,6 +36,7 @@ class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServ
       )((in: (Long, streams.BinaryStream)) => pureResult(in.asRight[Unit])) { (backend, baseUri) =>
         {
           basicRequest
+          .readTimeout(3.seconds)
             .post(uri"$baseUri/api/echo")
             .contentLength(penPineapple.length.toLong)
             .body(penPineapple)
@@ -52,6 +56,7 @@ class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServ
       } { (backend, baseUri) =>
         basicRequest
           .post(uri"$baseUri?kind=-1")
+          .readTimeout(3.seconds)
           .body(penPineapple)
           .send(backend)
           .map { r =>
@@ -85,6 +90,7 @@ class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServ
       testServer(in_stream_out_either_json_xml_stream(streams)) { s => pureResult(s.asRight[Unit]) } { (backend, baseUri) =>
         basicRequest
           .post(uri"$baseUri")
+          .readTimeout(3.seconds)
           .body(penPineapple)
           .header(Header.accept(MediaType.ApplicationXml, MediaType.ApplicationJson))
           .send(backend)

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerStreamingTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerStreamingTests.scala
@@ -4,9 +4,8 @@ import cats.syntax.all._
 import org.scalatest.matchers.should.Matchers._
 import sttp.capabilities.Streams
 import sttp.client3._
-import sttp.model.{Header, HeaderNames, MediaType}
+import sttp.model.{Header, MediaType}
 import sttp.monad.MonadError
-import sttp.tapir.tests.Test
 import sttp.tapir.tests.Streaming.{
   in_stream_out_either_json_xml_stream,
   in_stream_out_stream,
@@ -14,8 +13,13 @@ import sttp.tapir.tests.Streaming.{
   in_string_stream_out_either_stream_string,
   out_custom_content_type_stream_body
 }
+import sttp.tapir.tests.Test
 
-class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServerTest[F, S, OPTIONS, ROUTE], streams: Streams[S])(implicit
+class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](
+    createServerTest: CreateServerTest[F, S, OPTIONS, ROUTE],
+    streams: Streams[S],
+    streamingWithContentLengthSupport: Boolean = true
+)(implicit
     m: MonadError[F]
 ) {
 
@@ -23,85 +27,89 @@ class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServ
     import createServerTest._
 
     val penPineapple = "pen pineapple apple pen"
-
-    List(
-      testServer(in_stream_out_stream(streams))((s: streams.BinaryStream) => pureResult(s.asRight[Unit])) { (backend, baseUri) =>
-        basicRequest.post(uri"$baseUri/api/echo").body(penPineapple).send(backend).map(_.body shouldBe Right(penPineapple))
-      },
-      testServer(
-        in_stream_out_stream_with_content_length(streams)
-      )((in: (Long, streams.BinaryStream)) => pureResult(in.asRight[Unit])) { (backend, baseUri) =>
-        {
-          basicRequest
-            .post(uri"$baseUri/api/echo")
-            .contentLength(penPineapple.length.toLong)
-            .body(penPineapple)
-            .send(backend)
-            .map { response =>
-              response.body shouldBe Right(penPineapple)
-              if (response.headers.contains(Header(HeaderNames.TransferEncoding, "chunked"))) {
-                response.contentLength shouldBe None
-              } else {
-                response.contentLength shouldBe Some(penPineapple.length)
+    if (streamingWithContentLengthSupport)
+      List(
+        testServer(
+          in_stream_out_stream_with_content_length(streams)
+        )((in: (Long, streams.BinaryStream)) => pureResult(in.asRight[Unit])) { (backend, baseUri) =>
+          {
+            basicRequest
+              .post(uri"$baseUri/api/echo")
+              .contentLength(penPineapple.length.toLong)
+              .body(penPineapple)
+              .send(backend)
+              .map { response =>
+                response.body shouldBe Right(penPineapple)
+                if (streamingWithContentLengthSupport) {
+                  response.contentLength shouldBe Some(penPineapple.length)
+                } else {
+                  response.contentLength shouldBe None
+                }
               }
-            }
+          }
         }
-      },
-      testServer(out_custom_content_type_stream_body(streams)) { case (k, s) =>
-        pureResult((if (k < 0) (MediaType.ApplicationJson.toString(), s) else (MediaType.ApplicationXml.toString(), s)).asRight[Unit])
-      } { (backend, baseUri) =>
-        basicRequest
-          .post(uri"$baseUri?kind=-1")
-          .body(penPineapple)
-          .send(backend)
-          .map { r =>
-            r.body shouldBe Right(penPineapple)
-            r.contentType shouldBe Some(MediaType.ApplicationJson.toString())
-          } >>
-          basicRequest
-            .post(uri"$baseUri?kind=1")
-            .body(penPineapple)
-            .send(backend)
-            .map { r =>
-              r.body shouldBe Right(penPineapple)
-              r.contentType shouldBe Some(MediaType.ApplicationXml.toString())
-            }
-      },
-      testServer(in_string_stream_out_either_stream_string(streams)) {
-        case ("left", s) => pureResult((Left(s): Either[streams.BinaryStream, String]).asRight[Unit])
-        case _           => pureResult((Right("was not left"): Either[streams.BinaryStream, String]).asRight[Unit])
-      } { (backend, baseUri) =>
-        basicRequest
-          .post(uri"$baseUri?which=left")
-          .body(penPineapple)
-          .send(backend)
-          .map(_.body shouldBe Right(penPineapple)) >>
-          basicRequest
-            .post(uri"$baseUri?which=right")
-            .body(penPineapple)
-            .send(backend)
-            .map(_.body shouldBe Right("was not left"))
-      },
-      testServer(in_stream_out_either_json_xml_stream(streams)) { s => pureResult(s.asRight[Unit]) } { (backend, baseUri) =>
-        basicRequest
-          .post(uri"$baseUri")
-          .body(penPineapple)
-          .header(Header.accept(MediaType.ApplicationXml, MediaType.ApplicationJson))
-          .send(backend)
-          .map { r =>
-            r.contentType shouldBe Some(MediaType.ApplicationXml.toString())
-            r.body shouldBe Right(penPineapple)
-          } >>
-          basicRequest
-            .post(uri"$baseUri")
-            .body(penPineapple)
-            .header(Header.accept(MediaType.ApplicationJson, MediaType.ApplicationXml))
-            .send(backend)
-            .map { r =>
-              r.contentType shouldBe Some(MediaType.ApplicationJson.toString())
-              r.body shouldBe Right(penPineapple)
-            }
-      }
-    )
+      )
+    else
+      Nil ++
+        List(
+          testServer(in_stream_out_stream(streams))((s: streams.BinaryStream) => pureResult(s.asRight[Unit])) { (backend, baseUri) =>
+            basicRequest.post(uri"$baseUri/api/echo").body(penPineapple).send(backend).map(_.body shouldBe Right(penPineapple))
+          },
+          testServer(out_custom_content_type_stream_body(streams)) { case (k, s) =>
+            pureResult((if (k < 0) (MediaType.ApplicationJson.toString(), s) else (MediaType.ApplicationXml.toString(), s)).asRight[Unit])
+          } { (backend, baseUri) =>
+            basicRequest
+              .post(uri"$baseUri?kind=-1")
+              .body(penPineapple)
+              .send(backend)
+              .map { r =>
+                r.body shouldBe Right(penPineapple)
+                r.contentType shouldBe Some(MediaType.ApplicationJson.toString())
+              } >>
+              basicRequest
+                .post(uri"$baseUri?kind=1")
+                .body(penPineapple)
+                .send(backend)
+                .map { r =>
+                  r.body shouldBe Right(penPineapple)
+                  r.contentType shouldBe Some(MediaType.ApplicationXml.toString())
+                }
+          },
+          testServer(in_string_stream_out_either_stream_string(streams)) {
+            case ("left", s) => pureResult((Left(s): Either[streams.BinaryStream, String]).asRight[Unit])
+            case _           => pureResult((Right("was not left"): Either[streams.BinaryStream, String]).asRight[Unit])
+          } { (backend, baseUri) =>
+            basicRequest
+              .post(uri"$baseUri?which=left")
+              .body(penPineapple)
+              .send(backend)
+              .map(_.body shouldBe Right(penPineapple)) >>
+              basicRequest
+                .post(uri"$baseUri?which=right")
+                .body(penPineapple)
+                .send(backend)
+                .map(_.body shouldBe Right("was not left"))
+          },
+          testServer(in_stream_out_either_json_xml_stream(streams)) { s => pureResult(s.asRight[Unit]) } { (backend, baseUri) =>
+            basicRequest
+              .post(uri"$baseUri")
+              .body(penPineapple)
+              .header(Header.accept(MediaType.ApplicationXml, MediaType.ApplicationJson))
+              .send(backend)
+              .map { r =>
+                r.contentType shouldBe Some(MediaType.ApplicationXml.toString())
+                r.body shouldBe Right(penPineapple)
+              } >>
+              basicRequest
+                .post(uri"$baseUri")
+                .body(penPineapple)
+                .header(Header.accept(MediaType.ApplicationJson, MediaType.ApplicationXml))
+                .send(backend)
+                .map { r =>
+                  r.contentType shouldBe Some(MediaType.ApplicationJson.toString())
+                  r.body shouldBe Right(penPineapple)
+                }
+          }
+        )
   }
 }

--- a/tests/src/main/scala/sttp/tapir/tests/Streaming.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/Streaming.scala
@@ -7,11 +7,6 @@ import sttp.tapir._
 import java.nio.charset.StandardCharsets
 
 object Streaming {
-  def in_string_out_string_stream[S](s: Streams[S]) = {
-    val sb = streamTextBody(s)(CodecFormat.TextPlain(), Some(StandardCharsets.UTF_8))
-    endpoint.post.in("api" / "echo").in(stringBody).out(sb)
-  }
-
   def in_stream_out_stream[S](s: Streams[S]): PublicEndpoint[s.BinaryStream, Unit, s.BinaryStream, S] = {
     val sb = streamTextBody(s)(CodecFormat.TextPlain(), Some(StandardCharsets.UTF_8))
     endpoint.post.in("api" / "echo").in(sb).out(sb)

--- a/tests/src/main/scala/sttp/tapir/tests/Streaming.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/Streaming.scala
@@ -7,6 +7,11 @@ import sttp.tapir._
 import java.nio.charset.StandardCharsets
 
 object Streaming {
+  def in_string_out_string_stream[S](s: Streams[S]) = {
+    val sb = streamTextBody(s)(CodecFormat.TextPlain(), Some(StandardCharsets.UTF_8))
+    endpoint.post.in("api" / "echo").in(stringBody).out(sb)
+  }
+
   def in_stream_out_stream[S](s: Streams[S]): PublicEndpoint[s.BinaryStream, Unit, s.BinaryStream, S] = {
     val sb = streamTextBody(s)(CodecFormat.TextPlain(), Some(StandardCharsets.UTF_8))
     endpoint.post.in("api" / "echo").in(sb).out(sb)


### PR DESCRIPTION
This PR enhances Netty Cats Effect server with streaming. 
From now on, the public API is:
```scala
  NettyCatsServer
    .io()
    .use { server =>
      server
        .port(port)
        .host(host)
        .addEndpoint(serverEndpoint) // <<< ServerEndpoint[Fs2Streams[F]]
        .start()
    }
```

Implementation notes:
- I used `HttpStreamsServerHandler` from [netty-reactive-streams-http](https://github.com/playframework/netty-reactive-streams). Adding it to the pipeline allows using a response of type `DefaultStreamedHttpResponse`, which wraps a reactive `Publisher[HttpContent]`.
- However, this handler doesn't work together with `HttpObjectAggregator`, so I had to split the pipeline into streaming/non-streaming variants.
- Without `HttpObjectAggregator` we no longer can send `ChunkedInput`, but this isn't a problem, we can just send files as streams as well.
- A bigger problem is handling requests. Without `HttpObjectAggregator` we need to handle request which have a body as `StreamedHttpRequest`, which have a `.subscribe` method. Using fs2, I create streams which read data from this `.subscribe` interface and materialize it into byte arrays as raw values. This may introduce performance overhead.
- Empty requests fall through the `HttpStreamsServerHandler` as instances of a regular `FullHttpRequest`.