### PR TITLE
Use errorOutVariantPrepend in docs example.

### DIFF
--- a/doc/endpoint/oneof.md
+++ b/doc/endpoint/oneof.md
@@ -163,7 +163,7 @@ val base: PublicEndpoint[Unit, DomainException, Unit, Any] = endpoint
   )
 
 val specialised: PublicEndpoint[Unit, DomainException, Unit, Any] = base
-  .errorOutVariant(oneOfVariant(statusCode(StatusCode.Forbidden).and(stringBody.mapTo[SecurityException])))
+  .errorOutVariantPrepend(oneOfVariant(statusCode(StatusCode.Forbidden).and(stringBody.mapTo[SecurityException])))
 ```
 
 The `.errorOutEither` method allows adding an unrelated error output, at the cost of wrapping 

--- a/generated-doc/out/endpoint/oneof.md
+++ b/generated-doc/out/endpoint/oneof.md
@@ -159,7 +159,7 @@ val base: PublicEndpoint[Unit, DomainException, Unit, Any] = endpoint
   )
 
 val specialised: PublicEndpoint[Unit, DomainException, Unit, Any] = base
-  .errorOutVariant(oneOfVariant(statusCode(StatusCode.Forbidden).and(stringBody.mapTo[SecurityException])))
+  .errorOutVariantPrepend(oneOfVariant(statusCode(StatusCode.Forbidden).and(stringBody.mapTo[SecurityException])))
 ```
 
 The `.errorOutEither` method allows adding an unrelated error output, at the cost of wrapping 


### PR DESCRIPTION
It turns out that the docs section that describes `errorOutVariantPrepend` doesn't use `errorOutVariantPrepend` in its example. 