### PR TITLE
Changed type parameter of VertxZioServerOptions from F[_] to R of RIO[R, *] interop effect type, added widen method.

### DIFF
--- a/server/vertx-server/zio/src/main/scala/sttp/tapir/server/vertx/zio/VertxZioServerInterpreter.scala
+++ b/server/vertx-server/zio/src/main/scala/sttp/tapir/server/vertx/zio/VertxZioServerInterpreter.scala
@@ -19,7 +19,7 @@ import zio._
 import java.util.concurrent.atomic.AtomicReference
 
 trait VertxZioServerInterpreter[R] extends CommonServerInterpreter {
-  def vertxZioServerOptions[R2 <: R]: VertxZioServerOptions[RIO[R2, *]] = VertxZioServerOptions.default
+  def vertxZioServerOptions[R2 <: R]: VertxZioServerOptions[R2] = VertxZioServerOptions.default[R].widen
 
   def route[R2](e: ZServerEndpoint[R2, ZioStreams with WebSockets])(implicit
       runtime: Runtime[R & R2]
@@ -112,9 +112,9 @@ trait VertxZioServerInterpreter[R] extends CommonServerInterpreter {
 }
 
 object VertxZioServerInterpreter {
-  def apply[R](serverOptions: VertxZioServerOptions[RIO[R, *]] = VertxZioServerOptions.default[R]): VertxZioServerInterpreter[R] = {
+  def apply[R](serverOptions: VertxZioServerOptions[R] = VertxZioServerOptions.default[R]): VertxZioServerInterpreter[R] = {
     new VertxZioServerInterpreter[R] {
-      override def vertxZioServerOptions[R2 <: R]: VertxZioServerOptions[RIO[R2, *]] = serverOptions.asInstanceOf[VertxZioServerOptions[RIO[R2, *]]]
+      override def vertxZioServerOptions[R2 <: R]: VertxZioServerOptions[R2] = serverOptions.widen[R2]
     }
   }
 

--- a/server/vertx-server/zio/src/main/scala/sttp/tapir/server/vertx/zio/streams/zio.scala
+++ b/server/vertx-server/zio/src/main/scala/sttp/tapir/server/vertx/zio/streams/zio.scala
@@ -26,7 +26,7 @@ package object streams {
       dfd.await
   }
 
-  def zioReadStreamCompatible[F[_]](opts: VertxZioServerOptions[F])(implicit
+  def zioReadStreamCompatible[R](opts: VertxZioServerOptions[R])(implicit
       runtime: Runtime[Any]
   ): ReadStreamCompatible[ZioStreams] = new ReadStreamCompatible[ZioStreams] {
     override val streams: ZioStreams = ZioStreams

--- a/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/VertxStubServerTest.scala
+++ b/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/VertxStubServerTest.scala
@@ -10,8 +10,8 @@ import sttp.tapir.ztapir.RIOMonadError
 
 import scala.concurrent.Future
 
-object VertxZioCreateServerStubTest extends CreateServerStubTest[Task, VertxZioServerOptions[Task]] {
-  override def customiseInterceptors: CustomiseInterceptors[Task, VertxZioServerOptions[Task]] = VertxZioServerOptions.customiseInterceptors
+object VertxZioCreateServerStubTest extends CreateServerStubTest[Task, VertxZioServerOptions[Any]] {
+  override def customiseInterceptors: CustomiseInterceptors[Task, VertxZioServerOptions[Any]] = VertxZioServerOptions.customiseInterceptors
   override def stub[R]: SttpBackendStub[Task, R] = SttpBackendStub(new RIOMonadError[Any])
   override def asFuture[A]: Task[A] => Future[A] = task => Unsafe.unsafe(implicit u => Runtime.default.unsafe.runToFuture(task))
 }

--- a/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/ZioVertxTestServerInterpreter.scala
+++ b/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/ZioVertxTestServerInterpreter.scala
@@ -14,11 +14,11 @@ import _root_.zio.{Runtime, Task}
 import sttp.tapir.server.vertx.VertxTestServerInterpreter
 
 class ZioVertxTestServerInterpreter(vertx: Vertx)
-    extends TestServerInterpreter[Task, ZioStreams with WebSockets, VertxZioServerOptions[Task], Router => Route] {
+    extends TestServerInterpreter[Task, ZioStreams with WebSockets, VertxZioServerOptions[Any], Router => Route] {
   import ZioVertxTestServerInterpreter._
 
   override def route(es: List[ServerEndpoint[ZioStreams with WebSockets, Task]], interceptors: Interceptors): Router => Route = { router =>
-    val options: VertxZioServerOptions[Task] = interceptors(VertxZioServerOptions.customiseInterceptors).options
+    val options: VertxZioServerOptions[Any] = interceptors(VertxZioServerOptions.customiseInterceptors).options
     val interpreter = VertxZioServerInterpreter(options)
     es.map(interpreter.route(_)(runtime)(router)).last
   }

--- a/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/streams/ZStreamTest.scala
+++ b/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/streams/ZStreamTest.scala
@@ -15,7 +15,7 @@ class ZStreamTest extends AsyncFlatSpec with Matchers {
 
   private val runtime = ZIORuntime.default
 
-  private val options = VertxZioServerOptions.default.copy(maxQueueSizeForReadStream = 4)
+  private val options = VertxZioServerOptions.default[Any].copy(maxQueueSizeForReadStream = 4)
 
   def intAsBuffer(int: Int): Chunk[Byte] = {
     val buffer = ByteBuffer.allocate(4)

--- a/server/vertx-server/zio1/src/main/scala/sttp/tapir/server/vertx/zio/VertxZioServerInterpreter.scala
+++ b/server/vertx-server/zio1/src/main/scala/sttp/tapir/server/vertx/zio/VertxZioServerInterpreter.scala
@@ -20,7 +20,7 @@ import _root_.zio.blocking.Blocking
 import java.util.concurrent.atomic.AtomicReference
 
 trait VertxZioServerInterpreter[R <: Blocking] extends CommonServerInterpreter {
-  def vertxZioServerOptions: VertxZioServerOptions[RIO[R, *]] = VertxZioServerOptions.default
+  def vertxZioServerOptions: VertxZioServerOptions[R] = VertxZioServerOptions.default
 
   def route(e: ZServerEndpoint[R, ZioStreams with WebSockets])(implicit
       runtime: Runtime[R]
@@ -112,10 +112,10 @@ trait VertxZioServerInterpreter[R <: Blocking] extends CommonServerInterpreter {
 
 object VertxZioServerInterpreter {
   def apply[R <: Blocking](
-      serverOptions: VertxZioServerOptions[RIO[R, *]] = VertxZioServerOptions.default[R]
+      serverOptions: VertxZioServerOptions[R] = VertxZioServerOptions.default
   ): VertxZioServerInterpreter[R] = {
     new VertxZioServerInterpreter[R] {
-      override def vertxZioServerOptions: VertxZioServerOptions[RIO[R, *]] = serverOptions
+      override def vertxZioServerOptions: VertxZioServerOptions[R] = serverOptions
     }
   }
 

--- a/server/vertx-server/zio1/src/main/scala/sttp/tapir/server/vertx/zio/streams/zio.scala
+++ b/server/vertx-server/zio1/src/main/scala/sttp/tapir/server/vertx/zio/streams/zio.scala
@@ -27,7 +27,7 @@ package object streams {
       dfd.await
   }
 
-  def zioReadStreamCompatible[F[_]](opts: VertxZioServerOptions[F])(implicit
+  def zioReadStreamCompatible[R](opts: VertxZioServerOptions[R])(implicit
       runtime: Runtime[Any]
   ): ReadStreamCompatible[ZioStreams] = new ReadStreamCompatible[ZioStreams] {
 

--- a/server/vertx-server/zio1/src/test/scala/sttp/tapir/server/vertx/zio/VertxStubServerTest.scala
+++ b/server/vertx-server/zio1/src/test/scala/sttp/tapir/server/vertx/zio/VertxStubServerTest.scala
@@ -11,8 +11,8 @@ import sttp.tapir.ztapir.RIOMonadError
 
 import scala.concurrent.Future
 
-object VertxZioCreateServerStubTest extends CreateServerStubTest[RIO[Blocking, *], VertxZioServerOptions[RIO[Blocking, *]]] {
-  override def customiseInterceptors: CustomiseInterceptors[RIO[Blocking, *], VertxZioServerOptions[RIO[Blocking, *]]] =
+object VertxZioCreateServerStubTest extends CreateServerStubTest[RIO[Blocking, *], VertxZioServerOptions[Blocking]] {
+  override def customiseInterceptors: CustomiseInterceptors[RIO[Blocking, *], VertxZioServerOptions[Blocking]] =
     VertxZioServerOptions.customiseInterceptors
   override def stub[R]: SttpBackendStub[RIO[Blocking, *], R] = SttpBackendStub(new RIOMonadError[Blocking])
   override def asFuture[A]: RIO[Blocking, A] => Future[A] = task => Runtime.default.unsafeRunToFuture(task)

--- a/server/vertx-server/zio1/src/test/scala/sttp/tapir/server/vertx/zio/ZioVertxTestServerInterpreter.scala
+++ b/server/vertx-server/zio1/src/test/scala/sttp/tapir/server/vertx/zio/ZioVertxTestServerInterpreter.scala
@@ -15,14 +15,14 @@ import _root_.zio.blocking.Blocking
 import sttp.tapir.server.vertx.VertxTestServerInterpreter
 
 class ZioVertxTestServerInterpreter(vertx: Vertx)
-    extends TestServerInterpreter[RIO[Blocking, *], ZioStreams with WebSockets, VertxZioServerOptions[RIO[Blocking, *]], Router => Route] {
+    extends TestServerInterpreter[RIO[Blocking, *], ZioStreams with WebSockets, VertxZioServerOptions[Blocking], Router => Route] {
   import ZioVertxTestServerInterpreter._
 
   override def route(
       es: List[ServerEndpoint[ZioStreams with WebSockets, RIO[Blocking, *]]],
       interceptors: Interceptors
   ): Router => Route = { router =>
-    val options: VertxZioServerOptions[RIO[Blocking, *]] = interceptors(VertxZioServerOptions.customiseInterceptors).options
+    val options: VertxZioServerOptions[Blocking] = interceptors(VertxZioServerOptions.customiseInterceptors).options
     val interpreter = VertxZioServerInterpreter(options)
     es.map(interpreter.route(_)(runtime)(router)).last
   }

--- a/server/vertx-server/zio1/src/test/scala/sttp/tapir/server/vertx/zio/streams/ZStreamTest.scala
+++ b/server/vertx-server/zio1/src/test/scala/sttp/tapir/server/vertx/zio/streams/ZStreamTest.scala
@@ -5,6 +5,7 @@ import io.vertx.core.buffer.Buffer
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import _root_.zio._
+import _root_.zio.blocking.Blocking
 import _root_.zio.duration._
 import _root_.zio.stream.ZStream
 import _root_.zio.clock.Clock
@@ -17,7 +18,7 @@ class ZStreamTest extends AsyncFlatSpec with Matchers {
 
   private val runtime = ZIORuntime.default
 
-  private val options = VertxZioServerOptions.default.copy(maxQueueSizeForReadStream = 4)
+  private val options = VertxZioServerOptions.default[Blocking].copy(maxQueueSizeForReadStream = 4)
 
   def intAsBuffer(int: Int): Chunk[Byte] = {
     val buffer = ByteBuffer.allocate(4)


### PR DESCRIPTION
I noticed some changes in #3011 which I would like to use. And decided to make the same changes to VertxZioServerOptions also. Hope there would be no problem with backward compatibility. 