### PR TITLE
Added zServerLogicFallible method which can fail request effect F[_] in case ERROR_INPUT is subtype of Throwable.

### DIFF
--- a/integrations/zio/src/main/scala/sttp/tapir/ztapir/ZPartialServerEndpoint.scala
+++ b/integrations/zio/src/main/scala/sttp/tapir/ztapir/ZPartialServerEndpoint.scala
@@ -79,4 +79,14 @@ case class ZPartialServerEndpoint[R, SECURITY_INPUT, PRINCIPAL, INPUT, ERROR_OUT
       _ => securityLogic(_: SECURITY_INPUT).either.resurrect,
       _ => (u: PRINCIPAL) => (i: INPUT) => logic(u)(i).either.resurrect
     )
+
+  def serverLogicFallible[R0](
+      logic: PRINCIPAL => INPUT => ZIO[R0, ERROR_OUTPUT, OUTPUT]
+  )(implicit ev1: ERROR_OUTPUT <:< Throwable): ZServerEndpoint[R with R0, C] =
+    ServerEndpoint(
+      endpoint,
+      _ => securityLogic(_: SECURITY_INPUT).asRight.resurrect,
+      _ => (u: PRINCIPAL) => (i: INPUT) => logic(u)(i).asRight.resurrect
+    )
+
 }

--- a/integrations/zio/src/test/scala/sttp/tapir/ztapir/RecoverInterceptor.scala
+++ b/integrations/zio/src/test/scala/sttp/tapir/ztapir/RecoverInterceptor.scala
@@ -1,0 +1,28 @@
+package sttp.tapir.ztapir
+
+import sttp.model.StatusCode
+import sttp.monad.MonadError
+import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.interceptor._
+import sttp.tapir.server.model.ValuedEndpointOutput
+import sttp.tapir.ztapir.ZTapirTest.ResponseBodyType
+import zio.Task
+
+case class RecoverInterceptor[T](recoverF: Throwable => ValuedEndpointOutput[T]) extends RequestInterceptor[Task] {
+
+  override def apply[R, B](
+      responder: Responder[Task, B],
+      requestHandler: EndpointInterceptor[Task] => RequestHandler[Task, R, B]
+  ): RequestHandler[Task, R, B] = {
+
+    val next = requestHandler(EndpointInterceptor.noop)
+    new RequestHandler[Task, R, B] {
+      override def apply(request: ServerRequest, endpoints: List[ServerEndpoint[R, Task]])(implicit
+          monad: MonadError[Task]
+      ): Task[RequestResult[B]] = {
+        next(request, endpoints).catchNonFatalOrDie(e => responder(request, recoverF(e)).map(RequestResult.Response(_)))
+      }
+    }
+  }
+}

--- a/integrations/zio/src/test/scala/sttp/tapir/ztapir/TestErrorThrowable.scala
+++ b/integrations/zio/src/test/scala/sttp/tapir/ztapir/TestErrorThrowable.scala
@@ -1,0 +1,19 @@
+package sttp.tapir.ztapir
+
+import sttp.tapir.{Codec, DecodeResult}
+import sttp.tapir.CodecFormat.TextPlain
+
+import scala.util.control.NoStackTrace
+import scala.util.matching.Regex
+
+case class TestErrorThrowable(message: String) extends Throwable(message) with NoStackTrace
+
+object TestErrorThrowable {
+  val errorPattern: Regex = """TestErrorThrowable\((.*)\)""".r
+
+  implicit val codec: Codec[String, TestErrorThrowable, TextPlain] = Codec.string.mapDecode {
+    case errorPattern(message) => DecodeResult.Value(TestErrorThrowable(message))
+    case value => DecodeResult.Error(value, new RuntimeException(s"Unable to decode value $value"))
+  }(_.toString)
+
+}


### PR DESCRIPTION
## Motivation

At this moment there is no way to capture on Interceptor level the fact that business logic was failed. But sometimes it is very useful to be able to do it. This is because of wrapping effect in`.either.resurrect` for ZIO interop.

## Solution

I am suggesting to add new methods  - zServerLogicFallible/serverLogicFallible. With them, it becomes possible to attach logic to endpoint and catch its failing on Interceptor level (via MonadError[F].handleError) in case ERROR_OUTPUT is a subtype of Throwable. 
I created two tests for problem cases.

@adamw could you take a look at this.
Are those changes are consistent with Tapir design? If yes, is it ok to implement it in ZIO interop module or this should be implemented on more abstract level?

probably closes #1782