### PR TITLE
Add support for map for codegen

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -3,7 +3,12 @@ package sttp.tapir.codegen
 import sttp.tapir.codegen.BasicGenerator.{indent, mapSchemaSimpleTypeToType}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaMap, OpenapiSchemaObject, OpenapiSchemaSimpleType}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
+  OpenapiSchemaArray,
+  OpenapiSchemaMap,
+  OpenapiSchemaObject,
+  OpenapiSchemaSimpleType
+}
 
 class ClassDefinitionGenerator {
 
@@ -35,11 +40,10 @@ class ClassDefinitionGenerator {
         .flatten
         .toList
 
-      val properties = obj.properties.map {
-        case (key, schemaType) =>
-          val tpe = mapSchemaTypeToType(name, key, obj.required.contains(key), schemaType)
-          val fixedKey = fixKey(key)
-          s"$fixedKey: $tpe"
+      val properties = obj.properties.map { case (key, schemaType) =>
+        val tpe = mapSchemaTypeToType(name, key, obj.required.contains(key), schemaType)
+        val fixedKey = fixKey(key)
+        s"$fixedKey: $tpe"
       }
 
       s"""|case class $name (
@@ -59,11 +63,11 @@ class ClassDefinitionGenerator {
         addName(parentName, key) -> objectType.nullable
 
       case mapType: OpenapiSchemaMap =>
-        val innerType = mapSchemaTypeToType(addName(parentName, key), "item", required = false, mapType.items)
+        val innerType = mapSchemaTypeToType(addName(parentName, key), "item", required = true, mapType.items)
         s"Map[String, $innerType]" -> mapType.nullable
 
       case arrayType: OpenapiSchemaArray =>
-        val innerType = mapSchemaTypeToType(addName(parentName, key), "item", required = false, arrayType.items)
+        val innerType = mapSchemaTypeToType(addName(parentName, key), "item", required = true, arrayType.items)
         s"Seq[$innerType]" -> arrayType.nullable
 
       case _ =>

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -2,6 +2,7 @@ package sttp.tapir.codegen
 
 import sttp.tapir.codegen.BasicGenerator.{indent, mapSchemaSimpleTypeToType}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaObject, OpenapiSchemaSimpleType}
 
 class ClassDefinitionGenerator {
@@ -16,34 +17,55 @@ class ClassDefinitionGenerator {
   }
 
   private[codegen] def generateClass(name: String, obj: OpenapiSchemaObject): Seq[String] = {
-    def addName(parentName: String, key: String) = parentName + key.replace('_', ' ').replace('-', ' ').capitalize.replace(" ", "")
     def rec(name: String, obj: OpenapiSchemaObject, acc: List[String]): Seq[String] = {
       val innerClasses = obj.properties
-        .collect { case (propName, st: OpenapiSchemaObject) =>
-          val newName = addName(name, propName)
-          rec(newName, st, Nil)
+        .collect {
+          case (propName, st: OpenapiSchemaObject) =>
+            val newName = addName(name, propName)
+            rec(newName, st, Nil)
+
+          case (propName, OpenapiSchemaArray(st: OpenapiSchemaObject, _)) =>
+            val newName = addName(addName(name, propName), "item")
+            rec(newName, st, Nil)
         }
         .flatten
         .toList
-      val fs = obj.properties.collect {
-        case (k, st: OpenapiSchemaSimpleType) =>
-          val t = mapSchemaSimpleTypeToType(st)
-          innerTypePrinter(k, t._1, t._2 || !obj.required.contains(k))
-        case (k, st: OpenapiSchemaObject) =>
-          val t = addName(name, k)
-          innerTypePrinter(k, t, st.nullable || !obj.required.contains(k))
-        case (k, OpenapiSchemaArray(inner: OpenapiSchemaSimpleType, nullable)) =>
-          val innerT = mapSchemaSimpleTypeToType(inner)._1
-          innerTypePrinter(k, s"Seq[$innerT]", nullable || !obj.required.contains(k))
+
+      val properties = obj.properties.map {
+        case (key, schemaType) =>
+          val tpe = mapSchemaTypeToType(name, key, obj.required.contains(key), schemaType)
+          val fixedKey = fixKey(key)
+          s"$fixedKey: $tpe"
       }
-      require(fs.size == obj.properties.size, s"We can't serialize some of the properties yet! $name $obj")
+
       s"""|case class $name (
-          |${indent(2)(fs.mkString(",\n"))}
+          |${indent(2)(properties.mkString(",\n"))}
           |)""".stripMargin :: innerClasses ::: acc
     }
 
     rec(addName("", name), obj, Nil)
   }
+
+  private def mapSchemaTypeToType(parentName: String, key: String, required: Boolean, schemaType: OpenapiSchemaType): String = {
+    val (tpe, optional) = schemaType match {
+      case simpleType: OpenapiSchemaSimpleType =>
+        mapSchemaSimpleTypeToType(simpleType)
+
+      case objectType: OpenapiSchemaObject =>
+        addName(parentName, key) -> objectType.nullable
+
+      case arrayType: OpenapiSchemaArray =>
+        val innerType = mapSchemaTypeToType(addName(parentName, key), "item", required = false, arrayType.items)
+        s"Seq[$innerType]" -> arrayType.nullable
+
+      case _ =>
+        throw new NotImplementedError(s"We can't serialize some of the properties yet! $parentName $key $schemaType")
+    }
+
+    if (optional || !required) s"Option[$tpe]" else tpe
+  }
+
+  private def addName(parentName: String, key: String) = parentName + key.replace('_', ' ').replace('-', ' ').capitalize.replace(" ", "")
 
   private val reservedKeys = scala.reflect.runtime.universe.asInstanceOf[scala.reflect.internal.SymbolTable].nme.keywords.map(_.toString)
 
@@ -52,11 +74,5 @@ class ClassDefinitionGenerator {
       s"`$key`"
     else
       key
-  }
-
-  private def innerTypePrinter(key: String, tp: String, optional: Boolean) = {
-    val fixedType = if (optional) s"Option[$tp]" else tp
-    val fixedKey = fixKey(key)
-    s"$fixedKey: $fixedType"
   }
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -128,7 +128,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
               "objects" -> OpenapiSchemaMap(
                 OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(false)), Seq("text"), false),
                 false
-              ),
+              )
             ),
             Seq("objects"),
             false

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -2,7 +2,7 @@ package sttp.tapir.codegen
 
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaObject, OpenapiSchemaString}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaMap, OpenapiSchemaObject, OpenapiSchemaString}
 import sttp.tapir.codegen.testutils.CompileCheckTestBase
 
 class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
@@ -56,6 +56,21 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     new ClassDefinitionGenerator().classDefs(doc) shouldCompile ()
   }
 
+  it should "generate class with map" in {
+    val doc = OpenapiDocument(
+      "",
+      null,
+      null,
+      OpenapiComponent(
+        Map(
+          "Test" -> OpenapiSchemaObject(Map("texts" -> OpenapiSchemaMap(OpenapiSchemaString(false), false)), Seq("texts"), false)
+        )
+      )
+    )
+
+    new ClassDefinitionGenerator().classDefs(doc) shouldCompile ()
+  }
+
   it should "generate class with inner class" in {
     val doc = OpenapiDocument(
       "",
@@ -91,7 +106,31 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
                 false
               )
             ),
-            Seq("texts"),
+            Seq("objects"),
+            false
+          )
+        )
+      )
+    )
+
+    new ClassDefinitionGenerator().classDefs(doc) shouldCompile ()
+  }
+
+  it should "generate class with map with inner class" in {
+    val doc = OpenapiDocument(
+      "",
+      null,
+      null,
+      OpenapiComponent(
+        Map(
+          "Test" -> OpenapiSchemaObject(
+            Map(
+              "objects" -> OpenapiSchemaMap(
+                OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(false)), Seq("text"), false),
+                false
+              ),
+            ),
+            Seq("objects"),
             false
           )
         )

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -77,6 +77,30 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     new ClassDefinitionGenerator().classDefs(doc) shouldCompile ()
   }
 
+  it should "generate class with array with inner class" in {
+    val doc = OpenapiDocument(
+      "",
+      null,
+      null,
+      OpenapiComponent(
+        Map(
+          "Test" -> OpenapiSchemaObject(
+            Map(
+              "objects" -> OpenapiSchemaArray(
+                OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(false)), Seq("text"), false),
+                false
+              )
+            ),
+            Seq("texts"),
+            false
+          )
+        )
+      )
+    )
+
+    new ClassDefinitionGenerator().classDefs(doc) shouldCompile ()
+  }
+
   it should "nonrequired and required are not the same" in {
     val doc1 = OpenapiDocument(
       "",

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/SchemaParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/SchemaParserSpec.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.codegen.openapi.models
 
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiResponseContent
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaInt, OpenapiSchemaObject, OpenapiSchemaString}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaInt, OpenapiSchemaMap, OpenapiSchemaObject, OpenapiSchemaString}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
@@ -37,6 +37,36 @@ class SchemaParserSpec extends AnyFlatSpec with Matchers with Checkers {
           "User" -> OpenapiSchemaObject(
             Map("id" -> OpenapiSchemaInt(false), "name" -> OpenapiSchemaString(false)),
             Seq("id", "name"),
+            false
+          )
+        )
+      )
+    )
+  }
+
+  it should "parse map" in {
+    val yaml = """
+      |schemas:
+      |  User:
+      |    properties:
+      |      attributes:
+      |        type: object
+      |        additionalProperties:
+      |          type: string
+      |    required:
+      |      - attributes""".stripMargin
+
+    val res = parser
+      .parse(yaml)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[OpenapiComponent])
+
+    res shouldBe Right(
+      OpenapiComponent(
+        Map(
+          "User" -> OpenapiSchemaObject(
+            Map("attributes" -> OpenapiSchemaMap(OpenapiSchemaString(false), false)),
+            Seq("attributes"),
             false
           )
         )

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/SchemaParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/SchemaParserSpec.scala
@@ -1,7 +1,13 @@
 package sttp.tapir.codegen.openapi.models
 
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiResponseContent
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaInt, OpenapiSchemaMap, OpenapiSchemaObject, OpenapiSchemaString}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
+  OpenapiSchemaArray,
+  OpenapiSchemaInt,
+  OpenapiSchemaMap,
+  OpenapiSchemaObject,
+  OpenapiSchemaString
+}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers


### PR DESCRIPTION
Adds support for parsing [maps](https://swagger.io/docs/specification/data-models/dictionaries/).

```yaml
components:
  schemas:
    Model:
      required:
      - data
      type: object
      properties:
        data:
          type: object
          additionalProperties:
            type: object
            required:
              - value
            properties:
              value:
                type: integer
```
Produces
```scala
case class Model (
  data: Map[String, ModelDataItem]
)
case class ModelDataItem (
  value: Int
)
```

This also adds support for arrays and maps containing objects. Previously only simple types were supported as array items.