### PR TITLE
handle parameters defined on parent path of method (codegen)

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -27,7 +27,7 @@ class EndpointGenerator {
   }
 
   private[codegen] def generatedEndpoints(p: OpenapiPath): Seq[(String, String)] = {
-    p.methods.map { m =>
+    p.methods.map(_ withParentParameters p.parameters).map { m =>
       val definition =
         s"""|endpoint
             |  .${m.methodType}

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -67,14 +67,16 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       "",
       null,
       null,
-      OpenapiComponent(
-        Map(
-          "Test" -> OpenapiSchemaObject(Map("texts" -> OpenapiSchemaMap(OpenapiSchemaString(false), false)), Seq("texts"), false)
+      Some(
+        OpenapiComponent(
+          Map(
+            "Test" -> OpenapiSchemaObject(Map("texts" -> OpenapiSchemaMap(OpenapiSchemaString(false), false)), Seq("texts"), false)
+          )
         )
       )
     )
 
-    new ClassDefinitionGenerator().classDefs(doc) shouldCompile ()
+    new ClassDefinitionGenerator().classDefs(doc).get shouldCompile ()
   }
 
   it should "generate class with inner class" in {
@@ -105,23 +107,25 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       "",
       null,
       null,
-      OpenapiComponent(
-        Map(
-          "Test" -> OpenapiSchemaObject(
-            Map(
-              "objects" -> OpenapiSchemaArray(
-                OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(false)), Seq("text"), false),
-                false
-              )
-            ),
-            Seq("objects"),
-            false
+      Some(
+        OpenapiComponent(
+          Map(
+            "Test" -> OpenapiSchemaObject(
+              Map(
+                "objects" -> OpenapiSchemaArray(
+                  OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(false)), Seq("text"), false),
+                  false
+                )
+              ),
+              Seq("objects"),
+              false
+            )
           )
         )
       )
     )
 
-    new ClassDefinitionGenerator().classDefs(doc) shouldCompile ()
+    new ClassDefinitionGenerator().classDefs(doc).get shouldCompile ()
   }
 
   it should "generate class with map with inner class" in {
@@ -129,23 +133,25 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       "",
       null,
       null,
-      OpenapiComponent(
-        Map(
-          "Test" -> OpenapiSchemaObject(
-            Map(
-              "objects" -> OpenapiSchemaMap(
-                OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(false)), Seq("text"), false),
-                false
-              )
-            ),
-            Seq("objects"),
-            false
+      Some(
+        OpenapiComponent(
+          Map(
+            "Test" -> OpenapiSchemaObject(
+              Map(
+                "objects" -> OpenapiSchemaMap(
+                  OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(false)), Seq("text"), false),
+                  false
+                )
+              ),
+              Seq("objects"),
+              false
+            )
           )
         )
       )
     )
 
-    new ClassDefinitionGenerator().classDefs(doc) shouldCompile ()
+    new ClassDefinitionGenerator().classDefs(doc).get shouldCompile ()
   }
 
   it should "nonrequired and required are not the same" in {

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -31,14 +31,15 @@ object TestHelpers {
       |  version: '1.0'
       |paths:
       |  /books/{genre}/{year}:
+      |    parameters:
+      |    - name: genre
+      |      in: path
+      |      required: true
+      |      schema:
+      |        type: string
       |    post:
       |      operationId: postBooksGenreYear
       |      parameters:
-      |      - name: genre
-      |        in: path
-      |        required: true
-      |        schema:
-      |          type: string
       |      - name: year
       |        in: path
       |        required: true
@@ -135,7 +136,6 @@ object TestHelpers {
           OpenapiPathMethod(
             methodType = "post",
             parameters = Seq(
-              OpenapiParameter("genre", "path", true, None, OpenapiSchemaString(false)),
               OpenapiParameter("year", "path", true, None, OpenapiSchemaInt(false)),
               OpenapiParameter("limit", "query", true, Some("Maximum number of books to retrieve"), OpenapiSchemaInt(false)),
               OpenapiParameter("X-Auth-Token", "header", true, None, OpenapiSchemaString(false))
@@ -184,7 +184,8 @@ object TestHelpers {
             tags = Some(Seq("Bookshop")),
             operationId = Some("getBooksGenreYear")
           )
-        )
+        ),
+        parameters = Seq(OpenapiParameter("genre", "path", true, None, OpenapiSchemaString(false)))
       )
     ),
     Some(OpenapiComponent(
@@ -384,7 +385,8 @@ object TestHelpers {
             ),
             requestBody = None,
             summary = None,
-            tags = None
+            tags = None,
+            operationId = Some("getHello")
           )
         )
       )


### PR DESCRIPTION
Handles parameters defined directly on path objects (whilst still permitting overriding via identically-named parameters directly on the method, as per the openapi spec)

Contains some additional unrelated test changes (looks like recently merged prs weren't up-to-date so some tests didn't compile when reconciled)