### PR TITLE
reconcile #/components/parameters/ refs in codegen

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
@@ -1,6 +1,12 @@
 package sttp.tapir.codegen.openapi.models
 
-case class OpenapiComponent(schemas: Map[String, OpenapiSchemaType])
+import cats.syntax.either._
+
+import OpenapiModels.OpenapiParameter
+case class OpenapiComponent(
+    schemas: Map[String, OpenapiSchemaType],
+    parameters: Map[String, OpenapiParameter] = Map.empty
+)
 
 object OpenapiComponent {
   import io.circe._
@@ -8,8 +14,9 @@ object OpenapiComponent {
   implicit val OpenapiComponentDecoder: Decoder[OpenapiComponent] = { (c: HCursor) =>
     for {
       schemas <- c.downField("schemas").as[Map[String, OpenapiSchemaType]]
+      parameters <- c.downField("parameters").as[Map[String, OpenapiParameter]].orElse(Right(Map.empty[String, OpenapiParameter]))
     } yield {
-      OpenapiComponent(schemas)
+      OpenapiComponent(schemas, parameters.map{ case (k, v) => s"#/components/parameters/$k" -> v})
     }
   }
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -37,6 +37,7 @@ object TestHelpers {
       |      required: true
       |      schema:
       |        type: string
+      |    - $ref: '#/components/parameters/year'
       |    post:
       |      operationId: postBooksGenreYear
       |      parameters:
@@ -82,11 +83,7 @@ object TestHelpers {
       |        required: true
       |        schema:
       |          type: string
-      |      - name: year
-      |        in: path
-      |        required: true
-      |        schema:
-      |          type: integer
+      |      - $ref: '#/components/parameters/offset'
       |      - name: limit
       |        in: query
       |        description: Maximum number of books to retrieve
@@ -124,6 +121,20 @@ object TestHelpers {
       |      properties:
       |        title:
       |          type: string
+      |  parameters:
+      |    offset:
+      |      name: offset
+      |      in: query
+      |      description: Offset at which to start fetching books
+      |      required: true
+      |      schema:
+      |        type: integer
+      |    year:
+      |      name: year
+      |      in: path
+      |      required: true
+      |      schema:
+      |        type: integer
       |""".stripMargin
 
   val myBookshopDoc = OpenapiDocument(
@@ -137,7 +148,6 @@ object TestHelpers {
             methodType = "get",
             parameters = Seq(
               OpenapiParameter("genre", "path", true, None, OpenapiSchemaString(false)),
-              OpenapiParameter("year", "path", true, None, OpenapiSchemaInt(false)),
               OpenapiParameter("limit", "query", true, Some("Maximum number of books to retrieve"), OpenapiSchemaInt(false)),
               OpenapiParameter("X-Auth-Token", "header", true, None, OpenapiSchemaString(false))
             ),
@@ -152,7 +162,8 @@ object TestHelpers {
             requestBody = None,
             summary = None,
             tags = Some(Seq("Bookshop")),
-            operationId = Some("getBooksGenreYear")
+            operationId = Some("getBooksGenreYear"),
+            parameterRefs = Seq(OpenapiSchemaRef("#/components/parameters/offset"))
           ),
           OpenapiPathMethod(
             methodType = "post",
@@ -185,13 +196,19 @@ object TestHelpers {
             operationId = Some("postBooksGenreYear")
           )
         ),
-        parameters = Seq(OpenapiParameter("genre", "path", true, None, OpenapiSchemaString(false)))
+        parameters = Seq(OpenapiParameter("genre", "path", true, None, OpenapiSchemaString(false))),
+        parameterRefs = Seq(OpenapiSchemaRef("#/components/parameters/year"))
       )
     ),
     Some(
       OpenapiComponent(
         Map(
           "Book" -> OpenapiSchemaObject(Map("title" -> OpenapiSchemaString(false)), Seq("title"), false)
+        ),
+        Map(
+          "#/components/parameters/offset" ->
+            OpenapiParameter("offset", "query", true, Some("Offset at which to start fetching books"), OpenapiSchemaInt(false)),
+          "#/components/parameters/year" -> OpenapiParameter("year", "path", true, None, OpenapiSchemaInt(false))
         )
       )
     )


### PR DESCRIPTION
Parses and resolves `$ref: '#/components/parameters/foo'` style params. I'm not sure if this is really the best approach here, or if some other mechanism for reference objects would make sense... Splitting the parameters and parameter refs up, for example, loses ordering between them, so it may make more sense for parameters to be of type `Resolvable[OpenapiParameter]` for some `trait Resolvable[T] { def resolve(m: Map[String, T]): T }` or something. Also the `withReconciledParameters` method has got pretty messy. But it does seem to work, so it's got that going for it...