### PR TITLE
Use Enumeratum for enum codegen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1894,7 +1894,8 @@ lazy val openapiCodegenCore: ProjectMatrix = (projectMatrix in file("openapi-cod
       scalaTestPlusScalaCheck.value % Test,
       "com.47deg" %% "scalacheck-toolbox-datetime" % "0.7.0" % Test,
       scalaOrganization.value % "scala-reflect" % scalaVersion.value,
-      scalaOrganization.value % "scala-compiler" % scalaVersion.value % Test
+      scalaOrganization.value % "scala-compiler" % scalaVersion.value % Test,
+      "com.beachape" %% "enumeratum" % "1.7.3" % Test,
     )
   )
   .dependsOn(core % Test, circeJson % Test)

--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -58,9 +58,11 @@ val docs = TapirGeneratedEndpoints.generatedEndpoints.toOpenAPI("My Bookshop", "
 
 Currently, the generated code depends on `"io.circe" %% "circe-generic"`. In the future probably we will make the encoder/decoder json lib configurable (PRs welcome).
 
+String-like enums depend on `"com.beachape" %% "enumeratum"`. Other forms of OpenApi enum are not currently supported. 
+
 We currently miss a lot of OpenApi features like:
  - tags
- - enums/ADTs
+ - ADTs
  - missing model types and meta descriptions (like date, minLength)
  - file handling
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -4,6 +4,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaBoolean,
   OpenapiSchemaDouble,
+  OpenapiSchemaEnum,
   OpenapiSchemaFloat,
   OpenapiSchemaInt,
   OpenapiSchemaLong,
@@ -19,12 +20,13 @@ object BasicGenerator {
   val endpointGenerator = new EndpointGenerator()
 
   def generateObjects(doc: OpenapiDocument, packagePath: String, objName: String): String = {
+    val enumImport = if (doc.components.toSeq.flatMap(_.schemas).exists(_._2.isInstanceOf[OpenapiSchemaEnum])) "\n  import enumeratum._" else ""
     s"""|
         |package $packagePath
         |
         |object $objName {
         |
-        |${indent(2)(imports)}
+        |${indent(2)(imports)}$enumImport
         |
         |${indent(2)(classGenerator.classDefs(doc).getOrElse(""))}
         |

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -26,12 +26,9 @@ class ClassDefinitionGenerator {
       .map(_.mkString("\n"))
   }
 
-  // Uses enumeratum so as to work with scala 2, but ideally should probably generate scala 3 enums instead when it can
+  // Uses enumeratum so as to work with scala 2, but ideally should probably generate scala 3 enums instead where it can
   private[codegen] def generateEnum(name: String, obj: OpenapiSchemaEnum): Seq[String] = {
-    val members = obj.items.map{
-      case OpenapiSchemaConstantString(s) => s"case object $s extends $name"
-      case _ => throw new NotImplementedError("Only string enums are supported!")
-    }
+    val members = obj.items.map{ i => s"case object ${i.value} extends $name" }
     s"""|sealed trait $name extends EnumEntry
         |object $name extends Enum[$name] {
         |  val values = findValues

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -5,6 +5,8 @@ import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaArray,
+  OpenapiSchemaConstantString,
+  OpenapiSchemaEnum,
   OpenapiSchemaMap,
   OpenapiSchemaObject,
   OpenapiSchemaSimpleType
@@ -17,9 +19,24 @@ class ClassDefinitionGenerator {
       .map(_.schemas.flatMap {
         case (name, obj: OpenapiSchemaObject) =>
           generateClass(name, obj)
-        case _ => throw new NotImplementedError("Only objects supported!")
+        case (name, obj: OpenapiSchemaEnum) =>
+          generateEnum(name, obj)
+        case _ => throw new NotImplementedError("Only objects and enums supported!")
       })
       .map(_.mkString("\n"))
+  }
+
+  // Uses enumeratum so as to work with scala 2, but ideally should probably generate scala 3 enums instead when it can
+  private[codegen] def generateEnum(name: String, obj: OpenapiSchemaEnum): Seq[String] = {
+    val members = obj.items.map{
+      case OpenapiSchemaConstantString(s) => s"case object $s extends $name"
+      case _ => throw new NotImplementedError("Only string enums are supported!")
+    }
+    s"""|sealed trait $name extends EnumEntry
+        |object $name extends Enum[$name] {
+        |  val values = findValues
+        |${indent(2)(members.mkString("\n"))}
+        |}""".stripMargin :: Nil
   }
 
   private[codegen] def generateClass(name: String, obj: OpenapiSchemaObject): Seq[String] = {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
@@ -83,33 +83,15 @@ object OpenapiSchemaType {
     val nullable = false
   }
 
-  sealed trait OpenapiSchemaConstantValue[T] extends OpenapiSchemaType {
-    def value: T
-  }
   case class OpenapiSchemaConstantString(
       value: String
-  ) extends OpenapiSchemaConstantValue[String] {
+  ) extends OpenapiSchemaType {
     val nullable = false
-  }
-  case class OpenapiSchemaConstantBoolean(
-      value: Boolean
-  ) extends OpenapiSchemaConstantValue[Boolean] {
-    val nullable = false
-  }
-  case class OpenapiSchemaConstantLong(
-      value: Long
-  ) extends OpenapiSchemaConstantValue[Long] {
-    val nullable = false
-  }
-  case object OpenapiSchemaConstantNull extends OpenapiSchemaConstantValue[Null] {
-    val value = null
-    val nullable = true
   }
 
-  // Can't support non-primitive item types although that should be legal (see https://json-schema.org/draft/2020-12/json-schema-validation.html#enum)
-  // Maybe can't support heterogenous item types either, IDK, let's see...
+  // Can't support non-string enum types although that should apparently be legal (see https://json-schema.org/draft/2020-12/json-schema-validation.html#enum)
   case class OpenapiSchemaEnum(
-      items: Seq[OpenapiSchemaConstantValue[_]],
+      items: Seq[OpenapiSchemaConstantString],
       nullable: Boolean
   ) extends OpenapiSchemaType
 
@@ -254,20 +236,12 @@ object OpenapiSchemaType {
     }
   }
 
-  implicit val OpenapiSchemaConstantDecoder: Decoder[OpenapiSchemaConstantValue[_]] = { (c: HCursor) =>
-    c.value.fold(
-      Right(OpenapiSchemaConstantNull),
-      b => Right(OpenapiSchemaConstantBoolean(b)),
-      _.toLong.map(OpenapiSchemaConstantLong(_)).toRight(DecodingFailure("Numeric enums only support long literals", c.history)),
-      s => Right(OpenapiSchemaConstantString(s)),
-      _ => Left(DecodingFailure("Array enums are unsupported!", c.history)),
-      _ => Left(DecodingFailure("Object enums are unsupported!", c.history))
-    )
-  }
+  implicit val OpenapiSchemaConstantDecoder: Decoder[OpenapiSchemaConstantString] =
+    Decoder.decodeString.map(OpenapiSchemaConstantString.apply)
 
   implicit val OpenapiSchemaEnumDecoder: Decoder[OpenapiSchemaEnum] = { (c: HCursor) =>
     for {
-      items <- c.downField("enum").as[Seq[OpenapiSchemaConstantValue[_]]]
+      items <- c.downField("enum").as[Seq[OpenapiSchemaConstantString]]
       nb <- c.downField("nullable").as[Option[Boolean]]
     } yield OpenapiSchemaEnum(items, nb.getOrElse(false))
   }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -2,7 +2,14 @@ package sttp.tapir.codegen
 
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaMap, OpenapiSchemaObject, OpenapiSchemaString}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
+  OpenapiSchemaArray,
+  OpenapiSchemaConstantString,
+  OpenapiSchemaEnum,
+  OpenapiSchemaMap,
+  OpenapiSchemaObject,
+  OpenapiSchemaString
+}
 import sttp.tapir.codegen.testutils.CompileCheckTestBase
 
 class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
@@ -26,6 +33,23 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     )
 
     new ClassDefinitionGenerator().classDefs(doc).get shouldCompile ()
+  }
+
+  it should "generate simple enum" in {
+    val doc = OpenapiDocument(
+      "",
+      null,
+      null,
+      Some(
+        OpenapiComponent(
+          Map(
+            "Test" -> OpenapiSchemaEnum(Seq(OpenapiSchemaConstantString("paperback"), OpenapiSchemaConstantString("hardback")), false)
+          )
+        )
+      )
+    )
+    // the enumeratum import should be included by the BasicGenerator iff we generated enums
+    "import enumeratum._;" + (new ClassDefinitionGenerator().classDefs(doc).get) shouldCompile ()
   }
 
   it should "generate simple class with reserved propName" in {

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
@@ -2,7 +2,14 @@ package sttp.tapir.codegen.openapi.models
 
 import sttp.tapir.codegen.TestHelpers
 import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiDocument, OpenapiResponse, OpenapiResponseContent}
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaRef, OpenapiSchemaString, OpenapiSchemaUUID}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
+  OpenapiSchemaArray,
+  OpenapiSchemaConstantString,
+  OpenapiSchemaEnum,
+  OpenapiSchemaRef,
+  OpenapiSchemaString,
+  OpenapiSchemaUUID
+}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
@@ -71,7 +78,7 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers {
     res shouldBe (Right(
       TestHelpers.helloDocs
     ))
-}
+  }
 
   it should "parse bookstore yaml containing an endpoint with no parameters" in {
     val yaml = TestHelpers.generatedBookshopYaml
@@ -119,6 +126,23 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers {
         ),
         OpenapiResponse("default", "", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaUUID(false))))
       )
+    )
+  }
+
+  it should "parse enums" in {
+    val yaml =
+      """
+        |enum:
+        |- paperback
+        |- hardback""".stripMargin
+
+    val res = parser
+      .parse(yaml)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[OpenapiSchemaType])
+
+    res shouldBe Right(
+      OpenapiSchemaEnum(Seq(OpenapiSchemaConstantString("paperback"), OpenapiSchemaConstantString("hardback")), false)
     )
   }
 }


### PR DESCRIPTION
Maybe not the best solution... for scala 3, it would obviously make sense to just use scala enums; for scala 2 on the jvm, it might make sense to use java enums; some people probably don't even mind scala 2's enumeration too much. The choice of enumeratum however has the advantage that it works on both versions of scala on all platforms, so I _think_ it's the right one here.

We only include the import when we actually generate enums, so this doesn't introduce a dependency on enumeratum _unless_ enums are actually specified.