### PR TITLE
handle missing response content in codegen

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -86,12 +86,12 @@ class EndpointGenerator {
         }
       }
 
-    val rqBody = requestBody.fold("") { b =>
+    val rqBody = requestBody.map{ b =>
       if (b.content.size != 1) throw new NotImplementedError("We can handle only one requestBody content!")
       s".in(${contentTypeMapper(b.content.head.contentType, b.content.head.schema, b.required)})"
     }
 
-    (params :+ rqBody).mkString("\n")
+    (params ++ rqBody).mkString("\n")
   }
 
   private def tags(openapiTags: Option[Seq[String]]): String = {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -117,19 +117,19 @@ object OpenapiModels {
   }
 
   implicit val OpenapiResponseDecoder: Decoder[Seq[OpenapiResponse]] = { (c: HCursor) =>
-    implicit val InnerDecoder: Decoder[(String, Seq[OpenapiResponseContent])] = { (c: HCursor) =>
+    implicit val InnerDecoder: Decoder[(String, Option[Seq[OpenapiResponseContent]])] = { (c: HCursor) =>
       for {
         description <- c.downField("description").as[String]
-        content <- c.downField("content").as[Seq[OpenapiResponseContent]]
+        content <- c.downField("content").as[Option[Seq[OpenapiResponseContent]]]
       } yield {
         (description, content)
       }
     }
     for {
-      schema <- c.as[Map[String, (String, Seq[OpenapiResponseContent])]]
+      schema <- c.as[Map[String, (String, Option[Seq[OpenapiResponseContent]])]]
     } yield {
       schema.map { case (code, (desc, content)) =>
-        OpenapiResponse(code, desc, content)
+        OpenapiResponse(code, desc, content.getOrElse(Nil))
       }.toSeq
     }
   }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -114,6 +114,15 @@ object TestHelpers {
       |                type: string
       |      tags:
       |        - Bookshop
+      |    delete:
+      |      operationId: deleteBooksGenreYear
+      |      responses:
+      |        '200':
+      |          description: 'deletion was successful'
+      |        default:
+      |          description: 'deletion failed'
+      |      tags:
+      |        - Bookshop
       |components:
       |  schemas:
       |    Book:
@@ -196,6 +205,18 @@ object TestHelpers {
             summary = None,
             tags = Some(Seq("Bookshop")),
             operationId = Some("postBooksGenreYear")
+          ),
+          OpenapiPathMethod(
+            methodType = "delete",
+            parameters = Nil,
+            responses = Seq(
+              OpenapiResponse("200", "deletion was successful", Nil),
+              OpenapiResponse("default", "deletion failed", Nil)
+            ),
+            requestBody = None,
+            summary = None,
+            tags = Some(Seq("Bookshop")),
+            operationId = Some("deleteBooksGenreYear")
           )
         ),
         parameters = Seq(


### PR DESCRIPTION
Permits specifying a `Unit` output type by not providing a response content.