### PR TITLE
handle empty requestBody.content in codegen

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -86,9 +86,10 @@ class EndpointGenerator {
         }
       }
 
-    val rqBody = requestBody.map{ b =>
-      if (b.content.size != 1) throw new NotImplementedError("We can handle only one requestBody content!")
-      s".in(${contentTypeMapper(b.content.head.contentType, b.content.head.schema, b.required)})"
+    val rqBody = requestBody.flatMap{ b =>
+      if (b.content.isEmpty) None
+      else if (b.content.size != 1) throw new NotImplementedError("We can handle only one requestBody content!")
+      else Some(s".in(${contentTypeMapper(b.content.head.contentType, b.content.head.schema, b.required)})")
     }
 
     (params ++ rqBody).mkString("\n")

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -154,9 +154,9 @@ object OpenapiModels {
     for {
       requiredOpt <- c.downField("required").as[Option[Boolean]]
       description <- c.downField("description").as[Option[String]]
-      content <- c.downField("content").as[Option[Seq[OpenapiRequestBodyContent]]]
+      content <- c.downField("content").as[Seq[OpenapiRequestBodyContent]]
     } yield {
-      OpenapiRequestBody(required = requiredOpt.getOrElse(false), description, content.getOrElse(Nil))
+      OpenapiRequestBody(required = requiredOpt.getOrElse(false), description, content)
     }
   }
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -154,9 +154,9 @@ object OpenapiModels {
     for {
       requiredOpt <- c.downField("required").as[Option[Boolean]]
       description <- c.downField("description").as[Option[String]]
-      content <- c.downField("content").as[Seq[OpenapiRequestBodyContent]]
+      content <- c.downField("content").as[Option[Seq[OpenapiRequestBodyContent]]]
     } yield {
-      OpenapiRequestBody(required = requiredOpt.getOrElse(false), description, content)
+      OpenapiRequestBody(required = requiredOpt.getOrElse(false), description, content.getOrElse(Nil))
     }
   }
 


### PR DESCRIPTION
Probably the last one from me for a while - this will get tapir codegen to the point where it can generate the required code from some $realWorld stoplight output that I've been working with. Thanks so much for this project 😄 

Edit: I haven't touched the tests for this because it's super minor, and more a quirk of stoplight than anything else. I'd much rather the requestBody had just been fully absent from the output - which would already have worked - but instead I'm seeing
```
      requestBody:
        content: {}
```
Ridiculous. But the documentation [doesn't actually specify that the content map be non-empty](https://swagger.io/specification/#request-body-object)