### PR TITLE
Some codegen improvements

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -67,7 +67,7 @@ object BasicGenerator {
         ("Boolean", nb)
       case OpenapiSchemaRef(t) =>
         (t.split('/').last, false)
-      case _ => throw new NotImplementedError("Not all simple types supported!")
+      case x => throw new NotImplementedError(s"Not all simple types supported! Found $x")
     }
   }
 }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -21,9 +21,18 @@ class ClassDefinitionGenerator {
           generateClass(name, obj)
         case (name, obj: OpenapiSchemaEnum) =>
           generateEnum(name, obj, targetScala3)
-        case _ => throw new NotImplementedError("Only objects and enums supported!")
+        case (name, OpenapiSchemaMap(valueSchema, _)) => generateMap(name, valueSchema)
+        case (n, x) => throw new NotImplementedError(s"Only objects, enums and maps supported! (for $n found ${x})")
       })
       .map(_.mkString("\n"))
+  }
+
+  private[codegen] def generateMap(name: String, valueSchema: OpenapiSchemaType): Seq[String] = {
+    val valueSchemaName = valueSchema match {
+      case simpleType: OpenapiSchemaSimpleType => BasicGenerator.mapSchemaSimpleTypeToType(simpleType)._1
+      case otherType => throw new NotImplementedError(s"Only simple value types and refs are implemented for named maps (found $otherType)")
+    }
+    Seq(s"""type $name = Map[String, $valueSchemaName]""")
   }
 
   // Uses enumeratum for scala 2, but generates scala 3 enums instead where it can

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -14,12 +14,12 @@ class EndpointGenerator {
     val ge = doc.paths.flatMap(generatedEndpoints(ps))
     val definitions = ge
       .map { case (name, definition) =>
-        s"""|val $name =
+        s"""|lazy val $name =
             |${indent(2)(definition)}
             |""".stripMargin
       }
       .mkString("\n")
-    val allEP = s"val $allEndpoints = List(${ge.map(_._1).mkString(", ")})"
+    val allEP = s"lazy val $allEndpoints = List(${ge.map(_._1).mkString(", ")})"
 
     s"""|$definitions
         |
@@ -82,11 +82,11 @@ class EndpointGenerator {
             val (t, _) = mapSchemaSimpleTypeToType(st)
             val desc = param.description.fold("")(d => s""".description("$d")""")
             s""".in(${param.in}[$t]("${param.name}")$desc)"""
-          case _ => throw new NotImplementedError("Can't create non-simple params to input")
+          case x => throw new NotImplementedError(s"Can't create non-simple params to input - found $x")
         }
       }
 
-    val rqBody = requestBody.flatMap{ b =>
+    val rqBody = requestBody.flatMap { b =>
       if (b.content.isEmpty) None
       else if (b.content.size != 1) throw new NotImplementedError("We can handle only one requestBody content!")
       else Some(s".in(${contentTypeMapper(b.content.head.contentType, b.content.head.schema, b.required)})")
@@ -136,11 +136,11 @@ class EndpointGenerator {
           case OpenapiSchemaArray(st: OpenapiSchemaSimpleType, _) =>
             val (t, _) = mapSchemaSimpleTypeToType(st)
             s"List[$t]"
-          case _ => throw new NotImplementedError("Can't create non-simple or array params as output")
+          case x => throw new NotImplementedError(s"Can't create non-simple or array params as output (found $x)")
         }
         val req = if (required) outT else s"Option[$outT]"
         s"jsonBody[$req]"
-      case _ => throw new NotImplementedError("We only handle json and text!")
+      case x => throw new NotImplementedError(s"We only handle json and text! Found $x")
     }
   }
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
@@ -15,7 +15,7 @@ object OpenapiComponent {
   implicit val OpenapiComponentDecoder: Decoder[OpenapiComponent] = { (c: HCursor) =>
     for {
       schemas <- c.downField("schemas").as[Map[String, OpenapiSchemaType]]
-      parameters <- c.downField("parameters").as[Map[String, OpenapiParameter]].orElse(Right(Map.empty[String, OpenapiParameter]))
+      parameters <- c.downField("parameters").as[Option[Map[String, OpenapiParameter]]].map(_.getOrElse(Map.empty))
     } yield {
       OpenapiComponent(schemas, parameters.map { case (k, v) => s"#/components/parameters/$k" -> v })
     }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -169,8 +169,8 @@ object OpenapiModels {
     for {
       parameters <- c
         .downField("parameters")
-        .as[Seq[Resolvable[OpenapiParameter]]]
-        .orElse(Right(List.empty[Resolvable[OpenapiParameter]]))
+        .as[Option[Seq[Resolvable[OpenapiParameter]]]]
+        .map(_.getOrElse(Nil))
       responses <- c.downField("responses").as[Seq[OpenapiResponse]]
       requestBody <- c.downField("requestBody").as[Option[OpenapiRequestBody]]
       summary <- c.downField("summary").as[Option[String]]
@@ -183,7 +183,10 @@ object OpenapiModels {
 
   implicit val PartialOpenapiPathDecoder: Decoder[OpenapiPath] = { (c: HCursor) =>
     for {
-      parameters <- c.downField("parameters").as[Seq[Resolvable[OpenapiParameter]]].orElse(Right(List.empty[Resolvable[OpenapiParameter]]))
+      parameters <- c
+        .downField("parameters")
+        .as[Option[Seq[Resolvable[OpenapiParameter]]]]
+        .map(_.getOrElse(Nil))
       methods <- List("get", "put", "post", "delete", "options", "head", "patch", "patch", "connect")
         .traverse(method => c.downField(method).as[Option[OpenapiPathMethod]].map(_.map(_.copy(methodType = method))))
     } yield OpenapiPath("--partial--", methods.flatten, parameters)
@@ -202,7 +205,7 @@ object OpenapiModels {
       openapi <- c.downField("openapi").as[String]
       info <- c.downField("info").as[OpenapiInfo]
       paths <- c.downField("paths").as[Seq[OpenapiPath]]
-      components <- c.downField("components").as[Option[OpenapiComponent]].orElse(Right(None))
+      components <- c.downField("components").as[Option[OpenapiComponent]]
     } yield OpenapiDocument(openapi, info, paths, components)
   }
 

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -8,6 +8,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaEnum,
   OpenapiSchemaMap,
   OpenapiSchemaObject,
+  OpenapiSchemaRef,
   OpenapiSchemaString
 }
 import sttp.tapir.codegen.testutils.CompileCheckTestBase
@@ -258,9 +259,31 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val gen = new ClassDefinitionGenerator()
     val res = gen.classDefs(doc, true)
     // can't just check whether this compiles, because our tests only run on scala 2.12 - so instead just eyeball it...
-    res shouldBe Some(
-      """enum Test {
+    res shouldBe Some("""enum Test {
         |  case enum1, enum2
         |}""".stripMargin)
+  }
+
+  it should "generate named maps" in {
+    val doc = OpenapiDocument(
+      "",
+      null,
+      null,
+      Some(
+        OpenapiComponent(
+          Map(
+            "MyObject" -> OpenapiSchemaObject(Map("text" -> OpenapiSchemaString(true)), Seq("text"), false),
+            "MyEnum" -> OpenapiSchemaEnum(Seq(OpenapiSchemaConstantString("enum1"), OpenapiSchemaConstantString("enum2")), false),
+            "MyMapPrimitive" -> OpenapiSchemaMap(OpenapiSchemaString(false), false),
+            "MyMapObject" -> OpenapiSchemaMap(OpenapiSchemaRef("#/components/schemas/MyObject"), false),
+            "MyMapEnum" -> OpenapiSchemaMap(OpenapiSchemaRef("#/components/schemas/MyEnum"), false)
+          )
+        )
+      )
+    )
+
+    val gen = new ClassDefinitionGenerator()
+    val res = gen.classDefs(doc, false)
+    "import enumeratum._;" + res.get shouldCompile ()
   }
 }


### PR DESCRIPTION
Mixing up a few things in this pr:
- Fail codegen if parameters can't be decoded
- Added slightly more detail to a few of the error messages
- Support defining maps directly under schemas
- Make endpoint definitions lazy, to reduce occurrence of 'method too large' errors

Happy to put any of these changes into a separate pr if they're contentious, but figured there wasn't too much harm in putting a few little things all in the same pr