### PR TITLE
Add support showExtensions option for swagger-ui

### DIFF
--- a/doc/docs/openapi.md
+++ b/doc/docs/openapi.md
@@ -328,6 +328,8 @@ val openAPIYaml = OpenAPIDocsInterpreter().toOpenAPI(sampleEndpoint, Info("title
 However, to add extensions to other unusual places (like, `License` or `Server`, etc.) you should modify the `OpenAPI`
 object manually or using a tool such as [quicklens](https://github.com/softwaremill/quicklens).
 
+If you are using `tapir-swagger-ui` you need to set `withShowExtensions` option for `SwaggerUIOptions`.
+
 ## Hiding inputs/outputs
 
 It's possible to hide an input/output from the OpenAPI description using following syntax:

--- a/docs/swagger-ui/src/main/scala/sttp/tapir/swagger/SwaggerUI.scala
+++ b/docs/swagger-ui/src/main/scala/sttp/tapir/swagger/SwaggerUI.scala
@@ -53,9 +53,16 @@ object SwaggerUI {
     val swaggerInitializerJsWithReplacedUrl =
       swaggerInitializerJs.replace("https://petstore.swagger.io/v2/swagger.json", s"${concat(fullPathPrefix, options.yamlName)}")
 
+    val swaggerInitializerJsWithOptions =
+      swaggerInitializerJsWithReplacedUrl.replace(
+        "window.ui = SwaggerUIBundle({",
+        s"""window.ui = SwaggerUIBundle({
+           |    showExtensions: ${options.showExtensions},""".stripMargin
+      )
+
     val textJavascriptUtf8: EndpointIO.Body[String, String] = stringBodyUtf8AnyFormat(Codec.string.format(CodecFormat.TextJavascript()))
     val swaggerInitializerJsEndpoint =
-      baseEndpoint.in("swagger-initializer.js").out(textJavascriptUtf8).serverLogicPure[F](_ => Right(swaggerInitializerJsWithReplacedUrl))
+      baseEndpoint.in("swagger-initializer.js").out(textJavascriptUtf8).serverLogicPure[F](_ => Right(swaggerInitializerJsWithOptions))
 
     val resourcesEndpoint = staticResourcesGetServerEndpoint[F](prefixInput)(
       SwaggerUI.getClass.getClassLoader,

--- a/docs/swagger-ui/src/main/scala/sttp/tapir/swagger/SwaggerUIOptions.scala
+++ b/docs/swagger-ui/src/main/scala/sttp/tapir/swagger/SwaggerUIOptions.scala
@@ -12,15 +12,26 @@ package sttp.tapir.swagger
   *   referrer's uri). Also used for creating redirects. Defaults to `Nil`.
   * @param useRelativePaths
   *   Should relative paths be used for yaml references and redirects. Defaults to `true`.
+  * @param showExtensions
+  *   Should display the content of vendor extensions (x-) fields and values for Operations, Parameters, Responses, and Schema. Defaults to
+  *   `false`.
   */
-case class SwaggerUIOptions(pathPrefix: List[String], yamlName: String, contextPath: List[String], useRelativePaths: Boolean) {
+case class SwaggerUIOptions(
+    pathPrefix: List[String],
+    yamlName: String,
+    contextPath: List[String],
+    useRelativePaths: Boolean,
+    showExtensions: Boolean
+) {
   def pathPrefix(pathPrefix: List[String]): SwaggerUIOptions = copy(pathPrefix = pathPrefix)
   def yamlName(yamlName: String): SwaggerUIOptions = copy(yamlName = yamlName)
   def contextPath(contextPath: List[String]): SwaggerUIOptions = copy(contextPath = contextPath)
   def withRelativePaths: SwaggerUIOptions = copy(useRelativePaths = true)
   def withAbsolutePaths: SwaggerUIOptions = copy(useRelativePaths = false)
+  def withShowExtensions: SwaggerUIOptions = copy(showExtensions = true)
+  def withHideExtensions: SwaggerUIOptions = copy(showExtensions = false)
 }
 
 object SwaggerUIOptions {
-  val default: SwaggerUIOptions = SwaggerUIOptions(List("docs"), "docs.yaml", Nil, useRelativePaths = true)
+  val default: SwaggerUIOptions = SwaggerUIOptions(List("docs"), "docs.yaml", Nil, useRelativePaths = true, showExtensions = false)
 }


### PR DESCRIPTION
In swagger-ui, showing extensions is disabled by default, which results in them not being shown in tapir-swagger-ui, so the ability to control this option internally has been added.