### PR TITLE
add Pekko HTTP support to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ input and output parameters. An endpoint specification can be interpreted as:
   * [Http4s](https://tapir.softwaremill.com/en/latest/server/http4s.html) `HttpRoutes[F]`
   * [Netty](https://tapir.softwaremill.com/en/latest/server/netty.html)
   * [Finatra](https://tapir.softwaremill.com/en/latest/server/finatra.html) `FinatraRoute`
+  * [Pekko HTTP](https://tapir.softwaremill.com/en/latest/server/pekkohttp.html) `Route`s/`Directive`s
   * [Play](https://tapir.softwaremill.com/en/latest/server/play.html) `Route`
   * [Vert.X](https://tapir.softwaremill.com/en/latest/server/vertx.html) `Router => Route`
   * [ZIO Http](https://tapir.softwaremill.com/en/latest/server/ziohttp.html) `Http`


### PR DESCRIPTION
I just added it to the list based on alphabetic order but another option is to have it after Akka HTTP in the list.