### PR TITLE
Use uploadDir path from VertxServerSettings instead of internal Vertx default value + fix deprecations & unused imports

### DIFF
--- a/server/vertx-server/cats/src/main/scala/sttp/tapir/server/vertx/cats/VertxCatsServerInterpreter.scala
+++ b/server/vertx-server/cats/src/main/scala/sttp/tapir/server/vertx/cats/VertxCatsServerInterpreter.scala
@@ -39,7 +39,8 @@ trait VertxCatsServerInterpreter[F[_]] extends CommonServerInterpreter {
       e: ServerEndpoint[Fs2Streams[F] with WebSockets, F]
   ): Router => Route = { router =>
     val readStreamCompatible = fs2ReadStreamCompatible(vertxCatsServerOptions)
-    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint)).handler(endpointHandler(e, readStreamCompatible))
+    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint), vertxCatsServerOptions)
+      .handler(endpointHandler(e, readStreamCompatible))
   }
 
   private def endpointHandler[S <: Streams[S]](

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/VertxFutureServerInterpreter.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/VertxFutureServerInterpreter.scala
@@ -29,7 +29,7 @@ trait VertxFutureServerInterpreter extends CommonServerInterpreter {
     *   A function, that given a router, will attach this endpoint to it
     */
   def route[A, U, I, E, O](e: ServerEndpoint[VertxStreams with WebSockets, Future]): Router => Route = { router =>
-    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint))
+    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint), vertxFutureServerOptions)
       .handler(endpointHandler(e))
   }
 
@@ -40,7 +40,7 @@ trait VertxFutureServerInterpreter extends CommonServerInterpreter {
     *   A function, that given a router, will attach this endpoint to it
     */
   def blockingRoute(e: ServerEndpoint[VertxStreams with WebSockets, Future]): Router => Route = { router =>
-    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint))
+    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint), vertxFutureServerOptions)
       .blockingHandler(endpointHandler(e))
   }
 

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/VertxFutureServerOptions.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/VertxFutureServerOptions.scala
@@ -3,7 +3,6 @@ package sttp.tapir.server.vertx
 import io.vertx.core.logging.{Logger, LoggerFactory}
 import io.vertx.core.{Context, Vertx}
 import io.vertx.ext.web.RoutingContext
-import sttp.monad.{FutureMonad, MonadError}
 import sttp.tapir.server.interceptor.log.DefaultServerLog
 import sttp.tapir.server.interceptor.{CustomiseInterceptors, Interceptor}
 import sttp.tapir.{Defaults, TapirFile}
@@ -49,10 +48,7 @@ object VertxFutureServerOptions {
 
   val default: VertxFutureServerOptions = customiseInterceptors.options
 
-  def defaultServerLog(log: Logger): DefaultServerLog[Future] = {
-    import scala.concurrent.ExecutionContext.Implicits.global
-    implicit val monadError: MonadError[Future] = new FutureMonad
-
+  def defaultServerLog(log: Logger): DefaultServerLog[Future] =
     DefaultServerLog(
       doLogWhenReceived = debugLog(log)(_, None),
       doLogWhenHandled = debugLog(log),
@@ -60,7 +56,6 @@ object VertxFutureServerOptions {
       doLogExceptions = (msg: String, ex: Throwable) => Future.successful { log.error(msg, ex) },
       noLog = Future.successful(())
     )
-  }
 
   private def debugLog(log: Logger)(msg: String, exOpt: Option[Throwable]): Future[Unit] = Future.successful {
     VertxServerOptions.debugLog(log)(msg, exOpt)

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/interpreters/CommonServerInterpreter.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/interpreters/CommonServerInterpreter.scala
@@ -12,5 +12,5 @@ trait CommonServerInterpreter {
       routeDef: RouteDefinition,
       serverOptions: VertxServerOptions[F]
   ): Route =
-    attachDefaultHandlers(e.endpoint, createRoute(router, routeDef), serverOptions.uploadDirectory.getAbsolutePath)
+    attachDefaultHandlers(e.endpoint, createRoute(router, routeDef), serverOptions.uploadDirectory.getPath)
 }

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/interpreters/CommonServerInterpreter.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/interpreters/CommonServerInterpreter.scala
@@ -2,13 +2,15 @@ package sttp.tapir.server.vertx.interpreters
 
 import io.vertx.ext.web.{Route, Router}
 import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.vertx.VertxServerOptions
 import sttp.tapir.server.vertx.handlers.attachDefaultHandlers
 import sttp.tapir.server.vertx.routing.PathMapping.{RouteDefinition, createRoute}
 
 trait CommonServerInterpreter {
   protected def mountWithDefaultHandlers[C, F[_]](e: ServerEndpoint[C, F])(
       router: Router,
-      routeDef: RouteDefinition
+      routeDef: RouteDefinition,
+      serverOptions: VertxServerOptions[F]
   ): Route =
-    attachDefaultHandlers(e.endpoint, createRoute(router, routeDef))
+    attachDefaultHandlers(e.endpoint, createRoute(router, routeDef), serverOptions.uploadDirectory.getAbsolutePath)
 }

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/Pipe.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/Pipe.scala
@@ -1,16 +1,12 @@
 package sttp.tapir.server.vertx.streams
 
-import java.util.concurrent.atomic.AtomicReference
-
-import io.vertx.core.{AsyncResult, Handler}
 import io.vertx.core.buffer.Buffer
-import io.vertx.core.http.{WebSocketFrame => VertxWebSocketFrame}
-import io.vertx.core.http.ServerWebSocket
-import io.vertx.core.streams.ReadStream
-import io.vertx.core.streams.WriteStream
+import io.vertx.core.http.{ServerWebSocket, WebSocketFrame => VertxWebSocketFrame}
+import io.vertx.core.streams.{ReadStream, WriteStream}
 import sttp.ws.WebSocketFrame
 import sttp.ws.WebSocketFrame._
 
+import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
 
 object Pipe {

--- a/server/vertx-server/zio/src/main/scala/sttp/tapir/server/vertx/zio/VertxZioServerInterpreter.scala
+++ b/server/vertx-server/zio/src/main/scala/sttp/tapir/server/vertx/zio/VertxZioServerInterpreter.scala
@@ -24,7 +24,7 @@ trait VertxZioServerInterpreter[R] extends CommonServerInterpreter {
   def route[R2](e: ZServerEndpoint[R2, ZioStreams with WebSockets])(implicit
       runtime: Runtime[R & R2]
   ): Router => Route = { router =>
-    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint))
+    mountWithDefaultHandlers(e.widen)(router, extractRouteDefinition(e.endpoint), vertxZioServerOptions)
       .handler(endpointHandler(e))
   }
 

--- a/server/vertx-server/zio1/src/main/scala/sttp/tapir/server/vertx/zio/VertxZioServerInterpreter.scala
+++ b/server/vertx-server/zio1/src/main/scala/sttp/tapir/server/vertx/zio/VertxZioServerInterpreter.scala
@@ -25,7 +25,7 @@ trait VertxZioServerInterpreter[R <: Blocking] extends CommonServerInterpreter {
   def route(e: ZServerEndpoint[R, ZioStreams with WebSockets])(implicit
       runtime: Runtime[R]
   ): Router => Route = { router =>
-    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint))
+    mountWithDefaultHandlers(e)(router, extractRouteDefinition(e.endpoint), vertxZioServerOptions)
       .handler(endpointHandler(e))
   }
 


### PR DESCRIPTION
This pull request aims to improve codebase by utilizing the uploadDir path from the VertxServerSettings configuration instead of relying on the internal Vertx default value. 
Before this fix there was an issue where Vertx created unnecessary upload directories with default name (`file-uploads`) for every request, even without endpoints with file input type:
https://github.com/vert-x3/vertx-web/blob/master/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java#L234

The main cause is that BodyHandler by default is created with ability to handle file uploads and default upload dir:
https://github.com/vert-x3/vertx-web/blob/master/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/BodyHandlerImpl.java#L60
https://github.com/softwaremill/tapir/blob/master/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/handlers/package.scala#L12
