### PR TITLE
restore cross-build for refined on js platform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -635,7 +635,7 @@ lazy val refined: ProjectMatrix = (projectMatrix in file("integrations/refined")
   )
   .jvmPlatform(scalaVersions = scala2And3Versions)
   .jsPlatform(
-    scalaVersions = List(scala3),
+    scalaVersions = scala2And3Versions,
     settings = commonJsSettings ++ Seq(
       libraryDependencies ++= Seq(
         "io.github.cquiroz" %%% "scala-java-time" % Versions.jsScalaJavaTime % Test


### PR DESCRIPTION
I've accidentally broke the cross-compile for refined in https://github.com/softwaremill/tapir/pull/3038/files#r1301183280

This PR fixes that mistake