### PR TITLE
Fix extra dot in schema name for enumeratum

### DIFF
--- a/integrations/enumeratum/src/main/scala/sttp/tapir/codec/enumeratum/TapirCodecEnumeratum.scala
+++ b/integrations/enumeratum/src/main/scala/sttp/tapir/codec/enumeratum/TapirCodecEnumeratum.scala
@@ -90,7 +90,10 @@ trait TapirCodecEnumeratum {
   implicit def plainCodecByteEnumEntry[E <: ByteEnumEntry](implicit `enum`: ByteEnum[E]): Codec.PlainCodec[E] =
     plainCodecValueEnumEntry[Byte, E]
 
-  private def fullName[T](t: T) = t.getClass.getName.replace("$", ".")
+  private def fullName[T](t: T) = {
+    val s = t.getClass.getName.replace("$", ".")
+    if (s.endsWith(".")) s.dropRight(1) else s
+  }
 
   // no Codec.PlainCodec[Char]
 }

--- a/integrations/enumeratum/src/test/scala/sttp/tapir/codec/enumeratum/TapirCodecEnumeratumTest.scala
+++ b/integrations/enumeratum/src/test/scala/sttp/tapir/codec/enumeratum/TapirCodecEnumeratumTest.scala
@@ -42,42 +42,60 @@ class TapirCodecEnumeratumTest extends AnyFlatSpec with Matchers {
   }
 
   it should "find proper validator for enumeratum enum entries" in {
-    testEnumValidator(implicitly[Schema[TestEnumEntry]].validator)
-    testValueEnumValidator[Int, TestIntEnumEntry, IntEnum[TestIntEnumEntry]](implicitly[Schema[TestIntEnumEntry]].validator)
-    testValueEnumValidator[Long, TestLongEnumEntry, LongEnum[TestLongEnumEntry]](implicitly[Schema[TestLongEnumEntry]].validator)
-    testValueEnumValidator[Short, TestShortEnumEntry, ShortEnum[TestShortEnumEntry]](implicitly[Schema[TestShortEnumEntry]].validator)
-    testValueEnumValidator[String, TestStringEnumEntry, StringEnum[TestStringEnumEntry]](implicitly[Schema[TestStringEnumEntry]].validator)
-    testValueEnumValidator[Byte, TestByteEnumEntry, ByteEnum[TestByteEnumEntry]](implicitly[Schema[TestByteEnumEntry]].validator)
-    testValueEnumValidator[Char, TestCharEnumEntry, CharEnum[TestCharEnumEntry]](implicitly[Schema[TestCharEnumEntry]].validator)
+    testEnumValidator(implicitly[Schema[TestEnumEntry]].validator, "TestEnumEntry")
+    testValueEnumValidator[Int, TestIntEnumEntry, IntEnum[TestIntEnumEntry]](
+      implicitly[Schema[TestIntEnumEntry]].validator,
+      "TestIntEnumEntry"
+    )
+    testValueEnumValidator[Long, TestLongEnumEntry, LongEnum[TestLongEnumEntry]](
+      implicitly[Schema[TestLongEnumEntry]].validator,
+      "TestLongEnumEntry"
+    )
+    testValueEnumValidator[Short, TestShortEnumEntry, ShortEnum[TestShortEnumEntry]](
+      implicitly[Schema[TestShortEnumEntry]].validator,
+      "TestShortEnumEntry"
+    )
+    testValueEnumValidator[String, TestStringEnumEntry, StringEnum[TestStringEnumEntry]](
+      implicitly[Schema[TestStringEnumEntry]].validator,
+      "TestStringEnumEntry"
+    )
+    testValueEnumValidator[Byte, TestByteEnumEntry, ByteEnum[TestByteEnumEntry]](
+      implicitly[Schema[TestByteEnumEntry]].validator,
+      "TestByteEnumEntry"
+    )
+    testValueEnumValidator[Char, TestCharEnumEntry, CharEnum[TestCharEnumEntry]](
+      implicitly[Schema[TestCharEnumEntry]].validator,
+      "TestCharEnumEntry"
+    )
   }
 
-  private def testEnumValidator[E <: EnumEntry](validator: Validator[E])(implicit `enum`: Enum[E]): Unit = {
+  private def testEnumValidator[E <: EnumEntry](validator: Validator[E], shortName: String)(implicit `enum`: Enum[E]): Unit = {
     `enum`.values.foreach { v =>
       validator(v) shouldBe Nil
       validator match {
         case Validator.Enumeration(_, Some(encode), name) =>
           encode(v) shouldBe Some(v.entryName)
-          name shouldBe Some(SName(fullName(`enum`)))
+          name shouldBe Some(SName(fullName(shortName)))
         case a => fail(s"Expected enum validator with encode function: got $a")
       }
     }
   }
 
-  private def testValueEnumValidator[T, EE <: ValueEnumEntry[T], E <: ValueEnum[T, EE]](validator: Validator[EE])(implicit
-      `enum`: E
+  private def testValueEnumValidator[T, EE <: ValueEnumEntry[T], E <: ValueEnum[T, EE]](validator: Validator[EE], shortName: String)(
+      implicit `enum`: E
   ): Unit = {
     `enum`.values.foreach { v =>
       validator(v) shouldBe Nil
       validator match {
         case Validator.Enumeration(_, Some(encode), name) =>
           encode(v) shouldBe Some(v.value)
-          name shouldBe Some(SName(fullName(`enum`)))
+          name shouldBe Some(SName(fullName(shortName)))
         case a => fail(s"Expected enum validator with encode function: got $a")
       }
     }
   }
 
-  private def fullName[E](e: E) = s"$className${e.getClass.getSimpleName}".replace("$", ".").dropRight(1)
+  private def fullName(name: String) = s"sttp.tapir.codec.enumeratum.TapirCodecEnumeratumTest.$name"
 
   it should "find correct plain codec for enumeratum enum entries" in {
     testEnumPlainCodec(implicitly[PlainCodec[TestEnumEntry]])

--- a/integrations/enumeratum/src/test/scala/sttp/tapir/codec/enumeratum/TapirCodecEnumeratumTest.scala
+++ b/integrations/enumeratum/src/test/scala/sttp/tapir/codec/enumeratum/TapirCodecEnumeratumTest.scala
@@ -77,7 +77,7 @@ class TapirCodecEnumeratumTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  private def fullName[E](e: E) = s"$className${e.getClass.getSimpleName}".replace("$", ".")
+  private def fullName[E](e: E) = s"$className${e.getClass.getSimpleName}".replace("$", ".").dropRight(1)
 
   it should "find correct plain codec for enumeratum enum entries" in {
     testEnumPlainCodec(implicitly[PlainCodec[TestEnumEntry]])


### PR DESCRIPTION
This PR fixes schema name for enumeratum codec - currently it ends with extra dot like `a.b.TestEnum.`