### PR TITLE
Length validators: Support all unicode characters

### DIFF
--- a/core/src/main/scala/sttp/tapir/Validator.scala
+++ b/core/src/main/scala/sttp/tapir/Validator.scala
@@ -46,8 +46,41 @@ object Validator extends ValidatorMacros {
 
   // string
   def pattern[T <: String](value: String): Validator.Primitive[T] = Pattern(value)
+
+  /** Create a validator for minimum length constraints on strings.
+    *
+    * @param value
+    *   The minimum allowed length.
+    * @param countCodePoints
+    *   A boolean parameter that determines whether the validation will consider code points or character count. When set to true, the
+    *   validator will consider characters that are represented using two code units (a surrogate pair) in UTF-16 encoding allowing for a
+    *   more accurate length validation for strings containing such characters. Defaults to false, where length is validated based on the
+    *   number of `Char` values in the string.
+    */
   def minLength[T <: String](value: Int, countCodePoints: Boolean = false): Validator.Primitive[T] = MinLength(value, countCodePoints)
+
+  /** Create a validator for maximum length constraints on strings.
+   *
+   * @param value
+   * The maximum allowed length.
+   * @param countCodePoints
+   * A boolean parameter that determines whether the validation will consider code points or character count. When set to true, the
+   * validator will consider characters that are represented using two code units (a surrogate pair) in UTF-16 encoding allowing for a
+   * more accurate length validation for strings containing such characters. Defaults to false, where length is validated based on the
+   * number of `Char` values in the string.
+   */
   def maxLength[T <: String](value: Int, countCodePoints: Boolean = false): Validator.Primitive[T] = MaxLength(value, countCodePoints)
+
+  /** Create a validator for fixed length constraints on strings.
+   *
+   * @param value
+   * The fixed allowed length.
+   * @param countCodePoints
+   * A boolean parameter that determines whether the validation will consider code points or character count. When set to true, the
+   * validator will consider characters that are represented using two code units (a surrogate pair) in UTF-16 encoding allowing for a
+   * more accurate length validation for strings containing such characters. Defaults to false, where length is validated based on the
+   * number of `Char` values in the string.
+   */
   def fixedLength[T <: String](value: Int, countCodePoints: Boolean = false): Validator[T] =
     MinLength(value, countCodePoints).and(MaxLength(value, countCodePoints))
   def nonEmptyString[T <: String]: Validator.Primitive[T] = MinLength(1)

--- a/core/src/main/scala/sttp/tapir/Validator.scala
+++ b/core/src/main/scala/sttp/tapir/Validator.scala
@@ -51,13 +51,28 @@ object Validator extends ValidatorMacros {
     *
     * @param value
     *   The minimum allowed length.
+    */
+  def minLength[T <: String](value: Int): Validator.Primitive[T] = minLength(value, countCodePoints = false)
+
+  /** Create a validator for minimum length constraints on strings.
+    *
+    * @param value
+    *   The minimum allowed length.
     * @param countCodePoints
     *   A boolean parameter that determines whether the validation will consider code points or character count. When set to true, the
     *   validator will consider characters that are represented using two code units (a surrogate pair) in UTF-16 encoding allowing for a
-    *   more accurate length validation for strings containing such characters. Defaults to false, where length is validated based on the
-    *   number of `Char` values in the string.
+    *   more accurate length validation for strings containing such characters (like emojis). Defaults to false, where length is validated
+    *   based on the number of `Char` values in the string.
     */
-  def minLength[T <: String](value: Int, countCodePoints: Boolean = false): Validator.Primitive[T] = MinLength(value, countCodePoints)
+  def minLength[T <: String](value: Int, countCodePoints: Boolean): Validator.Primitive[T] =
+    MinLength(value, countCodePoints)
+
+  /** Create a validator for maximum length constraints on strings.
+    *
+    * @param value
+    *   The maximum allowed length.
+    */
+  def maxLength[T <: String](value: Int): Validator.Primitive[T] = maxLength(value, countCodePoints = false)
 
   /** Create a validator for maximum length constraints on strings.
     *
@@ -66,10 +81,18 @@ object Validator extends ValidatorMacros {
     * @param countCodePoints
     *   A boolean parameter that determines whether the validation will consider code points or character count. When set to true, the
     *   validator will consider characters that are represented using two code units (a surrogate pair) in UTF-16 encoding allowing for a
-    *   more accurate length validation for strings containing such characters. Defaults to false, where length is validated based on the
-    *   number of `Char` values in the string.
+    *   more accurate length validation for strings containing such characters (like emojis). Defaults to false, where length is validated
+    *   based on the number of `Char` values in the string.
     */
-  def maxLength[T <: String](value: Int, countCodePoints: Boolean = false): Validator.Primitive[T] = MaxLength(value, countCodePoints)
+  def maxLength[T <: String](value: Int, countCodePoints: Boolean): Validator.Primitive[T] =
+    MaxLength(value, countCodePoints)
+
+  /** Create a validator for fixed length constraints on strings.
+    *
+    * @param value
+    *   The fixed allowed length.
+    */
+  def fixedLength[T <: String](value: Int): Validator[T] = fixedLength(value, countCodePoints = false)
 
   /** Create a validator for fixed length constraints on strings.
     *
@@ -78,11 +101,12 @@ object Validator extends ValidatorMacros {
     * @param countCodePoints
     *   A boolean parameter that determines whether the validation will consider code points or character count. When set to true, the
     *   validator will consider characters that are represented using two code units (a surrogate pair) in UTF-16 encoding allowing for a
-    *   more accurate length validation for strings containing such characters. Defaults to false, where length is validated based on the
-    *   number of `Char` values in the string.
+    *   more accurate length validation for strings containing such characters (like emojis). Defaults to false, where length is validated
+    *   based on the number of `Char` values in the string.
     */
-  def fixedLength[T <: String](value: Int, countCodePoints: Boolean = false): Validator[T] =
+  def fixedLength[T <: String](value: Int, countCodePoints: Boolean): Validator[T] =
     MinLength(value, countCodePoints).and(MaxLength(value, countCodePoints))
+
   def nonEmptyString[T <: String]: Validator.Primitive[T] = MinLength(1)
 
   // iterable
@@ -145,18 +169,41 @@ object Validator extends ValidatorMacros {
   case class Pattern[T <: String](value: String) extends Primitive[T] {
     override def doValidate(t: T): ValidationResult = ValidationResult.validWhen(t.matches(value))
   }
-  case class MinLength[T <: String](value: Int, countCodePoints: Boolean = false) extends Primitive[T] {
+
+  case class MinLength[T <: String](value: Int, countCodePoints: Boolean) extends Primitive[T] {
+    // The auxiliary constructor, custom copy methods, and the custom apply method in the companion object
+    // have been introduced to maintain binary compatibility while adding a new field to the case class
+    def this(value: Int) = this(value, false)
+    def copy[TT <: String](value: Int): MinLength[TT] = MinLength[TT](value, false)
+    def copy[TT <: String](value: Int = this.value, countCodePoints: Boolean = this.countCodePoints): MinLength[TT] =
+      MinLength[TT](value, countCodePoints)
+
     override def doValidate(t: T): ValidationResult = {
       val size = if (countCodePoints) t.codePointCount(0, t.size) else t.size
       ValidationResult.validWhen(size >= value)
     }
   }
-  case class MaxLength[T <: String](value: Int, countCodePoints: Boolean = false) extends Primitive[T] {
+  object MinLength {
+    def apply[T <: String](value: Int) = new MinLength[T](value, false)
+  }
+
+  case class MaxLength[T <: String](value: Int, countCodePoints: Boolean) extends Primitive[T] {
+    // The auxiliary constructor, custom copy methods, and the custom apply method in the companion object
+    // have been introduced to maintain binary compatibility while adding a new field to the case class
+    def this(value: Int) = this(value, false)
+    def copy[TT <: String](value: Int): MaxLength[TT] = MaxLength[TT](value, false)
+    def copy[TT <: String](value: Int = this.value, countCodePoints: Boolean = this.countCodePoints): MaxLength[TT] =
+      MaxLength[TT](value, countCodePoints)
+
     override def doValidate(t: T): ValidationResult = {
       val size = if (countCodePoints) t.codePointCount(0, t.size) else t.size
       ValidationResult.validWhen(size <= value)
     }
   }
+  object MaxLength {
+    def apply[T <: String](value: Int) = new MaxLength[T](value, false)
+  }
+
   case class MinSize[T, C[_] <: Iterable[_]](value: Int) extends Primitive[C[T]] {
     override def doValidate(t: C[T]): ValidationResult = ValidationResult.validWhen(t.size >= value)
   }

--- a/core/src/main/scala/sttp/tapir/Validator.scala
+++ b/core/src/main/scala/sttp/tapir/Validator.scala
@@ -60,27 +60,27 @@ object Validator extends ValidatorMacros {
   def minLength[T <: String](value: Int, countCodePoints: Boolean = false): Validator.Primitive[T] = MinLength(value, countCodePoints)
 
   /** Create a validator for maximum length constraints on strings.
-   *
-   * @param value
-   * The maximum allowed length.
-   * @param countCodePoints
-   * A boolean parameter that determines whether the validation will consider code points or character count. When set to true, the
-   * validator will consider characters that are represented using two code units (a surrogate pair) in UTF-16 encoding allowing for a
-   * more accurate length validation for strings containing such characters. Defaults to false, where length is validated based on the
-   * number of `Char` values in the string.
-   */
+    *
+    * @param value
+    *   The maximum allowed length.
+    * @param countCodePoints
+    *   A boolean parameter that determines whether the validation will consider code points or character count. When set to true, the
+    *   validator will consider characters that are represented using two code units (a surrogate pair) in UTF-16 encoding allowing for a
+    *   more accurate length validation for strings containing such characters. Defaults to false, where length is validated based on the
+    *   number of `Char` values in the string.
+    */
   def maxLength[T <: String](value: Int, countCodePoints: Boolean = false): Validator.Primitive[T] = MaxLength(value, countCodePoints)
 
   /** Create a validator for fixed length constraints on strings.
-   *
-   * @param value
-   * The fixed allowed length.
-   * @param countCodePoints
-   * A boolean parameter that determines whether the validation will consider code points or character count. When set to true, the
-   * validator will consider characters that are represented using two code units (a surrogate pair) in UTF-16 encoding allowing for a
-   * more accurate length validation for strings containing such characters. Defaults to false, where length is validated based on the
-   * number of `Char` values in the string.
-   */
+    *
+    * @param value
+    *   The fixed allowed length.
+    * @param countCodePoints
+    *   A boolean parameter that determines whether the validation will consider code points or character count. When set to true, the
+    *   validator will consider characters that are represented using two code units (a surrogate pair) in UTF-16 encoding allowing for a
+    *   more accurate length validation for strings containing such characters. Defaults to false, where length is validated based on the
+    *   number of `Char` values in the string.
+    */
   def fixedLength[T <: String](value: Int, countCodePoints: Boolean = false): Validator[T] =
     MinLength(value, countCodePoints).and(MaxLength(value, countCodePoints))
   def nonEmptyString[T <: String]: Validator.Primitive[T] = MinLength(1)

--- a/core/src/test/scala/sttp/tapir/ValidatorTest.scala
+++ b/core/src/test/scala/sttp/tapir/ValidatorTest.scala
@@ -125,6 +125,13 @@ class ValidatorTest extends AnyFlatSpec with Matchers {
     v("abc") shouldBe empty
   }
 
+  it should "validate for minLength of string and include unicode characters" in {
+    val expected = 3
+    val v = Validator.minLength[String](expected, countCodePoints = true)
+    v("a\uD83E\uDD73") shouldBe List(ValidationError(v, "a\uD83E\uDD73"))
+    v("ab\uD83E\uDD73") shouldBe empty
+  }
+
   it should "validate for maxLength of string" in {
     val expected = 1
     val v = Validator.maxLength[String](expected)
@@ -132,11 +139,27 @@ class ValidatorTest extends AnyFlatSpec with Matchers {
     v("a") shouldBe empty
   }
 
+  it should "validate for maxLength of string and include unicode characters" in {
+    val expected = 1
+    val v = Validator.maxLength[String](expected, countCodePoints = true)
+    v("a\uD83E\uDD73") shouldBe List(ValidationError(v, "a\uD83E\uDD73"))
+    v("\uD83E\uDD73") shouldBe empty
+  }
+
   it should "validate for fixedLength of string" in {
-    val v = Validator.fixedLength[String](3)
-    v("ab") shouldBe List(ValidationError(Validator.minLength(3), "ab"))
-    v("abcd") shouldBe List(ValidationError(Validator.maxLength(3), "abcd"))
+    val expected = 3
+    val v = Validator.fixedLength[String](expected)
+    v("ab") shouldBe List(ValidationError(Validator.minLength(expected), "ab"))
+    v("abcd") shouldBe List(ValidationError(Validator.maxLength(expected), "abcd"))
     v("abc") shouldBe empty
+  }
+
+  it should "validate for fixedLength of string and include unicode characters" in {
+    val expected = 3
+    val v = Validator.fixedLength[String](expected, countCodePoints = true)
+    v("\uD83E\uDD73") shouldBe List(ValidationError(Validator.minLength(expected, true), "\uD83E\uDD73"))
+    v("abc\uD83E\uDD73") shouldBe List(ValidationError(Validator.maxLength(expected, true), "abc\uD83E\uDD73"))
+    v("ab\uD83E\uDD73") shouldBe empty
   }
 
   it should "validate for nonEmptyString of string" in {

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
@@ -122,8 +122,8 @@ private[schema] class TSchemaToASchema(toSchemaReference: ToSchemaReference, mar
           exclusiveMaximum = Option(exclusive).filter(identity)
         )
       case Validator.Pattern(value)                  => aschema.copy(pattern = Some(Pattern(value)))
-      case Validator.MinLength(value)                => aschema.copy(minLength = Some(value))
-      case Validator.MaxLength(value)                => aschema.copy(maxLength = Some(value))
+      case Validator.MinLength(value, _)             => aschema.copy(minLength = Some(value))
+      case Validator.MaxLength(value, _)             => aschema.copy(maxLength = Some(value))
       case Validator.MinSize(value)                  => aschema.copy(minItems = Some(value))
       case Validator.MaxSize(value)                  => aschema.copy(maxItems = Some(value))
       case Validator.Custom(_, _)                    => aschema


### PR DESCRIPTION
Follow up to https://github.com/softwaremill/tapir/issues/3201. This PR adds optional support for counting unicode characters during validation. 