### PR TITLE
Add OpenTelemetry metrics example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2037,6 +2037,9 @@ lazy val examples: ProjectMatrix = (projectMatrix in file("examples"))
       "com.github.jwt-scala" %% "jwt-circe" % Versions.jwtScala,
       "org.mock-server" % "mockserver-netty" % Versions.mockServer,
       "io.circe" %% "circe-generic-extras" % Versions.circeGenericExtras,
+      "io.opentelemetry" % "opentelemetry-sdk" % Versions.openTelemetry,
+      "io.opentelemetry" % "opentelemetry-sdk-metrics" % Versions.openTelemetry,
+      "io.opentelemetry" % "opentelemetry-exporter-otlp" % Versions.openTelemetry,
       scalaTest.value
     ),
     libraryDependencies ++= loggerDependencies,

--- a/examples/src/main/scala/sttp/tapir/examples/observability/OpenTelemetryMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/OpenTelemetryMetricsExample.scala
@@ -14,6 +14,7 @@ import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.metrics.opentelemetry.OpenTelemetryMetrics
 import sttp.tapir.server.netty.{NettyFutureServer, NettyFutureServerOptions}
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 

--- a/examples/src/main/scala/sttp/tapir/examples/observability/OpenTelemetryMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/OpenTelemetryMetricsExample.scala
@@ -1,6 +1,5 @@
 package sttp.tapir.examples.observability
 
-import akka.actor.ActorSystem
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.generic.auto._
 import io.opentelemetry.api.OpenTelemetry
@@ -57,8 +56,6 @@ import scala.concurrent.{Await, Future}
   * }}}
   */
 object OpenTelemetryMetricsExample extends App with StrictLogging {
-  implicit val actorSystem: ActorSystem = ActorSystem()
-  import actorSystem.dispatcher
 
   case class Person(name: String)
 

--- a/examples/src/main/scala/sttp/tapir/examples/observability/OpenTelemetryMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/OpenTelemetryMetricsExample.scala
@@ -94,5 +94,5 @@ object OpenTelemetryMetricsExample extends App with StrictLogging {
 
   Await.ready(NettyFutureServer().port(8080).addEndpoint(personEndpoint, serverOptions).start(), 1.minute)
 
-  logger.info(s"Server started. POST persons under http://localhost:8080/person.")
+  logger.info(s"""Server started. Try it with: curl -X POST localhost:8080/person -d '{"name": "Jacob"}'""")
 }

--- a/examples/src/main/scala/sttp/tapir/examples/observability/OpenTelemetryMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/OpenTelemetryMetricsExample.scala
@@ -1,0 +1,93 @@
+package sttp.tapir.examples.observability
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Route
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.generic.auto._
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.metrics.`export`.PeriodicMetricReader
+import sttp.tapir._
+import sttp.tapir.generic.auto._
+import sttp.tapir.json.circe.jsonBody
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.akkahttp.{AkkaHttpServerInterpreter, AkkaHttpServerOptions}
+import sttp.tapir.server.metrics.opentelemetry.OpenTelemetryMetrics
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+/** This example uses a gRPC <a href="https://opentelemetry.io/docs/concepts/components/#exporters">exporter</a> to send metrics to a <a href="https://opentelemetry.io/docs/collector/">collector</a>, which by
+  * default is expected to be running on `localhost:4317`.
+  *
+  * You can run a collector locally using Docker with the following command:
+  * {{{
+  *   docker run -p 4317:4317 otel/opentelemetry-collector:latest
+  * }}}
+  *
+  * Please refer to the <a href="https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/">exporter
+  * configuration</a> if you need to use a different host/port.
+  *
+  * Once this example app and the collector are running, and after you send some requests to the `/person` endpoint, you should start seeing
+  * the metrics in the collector logs (look for `InstrumentationScope tapir 1.0.0`), e.g.:
+  * {{{
+  *   InstrumentationScope tapir 1.0.0
+  *   Metric #0
+  *   Descriptor:
+  *        -> Name: request_active
+  *        -> Description: Active HTTP requests
+  *        -> Unit: 1
+  *        -> DataType: Sum
+  *        -> IsMonotonic: false
+  *        -> AggregationTemporality: Cumulative
+  *
+  *   ...
+  * }}}
+  */
+object OpenTelemetryMetricsExample extends App with StrictLogging {
+  implicit val actorSystem: ActorSystem = ActorSystem()
+  import actorSystem.dispatcher
+
+  case class Person(name: String)
+
+  // Simple endpoint returning 200 or 400 response with string body
+  val personEndpoint: ServerEndpoint[Any, Future] =
+    endpoint.post
+      .in("person")
+      .in(jsonBody[Person])
+      .out(stringBody)
+      .errorOut(stringBody)
+      .serverLogic { p =>
+        Thread.sleep(3000)
+        Future.successful(Either.cond(p.name == "Jacob", "Welcome", "Unauthorized"))
+      }
+
+  // An exporter that sends metrics to a collector over gRPC
+  val grpcExporter = OtlpGrpcMetricExporter.builder().build()
+
+  // A metric reader that exports using the gRPC exporter
+  val metricReader: PeriodicMetricReader = PeriodicMetricReader.builder(grpcExporter).build()
+
+  // A meter registry whose meters are read by the above reader
+  val meterProvider: SdkMeterProvider = SdkMeterProvider.builder().registerMetricReader(metricReader).build()
+
+  // An instance of OpenTelemetry using the above meter registry
+  val otel: OpenTelemetry = OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build()
+
+  val openTelemetryMetrics = OpenTelemetryMetrics.default[Future](otel)
+
+  val serverOptions: AkkaHttpServerOptions =
+    AkkaHttpServerOptions.customiseInterceptors
+      // Adds an interceptor which collects metrics by executing callbacks
+      .metricsInterceptor(openTelemetryMetrics.metricsInterceptor())
+      .options
+
+  val routes: Route = AkkaHttpServerInterpreter(serverOptions).toRoute(personEndpoint)
+
+  Await.result(Http().newServerAt("localhost", 8080).bindFlow(routes), 1.minute)
+
+  logger.info(s"Server started. POST persons under http://localhost:8080/person.")
+}

--- a/examples/src/main/scala/sttp/tapir/examples/observability/OpenTelemetryMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/OpenTelemetryMetricsExample.scala
@@ -31,6 +31,17 @@ import scala.concurrent.{Await, Future}
   * Please refer to the <a href="https://opentelemetry.io/docs/concepts/sdk-configuration/otlp-exporter-configuration/">exporter
   * configuration</a> if you need to use a different host/port.
   *
+  * The example code requires the following dependencies:
+  * {{{
+  *   val openTelemetryVersion = <OpenTelemetry version>
+  *
+  *   libraryDependencies ++= Seq(
+  *     "io.opentelemetry" % "opentelemetry-sdk" % openTelemetryVersion,
+  *     "io.opentelemetry" % "opentelemetry-sdk-metrics" % openTelemetryVersion,
+  *     "io.opentelemetry" % "opentelemetry-exporter-otlp" % openTelemetryVersion
+ *    )
+  * }}}
+  *
   * Once this example app and the collector are running, and after you send some requests to the `/person` endpoint, you should start seeing
   * the metrics in the collector logs (look for `InstrumentationScope tapir 1.0.0`), e.g.:
   * {{{

--- a/examples/src/main/scala/sttp/tapir/examples/observability/OpenTelemetryMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/OpenTelemetryMetricsExample.scala
@@ -39,7 +39,7 @@ import scala.concurrent.{Await, Future}
   *     "io.opentelemetry" % "opentelemetry-sdk" % openTelemetryVersion,
   *     "io.opentelemetry" % "opentelemetry-sdk-metrics" % openTelemetryVersion,
   *     "io.opentelemetry" % "opentelemetry-exporter-otlp" % openTelemetryVersion
- *    )
+  *    )
   * }}}
   *
   * Once this example app and the collector are running, and after you send some requests to the `/person` endpoint, you should start seeing


### PR DESCRIPTION
Adds a complete example of setting up OpenTelemetry metrics, using a gRPC exporter which sends the default metrics to an external collector.