### PR TITLE
Allow usage-site customisation of referenced schemas

### DIFF
--- a/core/src/main/scala/sttp/tapir/attribute.scala
+++ b/core/src/main/scala/sttp/tapir/attribute.scala
@@ -27,6 +27,7 @@ object AttributeKey extends AttributeKeyMacros
 case class AttributeMap private (private val storage: Map[String, Any]) {
   def get[T](k: AttributeKey[T]): Option[T] = storage.get(k.typeName).asInstanceOf[Option[T]]
   def put[T](k: AttributeKey[T], v: T): AttributeMap = copy(storage = storage + (k.typeName -> v))
+  def remove[T](k: AttributeKey[T]): AttributeMap = copy(storage = storage - k.typeName)
 
   def isEmpty: Boolean = storage.isEmpty
   def nonEmpty: Boolean = storage.nonEmpty

--- a/doc/docs/json-schema.md
+++ b/doc/docs/json-schema.md
@@ -9,7 +9,7 @@ You can conveniently generate JSON schema from Tapir schema, which can be derive
 Schema generation can now be performed like in the following example:
 
 ```scala mdoc:compile-only
-import sttp.apispec.{ReferenceOr, Schema => ASchema}
+import sttp.apispec.{Schema => ASchema}
 import sttp.tapir._
 import sttp.tapir.docs.apispec.schema._
 import sttp.tapir.generic.auto._
@@ -21,7 +21,7 @@ import sttp.tapir.generic.auto._
   case class Child(childName: String) // to illustrate unique name generation
   val tSchema = implicitly[Schema[Parent]]
 
-  val jsonSchema: ReferenceOr[ASchema] = TapirSchemaToJsonSchema(
+  val jsonSchema: ASchema = TapirSchemaToJsonSchema(
     tSchema,
     markOptionsAsNullable = true,
     metaSchema = MetaSchemaDraft04 // default
@@ -44,7 +44,7 @@ you will get a codec for `sttp.apispec.Schema`:
 import io.circe.Printer
 import io.circe.syntax._
 import sttp.apispec.circe._
-import sttp.apispec.{ReferenceOr, Schema => ASchema, SchemaType => ASchemaType}
+import sttp.apispec.{Schema => ASchema, SchemaType => ASchemaType}
 import sttp.tapir._
 import sttp.tapir.docs.apispec.schema._
 import sttp.tapir.generic.auto._
@@ -57,12 +57,12 @@ import sttp.tapir.Schema.annotations.title
   case class Child(childName: String)
   val tSchema = implicitly[Schema[Parent]]
 
-  val jsonSchema: ReferenceOr[ASchema] = TapirSchemaToJsonSchema(
+  val jsonSchema: ASchema = TapirSchemaToJsonSchema(
     tSchema,
     markOptionsAsNullable = true)
   
   // JSON serialization
-  val schemaAsJson = jsonSchema.getOrElse(ASchema(ASchemaType.Null)).asJson
+  val schemaAsJson = jsonSchema.asJson
   val schemaStr: String = Printer.spaces2.print(schemaAsJson.deepDropNullValues)
 ```
 

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/Schemas.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/Schemas.scala
@@ -12,12 +12,12 @@ class Schemas(
   def apply[T](codec: Codec[T, _, _]): ReferenceOr[ASchema] = apply(codec.schema)
 
   def apply(schema: TSchema[_]): ReferenceOr[ASchema] = {
-    SchemaKey(schema) match {
-      case Some(key) => Left(toSchemaReference.map(key))
+    schema.name match {
+      case Some(name) => Left(toSchemaReference.map(schema, name))
       case None =>
         schema.schemaType match {
           case TSchemaType.SArray(nested @ TSchema(_, Some(name), isOptional, _, _, _, _, _, _, _, _)) =>
-            Right(ASchema(SchemaType.Array).copy(items = Some(Left(toSchemaReference.map(SchemaKey(nested, name))))))
+            Right(ASchema(SchemaType.Array).copy(items = Some(Left(toSchemaReference.map(nested, name)))))
               .map(s => if (isOptional && markOptionsAsNullable) s.copy(nullable = Some(true)) else s)
           case TSchemaType.SOption(ts) => apply(ts)
           case _                       => tschemaToASchema(schema)

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/Schemas.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/Schemas.scala
@@ -1,7 +1,9 @@
 package sttp.tapir.docs.apispec.schema
 
-import sttp.apispec.{ReferenceOr, SchemaType, Schema => ASchema}
+import sttp.apispec.{SchemaType, Schema => ASchema}
 import sttp.tapir.{Codec, Schema => TSchema, SchemaType => TSchemaType}
+
+import scala.util.chaining._
 
 /** Converts a tapir schema to an OpenAPI/AsyncAPI reference (if the schema is named), or to the appropriate schema. */
 class Schemas(
@@ -9,16 +11,17 @@ class Schemas(
     toSchemaReference: ToSchemaReference,
     markOptionsAsNullable: Boolean
 ) {
-  def apply[T](codec: Codec[T, _, _]): ReferenceOr[ASchema] = apply(codec.schema)
+  def apply[T](codec: Codec[T, _, _]): ASchema = apply(codec.schema)
 
-  def apply(schema: TSchema[_]): ReferenceOr[ASchema] = {
+  def apply(schema: TSchema[_]): ASchema = {
     schema.name match {
-      case Some(name) => Left(toSchemaReference.map(schema, name))
+      case Some(name) => toSchemaReference.map(schema, name)
       case None =>
         schema.schemaType match {
           case TSchemaType.SArray(nested @ TSchema(_, Some(name), isOptional, _, _, _, _, _, _, _, _)) =>
-            Right(ASchema(SchemaType.Array).copy(items = Some(Left(toSchemaReference.map(nested, name)))))
-              .map(s => if (isOptional && markOptionsAsNullable) s.copy(nullable = Some(true)) else s)
+            ASchema(SchemaType.Array)
+              .copy(items = Some(toSchemaReference.map(nested, name)))
+              .pipe(s => if (isOptional && markOptionsAsNullable) s.copy(nullable = Some(true)) else s)
           case TSchemaType.SOption(ts) => apply(ts)
           case _                       => tschemaToASchema(schema)
         }

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/Schemas.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/Schemas.scala
@@ -3,8 +3,6 @@ package sttp.tapir.docs.apispec.schema
 import sttp.apispec.{SchemaType, Schema => ASchema}
 import sttp.tapir.{Codec, Schema => TSchema, SchemaType => TSchemaType}
 
-import scala.util.chaining._
-
 /** Converts a tapir schema to an OpenAPI/AsyncAPI reference (if the schema is named), or to the appropriate schema. */
 class Schemas(
     tschemaToASchema: TSchemaToASchema,
@@ -19,9 +17,10 @@ class Schemas(
       case None =>
         schema.schemaType match {
           case TSchemaType.SArray(nested @ TSchema(_, Some(name), isOptional, _, _, _, _, _, _, _, _)) =>
-            ASchema(SchemaType.Array)
+            val s = ASchema(SchemaType.Array)
               .copy(items = Some(toSchemaReference.map(nested, name)))
-              .pipe(s => if (isOptional && markOptionsAsNullable) s.copy(nullable = Some(true)) else s)
+
+            if (isOptional && markOptionsAsNullable) s.copy(nullable = Some(true)) else s
           case TSchemaType.SOption(ts) => apply(ts)
           case _                       => tschemaToASchema(schema)
         }

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/SchemasForEndpoints.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/SchemasForEndpoints.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.docs.apispec.schema
 
-import sttp.apispec.{Schema => ASchema, _}
+import sttp.apispec.{Schema => ASchema}
 import sttp.tapir.Schema.SName
 import sttp.tapir._
 import sttp.tapir.internal.IterableToListMap
@@ -18,7 +18,7 @@ class SchemasForEndpoints(
     *   A tuple: the first element can be used to create the components section in the docs. The second can be used to resolve (possible)
     *   top-level references from parameters / bodies.
     */
-  def apply(): (ListMap[SchemaId, ReferenceOr[ASchema]], Schemas) = {
+  def apply(): (ListMap[SchemaId, ASchema], Schemas) = {
     val keyedCombinedSchemas: Iterable[KeyedSchema] = ToKeyedSchemas.uniqueCombined(
       es.flatMap(e =>
         forInput(e.securityInput) ++ forInput(e.input) ++ forOutput(e.errorOutput) ++ forOutput(e.output)
@@ -29,8 +29,8 @@ class SchemasForEndpoints(
     val toSchemaReference = new ToSchemaReference(keysToIds, keyedCombinedSchemas.toMap)
     val tschemaToASchema = new TSchemaToASchema(toSchemaReference, markOptionsAsNullable)
 
-    val keysToSchemas: ListMap[SchemaKey, ReferenceOr[ASchema]] = keyedCombinedSchemas.map(td => (td._1, tschemaToASchema(td._2))).toListMap
-    val schemaIds: Map[SchemaKey, (SchemaId, ReferenceOr[ASchema])] = keysToSchemas.map { case (k, v) => k -> ((keysToIds(k), v)) }
+    val keysToSchemas: ListMap[SchemaKey, ASchema] = keyedCombinedSchemas.map(td => (td._1, tschemaToASchema(td._2))).toListMap
+    val schemaIds: Map[SchemaKey, (SchemaId, ASchema)] = keysToSchemas.map { case (k, v) => k -> ((keysToIds(k), v)) }
 
     val schemas = new Schemas(tschemaToASchema, toSchemaReference, markOptionsAsNullable)
 

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
@@ -9,8 +9,6 @@ import sttp.tapir.docs.apispec.{DocsExtensions, exampleValue}
 import sttp.tapir.internal._
 import sttp.tapir.{Validator, Schema => TSchema, SchemaType => TSchemaType}
 
-import scala.util.chaining._
-
 /** Converts a tapir schema to an OpenAPI/AsyncAPI schema, using `toSchemaReference` to resolve nested references. */
 private[schema] class TSchemaToASchema(toSchemaReference: ToSchemaReference, markOptionsAsNullable: Boolean) {
   def apply[T](schema: TSchema[T], isOptionElement: Boolean = false): ASchema = {
@@ -68,11 +66,12 @@ private[schema] class TSchemaToASchema(toSchemaReference: ToSchemaReference, mar
     if (result.$ref.isEmpty) {
       // only customising non-reference schemas; references might get enriched with some meta-data if there
       // are multiple different customisations of the referenced schema in ToSchemaReference (#1203)
-      result
-        .pipe(s => if (nullable) s.copy(nullable = Some(true)) else s)
-        .pipe(addMetadata(_, schema))
-        .pipe(addTitle(_, schema))
-        .pipe(addConstraints(_, primitiveValidators, schemaIsWholeNumber))
+      var s = result
+      s = if (nullable) s.copy(nullable = Some(true)) else s
+      s = addMetadata(s, schema)
+      s = addTitle(s, schema)
+      s = addConstraints(s, primitiveValidators, schemaIsWholeNumber)
+      s
     } else result
   }
 

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TSchemaToASchema.scala
@@ -4,63 +4,58 @@ import sttp.apispec.{Schema => ASchema, _}
 import sttp.tapir.Schema.Title
 import sttp.tapir.Validator.EncodeToRaw
 import sttp.tapir.docs.apispec.DocsExtensionAttribute.RichSchema
+import sttp.tapir.docs.apispec.schema.TSchemaToASchema.{tDefaultToADefault, tExampleToAExample}
 import sttp.tapir.docs.apispec.{DocsExtensions, exampleValue}
-import sttp.tapir.internal.{IterableToListMap, _}
+import sttp.tapir.internal._
 import sttp.tapir.{Validator, Schema => TSchema, SchemaType => TSchemaType}
+
+import scala.util.chaining._
 
 /** Converts a tapir schema to an OpenAPI/AsyncAPI schema, using `toSchemaReference` to resolve nested references. */
 private[schema] class TSchemaToASchema(toSchemaReference: ToSchemaReference, markOptionsAsNullable: Boolean) {
-  def apply[T](schema: TSchema[T], isOptionElement: Boolean = false): ReferenceOr[ASchema] = {
+  def apply[T](schema: TSchema[T], isOptionElement: Boolean = false): ASchema = {
     val nullable = markOptionsAsNullable && isOptionElement
     val result = schema.schemaType match {
-      case TSchemaType.SInteger() => Right(ASchema(SchemaType.Integer))
-      case TSchemaType.SNumber()  => Right(ASchema(SchemaType.Number))
-      case TSchemaType.SBoolean() => Right(ASchema(SchemaType.Boolean))
-      case TSchemaType.SString()  => Right(ASchema(SchemaType.String))
+      case TSchemaType.SInteger() => ASchema(SchemaType.Integer)
+      case TSchemaType.SNumber()  => ASchema(SchemaType.Number)
+      case TSchemaType.SBoolean() => ASchema(SchemaType.Boolean)
+      case TSchemaType.SString()  => ASchema(SchemaType.String)
       case p @ TSchemaType.SProduct(fields) =>
-        Right(
-          ASchema(SchemaType.Object).copy(
-            required = p.required.map(_.encodedName),
-            properties = extractProperties(fields)
-          )
+        ASchema(SchemaType.Object).copy(
+          required = p.required.map(_.encodedName),
+          properties = extractProperties(fields)
         )
       case TSchemaType.SArray(nested @ TSchema(_, Some(name), _, _, _, _, _, _, _, _, _)) =>
-        Right(ASchema(SchemaType.Array).copy(items = Some(Left(toSchemaReference.map(nested, name)))))
-      case TSchemaType.SArray(el) => Right(ASchema(SchemaType.Array).copy(items = Some(apply(el))))
-      case TSchemaType.SOption(nested @ TSchema(_, Some(name), _, _, _, _, _, _, _, _, _)) =>
-        Left(toSchemaReference.map(nested, name))
-      case TSchemaType.SOption(el)    => apply(el, isOptionElement = true)
-      case TSchemaType.SBinary()      => Right(ASchema(SchemaType.String).copy(format = SchemaFormat.Binary))
-      case TSchemaType.SDate()        => Right(ASchema(SchemaType.String).copy(format = SchemaFormat.Date))
-      case TSchemaType.SDateTime()    => Right(ASchema(SchemaType.String).copy(format = SchemaFormat.DateTime))
-      case TSchemaType.SRef(fullName) => Left(toSchemaReference.mapDirect(fullName))
+        ASchema(SchemaType.Array).copy(items = Some(toSchemaReference.map(nested, name)))
+      case TSchemaType.SArray(el) => ASchema(SchemaType.Array).copy(items = Some(apply(el)))
+      case TSchemaType.SOption(nested @ TSchema(_, Some(name), _, _, _, _, _, _, _, _, _)) => toSchemaReference.map(nested, name)
+      case TSchemaType.SOption(el)                                                         => apply(el, isOptionElement = true)
+      case TSchemaType.SBinary()      => ASchema(SchemaType.String).copy(format = SchemaFormat.Binary)
+      case TSchemaType.SDate()        => ASchema(SchemaType.String).copy(format = SchemaFormat.Date)
+      case TSchemaType.SDateTime()    => ASchema(SchemaType.String).copy(format = SchemaFormat.DateTime)
+      case TSchemaType.SRef(fullName) => toSchemaReference.mapDirect(fullName)
       case TSchemaType.SCoproduct(schemas, d) =>
-        Right(
-          ASchema
-            .apply(
-              schemas
-                .filterNot(_.hidden)
-                .map {
-                  case nested @ TSchema(_, Some(name), _, _, _, _, _, _, _, _, _) => Left(toSchemaReference.map(nested, name))
-                  case t                                                          => apply(t)
-                }
-                .sortBy {
-                  case Left(Reference(ref, _, _)) => ref
-                  case Right(schema) => schema.`type`.collect { case t: BasicSchemaType => t.value }.getOrElse("") + schema.toString
-                },
-              d.map(tDiscriminatorToADiscriminator)
-            )
+        ASchema.oneOf(
+          schemas
+            .filterNot(_.hidden)
+            .map {
+              case nested @ TSchema(_, Some(name), _, _, _, _, _, _, _, _, _) => toSchemaReference.map(nested, name)
+              case t                                                          => apply(t)
+            }
+            .sortBy {
+              case schema if schema.$ref.isDefined => schema.$ref.get
+              case schema => schema.`type`.collect { case t: BasicSchemaType => t.value }.getOrElse("") + schema.toString
+            },
+          d.map(tDiscriminatorToADiscriminator)
         )
       case p @ TSchemaType.SOpenProduct(fields, valueSchema) =>
-        Right(
-          ASchema(SchemaType.Object).copy(
-            required = p.required.map(_.encodedName),
-            properties = extractProperties(fields),
-            additionalProperties = Some(valueSchema.name match {
-              case Some(name) => Left(toSchemaReference.map(valueSchema, name))
-              case _          => apply(valueSchema)
-            }).filterNot(_ => valueSchema.hidden)
-          )
+        ASchema(SchemaType.Object).copy(
+          required = p.required.map(_.encodedName),
+          properties = extractProperties(fields),
+          additionalProperties = Some(valueSchema.name match {
+            case Some(name) => toSchemaReference.map(valueSchema, name)
+            case _          => apply(valueSchema)
+          }).filterNot(_ => valueSchema.hidden)
         )
     }
 
@@ -70,11 +65,15 @@ private[schema] class TSchemaToASchema(toSchemaReference: ToSchemaReference, mar
       case _                      => false
     }
 
-    result
-      .map(s => if (nullable) s.copy(nullable = Some(true)) else s)
-      .map(addMetadata(_, schema))
-      .map(addTitle(_, schema))
-      .map(addConstraints(_, primitiveValidators, schemaIsWholeNumber))
+    if (result.$ref.isEmpty) {
+      // only customising non-reference schemas; references might get enriched with some meta-data if there
+      // are multiple different customisations of the referenced schema in ToSchemaReference (#1203)
+      result
+        .pipe(s => if (nullable) s.copy(nullable = Some(true)) else s)
+        .pipe(addMetadata(_, schema))
+        .pipe(addTitle(_, schema))
+        .pipe(addConstraints(_, primitiveValidators, schemaIsWholeNumber))
+    } else result
   }
 
   private def extractProperties[T](fields: List[TSchemaType.SProductField[T]]) = {
@@ -82,7 +81,7 @@ private[schema] class TSchemaToASchema(toSchemaReference: ToSchemaReference, mar
       .filterNot(_.schema.hidden)
       .map { f =>
         f.schema.name match {
-          case Some(name) => f.name.encodedName -> Left(toSchemaReference.map(f.schema, name))
+          case Some(name) => f.name.encodedName -> toSchemaReference.map(f.schema, name)
           case None       => f.name.encodedName -> apply(f.schema)
         }
       }
@@ -95,8 +94,8 @@ private[schema] class TSchemaToASchema(toSchemaReference: ToSchemaReference, mar
   private def addMetadata(oschema: ASchema, tschema: TSchema[_]): ASchema = {
     oschema.copy(
       description = tschema.description.orElse(oschema.description),
-      default = tschema.default.flatMap { case (_, raw) => raw.flatMap(r => exampleValue(tschema, r)) }.orElse(oschema.default),
-      example = tschema.encodedExample.flatMap(exampleValue(tschema, _)).orElse(oschema.example),
+      default = tDefaultToADefault(tschema).orElse(oschema.default),
+      example = tExampleToAExample(tschema).orElse(oschema.example),
       format = tschema.format.orElse(oschema.format),
       deprecated = (if (tschema.deprecated) Some(true) else None).orElse(oschema.deprecated),
       extensions = DocsExtensions.fromIterable(tschema.docsExtensions)
@@ -155,8 +154,8 @@ private[schema] class TSchemaToASchema(toSchemaReference: ToSchemaReference, mar
   private def tDiscriminatorToADiscriminator(discriminator: TSchemaType.SDiscriminator): Discriminator = {
     val schemas = Some(
       discriminator.mapping
-        .map { case (k, TSchemaType.SRef(fullName)) =>
-          k -> toSchemaReference.mapDiscriminator(fullName).$ref
+        .flatMap { case (k, TSchemaType.SRef(fullName)) =>
+          toSchemaReference.mapDiscriminator(fullName).$ref.map(k -> _)
         }
         .toList
         .sortBy(_._1)
@@ -164,4 +163,11 @@ private[schema] class TSchemaToASchema(toSchemaReference: ToSchemaReference, mar
     )
     Discriminator(discriminator.name.encodedName, schemas)
   }
+}
+
+object TSchemaToASchema {
+  def tDefaultToADefault(schema: TSchema[_]): Option[ExampleValue] = schema.default.flatMap { case (_, raw) =>
+    raw.flatMap(r => exampleValue(schema, r))
+  }
+  def tExampleToAExample(schema: TSchema[_]): Option[ExampleValue] = schema.encodedExample.flatMap(exampleValue(schema, _))
 }

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TapirSchemaToJsonSchema.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TapirSchemaToJsonSchema.scala
@@ -18,15 +18,15 @@ object TapirSchemaToJsonSchema {
   ): ReferenceOr[ASchema] = {
 
     val asKeyedSchemas = toKeyedSchemas(schema).drop(1)
-    val keyedSchemas = ToKeyedSchemas.unique(asKeyedSchemas)
+    val keyedSchemas = ToKeyedSchemas.uniqueCombined(asKeyedSchemas)
 
     val keysToIds = calculateUniqueIds(keyedSchemas.map(_._1), (key: SchemaKey) => schemaName(key.name))
-    val toSchemaReference = new ToSchemaReference(keysToIds, refRoot = "#/$defs/")
+    val toSchemaReference = new ToSchemaReference(keysToIds, keyedSchemas.toMap, refRoot = "#/$defs/")
     val tschemaToASchema = new TSchemaToASchema(toSchemaReference, markOptionsAsNullable)
     val keysToSchemas = keyedSchemas.map(td => (td._1, tschemaToASchema(td._2))).toListMap
     val schemaIds = keysToSchemas.map { case (k, v) => k -> ((keysToIds(k), v)) }
 
-    val nestedKeyedSchemas = (schemaIds.values)
+    val nestedKeyedSchemas = schemaIds.values
     val rootApiSpecSchemaOrRef: ReferenceOr[ASchema] = tschemaToASchema(schema)
 
     val defsList: ListMap[SchemaId, ASchema] =

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TapirSchemaToJsonSchema.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/TapirSchemaToJsonSchema.scala
@@ -6,9 +6,6 @@ import sttp.tapir.{Schema => TSchema}
 import scala.collection.immutable.ListMap
 
 object TapirSchemaToJsonSchema {
-
-  private val toKeyedSchemas = new ToKeyedSchemas
-
   def apply(
       schema: TSchema[_],
       markOptionsAsNullable: Boolean,
@@ -17,7 +14,7 @@ object TapirSchemaToJsonSchema {
       schemaName: TSchema.SName => String = defaultSchemaName
   ): ReferenceOr[ASchema] = {
 
-    val asKeyedSchemas = toKeyedSchemas(schema).drop(1)
+    val asKeyedSchemas = ToKeyedSchemas(schema).drop(1)
     val keyedSchemas = ToKeyedSchemas.uniqueCombined(asKeyedSchemas)
 
     val keysToIds = calculateUniqueIds(keyedSchemas.map(_._1), (key: SchemaKey) => schemaName(key.name))

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/ToKeyedSchemas.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/ToKeyedSchemas.scala
@@ -1,5 +1,6 @@
 package sttp.tapir.docs.apispec.schema
 
+import sttp.tapir.Schema.Title
 import sttp.tapir.{Codec, Schema => TSchema, SchemaType => TSchemaType}
 
 private[docs] object ToKeyedSchemas {
@@ -50,7 +51,8 @@ private[docs] object ToKeyedSchemas {
     if (s1.default != s2.default) result = result.copy(default = None)
     if (s1.encodedExample != s2.encodedExample) result = result.copy(encodedExample = None)
     if (s1.deprecated != s2.deprecated) result = result.deprecated(false)
-    // TODO: attributes
+    if (s1.attributes.get(Title.Attribute) != s2.attributes.get(Title.Attribute))
+      result = result.copy(attributes = result.attributes.remove(Title.Attribute))
     result
   }
 }

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/ToKeyedSchemas.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/ToKeyedSchemas.scala
@@ -29,21 +29,33 @@ private[docs] class ToKeyedSchemas {
   private def coproductSchemas[T](st: TSchemaType.SCoproduct[T]): List[KeyedSchema] = st.subtypes.flatMap(apply)
 }
 
-object ToKeyedSchemas {
+private[docs] object ToKeyedSchemas {
 
   /** Keeps only the first object data for each [[SchemaKey]]. In case of recursive objects, the first one is the most complete as it
     * contains the built-up structure, unlike subsequent ones, which only represent leaves (#354, later extended for #2358, so that the
     * schemas have a secondary key - the product fields (if any)).
+    *
+    * There might also be multiple copies of the same schema due to independent usage-site customisations (e.g. description). In this case,
+    * we combine the schemas, reverting all per-usage customisable properties to their default values. These properties should be added when
+    * creating a reference schema (#1203).
     */
-  def unique(objs: Iterable[KeyedSchema]): Iterable[KeyedSchema] = {
-    val seen: collection.mutable.Set[SchemaKey] = collection.mutable.Set()
-    val result: ListBuffer[KeyedSchema] = ListBuffer()
-    objs.foreach { obj =>
-      if (!seen.contains(obj._1)) {
-        seen.add(obj._1)
-        result += obj
-      }
+  def uniqueCombined(objs: Iterable[KeyedSchema]): Iterable[KeyedSchema] = {
+    val grouped = objs.groupBy(_._1)
+
+    // taking care to maintain the original order of keys in objs
+    objs.map(_._1).toList.distinct.map { key =>
+      (key, grouped(key).map(_._2).reduce(combine))
     }
-    result.toList
+  }
+
+  /** Combines the two schemas, reverting all per-usage customisable properties to their default values, if their values diverge. */
+  private def combine(s1: TSchema[_], s2: TSchema[_]): TSchema[_] = {
+    var result = s1
+    if (s1.description != s2.description) result = result.copy(description = None)
+    if (s1.default != s2.default) result = result.copy(default = None)
+    if (s1.encodedExample != s2.encodedExample) result = result.copy(encodedExample = None)
+    if (s1.deprecated != s2.deprecated) result = result.deprecated(false)
+    // TODO: attributes
+    result
   }
 }

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/ToKeyedSchemas.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/ToKeyedSchemas.scala
@@ -2,12 +2,10 @@ package sttp.tapir.docs.apispec.schema
 
 import sttp.tapir.{Codec, Schema => TSchema, SchemaType => TSchemaType}
 
-import scala.collection.mutable.ListBuffer
+private[docs] object ToKeyedSchemas {
+  def apply[T](codec: Codec[_, T, _]): List[KeyedSchema] = apply(codec.schema)
 
-private[docs] class ToKeyedSchemas {
-  private[docs] def apply[T](codec: Codec[_, T, _]): List[KeyedSchema] = apply(codec.schema)
-
-  private[docs] def apply(schema: TSchema[_]): List[KeyedSchema] = {
+  def apply(schema: TSchema[_]): List[KeyedSchema] = {
     val thisSchema = SchemaKey(schema).map(_ -> schema).toList
     val nestedSchemas = schema match {
       case TSchema(TSchemaType.SArray(o), _, _, _, _, _, _, _, _, _, _)            => apply(o)
@@ -27,9 +25,6 @@ private[docs] class ToKeyedSchemas {
   private def productSchemas[T](st: TSchemaType.SProduct[T]): List[KeyedSchema] = st.fields.flatMap(a => apply(a.schema))
 
   private def coproductSchemas[T](st: TSchemaType.SCoproduct[T]): List[KeyedSchema] = st.subtypes.flatMap(apply)
-}
-
-private[docs] object ToKeyedSchemas {
 
   /** Keeps only the first object data for each [[SchemaKey]]. In case of recursive objects, the first one is the most complete as it
     * contains the built-up structure, unlike subsequent ones, which only represent leaves (#354, later extended for #2358, so that the

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/ToSchemaReference.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/ToSchemaReference.scala
@@ -1,21 +1,28 @@
 package sttp.tapir.docs.apispec.schema
 
-import sttp.apispec.Reference
+import sttp.apispec.{Schema => ASchema}
 import sttp.tapir.{Schema => TSchema}
+import sttp.tapir.Schema.Title
+import sttp.tapir.docs.apispec.schema.TSchemaToASchema.{tDefaultToADefault, tExampleToAExample}
 
 private[schema] class ToSchemaReference(
     keyToId: Map[SchemaKey, SchemaId],
     keyToSchema: Map[SchemaKey, TSchema[_]],
     refRoot: String = "#/components/schemas/"
 ) {
-
-  def map(schema: TSchema[_], name: TSchema.SName): Reference = {
+  def map(schema: TSchema[_], name: TSchema.SName): ASchema = {
     val key = SchemaKey(schema, name)
     val maybeId = keyToId.get(key)
     var result = map(key.name, maybeId)
     keyToSchema.get(key).foreach { originalSchema =>
-      // checking if we don't need to enrich the reference, as it might contain additional usage-site specific properties (#1203)
+      // checking if we don't need to enrich the reference, as it might contain additional usage-site specific properties
+      // the differently customised properties are reset to their default values in ToKeyedSchemas (#1203)
       if (originalSchema.description != schema.description) result = result.copy(description = schema.description)
+      if (originalSchema.default != schema.default) result = result.copy(default = tDefaultToADefault(schema))
+      if (originalSchema.encodedExample != schema.encodedExample) result = result.copy(example = tExampleToAExample(schema))
+      if (originalSchema.deprecated != schema.deprecated && schema.deprecated) result = result.copy(deprecated = Some(schema.deprecated))
+      if (originalSchema.attributes.get(Title.Attribute) != schema.attributes.get(Title.Attribute))
+        result = result.copy(title = schema.attributes.get(Title.Attribute).map(_.value))
     }
     result
   }
@@ -26,14 +33,14 @@ private[schema] class ToSchemaReference(
     *
     * When mapping a referenced used in a discriminator, we choose the variant with the higher number of fields in [[mapDiscriminator]].
     */
-  def mapDirect(name: TSchema.SName): Reference =
+  def mapDirect(name: TSchema.SName): ASchema =
     map(name, keyToId.filter(_._1.name == name).toList.sortBy(_._1.fields.size).headOption.map(_._2))
 
-  def mapDiscriminator(name: TSchema.SName): Reference =
+  def mapDiscriminator(name: TSchema.SName): ASchema =
     map(name, keyToId.filter(_._1.name == name).toList.sortBy(-_._1.fields.size).headOption.map(_._2))
 
-  private def map(name: TSchema.SName, maybeId: Option[SchemaId]): Reference = maybeId match {
-    case Some(id) => Reference.to(refRoot, id)
-    case None     => Reference(name.fullName) // no reference to internal model found. assuming external reference
+  private def map(name: TSchema.SName, maybeId: Option[SchemaId]): ASchema = maybeId match {
+    case Some(id) => ASchema.referenceTo(refRoot, id)
+    case None     => ASchema.referenceTo("", name.fullName) // no reference to internal model found. assuming external reference
   }
 }

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/schema.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/schema.scala
@@ -8,10 +8,13 @@ package object schema {
     val shortName = info.fullName.split('.').last
     (shortName +: info.typeParameterShortNames).mkString("_")
   }
+
   /*
-  SchemaId - used in the documentation to identify a schema in the components section, and to use in in references
-  SchemaKey - used as a key to differentiate between schemas when collecting all used schemas within an endpoint
-  SName - the name of the class + type parameters associated with a schema
+  SchemaId:  Used in the documentation to identify a schema in the components section, and to use in in references.
+             Typically contains the type name, possibly with a suffix for disambiguation.
+  SchemaKey: Used as a key to differentiate between schemas when collecting all used schemas within an endpoint.
+             Each schema key corresponds to an entry in the components section.
+  SName:     The name of the class + type parameters associated with a schema.
    */
 
   private[docs] type KeyedSchema = (SchemaKey, TSchema[_])

--- a/docs/apispec-docs/src/test/scala/sttp/tapir/docs/apispec/schema/TapirSchemaToJsonSchemaTest.scala
+++ b/docs/apispec-docs/src/test/scala/sttp/tapir/docs/apispec/schema/TapirSchemaToJsonSchemaTest.scala
@@ -23,7 +23,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val tSchema = implicitly[Schema[Parent]]
 
     // when
-    val result: ASchema = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true).value
+    val result: ASchema = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true)
 
     // then
     result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}},"$$defs":{"Child":{"title":"Child","required":["childId"],"type":"object","properties":{"childId":{"type":"string"},"childNames":{"type":"array","items":{"type":"string"}}}}}}"""
@@ -35,7 +35,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val tSchema = implicitly[Schema[List[Int]]]
 
     // when
-    val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true).value
+    val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true)
 
     // then
     result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","type":"array","items":{"type":"integer","format":"int32"}}"""
@@ -51,7 +51,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val tSchema = implicitly[Schema[Parent]]
 
     // when
-    val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true).value
+    val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true)
 
     // then
     result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","required":["innerChildField","childDetails"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"},"childDetails":{"$$ref":"#/$$defs/Child1"}},"$$defs":{"Child":{"title":"Child","required":["childName"],"type":"object","properties":{"childName":{"type":"string"}}},"Child1":{"title":"Child1","required":["age"],"type":"object","properties":{"age":{"type":"integer","format":"int32"},"height":{"type":["integer", "null"],"format":"int32"}}}}}"""
@@ -64,7 +64,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val tSchema = implicitly[Schema[Parent]]
 
     // when
-    val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = false).value
+    val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = false)
 
     // then
     result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}},"$$defs":{"Child":{"title":"Child","type":"object","properties":{"childName":{"type":"string"}}}}}"""
@@ -78,7 +78,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val tSchema = implicitly[Schema[Parent]]
 
     // when
-    val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true).value
+    val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true)
 
     // then
     result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}},"$$defs":{"Child":{"title":"Child","type":"object","properties":{"childName":{"type":["string","null"]}}}}}"""
@@ -97,7 +97,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val tSchema = implicitly[Schema[Outer]]
 
     // when
-    val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true).value
+    val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true)
 
     // then
     result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","title":"MyOwnTitle1","required":["inner"],"type":"object","properties":{"inner":{"$$ref":"#/$$defs/Parent"}},"$$defs":{"Parent":{"title":"Parent","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}}},"Child":{"title":"MyOwnTitle3","type":"object","properties":{"childName":{"type":["string","null"]}}}}}"""
@@ -113,7 +113,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val tSchema = implicitly[Schema[Parent]]
 
     // when
-    val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true, addTitleToDefs = false).value
+    val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true, addTitleToDefs = false)
 
     // then
     result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}},"$$defs":{"Child":{"title":"MyChild","type":"object","properties":{"childName":{"type":["string","null"]}}}}}"""

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIComponents.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIComponents.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.docs.asyncapi
 
-import sttp.apispec.{ReferenceOr, Schema => ASchema}
+import sttp.apispec.{Schema => ASchema}
 import sttp.apispec.asyncapi.{Components, Message}
 import sttp.tapir.docs.apispec.SecuritySchemes
 import sttp.tapir.docs.apispec.schema.SchemaId
@@ -9,7 +9,7 @@ import sttp.tapir.internal.IterableToListMap
 import scala.collection.immutable.ListMap
 
 private[asyncapi] class EndpointToAsyncAPIComponents(
-    idToSchema: ListMap[SchemaId, ReferenceOr[ASchema]],
+    idToSchema: ListMap[SchemaId, ASchema],
     keyToMessage: ListMap[MessageKey, Message],
     securitySchemes: SecuritySchemes
 ) {

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIDocs.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIDocs.scala
@@ -16,11 +16,10 @@ private[asyncapi] object EndpointToAsyncAPIDocs {
   ): AsyncAPI = {
     val wsEndpointsWithWrapper = es.map(e => (e, findWebSocket(e))).collect { case (e, Some(ws)) => (e, ws) }
     val wsEndpoints = wsEndpointsWithWrapper.map(_._1).map(nameAllPathCapturesInEndpoint)
-    val toKeyedSchemas = new ToKeyedSchemas
     val (keyToSchema, schemas) =
-      new SchemasForEndpoints(wsEndpoints, options.schemaName, toKeyedSchemas, markOptionsAsNullable = false, additionalOutputs = Nil)
+      new SchemasForEndpoints(wsEndpoints, options.schemaName, markOptionsAsNullable = false, additionalOutputs = Nil)
         .apply()
-    val (codecToMessageKey, keyToMessage) = new MessagesForEndpoints(schemas, options.schemaName, toKeyedSchemas)(
+    val (codecToMessageKey, keyToMessage) = new MessagesForEndpoints(schemas, options.schemaName)(
       wsEndpointsWithWrapper.map(_._2)
     )
     val securitySchemes = SecuritySchemesForEndpoints(wsEndpoints, apiKeyAuthTypeName = "httpApiKey")

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIDocs.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/EndpointToAsyncAPIDocs.scala
@@ -2,7 +2,7 @@ package sttp.tapir.docs.asyncapi
 
 import sttp.apispec.asyncapi.{AsyncAPI, Info, Server}
 import sttp.tapir._
-import sttp.tapir.docs.apispec.schema.{SchemasForEndpoints, ToKeyedSchemas}
+import sttp.tapir.docs.apispec.schema.SchemasForEndpoints
 import sttp.tapir.docs.apispec._
 import sttp.tapir.internal._
 

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/MessagesForEndpoints.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/MessagesForEndpoints.scala
@@ -11,7 +11,7 @@ import sttp.ws.WebSocketFrame
 
 import scala.collection.immutable.ListMap
 
-private[asyncapi] class MessagesForEndpoints(schemas: Schemas, schemaName: SName => String, toKeyedSchemas: ToKeyedSchemas) {
+private[asyncapi] class MessagesForEndpoints(schemas: Schemas, schemaName: SName => String) {
   private type CodecData = Either[(SName, MediaType), TSchema[_]]
 
   private case class CodecWithInfo[T](codec: Codec[WebSocketFrame, T, _ <: CodecFormat], info: EndpointIO.Info[T])
@@ -28,7 +28,7 @@ private[asyncapi] class MessagesForEndpoints(schemas: Schemas, schemaName: SName
   }
 
   private def toData(codec: Codec[_, _, _ <: CodecFormat]): CodecData =
-    toKeyedSchemas.apply(codec).headOption match { // the first element, if any, corresponds to the object
+    ToKeyedSchemas.apply(codec).headOption match { // the first element, if any, corresponds to the object
       case Some(os) => Left((os._1.name, codec.format.mediaType))
       case None     => Right(codec.schema.copy(description = None, deprecated = false))
     }

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointInputToParameterConverter.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointInputToParameterConverter.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.docs.openapi
 
-import sttp.apispec.{ReferenceOr, Schema}
+import sttp.apispec.Schema
 import sttp.apispec.openapi.{MediaType, Parameter, ParameterIn}
 import sttp.tapir.docs.apispec.DocsExtensionAttribute.RichEndpointIOInfo
 import sttp.tapir.docs.apispec.DocsExtensions
@@ -9,7 +9,7 @@ import sttp.tapir.{Codec, EndpointIO, EndpointInput}
 import scala.collection.immutable.ListMap
 
 private[openapi] object EndpointInputToParameterConverter {
-  def from[T](query: EndpointInput.Query[T], schema: ReferenceOr[Schema]): Parameter = {
+  def from[T](query: EndpointInput.Query[T], schema: Schema): Parameter = {
     val examples = ExampleConverter.convertExamples(query.codec, query.info.examples)
 
     Parameter(
@@ -39,7 +39,7 @@ private[openapi] object EndpointInputToParameterConverter {
       allowEmptyValue = query.flagValue.fold(None: Option[Boolean])(_ => Some(true))
     )
 
-  def from[T](pathCapture: EndpointInput.PathCapture[T], schema: ReferenceOr[Schema]): Parameter = {
+  def from[T](pathCapture: EndpointInput.PathCapture[T], schema: Schema): Parameter = {
     val examples = ExampleConverter.convertExamples(pathCapture.codec, pathCapture.info.examples)
     Parameter(
       name = pathCapture.name.getOrElse("?"),
@@ -53,7 +53,7 @@ private[openapi] object EndpointInputToParameterConverter {
     )
   }
 
-  def from[T](header: EndpointIO.Header[T], schema: ReferenceOr[Schema]): Parameter = {
+  def from[T](header: EndpointIO.Header[T], schema: Schema): Parameter = {
     val examples = ExampleConverter.convertExamples(header.codec, header.info.examples)
     Parameter(
       name = header.name,
@@ -68,7 +68,7 @@ private[openapi] object EndpointInputToParameterConverter {
     )
   }
 
-  def from[T](header: EndpointIO.FixedHeader[T], schema: ReferenceOr[Schema]): Parameter = {
+  def from[T](header: EndpointIO.FixedHeader[T], schema: Schema): Parameter = {
     val baseExamples = ExampleConverter.convertExamples(header.codec, header.info.examples)
     val examples =
       if (baseExamples.multipleExamples.nonEmpty) baseExamples
@@ -87,7 +87,7 @@ private[openapi] object EndpointInputToParameterConverter {
     )
   }
 
-  def from[T](cookie: EndpointInput.Cookie[T], schema: ReferenceOr[Schema]): Parameter = {
+  def from[T](cookie: EndpointInput.Cookie[T], schema: Schema): Parameter = {
     val examples = ExampleConverter.convertExamples(cookie.codec, cookie.info.examples)
     Parameter(
       name = cookie.name,

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIComponents.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIComponents.scala
@@ -1,6 +1,5 @@
 package sttp.tapir.docs.openapi
 
-import sttp.apispec.ReferenceOr
 import sttp.apispec.{Schema => ASchema}
 import sttp.apispec.openapi.Components
 import sttp.tapir.docs.apispec.SecuritySchemes
@@ -10,7 +9,7 @@ import sttp.tapir.internal.{IterableToListMap, SortListMap}
 import scala.collection.immutable.ListMap
 
 private[openapi] class EndpointToOpenAPIComponents(
-    idToSchema: ListMap[SchemaId, ReferenceOr[ASchema]],
+    idToSchema: ListMap[SchemaId, ASchema],
     securitySchemes: SecuritySchemes
 ) {
   def components: Option[Components] = {

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIDocs.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIDocs.scala
@@ -2,7 +2,7 @@ package sttp.tapir.docs.openapi
 
 import sttp.apispec.openapi._
 import sttp.tapir._
-import sttp.tapir.docs.apispec.schema.{SchemasForEndpoints, ToKeyedSchemas}
+import sttp.tapir.docs.apispec.schema.SchemasForEndpoints
 import sttp.tapir.docs.apispec.{DocsExtension, DocsExtensions, SecuritySchemesForEndpoints, nameAllPathCapturesInEndpoint}
 import sttp.tapir.internal._
 
@@ -16,10 +16,8 @@ private[openapi] object EndpointToOpenAPIDocs {
       docsExtensions: List[DocsExtension[_]]
   ): OpenAPI = {
     val es2 = es.filter(e => findWebSocket(e).isEmpty).map(nameAllPathCapturesInEndpoint)
-    val toKeyedSchemas = new ToKeyedSchemas
     val additionalOutputs = es2.flatMap(e => options.defaultDecodeFailureOutput(e.input)).toSet.toList
-    val (idToSchema, schemas) =
-      new SchemasForEndpoints(es2, options.schemaName, toKeyedSchemas, options.markOptionsAsNullable, additionalOutputs).apply()
+    val (idToSchema, schemas) = new SchemasForEndpoints(es2, options.schemaName, options.markOptionsAsNullable, additionalOutputs).apply()
     val securitySchemes = SecuritySchemesForEndpoints(es2, apiKeyAuthTypeName = "apiKey")
     val pathCreator = new EndpointToOpenAPIPaths(schemas, securitySchemes, options)
     val componentsCreator = new EndpointToOpenAPIComponents(idToSchema, securitySchemes)

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIPaths.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOpenAPIPaths.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.docs.openapi
 
 import sttp.model.Method
-import sttp.apispec.{ReferenceOr, Schema => ASchema, SchemaType => ASchemaType}
+import sttp.apispec.{Schema => ASchema, SchemaType => ASchemaType}
 import sttp.apispec.openapi._
 import sttp.tapir._
 import sttp.tapir.docs.apispec.DocsExtensionAttribute.{RichEndpointIOInfo, RichEndpointInfo}
@@ -105,7 +105,7 @@ private[openapi] class EndpointToOpenAPIPaths(schemas: Schemas, securitySchemes:
 
   private def headerToParameter[T](header: EndpointIO.Header[T]) = EndpointInputToParameterConverter.from(header, schemas(header.codec))
   private def fixedHeaderToParameter[T](header: EndpointIO.FixedHeader[_]) =
-    EndpointInputToParameterConverter.from(header, Right(ASchema(ASchemaType.String)))
+    EndpointInputToParameterConverter.from(header, ASchema(ASchemaType.String))
   private def cookieToParameter[T](cookie: EndpointInput.Cookie[T]) = EndpointInputToParameterConverter.from(cookie, schemas(cookie.codec))
   private def pathCaptureToParameter[T](p: EndpointInput.PathCapture[T]) = EndpointInputToParameterConverter.from(p, schemas(p.codec))
 

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOperationResponse.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOperationResponse.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.docs.openapi
 
 import sttp.model.StatusCode
-import sttp.apispec.{ReferenceOr, Schema => ASchema, SchemaType => ASchemaType}
+import sttp.apispec.{Schema => ASchema, SchemaType => ASchemaType}
 import sttp.apispec.openapi._
 import sttp.tapir._
 import sttp.tapir.docs.apispec.DocsExtensionAttribute.RichEndpointIOInfo
@@ -125,7 +125,7 @@ private[openapi] class EndpointToOperationResponse(
             Header(
               description = info.description,
               required = Some(true),
-              schema = Option(Right(ASchema(ASchemaType.String)))
+              schema = Option(ASchema(ASchemaType.String))
             )
           )
         )

--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/ExampleConverter.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/ExampleConverter.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.docs.openapi
 
 import sttp.apispec._
-import sttp.apispec.openapi.Example
+import sttp.apispec.openapi.{Example, ReferenceOr}
 import sttp.tapir.docs.apispec.exampleValue
 import sttp.tapir.internal.IterableToListMap
 import sttp.tapir.{Codec, EndpointIO, Schema => TSchema}

--- a/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_enum_adding_default_when_encoded_value_specified.yml
+++ b/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_enum_adding_default_when_encoded_value_specified.yml
@@ -32,9 +32,9 @@ components:
       properties:
         fruitType:
           $ref: '#/components/schemas/FruitType'
+          default: PEAR
     FruitType:
       type: string
-      default: PEAR
       enum:
         - APPLE
         - PEAR

--- a/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_enum_default.yml
+++ b/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_enum_default.yml
@@ -12,6 +12,7 @@ paths:
           required: false
           schema:
             $ref: '#/components/schemas/FruitType'
+            default: PEAR
             example: APPLE
       responses:
         '200':
@@ -30,7 +31,6 @@ components:
   schemas:
     FruitType:
       type: string
-      default: PEAR
       enum:
         - APPLE
         - PEAR

--- a/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_enum_using_first_specified_default_value.yml
+++ b/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_enum_using_first_specified_default_value.yml
@@ -12,6 +12,7 @@ paths:
           required: false
           schema:
             $ref: '#/components/schemas/FruitType'
+            default: PEAR
       responses:
         '200':
           description: ''
@@ -34,6 +35,7 @@ paths:
           required: false
           schema:
             $ref: '#/components/schemas/FruitType'
+            default: APPLE
       responses:
         '200':
           description: ''
@@ -51,7 +53,6 @@ components:
   schemas:
     FruitType:
       type: string
-      default: PEAR
       enum:
         - APPLE
         - PEAR

--- a/docs/openapi-docs/src/test/resources/expected_default_and_example_on_nested_option_field.yml
+++ b/docs/openapi-docs/src/test/resources/expected_default_and_example_on_nested_option_field.yml
@@ -11,7 +11,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ClassWithNestedOptionalField'
-              required: true
+        required: true
       responses:
         '200':
           description: ''

--- a/docs/openapi-docs/src/test/resources/multi_customise_schema/inlined.yml
+++ b/docs/openapi-docs/src/test/resources/multi_customise_schema/inlined.yml
@@ -1,0 +1,48 @@
+openapi: 3.1.0
+info:
+  title: Schemas
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Data2'
+        required: true
+      responses:
+        '200':
+          description: ''
+        '400':
+          description: 'Invalid value for: body'
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    Data2:
+      required:
+        - a
+        - b
+      type: object
+      properties:
+        a:
+          required:
+            - x
+          type: object
+          properties:
+            x:
+              type: string
+          description: aaa
+          deprecated: true
+        b:
+          required:
+            - x
+          type: object
+          properties:
+            x:
+              type: string
+          description: bbb

--- a/docs/openapi-docs/src/test/resources/multi_customise_schema/nested_body.yml
+++ b/docs/openapi-docs/src/test/resources/multi_customise_schema/nested_body.yml
@@ -1,0 +1,45 @@
+openapi: 3.1.0
+info:
+  title: Schemas
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Data2'
+        required: true
+      responses:
+        '200':
+          description: ''
+        '400':
+          description: 'Invalid value for: body'
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    Data1:
+      required:
+        - x
+      type: object
+      properties:
+        x:
+          type: string
+    Data2:
+      required:
+        - a
+        - b
+      type: object
+      properties:
+        a:
+          $ref: '#/components/schemas/Data1'
+          description: aaa
+          deprecated: true
+        b:
+          $ref: '#/components/schemas/Data1'
+          description: bbb

--- a/docs/openapi-docs/src/test/resources/multi_customise_schema/top_level_body.yml
+++ b/docs/openapi-docs/src/test/resources/multi_customise_schema/top_level_body.yml
@@ -1,0 +1,38 @@
+openapi: 3.1.0
+info:
+  title: Schemas
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Data1'
+              description: d1
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Data1'
+                description: d2
+        '400':
+          description: 'Invalid value for: body'
+          content:
+            text/plain:
+              schema:
+                type: string
+components:
+  schemas:
+    Data1:
+      required:
+        - x
+      type: object
+      properties:
+        x:
+          type: string

--- a/docs/openapi-docs/src/test/scalajvm-2/sttp/tapir/docs/openapi/VerifyYamlEnumeratumTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm-2/sttp/tapir/docs/openapi/VerifyYamlEnumeratumTest.scala
@@ -50,6 +50,8 @@ class VerifyYamlEnumeratumTest extends AnyFunSuite with Matchers {
     val actualYaml =
       OpenAPIDocsInterpreter().toOpenAPI(ep, Info("Fruits", "1.0")).toYaml
 
+    // TODO fix test
+
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
@@ -68,6 +70,8 @@ class VerifyYamlEnumeratumTest extends AnyFunSuite with Matchers {
     val actualYaml =
       OpenAPIDocsInterpreter().toOpenAPI(List(ep1, ep2), Info("Fruits", "1.0")).toYaml
 
+    // TODO fix test
+    
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 
@@ -94,6 +98,8 @@ class VerifyYamlEnumeratumTest extends AnyFunSuite with Matchers {
     val actualYaml =
       OpenAPIDocsInterpreter().toOpenAPI(ep, Info("Fruits", "1.0")).toYaml
 
+    // TODO fix test    
+    
     noIndentation(actualYaml) shouldBe expectedYaml
   }
 

--- a/docs/openapi-docs/src/test/scalajvm-2/sttp/tapir/docs/openapi/VerifyYamlEnumeratumTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm-2/sttp/tapir/docs/openapi/VerifyYamlEnumeratumTest.scala
@@ -56,7 +56,7 @@ class VerifyYamlEnumeratumTest extends AnyFunSuite with Matchers {
   }
 
   // #1800
-  test("should use first specified default value") {
+  test("should use different default values") {
     val expectedYaml = load("enum/expected_enumeratum_enum_using_first_specified_default_value.yml")
     val ep1 = endpoint
       .in("fruit-by-type1")

--- a/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlMultiCustomiseSchemaTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlMultiCustomiseSchemaTest.scala
@@ -23,6 +23,8 @@ class VerifyYamlMultiCustomiseSchemaTest extends AnyFunSuite with Matchers {
     val actualYaml = OpenAPIDocsInterpreter().toOpenAPI(List(e), Info("Schemas", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
+    println(actualYaml)
+
     actualYamlNoIndent shouldBe expectedYaml
   }
 

--- a/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlMultiCustomiseSchemaTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlMultiCustomiseSchemaTest.scala
@@ -23,8 +23,6 @@ class VerifyYamlMultiCustomiseSchemaTest extends AnyFunSuite with Matchers {
     val actualYaml = OpenAPIDocsInterpreter().toOpenAPI(List(e), Info("Schemas", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
-    println(actualYaml)
-
     actualYamlNoIndent shouldBe expectedYaml
   }
 
@@ -34,6 +32,18 @@ class VerifyYamlMultiCustomiseSchemaTest extends AnyFunSuite with Matchers {
 
     val actualYaml = OpenAPIDocsInterpreter().toOpenAPI(List(e), Info("Schemas", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("top-level body references") {
+    val e = endpoint.get.in(jsonBody[Data1].schema(_.description("d1"))).out(jsonBody[Data1].schema(_.description("d2")))
+    val expectedYaml = load("multi_customise_schema/top_level_body.yml")
+
+    val actualYaml = OpenAPIDocsInterpreter().toOpenAPI(List(e), Info("Schemas", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    println(actualYaml)
 
     actualYamlNoIndent shouldBe expectedYaml
   }

--- a/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlMultiCustomiseSchemaTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlMultiCustomiseSchemaTest.scala
@@ -43,8 +43,6 @@ class VerifyYamlMultiCustomiseSchemaTest extends AnyFunSuite with Matchers {
     val actualYaml = OpenAPIDocsInterpreter().toOpenAPI(List(e), Info("Schemas", "1.0")).toYaml
     val actualYamlNoIndent = noIndentation(actualYaml)
 
-    println(actualYaml)
-
     actualYamlNoIndent shouldBe expectedYaml
   }
 }

--- a/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlMultiCustomiseSchemaTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlMultiCustomiseSchemaTest.scala
@@ -1,0 +1,43 @@
+package sttp.tapir.docs.openapi
+
+import io.circe.generic.auto._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import sttp.apispec.openapi.Info
+import sttp.apispec.openapi.circe.yaml._
+import sttp.tapir.Schema.annotations.{deprecated, description}
+import sttp.tapir.generic.auto._
+import sttp.tapir._
+import sttp.tapir.json.circe._
+
+/** Tests which check that multiple, independent customisations of schemas for same data types don't get lost / overridden. Such
+  * customisations should be moved to the `$ref` (as allowed by OpenAPI 3.1), or kept inline, if the schema doesn't have a name.
+  */
+class VerifyYamlMultiCustomiseSchemaTest extends AnyFunSuite with Matchers {
+  import VerifyYamlMultiCustomiseSchemaTest._
+
+  test("nested body references") {
+    val e = endpoint.get.in(jsonBody[Data2])
+    val expectedYaml = load("multi_customise_schema/nested_body.yml")
+
+    val actualYaml = OpenAPIDocsInterpreter().toOpenAPI(List(e), Info("Schemas", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("inlined schemas") {
+    val e = endpoint.get.in(jsonBody[Data2].schema(_.modify(_.a)(_.name(None)).modify(_.b)(_.name(None))))
+    val expectedYaml = load("multi_customise_schema/inlined.yml")
+
+    val actualYaml = OpenAPIDocsInterpreter().toOpenAPI(List(e), Info("Schemas", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+}
+
+object VerifyYamlMultiCustomiseSchemaTest {
+  case class Data1(x: String)
+  case class Data2(@deprecated @description("aaa") a: Data1, @description("bbb") b: Data1)
+}

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -10,7 +10,7 @@ object Versions {
   val sttp = "3.9.0"
   val sttpModel = "1.7.2"
   val sttpShared = "1.3.16"
-  val sttpApispec = "0.6.3"
+  val sttpApispec = "0.6.3+0-f0c880e6+20231009-1044-SNAPSHOT"
   val akkaHttp = "10.2.10"
   val akkaStreams = "2.6.20"
   val pekkoHttp = "1.0.0"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -10,7 +10,7 @@ object Versions {
   val sttp = "3.9.0"
   val sttpModel = "1.7.2"
   val sttpShared = "1.3.16"
-  val sttpApispec = "0.6.3+0-f0c880e6+20231009-1044-SNAPSHOT"
+  val sttpApispec = "0.7.0"
   val akkaHttp = "10.2.10"
   val akkaStreams = "2.6.20"
   val pekkoHttp = "1.0.0"


### PR DESCRIPTION
Closes #1203

Also: https://softwaremill.community/t/tapir-redoc-annotations-not-working-as-expected/289

To implement this change, it was necessary to change the way schemas are referenced: this is no longer done using the `Reference` object and an `Either[Reference, Schema]`. Instead, schemas [can include a reference](https://github.com/softwaremill/sttp-apispec/pull/117) as part of the schema, as well as other properties. This is in-line with the changes done to JSON schema, and also referenced in the [OpenAPI docs](https://spec.openapis.org/oas/v3.1.0#reference-object).