### PR TITLE
Feature: Add iron's RefinedTypeOps support

### DIFF
--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
@@ -49,23 +49,11 @@ trait TapirCodecIron extends DescriptionWitness with LowPriorityValidatorForPred
         }
       }(identity)
 
-  inline given refinedTypeSchema[T](using mirror: RefinedTypeOps.Mirror[T])(using
-    inline vSchema: Schema[mirror.BaseType],
-    inline constraint: Constraint[mirror.BaseType, mirror.ConstraintType],
-    inline validatorTranslation: ValidatorForPredicate[mirror.BaseType, mirror.ConstraintType]
-  ): Schema[T] =
-    val ops = new RefinedTypeOpsImpl[mirror.BaseType, mirror.ConstraintType, T] {}
-    import ops.*
-    summon[Schema[mirror.IronType]].map(input => Some(ops(input)))(_.value)
+  given refinedTypeSchema[T](using m: RefinedTypeOps.Mirror[T], ev: Schema[m.IronType]): Schema[T] =
+    ev.asInstanceOf[Schema[T]]
 
-  inline given refinedTypeCodec[R, T, CF <: CodecFormat] (using mirror: RefinedTypeOps.Mirror[T])(using
-    inline tm: Codec[R, mirror.BaseType, CF],
-    inline constraint: Constraint[mirror.BaseType, mirror.ConstraintType],
-    inline validatorTranslation: ValidatorForPredicate[mirror.BaseType, mirror.ConstraintType]
-  ): Codec[R, T, CF] =
-    val ops = new RefinedTypeOpsImpl[mirror.BaseType, mirror.ConstraintType, T] {}
-    import ops.*
-    summon[Codec[R, mirror.IronType, CF]].map(ops(_))(_.value)
+  given refinedTypeCodec[R, T, CF <: CodecFormat] (using m: RefinedTypeOps.Mirror[T], ev: Codec[R, m.IronType, CF]): Codec[R, T, CF] =
+    ev.asInstanceOf[Codec[R, T, CF]]
 
   inline given (using
       inline vSchema: Schema[String],

--- a/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/RefinedInt.scala
+++ b/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/RefinedInt.scala
@@ -1,0 +1,8 @@
+package sttp.iron.codec.iron
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.all.*
+
+type RefinedIntConstraint = Interval.ClosedOpen[0, 10]
+opaque type RefinedInt <: Int = Int :| RefinedIntConstraint
+object RefinedInt extends RefinedTypeOpsImpl[Int, RefinedIntConstraint, RefinedInt]

--- a/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
+++ b/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
@@ -18,6 +18,11 @@ import io.github.iltotore.iron.constraint.all.*
 import sttp.tapir.Validator
 import sttp.tapir.ValidationError
 
+// Opaque aliases can't be included into class bodies
+type RefinedIntConstraint = Interval.ClosedOpen[0, 10]
+opaque type RefinedInt <: Int = Int :| RefinedIntConstraint
+object RefinedInt extends RefinedTypeOpsImpl[Int, RefinedIntConstraint, RefinedInt]
+
 class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
 
   val schema: Schema[Double :| Positive] = summon[Schema[Double :| Positive]]
@@ -214,5 +219,9 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
       case Validator.Mapped(Validator.Any(List(Validator.Max(1, true), Validator.Min(3, true))), _) =>
     }
   }
+
+  "Instances for opaque refined type" should "correctly derived" in:
+    summon[Schema[RefinedInt]]
+    summon[Codec[String, RefinedInt, TextPlain]]
 
 }

--- a/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
+++ b/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
@@ -18,11 +18,6 @@ import io.github.iltotore.iron.constraint.all.*
 import sttp.tapir.Validator
 import sttp.tapir.ValidationError
 
-// Opaque aliases can't be included into class bodies
-type RefinedIntConstraint = Interval.ClosedOpen[0, 10]
-opaque type RefinedInt <: Int = Int :| RefinedIntConstraint
-object RefinedInt extends RefinedTypeOpsImpl[Int, RefinedIntConstraint, RefinedInt]
-
 class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
 
   val schema: Schema[Double :| Positive] = summon[Schema[Double :| Positive]]
@@ -220,7 +215,7 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
     }
   }
 
-  "Instances for opaque refined type" should "correctly derived" in:
+  "Instances for opaque refined type" should "be correctly derived" in:
     summon[Schema[RefinedInt]]
     summon[Codec[String, RefinedInt, TextPlain]]
 


### PR DESCRIPTION
Using the Iron library, a common pattern is to hide the constrained type behind an opaque alias, to disallow similarly constrained types (The same result can be obtained using `DescribedAs`, but I prefer not messing description with identity).

```scala
type RefinedIntConstraint = Interval.ClosedOpen[0, 10]
opaque type RefinedInt <: Int = Int :| RefinedIntConstraint

object RefinedInt extends RefinedTypeOpsImpl[Int, RefinedIntConstraint, RefinedInt]
```

Once the alias is opaque, it is not possible anymore to derive instances with the `Value :| Predicate` type pattern. 

This PR provides instances relying on the given `RefinedTypeOps.Mirror[T]` instance that is provided by `RefinedTypeOpsImpl`.

I wonder if the provided tests are enough or if there is corner cases I need to be aware of.