### PR TITLE
added support for (array of) object without properties

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
@@ -255,11 +255,11 @@ object OpenapiSchemaType {
         .downField("type")
         .as[Option[String]]
         .ensure(DecodingFailure("Given type is not object!", c.history))(v => v.forall(_ == "object"))
-      f <- c.downField("properties").as[Map[String, OpenapiSchemaType]]
+      f <- c.downField("properties").as[Option[Map[String, OpenapiSchemaType]]]
       r <- c.downField("required").as[Option[Seq[String]]]
       nb <- c.downField("nullable").as[Option[Boolean]]
     } yield {
-      OpenapiSchemaObject(f, r.getOrElse(Seq.empty), nb.getOrElse(false))
+      OpenapiSchemaObject(f.getOrElse(Map.empty), r.getOrElse(Seq.empty), nb.getOrElse(false))
     }
   }
 
@@ -275,7 +275,7 @@ object OpenapiSchemaType {
 
   implicit val OpenapiSchemaArrayDecoder: Decoder[OpenapiSchemaArray] = { (c: HCursor) =>
     for {
-      _ <- c.downField("type").as[String].ensure(DecodingFailure("Given type is not array!", c.history))(v => v == "array")
+      _ <- c.downField("type").as[String].ensure(DecodingFailure("Given type is not array!", c.history))(v => v == "array" || v == "object")
       f <- c.downField("items").as[OpenapiSchemaType]
       nb <- c.downField("nullable").as[Option[Boolean]]
     } yield {
@@ -289,8 +289,8 @@ object OpenapiSchemaType {
       Decoder[OpenapiSchemaSimpleType].widen,
       Decoder[OpenapiSchemaMixedType].widen,
       Decoder[OpenapiSchemaNot].widen,
-      Decoder[OpenapiSchemaObject].widen,
       Decoder[OpenapiSchemaMap].widen,
+      Decoder[OpenapiSchemaObject].widen,
       Decoder[OpenapiSchemaArray].widen
     ).reduceLeft(_ or _)
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/SchemaParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/SchemaParserSpec.scala
@@ -146,4 +146,22 @@ class SchemaParserSpec extends AnyFlatSpec with Matchers with Checkers {
     res shouldBe Right(Seq(OpenapiResponseContent("application/json", OpenapiSchemaArray(OpenapiSchemaString(false), false))))
   }
 
+  it should "parse array of object without properties yaml" in {
+    // https://swagger.io/docs/specification/basic-structure/
+    val yaml =
+      """application/json:
+        |  schema:
+        |    type: array
+        |    items:
+        |      type: object
+        |      """.stripMargin
+
+    val res = parser
+      .parse(yaml)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[Seq[OpenapiResponseContent]])
+
+    res shouldBe Right(Seq(OpenapiResponseContent("application/json", OpenapiSchemaArray(OpenapiSchemaObject(Map.empty, Seq.empty, false), false))))
+  }
+
 }


### PR DESCRIPTION
I came across the across the following openAPI def (https://github.com/dahag-ag/keycloak-openapi/blob/0ec0f45ec0890ca12f9733aa4f5794a2e7a1d98b/OpenApiDefinitions/keycloak-21.0.0.yml#L7623):

The current version of the sbt-openapi-codegen does not support this and halts the import. This PR fixes that


```yaml
components:
  schemas:
    ClientPoliciesRepresentation:
      type: object
      properties:
        policies:
          type: array
          items:
            type: object
            description: ClientPolicyRepresentation
```