### PR TITLE
escaping descriptions when generating endpoint from openapi

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -1,9 +1,9 @@
 package sttp.tapir.codegen
-
 import sttp.tapir.codegen.BasicGenerator.{indent, mapSchemaSimpleTypeToType}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiDocument, OpenapiParameter, OpenapiPath, OpenapiRequestBody, OpenapiResponse}
-import sttp.tapir.codegen.openapi.models.{OpenapiComponent, OpenapiSchemaType, OpenapiSecuritySchemeType}
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaSimpleType}
+import sttp.tapir.codegen.openapi.models.{OpenapiComponent, OpenapiSchemaType, OpenapiSecuritySchemeType}
+import sttp.tapir.codegen.util.JavaEscape
 
 class EndpointGenerator {
 
@@ -107,7 +107,7 @@ class EndpointGenerator {
         param.schema match {
           case st: OpenapiSchemaSimpleType =>
             val (t, _) = mapSchemaSimpleTypeToType(st)
-            val desc = param.description.fold("")(d => s""".description("$d")""")
+            val desc = param.description.map(d=>JavaEscape.escapeString(d)).fold("")(d => s""".description("$d")""")
             s""".in(${param.in}[$t]("${param.name}")$desc)"""
           case x => throw new NotImplementedError(s"Can't create non-simple params to input - found $x")
         }
@@ -135,7 +135,7 @@ class EndpointGenerator {
     // .out(jsonBody[List[Book]])
     responses
       .map { resp =>
-        val d = s""".description("${resp.description}")"""
+        val d = s""".description("${JavaEscape.escapeString(resp.description)}")"""
         resp.content match {
           case Nil =>
             resp.code match {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/util/JavaEscape.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/util/JavaEscape.scala
@@ -1,0 +1,16 @@
+package sttp.tapir.codegen.util
+
+object JavaEscape {
+  def escapeString(str: String): String = {
+    str.flatMap {
+      case '\\' => "\\\\"
+      case '"'  => "\\\""
+      case '\n' => "\\n"
+      case '\t' => "\\t"
+      case '\r' => "\\r"
+      case '\b' => "\\b"
+      case '\f' => "\\f"
+      case char => char.toString
+    }
+  }
+}

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -2,15 +2,7 @@ package sttp.tapir.codegen
 
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  OpenapiSchemaArray,
-  OpenapiSchemaConstantString,
-  OpenapiSchemaEnum,
-  OpenapiSchemaMap,
-  OpenapiSchemaObject,
-  OpenapiSchemaRef,
-  OpenapiSchemaString
-}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaConstantString, OpenapiSchemaEnum, OpenapiSchemaMap, OpenapiSchemaObject, OpenapiSchemaRef, OpenapiSchemaString}
 import sttp.tapir.codegen.testutils.CompileCheckTestBase
 
 class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
@@ -289,5 +281,58 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val gen = new ClassDefinitionGenerator()
     val res = gen.classDefs(doc, false)
     "import enumeratum._;" + res.get shouldCompile ()
+  }
+
+  import cats.implicits._
+  import io.circe._
+  import io.circe.yaml.parser
+
+  it should "" in {
+    val quotedString = """a "quoted" string"""
+    val yaml =
+      s"""
+        |openapi: 3.0.0
+        |info:
+        |  version: required field, not relevant for test
+        |  title: required field, not relevant for test
+        |paths:
+        |  /foo:
+        |    get:
+        |      description: hello
+        |      parameters:
+        |        - name: search
+        |          in: query
+        |          required: true
+        |          description: $quotedString
+        |          schema:
+        |            type: string
+        |      responses:
+        |        '200':
+        |          description: required field, not relevant for test
+        |""".stripMargin
+
+    val parserRes: Either[Error, OpenapiDocument] = parser
+      .parse(yaml)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[OpenapiDocument])
+
+    val res: String = parserRes match {
+      case Left(value) => throw new Exception(value)
+      case Right(doc) =>  new EndpointGenerator().endpointDefs(doc)
+    }
+
+    val compileUnit =
+      s"""
+         |import sttp.tapir._
+         |
+         |object TapirGeneratedEndpoints {
+         |  $res
+         |}
+         |  """.stripMargin
+    println(compileUnit)
+    compileUnit shouldCompile ()
+
+
+
   }
 }


### PR DESCRIPTION
yaml files like this:


```yaml
openapi: 3.0.0
info:
  version: …
  title: …
paths:
  /foo:
    get:
      description: …
      parameters:
        - name: …
          in: …
          required: …
          description: a "quoted" string
          schema:
            type: …
      responses:
        '200':
          description: …
```

Causes the generated code to not compile. The quotes are not escaped.

current solution just uses simple call to an included escape function. Perhaps we should use a cats show typeclass to stringify any descriptions and documentation. 

the whole module feels somewhat brittle to me. 