### PR TITLE
Reduce CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       uses: nick-fields/retry@v2
       with:
         timeout_minutes: 30
-        max_attempts: 2
+        max_attempts: 3
         command: sbt $SBT_JAVA_OPTS -v "testScoped ${{ matrix.scala-version }} ${{ matrix.target-platform }}"
     # The finatra tests take a really long time (1/3 of the build duration); hence, they are disabled and need to be run separately
     #- name: Test finatra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
       if: matrix.target-platform != 'JS'
       uses: nick-fields/retry@v2
       with:
-        timeout_minutes: 45
-        max_attempts: 3
+        timeout_minutes: 30
+        max_attempts: 2
         command: sbt $SBT_JAVA_OPTS -v "testScoped ${{ matrix.scala-version }} ${{ matrix.target-platform }}"
     # The finatra tests take a really long time (1/3 of the build duration); hence, they are disabled and need to be run separately
     #- name: Test finatra


### PR DESCRIPTION
Currently the main `ci` job times out after 45 minutes, then gets retried at most 3 times. 
I propose reducing the timeout value to 30 minutes (our longest successful builds take up to ~24 minutes now) to get
faster recovery of flaky builds.