### PR TITLE
Add RejectContext to RejectHandler.

### DIFF
--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/reject/RejectContext.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/reject/RejectContext.scala
@@ -1,0 +1,6 @@
+package sttp.tapir.server.interceptor.reject
+
+import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.interceptor.RequestResult
+
+case class RejectContext(failure: RequestResult.Failure, request: ServerRequest)

--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/reject/RejectInterceptor.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/reject/RejectInterceptor.scala
@@ -27,7 +27,7 @@ class RejectInterceptor[F[_]](handler: RejectHandler[F]) extends RequestIntercep
         next(request, endpoints).flatMap {
           case r: RequestResult.Response[B] => (r: RequestResult[B]).unit
           case f: RequestResult.Failure =>
-            handler(f).flatMap {
+            handler(RejectContext(f, request)).flatMap {
               case Some(value) => responder(request, value).map(RequestResult.Response(_))
               case None        => (f: RequestResult[B]).unit
             }


### PR DESCRIPTION
### Motivation

Sometimes, in order to form the body of the response in the case of 404 Not Found, it is necessary to use data from the request (for example headers: requestId, cookie etc). It is impossible to do this without implementing your custom RejectInterceptor.

Implementing custom reject interceptor and prepending it to CustomiseInterceptors brake standard interceptor order and may lead to unwanted behavior.