### PR TITLE
[bugfix] Allow calling Pickler.derive on non-mirrored types

### DIFF
--- a/json/pickler/src/main/scala/sttp/tapir/json/pickler/Pickler.scala
+++ b/json/pickler/src/main/scala/sttp/tapir/json/pickler/Pickler.scala
@@ -107,7 +107,7 @@ object Pickler:
       case _ =>
         error("Unexpected non-enum type passed to derivedEnumeration")
 
-  private[tapir] inline given nonMirrorPickler[T](using PicklerConfiguration, NotGiven[Mirror.Of[T]]): Pickler[T] =
+  private[pickler] inline given nonMirrorPickler[T](using PicklerConfiguration, NotGiven[Mirror.Of[T]]): Pickler[T] =
     summonFrom {
       // It turns out that summoning a Pickler can sometimes fall into this branch, even if we explicitly state that we wan't a NotGiven in the method signature
       case m: Mirror.Of[T] =>

--- a/json/pickler/src/main/scala/sttp/tapir/json/pickler/Pickler.scala
+++ b/json/pickler/src/main/scala/sttp/tapir/json/pickler/Pickler.scala
@@ -33,12 +33,8 @@ object Pickler:
   inline def derived[T: ClassTag](using PicklerConfiguration): Pickler[T] =
     summonFrom {
       case schema: Schema[T] => fromExistingSchemaAndRw[T](schema)
-      case _ =>
-        summonFrom {
-          case m: Mirror.Of[T] => buildNewPickler[T]()
-          case _ => errorForType[T]("Cannot derive Pickler[%s], you need to provide both Schema and uPickle ReadWriter for this type.")
-
-        }
+      case m: Mirror.Of[T]   => buildNewPickler[T]()
+      case _ => errorForType[T]("Cannot derive Pickler[%s], you need to provide both Schema and uPickle ReadWriter for this type.")
     }
 
   /** Create a coproduct pickler (e.g. for an `enum` or `sealed trait`), where the value of the discriminator between child types is a read

--- a/json/pickler/src/main/scala/sttp/tapir/json/pickler/Pickler.scala
+++ b/json/pickler/src/main/scala/sttp/tapir/json/pickler/Pickler.scala
@@ -132,7 +132,7 @@ object Pickler:
       // It turns out that summoning a Pickler can sometimes fall into this branch, even if we explicitly state that we want a NotGiven in the method signature
       case m: Mirror.Of[T] =>
         errorForType[T](
-          "Found unexpected Mirror. Failed to summon a Pickler[%s]. Try using Pickler.derived or importing sttp.tapir.json.pickler.generic.auto.*"
+          "Found unexpected Mirror. Failed to summon a Pickler[%s]. Please report it as an issue at https://github.com/softwaremill/tapir/issues. To avoid this issue, try using Pickler.derived or importing sttp.tapir.json.pickler.generic.auto.*"
         )
     }
 

--- a/json/pickler/src/test/scala/sttp/tapir/json/pickler/PicklerBasicTest.scala
+++ b/json/pickler/src/test/scala/sttp/tapir/json/pickler/PicklerBasicTest.scala
@@ -11,6 +11,7 @@ import upickle.AttributeTagged
 import upickle.core.{ObjVisitor, Visitor}
 
 import java.util.UUID
+import java.util.TimeZone
 
 import Fixtures.*
 
@@ -79,6 +80,14 @@ class PicklerBasicTest extends AnyFlatSpec with Matchers {
     given CustomPickle.Writer[FlatClass] = CustomPickle.getWriter
 
     Pickler.derived[FlatClass].toCodec.encode(FlatClass(5, "txt")) shouldBe """"custom-5""""
+  }
+
+  it should "work with provider uPickle ReadWriter on a non-mirrored type" in {
+    given Schema[TimeZone] = Schema(SchemaType.SString())
+    given udefault.ReadWriter[TimeZone] = upickle.default.readwriter[String].bimap[TimeZone](_.getID, TimeZone.getTimeZone)
+    val ptz: Pickler[TimeZone] = Pickler.derived
+
+    ptz.toCodec.encode(TimeZone.getTimeZone("America/Los_Angeles")) shouldBe "\"America/Los_Angeles\""
   }
 
   it should "fail to derive a Pickler when there's a Schema but missing ReadWriter" in {

--- a/json/pickler/src/test/scala/sttp/tapir/json/pickler/PicklerBasicTest.scala
+++ b/json/pickler/src/test/scala/sttp/tapir/json/pickler/PicklerBasicTest.scala
@@ -10,8 +10,7 @@ import sttp.tapir.{Schema, SchemaType}
 import upickle.AttributeTagged
 import upickle.core.{ObjVisitor, Visitor}
 
-import java.util.UUID
-import java.util.TimeZone
+import java.util.{TimeZone, UUID}
 
 import Fixtures.*
 


### PR DESCRIPTION
Fixes https://github.com/softwaremill/tapir/issues/3287

For custom type `T` which are not products or coproducts, one should be able to derive a Pickler by providing implicit `Reader[T]`, `Writer[T]` (or `ReadWriter[T]`) and `Schema[T]`, then just calling `Pickler.derive[T]`.

Currenlty `derive` requires a `Mirror.Of[T]` in its signature, which needs to be removed and moved deeper into a `summonFrom` resolution, to defer determining how to construct the Pickler.
Additionally, the `nonMirrorPickler[T]` method will have a better error message, indicating that user should use `Pickler.derived[T]`

We can't hide `nonMirrorPickler` entirely, because it has to be in scope for correct resolution of predefined picklers (like String, List, Option, etc).