### PR TITLE
feat: Update Iron to v2.3.0

### DIFF
--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
@@ -5,7 +5,6 @@ import io.github.iltotore.iron.:|
 import io.github.iltotore.iron.refineEither
 import io.github.iltotore.iron.refineOption
 import io.github.iltotore.iron.RefinedTypeOps
-import io.github.iltotore.iron.RefinedTypeOpsImpl
 import io.github.iltotore.iron.constraint.any.*
 import io.github.iltotore.iron.constraint.string.*
 import io.github.iltotore.iron.constraint.collection.*

--- a/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/RefinedInt.scala
+++ b/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/RefinedInt.scala
@@ -5,4 +5,4 @@ import io.github.iltotore.iron.constraint.all.*
 
 type RefinedIntConstraint = Interval.ClosedOpen[0, 10]
 opaque type RefinedInt <: Int = Int :| RefinedIntConstraint
-object RefinedInt extends RefinedTypeOpsImpl[Int, RefinedIntConstraint, RefinedInt]
+object RefinedInt extends RefinedTypeOps[Int, RefinedIntConstraint, RefinedInt]

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -27,7 +27,7 @@ object Versions {
   val scalaTest = "3.2.17"
   val scalaTestPlusScalaCheck = "3.2.17.0"
   val refined = "0.11.0"
-  val iron = "2.2.1"
+  val iron = "2.3.0"
   val enumeratum = "1.7.3"
   val zio1 = "1.0.18"
   val zio1InteropCats = "13.0.0.2"


### PR DESCRIPTION
Iron v2.3.0 introduced a slight name change in `RefinedTypeOps`, causing this module to not be compatible with the latest version. This PR fixes this issue.

I'm have little experience working with SBT so I'd suggest to make sure my changes are valid.