### PR TITLE
syntactic sugar: add Codec.mapEither

### DIFF
--- a/core/src/main/scala/sttp/tapir/Codec.scala
+++ b/core/src/main/scala/sttp/tapir/Codec.scala
@@ -87,6 +87,22 @@ trait Codec[L, H, +CF <: CodecFormat] { outer =>
   def mapDecode[HH](f: H => DecodeResult[HH])(g: HH => H): Codec[L, HH, CF] = map(Mapping.fromDecode(f)(g))
   def map[HH](f: H => HH)(g: HH => H): Codec[L, HH, CF] = mapDecode(f.andThen(Value(_)))(g)
 
+  /** Maps this codec to the given higher-level type `HH`.
+    *
+    * @param f
+    *   decoding function
+    * @param g
+    *   encoding function
+    * @tparam HH
+    *   target type
+    * @see
+    *   [[map]]
+    * @see
+    *   [[mapDecode]]
+    */
+  def emap[HH](f: H => Either[String, HH])(g: HH => H): Codec[L, HH, CF] =
+    mapDecode(s => DecodeResult.fromEitherString(s.toString, f(s)))(g)
+
   /** Adds the given validator to the codec's schema, and maps this codec to the given higher-level type `HH`.
     *
     * Unlike a `.validate(v).map(f)(g)` invocation, during decoding the validator is run before applying the `f` function. If there are

--- a/core/src/main/scala/sttp/tapir/Codec.scala
+++ b/core/src/main/scala/sttp/tapir/Codec.scala
@@ -99,8 +99,10 @@ trait Codec[L, H, +CF <: CodecFormat] { outer =>
     *   [[map]]
     * @see
     *   [[mapDecode]]
+    * @see
+    *   [[mapValidate]]
     */
-  def emap[HH](f: H => Either[String, HH])(g: HH => H): Codec[L, HH, CF] =
+  def mapEither[HH](f: H => Either[String, HH])(g: HH => H): Codec[L, HH, CF] =
     mapDecode(s => DecodeResult.fromEitherString(s.toString, f(s)))(g)
 
   /** Adds the given validator to the codec's schema, and maps this codec to the given higher-level type `HH`.

--- a/core/src/test/scala/sttp/tapir/CodecTest.scala
+++ b/core/src/test/scala/sttp/tapir/CodecTest.scala
@@ -89,8 +89,8 @@ class CodecTest extends AnyFlatSpec with Matchers with Checkers with Inside {
     codec.schema.validator should not be (Validator.pass)
   }
 
-  it should "provide an emap function" in {
-    val codec: Codec[String, Int, TextPlain] = Codec.string.emap(s => Try(s.toInt).toEither.left.map(_.getMessage))(_.toString)
+  it should "provide a mapEither function" in {
+    val codec: Codec[String, Int, TextPlain] = Codec.string.mapEither(s => Try(s.toInt).toEither.left.map(_.getMessage))(_.toString)
     codec.encode(10) should be("10")
     codec.decode("10") should be(DecodeResult.Value(10))
     inside(codec.decode("foo")) { case DecodeResult.Error(original, error) =>


### PR DESCRIPTION
This is a proposition to add a `Codec.emap` function for mapping with `Either`, similar to what is done in several libraries with codecs:

- circe has `Codec.iemap`: https://github.com/circe/circe/blob/cddf7f28c37aaff46407e097b48135d8b411520b/modules/core/shared/src/main/scala/io/circe/Codec.scala#L42
- doobie has `Meta.timap`: https://github.com/tpolecat/doobie/blob/e79bab24b2ae1bc639f3a846dcdd74343696a786/modules/core/src/main/scala/doobie/util/meta/meta.scala#L33
- skunk has `Decoder.emap`: https://github.com/typelevel/skunk/blob/3911dc47e9429bea0663227a4dc5647d72a95bb3/modules/core/shared/src/main/scala/Decoder.scala#L32
- ...