### PR TITLE
[bugfix] Fix blocking implementation for CatsMonadAsyncError

### DIFF
--- a/integrations/cats-effect/src/main/scala/sttp/tapir/integ/cats/effect/CatsMonadError.scala
+++ b/integrations/cats-effect/src/main/scala/sttp/tapir/integ/cats/effect/CatsMonadError.scala
@@ -13,4 +13,5 @@ class CatsMonadError[F[_]](implicit F: Sync[F]) extends MonadError[F] {
   override def suspend[T](t: => F[T]): F[T] = F.defer(t)
   override def flatten[T](ffa: F[F[T]]): F[T] = F.flatten(ffa)
   override def ensure[T](f: F[T], e: => F[Unit]): F[T] = F.guaranteeCase(f)(_ => e)
+  override def blocking[T](t: => T): F[T] = F.blocking(t)
 }

--- a/server/armeria-server/cats/src/main/scala/sttp/tapir/server/armeria/cats/CatsMonadAsyncError.scala
+++ b/server/armeria-server/cats/src/main/scala/sttp/tapir/server/armeria/cats/CatsMonadAsyncError.scala
@@ -9,4 +9,7 @@ import sttp.tapir.integ.cats.effect.CatsMonadError
 private class CatsMonadAsyncError[F[_]](implicit F: Async[F]) extends CatsMonadError[F] with MonadAsyncError[F] {
   override def async[T](register: ((Either[Throwable, T]) => Unit) => Canceler): F[T] =
     F.async(cb => F.delay(register(cb)).map(c => Some(F.delay(c.cancel()))))
+  
+  override def blocking[T](t: => T): F[T] = 
+    F.blocking(t)
 }


### PR DESCRIPTION
A follow-up to https://softwaremill.community/t/sttp-monad-monaderror-blocking-for-cats-effect/314

We shouldn't use the default implementation which does `F.delay(t)`