### PR TITLE
Codegen any type support

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -2,6 +2,7 @@ package sttp.tapir.codegen
 
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
+  OpenapiSchemaAny,
   OpenapiSchemaBoolean,
   OpenapiSchemaDouble,
   OpenapiSchemaEnum,
@@ -66,6 +67,8 @@ object BasicGenerator {
         ("String", nb)
       case OpenapiSchemaBoolean(nb) =>
         ("Boolean", nb)
+      case OpenapiSchemaAny(nb) =>
+        ("io.circe.Json", nb)
       case OpenapiSchemaRef(t) =>
         (t.split('/').last, false)
       case x => throw new NotImplementedError(s"Not all simple types supported! Found $x")

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -3,6 +3,7 @@ package sttp.tapir.codegen
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
+  OpenapiSchemaAny,
   OpenapiSchemaArray,
   OpenapiSchemaConstantString,
   OpenapiSchemaEnum,
@@ -100,6 +101,23 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
         OpenapiComponent(
           Map(
             "Test" -> OpenapiSchemaObject(Map("texts" -> OpenapiSchemaMap(OpenapiSchemaString(false), false)), Seq("texts"), false)
+          )
+        )
+      )
+    )
+
+    new ClassDefinitionGenerator().classDefs(doc).get shouldCompile ()
+  }
+
+  it should "generate class with any type" in {
+    val doc = OpenapiDocument(
+      "",
+      null,
+      null,
+      Some(
+        OpenapiComponent(
+          Map(
+            "Test" -> OpenapiSchemaObject(Map("anyType" -> OpenapiSchemaAny(false)), Seq("anyType"), false)
           )
         )
       )

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/SchemaParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/SchemaParserSpec.scala
@@ -2,6 +2,7 @@ package sttp.tapir.codegen.openapi.models
 
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiResponseContent
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
+  OpenapiSchemaAny,
   OpenapiSchemaArray,
   OpenapiSchemaInt,
   OpenapiSchemaMap,
@@ -27,6 +28,7 @@ class SchemaParserSpec extends AnyFlatSpec with Matchers with Checkers {
     val yaml = """
       |schemas:
       |  User:
+      |    type: object
       |    properties:
       |      id:
       |        type: integer
@@ -61,6 +63,7 @@ class SchemaParserSpec extends AnyFlatSpec with Matchers with Checkers {
     val yaml = """
       |schemas:
       |  User:
+      |    type: object
       |    properties:
       |      attributes:
       |        type: object
@@ -80,6 +83,34 @@ class SchemaParserSpec extends AnyFlatSpec with Matchers with Checkers {
           "User" -> OpenapiSchemaObject(
             Map("attributes" -> OpenapiSchemaMap(OpenapiSchemaString(false), false)),
             Seq("attributes"),
+            false
+          )
+        )
+      )
+    )
+  }
+
+  it should "parse any type" in {
+    val yaml = """
+      |schemas:
+      |  User:
+      |    type: object
+      |    properties:
+      |      anyValue: {}
+      |    required:
+      |      - anyValue""".stripMargin
+
+    val res = parser
+      .parse(yaml)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[OpenapiComponent])
+
+    res shouldBe Right(
+      OpenapiComponent(
+        Map(
+          "User" -> OpenapiSchemaObject(
+            Map("anyValue" -> OpenapiSchemaAny(false)),
+            Seq("anyValue"),
             false
           )
         )


### PR DESCRIPTION
Adds support for [any type](https://swagger.io/docs/specification/data-models/data-types/#any)

Previously schema without a type was incorrectly parsed as an object.