### PR TITLE
MaxContentLength support (streaming)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -345,10 +345,7 @@ lazy val rootProject = (project in file("."))
     testFinatra := (Test / test).all(filterProject(p => p.contains("finatra"))).value,
     compileScoped := Def.inputTaskDyn {
       val args = spaceDelimited("<arg>").parsed
-      Def.task {
-        Def.taskDyn((Compile / compile).all(filterByVersionAndPlatform(args.head, args(1))))
-        Def.taskDyn((Test / compile).all(filterByVersionAndPlatform(args.head, args(1))))
-      }
+      Def.taskDyn((Test / compile).all(filterByVersionAndPlatform(args.head, args(1))))
     }.evaluated,
     testScoped := Def.inputTaskDyn {
       val args = spaceDelimited("<arg>").parsed

--- a/build.sbt
+++ b/build.sbt
@@ -345,7 +345,10 @@ lazy val rootProject = (project in file("."))
     testFinatra := (Test / test).all(filterProject(p => p.contains("finatra"))).value,
     compileScoped := Def.inputTaskDyn {
       val args = spaceDelimited("<arg>").parsed
-      Def.taskDyn((Compile / compile).all(filterByVersionAndPlatform(args.head, args(1))))
+      Def.task {
+        Def.taskDyn((Compile / compile).all(filterByVersionAndPlatform(args.head, args(1))))
+        Def.taskDyn((Test / compile).all(filterByVersionAndPlatform(args.head, args(1))))
+      }
     }.evaluated,
     testScoped := Def.inputTaskDyn {
       val args = spaceDelimited("<arg>").parsed

--- a/integrations/zio/src/test/scala/sttp/tapir/ztapir/ZTapirTest.scala
+++ b/integrations/zio/src/test/scala/sttp/tapir/ztapir/ZTapirTest.scala
@@ -29,7 +29,7 @@ object ZTapirTest extends ZIOSpecDefault with ZTapir {
   private val exampleRequestBody = new RequestBody[TestEffect, RequestBodyType] {
     override val streams: Streams[RequestBodyType] = null.asInstanceOf[Streams[RequestBodyType]]
     override def toRaw[R](serverRequest: ServerRequest, bodyType: RawBodyType[R]): TestEffect[RawValue[R]] = ???
-    override def toStream(serverRequest: ServerRequest): streams.BinaryStream = ???
+    override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = ???
   }
 
   private val exampleToResponse: ToResponseBody[ResponseBodyType, RequestBodyType] = new ToResponseBody[ResponseBodyType, RequestBodyType] {

--- a/integrations/zio1/src/test/scala/sttp/tapir/ztapir/ZTapirTest.scala
+++ b/integrations/zio1/src/test/scala/sttp/tapir/ztapir/ZTapirTest.scala
@@ -31,7 +31,7 @@ object ZTapirTest extends DefaultRunnableSpec with ZTapir {
   private val exampleRequestBody = new RequestBody[TestEffect, RequestBodyType] {
     override val streams: Streams[RequestBodyType] = null.asInstanceOf[Streams[RequestBodyType]]
     override def toRaw[R](serverRequest: ServerRequest, bodyType: RawBodyType[R]): TestEffect[RawValue[R]] = ???
-    override def toStream(serverRequest: ServerRequest): streams.BinaryStream = ???
+    override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = ???
   }
 
   private val exampleToResponse: ToResponseBody[ResponseBodyType, RequestBodyType] = new ToResponseBody[ResponseBodyType, RequestBodyType] {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -10,8 +10,16 @@ object Versions {
   val helidon = "4.0.0"
   val sttp = "3.9.1"
   val sttpModel = "1.7.6"
+<<<<<<< HEAD
   val sttpShared = "1.3.16"
   val sttpApispec = "0.7.2"
+||||||| parent of 80ba6cbbd (Switch to sttp-shared 1.3.17)
+  val sttpShared = "1.3.16"
+  val sttpApispec = "0.7.1"
+=======
+  val sttpShared = "1.3.17"
+  val sttpApispec = "0.7.1"
+>>>>>>> 80ba6cbbd (Switch to sttp-shared 1.3.17)
   val akkaHttp = "10.2.10"
   val akkaStreams = "2.6.20"
   val pekkoHttp = "1.0.0"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -10,16 +10,8 @@ object Versions {
   val helidon = "4.0.0"
   val sttp = "3.9.1"
   val sttpModel = "1.7.6"
-<<<<<<< HEAD
-  val sttpShared = "1.3.16"
-  val sttpApispec = "0.7.2"
-||||||| parent of 80ba6cbbd (Switch to sttp-shared 1.3.17)
-  val sttpShared = "1.3.16"
-  val sttpApispec = "0.7.1"
-=======
   val sttpShared = "1.3.17"
-  val sttpApispec = "0.7.1"
->>>>>>> 80ba6cbbd (Switch to sttp-shared 1.3.17)
+  val sttpApispec = "0.7.2"
   val akkaHttp = "10.2.10"
   val akkaStreams = "2.6.20"
   val pekkoHttp = "1.0.0"

--- a/server/akka-grpc-server/src/main/scala/sttp/tapir/server/akkagrpc/AkkaGrpcRequestBody.scala
+++ b/server/akka-grpc-server/src/main/scala/sttp/tapir/server/akkagrpc/AkkaGrpcRequestBody.scala
@@ -25,7 +25,7 @@ private[akkagrpc] class AkkaGrpcRequestBody(serverOptions: AkkaHttpServerOptions
   override def toRaw[R](request: ServerRequest, bodyType: RawBodyType[R]): Future[RawValue[R]] =
     toRawFromEntity(request, akkaRequestEntity(request), bodyType)
 
-  override def toStream(request: ServerRequest): streams.BinaryStream = ???
+  override def toStream(request: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = ???
 
   private def akkaRequestEntity(request: ServerRequest) = request.underlying.asInstanceOf[RequestContext].request.entity
 

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaRequestBody.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaRequestBody.scala
@@ -23,7 +23,10 @@ private[akkahttp] class AkkaRequestBody(serverOptions: AkkaHttpServerOptions)(im
   override val streams: AkkaStreams = AkkaStreams
   override def toRaw[R](request: ServerRequest, bodyType: RawBodyType[R]): Future[RawValue[R]] =
     toRawFromEntity(request, akkeRequestEntity(request), bodyType)
-  override def toStream(request: ServerRequest): streams.BinaryStream = akkeRequestEntity(request).dataBytes
+  override def toStream(request: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = {
+    val stream = akkeRequestEntity(request).dataBytes
+    maxBytes.map(AkkaStreams.limitBytes(stream, _)).getOrElse(stream)
+  }
 
   private def akkeRequestEntity(request: ServerRequest) = request.underlying.asInstanceOf[RequestContext].request.entity
 

--- a/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerTest.scala
+++ b/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerTest.scala
@@ -152,8 +152,11 @@ class AkkaHttpServerTest extends TestSuite with EitherValues {
           }
         }
       )
+      def drainAkka(stream: AkkaStreams.BinaryStream): Future[Unit] =
+        stream.runWith(Sink.ignore).map(_ => ())
+
       new AllServerTests(createServerTest, interpreter, backend).tests() ++
-        new ServerStreamingTests(createServerTest, AkkaStreams).tests() ++
+        new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(AkkaStreams)(drainAkka) ++
         new ServerWebSocketTests(createServerTest, AkkaStreams) {
           override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = Flow.fromFunction(f)
           override def emptyPipe[A, B]: Flow[A, B, Any] = Flow.fromSinkAndSource(Sink.ignore, Source.empty)

--- a/server/armeria-server/cats/src/main/scala/sttp/tapir/server/armeria/cats/TapirCatsService.scala
+++ b/server/armeria-server/cats/src/main/scala/sttp/tapir/server/armeria/cats/TapirCatsService.scala
@@ -84,8 +84,10 @@ private object Fs2StreamCompatible {
           dispatcher
         )
 
-      override def fromArmeriaStream(publisher: Publisher[HttpData]): Stream[F, Byte] =
-        publisher.toStreamBuffered[F](4).flatMap(httpData => Stream.chunk(Chunk.array(httpData.array())))
+      override def fromArmeriaStream(publisher: Publisher[HttpData], maxBytes: Option[Long]): Stream[F, Byte] = {
+        val stream = publisher.toStreamBuffered[F](4).flatMap(httpData => Stream.chunk(Chunk.array(httpData.array())))
+        maxBytes.map(Fs2Streams.limitBytes(stream, _)).getOrElse(stream)
+      }
     }
   }
 }

--- a/server/armeria-server/cats/src/test/scala/sttp/tapir/server/armeria/cats/ArmeriaCatsServerTest.scala
+++ b/server/armeria-server/cats/src/test/scala/sttp/tapir/server/armeria/cats/ArmeriaCatsServerTest.scala
@@ -13,9 +13,11 @@ class ArmeriaCatsServerTest extends TestSuite {
 
     val interpreter = new ArmeriaCatsTestServerInterpreter(dispatcher)
     val createServerTest = new DefaultCreateServerTest(backend, interpreter)
+    def drainFs2(stream: Fs2Streams[IO]#BinaryStream): IO[Unit] =
+      stream.compile.drain.void
 
     new AllServerTests(createServerTest, interpreter, backend, basic = false, options = false).tests() ++
       new ServerBasicTests(createServerTest, interpreter, supportsUrlEncodedPathSegments = false).tests() ++
-      new ServerStreamingTests(createServerTest, Fs2Streams[IO]).tests()
+      new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(Fs2Streams[IO])(drainFs2)
   }
 }

--- a/server/armeria-server/src/main/scala/sttp/tapir/server/armeria/ArmeriaRequestBody.scala
+++ b/server/armeria-server/src/main/scala/sttp/tapir/server/armeria/ArmeriaRequestBody.scala
@@ -23,9 +23,9 @@ private[armeria] final class ArmeriaRequestBody[F[_], S <: Streams[S]](
 
   override val streams: Streams[S] = streamCompatible.streams
 
-  override def toStream(serverRequest: ServerRequest): streams.BinaryStream = {
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = {
     streamCompatible
-      .fromArmeriaStream(armeriaCtx(serverRequest).request().filter(x => x.isInstanceOf[HttpData]).asInstanceOf[StreamMessage[HttpData]])
+      .fromArmeriaStream(armeriaCtx(serverRequest).request().filter(x => x.isInstanceOf[HttpData]).asInstanceOf[StreamMessage[HttpData]], maxBytes)
       .asInstanceOf[streams.BinaryStream]
   }
 

--- a/server/armeria-server/src/main/scala/sttp/tapir/server/armeria/StreamCompatible.scala
+++ b/server/armeria-server/src/main/scala/sttp/tapir/server/armeria/StreamCompatible.scala
@@ -7,5 +7,5 @@ import sttp.capabilities.Streams
 private[armeria] trait StreamCompatible[S <: Streams[S]] {
   val streams: S
   def asStreamMessage(s: streams.BinaryStream): Publisher[HttpData]
-  def fromArmeriaStream(s: Publisher[HttpData]): streams.BinaryStream
+  def fromArmeriaStream(s: Publisher[HttpData], maxBytes: Option[Long]): streams.BinaryStream
 }

--- a/server/armeria-server/src/main/scala/sttp/tapir/server/armeria/TapirFutureService.scala
+++ b/server/armeria-server/src/main/scala/sttp/tapir/server/armeria/TapirFutureService.scala
@@ -51,7 +51,7 @@ private[armeria] final case class TapirFutureService(
 private object ArmeriaStreamCompatible extends StreamCompatible[ArmeriaStreams] {
   override val streams: ArmeriaStreams = ArmeriaStreams
 
-  override def fromArmeriaStream(s: Publisher[HttpData]): Publisher[HttpData] = s
+  override def fromArmeriaStream(s: Publisher[HttpData], maxBytes: Option[Long]): Publisher[HttpData] = s
 
   override def asStreamMessage(s: Publisher[HttpData]): Publisher[HttpData] = s
 }

--- a/server/armeria-server/src/test/scala/sttp/tapir/server/armeria/ArmeriaFutureServerTest.scala
+++ b/server/armeria-server/src/test/scala/sttp/tapir/server/armeria/ArmeriaFutureServerTest.scala
@@ -5,6 +5,7 @@ import sttp.capabilities.armeria.ArmeriaStreams
 import sttp.monad.FutureMonad
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
+import scala.concurrent.Future
 
 class ArmeriaFutureServerTest extends TestSuite {
 
@@ -16,6 +17,6 @@ class ArmeriaFutureServerTest extends TestSuite {
 
     new AllServerTests(createServerTest, interpreter, backend, basic = false, options = false).tests() ++
       new ServerBasicTests(createServerTest, interpreter, supportsUrlEncodedPathSegments = false).tests() ++
-      new ServerStreamingTests(createServerTest, ArmeriaStreams).tests()
+      new ServerStreamingTests(createServerTest, maxLengthSupported = false).tests(ArmeriaStreams)(_ => Future.unit)
   }
 }

--- a/server/armeria-server/zio/src/main/scala/sttp/tapir/server/armeria/zio/TapirZioService.scala
+++ b/server/armeria-server/zio/src/main/scala/sttp/tapir/server/armeria/zio/TapirZioService.scala
@@ -76,8 +76,10 @@ private object ZioStreamCompatible {
             .getOrThrowFiberFailure()
         )
 
-      override def fromArmeriaStream(publisher: Publisher[HttpData]): Stream[Throwable, Byte] =
-        publisher.toZIOStream().mapConcatChunk(httpData => Chunk.fromArray(httpData.array()))
+      override def fromArmeriaStream(publisher: Publisher[HttpData], maxBytes: Option[Long]): Stream[Throwable, Byte] = {
+        val stream = publisher.toZIOStream().mapConcatChunk(httpData => Chunk.fromArray(httpData.array()))
+        maxBytes.map(ZioStreams.limitBytes(stream, _)).getOrElse(stream)
+      }
     }
   }
 }

--- a/server/armeria-server/zio/src/test/scala/sttp/tapir/server/armeria/zio/ArmeriaZioServerTest.scala
+++ b/server/armeria-server/zio/src/test/scala/sttp/tapir/server/armeria/zio/ArmeriaZioServerTest.scala
@@ -7,6 +7,7 @@ import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
 import sttp.tapir.ztapir.RIOMonadError
 import zio.Task
+import zio.stream.ZSink
 
 class ArmeriaZioServerTest extends TestSuite {
 
@@ -16,9 +17,11 @@ class ArmeriaZioServerTest extends TestSuite {
 
     val interpreter = new ArmeriaZioTestServerInterpreter()
     val createServerTest = new DefaultCreateServerTest(backend, interpreter)
+    def drainZStream(zStream: ZioStreams.BinaryStream): Task[Unit] =
+      zStream.run(ZSink.drain)
 
     new AllServerTests(createServerTest, interpreter, backend, basic = false, options = false).tests() ++
       new ServerBasicTests(createServerTest, interpreter, supportsUrlEncodedPathSegments = false).tests() ++
-      new ServerStreamingTests(createServerTest, ZioStreams).tests()
+      new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(ZioStreams)(drainZStream)
   }
 }

--- a/server/armeria-server/zio1/src/main/scala/sttp/tapir/server/armeria/zio/TapirZioService.scala
+++ b/server/armeria-server/zio1/src/main/scala/sttp/tapir/server/armeria/zio/TapirZioService.scala
@@ -72,7 +72,7 @@ private object ZioStreamCompatible {
       override def asStreamMessage(stream: Stream[Throwable, Byte]): Publisher[HttpData] =
         runtime.unsafeRun(stream.mapChunks(c => Chunk.single(HttpData.wrap(c.toArray))).toPublisher)
 
-      override def fromArmeriaStream(publisher: Publisher[HttpData]): Stream[Throwable, Byte] =
+      override def fromArmeriaStream(publisher: Publisher[HttpData], maxBytes: Option[Long]): Stream[Throwable, Byte] =
         publisher.toStream().mapConcatChunk(httpData => Chunk.fromArray(httpData.array()))
     }
   }

--- a/server/armeria-server/zio1/src/test/scala/sttp/tapir/server/armeria/zio/ArmeriaZioServerTest.scala
+++ b/server/armeria-server/zio1/src/test/scala/sttp/tapir/server/armeria/zio/ArmeriaZioServerTest.scala
@@ -19,6 +19,6 @@ class ArmeriaZioServerTest extends TestSuite {
 
     new AllServerTests(createServerTest, interpreter, backend, basic = false, options = false).tests() ++
       new ServerBasicTests(createServerTest, interpreter, supportsUrlEncodedPathSegments = false).tests() ++
-      new ServerStreamingTests(createServerTest, ZioStreams).tests()
+      new ServerStreamingTests(createServerTest, maxLengthSupported = false).tests(ZioStreams)(_ => Task.unit)
   }
 }

--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/exception/ExceptionHandler.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/exception/ExceptionHandler.scala
@@ -1,5 +1,6 @@
 package sttp.tapir.server.interceptor.exception
 
+import sttp.capabilities.StreamMaxLengthExceededException
 import sttp.model.StatusCode
 import sttp.monad.MonadError
 import sttp.tapir.server.model.ValuedEndpointOutput
@@ -25,7 +26,12 @@ object ExceptionHandler {
 
 case class DefaultExceptionHandler[F[_]](response: (StatusCode, String) => ValuedEndpointOutput[_]) extends ExceptionHandler[F] {
   override def apply(ctx: ExceptionContext)(implicit monad: MonadError[F]): F[Option[ValuedEndpointOutput[_]]] =
-    monad.unit(Some(response(StatusCode.InternalServerError, "Internal server error")))
+    ctx.e match {
+      case StreamMaxLengthExceededException(maxBytes) =>
+        monad.unit(Some(response(StatusCode.PayloadTooLarge, s"Payload limit (${maxBytes}B) exceeded")))
+      case _ =>
+        monad.unit(Some(response(StatusCode.InternalServerError, "Internal server error")))
+    }
 }
 
 object DefaultExceptionHandler {

--- a/server/core/src/main/scala/sttp/tapir/server/interpreter/RequestBody.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interpreter/RequestBody.scala
@@ -12,13 +12,7 @@ case class MaxContentLength(value: Long)
 trait RequestBody[F[_], S] {
   val streams: Streams[S]
   def toRaw[R](serverRequest: ServerRequest, bodyType: RawBodyType[R]): F[RawValue[R]]
-  def toStream(serverRequest: ServerRequest, endpointInfo: EndpointInfo): streams.BinaryStream = {
-    endpointInfo.attributes.get(AttributeKey[MaxContentLength]) match {
-      case Some(MaxContentLength(maxBytes)) => streams.limitBytes(toStream(serverRequest), maxBytes)
-      case None => toStream(serverRequest)
-    }
-  }
-  def toStream(serverRequest: ServerRequest): streams.BinaryStream
+  def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream
 
 }
 

--- a/server/core/src/main/scala/sttp/tapir/server/interpreter/RequestBody.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interpreter/RequestBody.scala
@@ -3,12 +3,23 @@ package sttp.tapir.server.interpreter
 import sttp.capabilities.Streams
 import sttp.model.Part
 import sttp.tapir.model.ServerRequest
+import sttp.tapir.AttributeKey
+import sttp.tapir.EndpointInfo
 import sttp.tapir.{FileRange, RawBodyType, RawPart}
+
+case class MaxContentLength(value: Long)
 
 trait RequestBody[F[_], S] {
   val streams: Streams[S]
   def toRaw[R](serverRequest: ServerRequest, bodyType: RawBodyType[R]): F[RawValue[R]]
+  def toStream(serverRequest: ServerRequest, endpointInfo: EndpointInfo): streams.BinaryStream = {
+    endpointInfo.attributes.get(AttributeKey[MaxContentLength]) match {
+      case Some(MaxContentLength(maxBytes)) => streams.limitBytes(toStream(serverRequest), maxBytes)
+      case None => toStream(serverRequest)
+    }
+  }
   def toStream(serverRequest: ServerRequest): streams.BinaryStream
+
 }
 
 case class RawValue[R](value: R, createdFiles: Seq[FileRange] = Nil)

--- a/server/core/src/test/scala/sttp/tapir/server/TestUtil.scala
+++ b/server/core/src/test/scala/sttp/tapir/server/TestUtil.scala
@@ -15,7 +15,7 @@ object TestUtil {
   object TestRequestBody extends RequestBody[Id, NoStreams] {
     override val streams: Streams[NoStreams] = NoStreams
     override def toRaw[R](serverRequest: ServerRequest, bodyType: RawBodyType[R]): Id[RawValue[R]] = ???
-    override def toStream(serverRequest: ServerRequest): streams.BinaryStream = ???
+    override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = ???
   }
 
   object UnitToResponseBody extends ToResponseBody[Unit, NoStreams] {

--- a/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraRequestBody.scala
+++ b/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraRequestBody.scala
@@ -114,7 +114,8 @@ class FinatraRequestBody(serverOptions: FinatraServerOptions) extends RequestBod
       .map(_.toList)
   }
 
-  override def toStream(serverRequest: ServerRequest): streams.BinaryStream = throw new UnsupportedOperationException()
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream =
+    throw new UnsupportedOperationException()
 
   private def finatraRequest(serverRequest: ServerRequest) = serverRequest.underlying.asInstanceOf[Request]
 }

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestBody.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestBody.scala
@@ -22,7 +22,10 @@ private[http4s] class Http4sRequestBody[F[_]: Async](
     val r = http4sRequest(serverRequest)
     toRawFromStream(serverRequest, r.body, bodyType, r.charset)
   }
-  override def toStream(serverRequest: ServerRequest): streams.BinaryStream = http4sRequest(serverRequest).body
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = {
+    val stream = http4sRequest(serverRequest).body
+    maxBytes.map(Fs2Streams.limitBytes(stream, _)).getOrElse(stream)
+  }
 
   private def http4sRequest(serverRequest: ServerRequest): Request[F] = serverRequest.underlying.asInstanceOf[Request[F]]
 

--- a/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerTest.scala
+++ b/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerTest.scala
@@ -133,8 +133,11 @@ class Http4sServerTest[R >: Fs2Streams[IO] with WebSockets] extends TestSuite wi
       }
     )
 
+    def drainFs2(stream: Fs2Streams[IO]#BinaryStream): IO[Unit] =
+      stream.compile.drain.void
+
     new AllServerTests(createServerTest, interpreter, backend).tests() ++
-      new ServerStreamingTests(createServerTest, Fs2Streams[IO]).tests() ++
+      new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(Fs2Streams[IO])(drainFs2) ++
       new ServerWebSocketTests(createServerTest, Fs2Streams[IO]) {
         override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = in => in.map(f)
         override def emptyPipe[A, B]: Pipe[IO, A, B] = _ => fs2.Stream.empty

--- a/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerTest.scala
+++ b/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerTest.scala
@@ -14,7 +14,7 @@ import sttp.tapir.server.http4s.Http4sServerSentEvents
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
 import zio.interop.catz._
-import zio.stream.ZStream
+import zio.stream.{ZSink, ZStream}
 import zio.{Task, ZIO}
 
 import java.util.UUID
@@ -50,9 +50,11 @@ class ZHttp4sServerTest extends TestSuite with OptionValues {
           .map(_.body.toOption.value shouldBe List(sse1, sse2))
       }
     )
+    def drainZStream(zStream: ZioStreams.BinaryStream): Task[Unit] =
+      zStream.run(ZSink.drain)
 
     new AllServerTests(createServerTest, interpreter, backend).tests() ++
-      new ServerStreamingTests(createServerTest, ZioStreams).tests() ++
+    new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(ZioStreams)(drainZStream) ++
       new ServerWebSocketTests(createServerTest, ZioStreams) {
         override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = in => in.map(f)
         override def emptyPipe[A, B]: streams.Pipe[A, B] = _ => ZStream.empty

--- a/server/http4s-server/zio1/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerTest.scala
+++ b/server/http4s-server/zio1/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerTest.scala
@@ -10,7 +10,7 @@ import sttp.tapir._
 import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
-import zio.{RIO, UIO}
+import zio.{RIO, Task, UIO}
 import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.interop.catz._
@@ -53,7 +53,7 @@ class ZHttp4sServerTest extends TestSuite with OptionValues {
     )
 
     new AllServerTests(createServerTest, interpreter, backend).tests() ++
-      new ServerStreamingTests(createServerTest, ZioStreams).tests() ++
+      new ServerStreamingTests(createServerTest, maxLengthSupported = false).tests(ZioStreams)(_ => Task.unit) ++
       new ServerWebSocketTests(createServerTest, ZioStreams) {
         override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = in => in.map(f)
         override def emptyPipe[A, B]: streams.Pipe[A, B] = _ => zio.stream.Stream.empty

--- a/server/jdkhttp-server/src/main/scala/sttp/tapir/server/jdkhttp/internal/JdkHttpRequestBody.scala
+++ b/server/jdkhttp-server/src/main/scala/sttp/tapir/server/jdkhttp/internal/JdkHttpRequestBody.scala
@@ -14,7 +14,8 @@ import java.io._
 import java.nio.ByteBuffer
 import java.nio.file.{Files, StandardCopyOption}
 
-private[jdkhttp] class JdkHttpRequestBody(createFile: ServerRequest => TapirFile, multipartFileThresholdBytes: Long) extends RequestBody[Id, NoStreams] {
+private[jdkhttp] class JdkHttpRequestBody(createFile: ServerRequest => TapirFile, multipartFileThresholdBytes: Long)
+    extends RequestBody[Id, NoStreams] {
   override val streams: capabilities.Streams[NoStreams] = NoStreams
 
   override def toRaw[RAW](serverRequest: ServerRequest, bodyType: RawBodyType[RAW]): RawValue[RAW] = {
@@ -76,9 +77,10 @@ private[jdkhttp] class JdkHttpRequestBody(createFile: ServerRequest => TapirFile
     )
   }
 
-  override def toStream(serverRequest: ServerRequest): streams.BinaryStream = throw new UnsupportedOperationException(
-    "Streaming is not supported"
-  )
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream =
+    throw new UnsupportedOperationException(
+      "Streaming is not supported"
+    )
 
   private def jdkHttpRequest(serverRequest: ServerRequest): HttpExchange =
     serverRequest.underlying.asInstanceOf[HttpExchange]

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsRequestBody.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/internal/NettyCatsRequestBody.scala
@@ -36,7 +36,7 @@ private[netty] class NettyCatsRequestBody[F[_]](createFile: ServerRequest => F[T
       case RawBodyType.FileBody =>
         createFile(serverRequest)
           .flatMap(tapirFile => {
-            toStream(serverRequest)
+            toStream(serverRequest, maxBytes = None) // TODO
               .through(
                 Files[F](Files.forAsync[F]).writeAll(Path.fromNioPath(tapirFile.toPath))
               )
@@ -48,17 +48,18 @@ private[netty] class NettyCatsRequestBody[F[_]](createFile: ServerRequest => F[T
     }
   }
 
-  override def toStream(serverRequest: ServerRequest): streams.BinaryStream = {
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = {
     val nettyRequest = serverRequest.underlying.asInstanceOf[StreamedHttpRequest]
-    fs2.Stream
+    val stream = fs2.Stream
       .eval(StreamSubscriber[F, HttpContent](NettyRequestBody.DefaultChunkSize))
       .flatMap(s => s.sub.stream(Sync[F].delay(nettyRequest.subscribe(s))))
       .flatMap(httpContent => fs2.Stream.chunk(Chunk.byteBuffer(httpContent.content.nioBuffer())))
+    maxBytes.map(Fs2Streams.limitBytes(stream, _)).getOrElse(stream)
   }
 
   private def nettyRequestBytes(serverRequest: ServerRequest): F[Array[Byte]] = serverRequest.underlying match {
     case req: FullHttpRequest   => monad.delay(ByteBufUtil.getBytes(req.content()))
-    case _: StreamedHttpRequest => toStream(serverRequest).compile.to(Chunk).map(_.toArray[Byte])
+    case _: StreamedHttpRequest => toStream(serverRequest, maxBytes = None).compile.to(Chunk).map(_.toArray[Byte]) // TODO
     case other => monad.raiseError(new UnsupportedOperationException(s"Unexpected Netty request of type ${other.getClass().getName()}"))
   }
 }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyRequestBody.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyRequestBody.scala
@@ -41,7 +41,8 @@ class NettyRequestBody[F[_]](createFile: ServerRequest => F[TapirFile])(implicit
     }
   }
 
-  override def toStream(serverRequest: ServerRequest): streams.BinaryStream = throw new UnsupportedOperationException()
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream =
+    throw new UnsupportedOperationException()
 
   private def nettyRequest(serverRequest: ServerRequest): FullHttpRequest = serverRequest.underlying.asInstanceOf[FullHttpRequest]
 }

--- a/server/netty-server/zio/src/test/scala/sttp/tapir/server/netty/zio/NettyZioServerTest.scala
+++ b/server/netty-server/zio/src/test/scala/sttp/tapir/server/netty/zio/NettyZioServerTest.scala
@@ -14,8 +14,12 @@ import zio.{Task, ZIO}
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
+import zio.stream.ZSink
 
 class NettyZioServerTest extends TestSuite with EitherValues {
+  def drainZStream(zStream: ZioStreams.BinaryStream): Task[Unit] =
+    zStream.run(ZSink.drain)
+
   override def tests: Resource[IO, List[Test]] =
     backendResource.flatMap { backend =>
       Resource
@@ -31,7 +35,7 @@ class NettyZioServerTest extends TestSuite with EitherValues {
 
           val tests =
             new AllServerTests(createServerTest, interpreter, backend, staticContent = false, multipart = false).tests() ++
-              new ServerStreamingTests(createServerTest, ZioStreams).tests() ++
+              new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(ZioStreams)(drainZStream) ++
               new ServerCancellationTests(createServerTest)(monadError, asyncInstance).tests() ++
               new ServerGracefulShutdownTests(createServerTest, zioSleeper).tests()
 

--- a/server/nima-server/src/main/scala/sttp/tapir/server/nima/internal/NimaRequestBody.scala
+++ b/server/nima-server/src/main/scala/sttp/tapir/server/nima/internal/NimaRequestBody.scala
@@ -32,7 +32,8 @@ private[nima] class NimaRequestBody(createFile: ServerRequest => TapirFile) exte
     }
   }
 
-  override def toStream(serverRequest: ServerRequest): streams.BinaryStream = throw new UnsupportedOperationException()
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream =
+    throw new UnsupportedOperationException()
 
   private def nimaRequest(serverRequest: ServerRequest): JavaNimaServerRequest =
     serverRequest.underlying.asInstanceOf[JavaNimaServerRequest]

--- a/server/pekko-grpc-server/src/main/scala/sttp/tapir/server/pekkogrpc/PekkoGrpcRequestBody.scala
+++ b/server/pekko-grpc-server/src/main/scala/sttp/tapir/server/pekkogrpc/PekkoGrpcRequestBody.scala
@@ -25,7 +25,7 @@ private[pekkogrpc] class PekkoGrpcRequestBody(serverOptions: PekkoHttpServerOpti
   override def toRaw[R](request: ServerRequest, bodyType: RawBodyType[R]): Future[RawValue[R]] =
     toRawFromEntity(request, akkaRequestEntity(request), bodyType)
 
-  override def toStream(request: ServerRequest): streams.BinaryStream = ???
+  override def toStream(request: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = ???
 
   private def akkaRequestEntity(request: ServerRequest) = request.underlying.asInstanceOf[RequestContext].request.entity
 

--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoRequestBody.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoRequestBody.scala
@@ -23,7 +23,10 @@ private[pekkohttp] class PekkoRequestBody(serverOptions: PekkoHttpServerOptions)
   override val streams: PekkoStreams = PekkoStreams
   override def toRaw[R](request: ServerRequest, bodyType: RawBodyType[R]): Future[RawValue[R]] =
     toRawFromEntity(request, akkeRequestEntity(request), bodyType)
-  override def toStream(request: ServerRequest): streams.BinaryStream = akkeRequestEntity(request).dataBytes
+  override def toStream(request: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = {
+    val stream = akkeRequestEntity(request).dataBytes
+    maxBytes.map(PekkoStreams.limitBytes(stream, _)).getOrElse(stream)
+  }
 
   private def akkeRequestEntity(request: ServerRequest) = request.underlying.asInstanceOf[RequestContext].request.entity
 

--- a/server/pekko-http-server/src/test/scala/sttp/tapir/server/pekkohttp/PekkoHttpServerTest.scala
+++ b/server/pekko-http-server/src/test/scala/sttp/tapir/server/pekkohttp/PekkoHttpServerTest.scala
@@ -100,8 +100,11 @@ class PekkoHttpServerTest extends TestSuite with EitherValues {
             .unsafeToFuture()
         }
       )
+      def drainPekko(stream: PekkoStreams.BinaryStream): Future[Unit] =
+        stream.runWith(Sink.ignore).map(_ => ())
+
       new AllServerTests(createServerTest, interpreter, backend).tests() ++
-        new ServerStreamingTests(createServerTest, PekkoStreams).tests() ++
+        new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(PekkoStreams)(drainPekko) ++
         new ServerWebSocketTests(createServerTest, PekkoStreams) {
           override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = Flow.fromFunction(f)
           override def emptyPipe[A, B]: Flow[A, B, Any] = Flow.fromSinkAndSource(Sink.ignore, Source.empty)

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
@@ -30,7 +30,10 @@ private[play] class PlayRequestBody(serverOptions: PlayServerOptions)(implicit
     toRaw(request, bodyType, charset, () => request.body, None)
   }
 
-  override def toStream(serverRequest: ServerRequest): streams.BinaryStream = playRequest(serverRequest).body
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = {
+    val stream = playRequest(serverRequest).body
+    maxBytes.map(PekkoStreams.limitBytes(stream, _)).getOrElse(stream)
+  }
 
   private def toRaw[R](
       request: Request[PekkoStreams.BinaryStream],

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
@@ -104,6 +104,9 @@ class PlayServerTest extends TestSuite {
         }
       )
 
+      def drainPekko(stream: PekkoStreams.BinaryStream): Future[Unit] =
+        stream.runWith(Sink.ignore).map(_ => ())
+
       new ServerBasicTests(
         createServerTest,
         interpreter,
@@ -113,7 +116,7 @@ class PlayServerTest extends TestSuite {
       ).tests() ++
         new ServerMultipartTests(createServerTest, partOtherHeaderSupport = false).tests() ++
         new AllServerTests(createServerTest, interpreter, backend, basic = false, multipart = false, options = false).tests() ++
-        new ServerStreamingTests(createServerTest, PekkoStreams).tests() ++
+        new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(PekkoStreams)(drainPekko) ++
         new PlayServerWithContextTest(backend).tests() ++
         new ServerWebSocketTests(createServerTest, PekkoStreams) {
           override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = Flow.fromFunction(f)

--- a/server/sttp-stub-server/src/main/scala/sttp/tapir/server/stub/SttpRequestBody.scala
+++ b/server/sttp-stub-server/src/main/scala/sttp/tapir/server/stub/SttpRequestBody.scala
@@ -29,7 +29,7 @@ class SttpRequestBody[F[_]](implicit ME: MonadError[F]) extends RequestBody[F, A
       case _ => throw new IllegalArgumentException("Stream body provided while endpoint accepts raw body type")
     }
 
-  override def toStream(serverRequest: ServerRequest): streams.BinaryStream = body(serverRequest) match {
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = body(serverRequest) match {
     case Right(stream) => stream
     case _             => throw new IllegalArgumentException("Raw body provided while endpoint accepts stream body")
   }

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerStreamingTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerStreamingTests.scala
@@ -4,27 +4,29 @@ import cats.syntax.all._
 import org.scalatest.matchers.should.Matchers._
 import sttp.capabilities.Streams
 import sttp.client3._
-import sttp.model.{Header, HeaderNames, MediaType}
+import sttp.model.{Header, MediaType, StatusCode}
 import sttp.monad.MonadError
+import sttp.monad.syntax._
 import sttp.tapir.tests.Test
-import sttp.tapir.tests.Streaming.{
-  in_stream_out_either_json_xml_stream,
-  in_stream_out_stream,
-  in_stream_out_stream_with_content_length,
-  in_string_stream_out_either_stream_string,
-  out_custom_content_type_stream_body
-}
+import sttp.tapir.tests.Streaming._
+import sttp.tapir.server.interpreter.MaxContentLength
+import sttp.tapir.AttributeKey
+import cats.effect.IO
+import sttp.capabilities.fs2.Fs2Streams
 
-class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServerTest[F, S, OPTIONS, ROUTE], streams: Streams[S])(implicit
+class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](
+    createServerTest: CreateServerTest[F, S, OPTIONS, ROUTE],
+    maxLengthSupported: Boolean
+)(implicit
     m: MonadError[F]
 ) {
 
-  def tests(): List[Test] = {
+  def tests(streams: Streams[_ >: S])(drain: streams.BinaryStream => F[Unit]): List[Test] = {
     import createServerTest._
 
     val penPineapple = "pen pineapple apple pen"
 
-    List(
+    val baseTests = List(
       testServer(in_stream_out_stream(streams))((s: streams.BinaryStream) => pureResult(s.asRight[Unit])) { (backend, baseUri) =>
         basicRequest.post(uri"$baseUri/api/echo").body(penPineapple).send(backend).map(_.body shouldBe Right(penPineapple))
       },
@@ -99,5 +101,41 @@ class ServerStreamingTests[F[_], S, OPTIONS, ROUTE](createServerTest: CreateServ
             }
       }
     )
+
+    val maxContentLengthTests = List(
+      {
+        val inputByteCount = 1024
+        val maxBytes = 1024L
+        val inputStream = fs2.Stream.fromIterator[IO](Iterator.fill[Byte](inputByteCount)('5'.toByte), chunkSize = 256)
+        testServer(
+          in_stream_out_stream(streams).attribute(AttributeKey[MaxContentLength], MaxContentLength(maxBytes)),
+          "with request content length == max"
+        )((s: streams.BinaryStream) => pureResult(s.asRight[Unit])) { (backend, baseUri) =>
+          basicRequest
+            .post(uri"$baseUri/api/echo")
+            .streamBody(Fs2Streams[IO])(inputStream)
+            .send(backend)
+            .map(resp => assert(resp.isSuccess, "Response 200 OK"))
+        }
+      }, {
+        val inputByteCount = 1024
+        val maxBytes = 1023L
+        val inputStream = fs2.Stream.fromIterator[IO](Iterator.fill[Byte](inputByteCount)('5'.toByte), chunkSize = 256)
+        testServer(
+          in_stream_out_string(streams).attribute(AttributeKey[MaxContentLength], MaxContentLength(maxBytes)),
+          "with request content length > max"
+        )((s: streams.BinaryStream) => drain(s).flatMap(_ => pureResult("ok".asRight[Unit]))) { (backend, baseUri) =>
+          basicRequest
+            .post(uri"$baseUri/api/echo")
+            .streamBody(Fs2Streams[IO])(inputStream)
+            .send(backend)
+            .map(_.code shouldBe (StatusCode.PayloadTooLarge))
+        }
+      }
+    )
+
+    if (maxLengthSupported)
+      baseTests ++ maxContentLengthTests
+    else baseTests
   }
 }

--- a/server/vertx-server/cats/src/main/scala/sttp/tapir/server/vertx/cats/streams/fs2.scala
+++ b/server/vertx-server/cats/src/main/scala/sttp/tapir/server/vertx/cats/streams/fs2.scala
@@ -107,8 +107,10 @@ object fs2 {
           }
         }
 
-      override def fromReadStream(readStream: ReadStream[Buffer]): Stream[F, Byte] =
-        fromReadStreamInternal(readStream).map(buffer => Chunk.array(buffer.getBytes)).unchunks
+      override def fromReadStream(readStream: ReadStream[Buffer], maxBytes: Option[Long]): Stream[F, Byte] = {
+        val stream = fromReadStreamInternal(readStream).map(buffer => Chunk.array(buffer.getBytes)).unchunks
+        maxBytes.map(Fs2Streams.limitBytes(stream, _)).getOrElse(stream)
+      }
 
       private def fromReadStreamInternal[T](readStream: ReadStream[T]): Stream[F, T] =
         opts.dispatcher.unsafeRunSync {

--- a/server/vertx-server/cats/src/test/scala/sttp/tapir/server/vertx/cats/streams/Fs2StreamTest.scala
+++ b/server/vertx-server/cats/src/test/scala/sttp/tapir/server/vertx/cats/streams/Fs2StreamTest.scala
@@ -148,7 +148,7 @@ class Fs2StreamTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
     val opts = options.copy(maxQueueSizeForReadStream = 128)
     val count = 100
     val readStream = new FakeStream()
-    val stream = streams.fs2.fs2ReadStreamCompatible[IO](opts)(implicitly).fromReadStream(readStream)
+    val stream = streams.fs2.fs2ReadStreamCompatible[IO](opts)(implicitly).fromReadStream(readStream, None)
     (for {
       resultFiber <- stream
         .chunkN(4)
@@ -174,7 +174,7 @@ class Fs2StreamTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
   it should "drain read stream with small buffer" in {
     val count = 100
     val readStream = new FakeStream()
-    val stream = streams.fs2.fs2ReadStreamCompatible[IO](options).fromReadStream(readStream)
+    val stream = streams.fs2.fs2ReadStreamCompatible[IO](options).fromReadStream(readStream, None)
     (for {
       resultFiber <- stream
         .chunkN(4)
@@ -205,7 +205,7 @@ class Fs2StreamTest extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
     val ex = new Exception("!")
     val count = 50
     val readStream = new FakeStream()
-    val stream = streams.fs2.fs2ReadStreamCompatible[IO](options).fromReadStream(readStream)
+    val stream = streams.fs2.fs2ReadStreamCompatible[IO](options).fromReadStream(readStream, None)
     (for {
       resultFiber <- stream
         .chunkN(4)

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/decoders/VertxRequestBody.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/decoders/VertxRequestBody.scala
@@ -95,9 +95,9 @@ class VertxRequestBody[F[_], S <: Streams[S]](
     })
   }
 
-  override def toStream(serverRequest: ServerRequest): streams.BinaryStream =
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream =
     readStreamCompatible
-      .fromReadStream(routingContext(serverRequest).request)
+      .fromReadStream(routingContext(serverRequest).request, maxBytes)
       .asInstanceOf[streams.BinaryStream]
 
   private def extractStringPart[B](part: String, bodyType: RawBodyType[B]): Option[Any] = {

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/ReadStreamCompatible.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/ReadStreamCompatible.scala
@@ -9,7 +9,7 @@ import sttp.ws.WebSocketFrame
 trait ReadStreamCompatible[S <: Streams[S]] {
   val streams: S
   def asReadStream(s: streams.BinaryStream): ReadStream[Buffer]
-  def fromReadStream(s: ReadStream[Buffer]): streams.BinaryStream
+  def fromReadStream(s: ReadStream[Buffer], maxBytes: Option[Long]): streams.BinaryStream
 
   def webSocketPipe[REQ, RESP](
       readStream: ReadStream[WebSocketFrame],

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/package.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/package.scala
@@ -18,7 +18,7 @@ package object streams {
     override def asReadStream(readStream: ReadStream[Buffer]): ReadStream[Buffer] =
       readStream
 
-    override def fromReadStream(readStream: ReadStream[Buffer]): ReadStream[Buffer] =
+    override def fromReadStream(readStream: ReadStream[Buffer], maxBytes: Option[Long]): ReadStream[Buffer] = // TODO support maxBytes
       readStream
 
     override def webSocketPipe[REQ, RESP](

--- a/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxServerTest.scala
+++ b/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxServerTest.scala
@@ -9,6 +9,7 @@ import sttp.tapir.server.vertx.streams.VertxStreams
 import sttp.tapir.tests.{Test, TestSuite}
 
 import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 
 class VertxServerTest extends TestSuite {
   def vertxResource: Resource[IO, Vertx] =
@@ -26,7 +27,7 @@ class VertxServerTest extends TestSuite {
           createServerTest,
           partContentTypeHeaderSupport = false, // README: doesn't seem supported but I may be wrong
           partOtherHeaderSupport = false
-        ).tests() ++ new ServerStreamingTests(createServerTest, VertxStreams).tests() ++
+        ).tests() ++ new ServerStreamingTests(createServerTest, maxLengthSupported = false).tests(VertxStreams)(_ => Future.unit) ++
         (new ServerWebSocketTests(createServerTest, VertxStreams) {
           override def functionToPipe[A, B](f: A => B): VertxStreams.Pipe[A, B] = in => new ReadStreamMapping(in, f)
           override def emptyPipe[A, B]: VertxStreams.Pipe[A, B] = _ => new EmptyReadStream()

--- a/server/vertx-server/zio/src/main/scala/sttp/tapir/server/vertx/zio/streams/zio.scala
+++ b/server/vertx-server/zio/src/main/scala/sttp/tapir/server/vertx/zio/streams/zio.scala
@@ -103,8 +103,10 @@ package object streams {
       }).toEither
         .fold(throw _, identity)
 
-    override def fromReadStream(readStream: ReadStream[Buffer]): Stream[Throwable, Byte] =
-      fromReadStreamInternal(readStream).mapConcatChunk(buffer => Chunk.fromArray(buffer.getBytes))
+    override def fromReadStream(readStream: ReadStream[Buffer], maxBytes: Option[Long]): Stream[Throwable, Byte] = {
+      val stream = fromReadStreamInternal(readStream).mapConcatChunk(buffer => Chunk.fromArray(buffer.getBytes))
+      maxBytes.map(ZioStreams.limitBytes(stream, _)).getOrElse(stream)
+    }
 
     private def fromReadStreamInternal[T](readStream: ReadStream[T]): Stream[Throwable, T] =
       unsafeRunSync(for {

--- a/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/ZioVertxServerTest.scala
+++ b/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/ZioVertxServerTest.scala
@@ -1,18 +1,19 @@
 package sttp.tapir.server.vertx.zio
 
+import _root_.zio.stream.ZStream
+import _root_.zio.{Task, ZIO}
 import cats.effect.{IO, Resource}
 import io.vertx.core.Vertx
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers._
 import sttp.capabilities.zio.ZioStreams
+import sttp.client3.basicRequest
 import sttp.monad.MonadError
+import sttp.tapir._
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
-import sttp.tapir._
-import _root_.zio.{Task, ZIO}
-import _root_.zio.stream.ZStream
-import org.scalatest.OptionValues
-import sttp.client3.basicRequest
 import sttp.tapir.ztapir.RIOMonadError
-import org.scalatest.matchers.should.Matchers._
+import zio.stream.ZSink
 
 class ZioVertxServerTest extends TestSuite with OptionValues {
   def vertxResource: Resource[IO, Vertx] =
@@ -32,6 +33,8 @@ class ZioVertxServerTest extends TestSuite with OptionValues {
           basicRequest.get(baseUri).send(backend).map(_.body.toOption.value should not include "vert.x-eventloop-thread")
         }
       )
+      def drainZStream(zStream: ZioStreams.BinaryStream): Task[Unit] =
+        zStream.run(ZSink.drain)
 
       new AllServerTests(createServerTest, interpreter, backend, multipart = false, reject = false, options = false).tests() ++
         new ServerMultipartTests(
@@ -39,7 +42,7 @@ class ZioVertxServerTest extends TestSuite with OptionValues {
           partContentTypeHeaderSupport = false, // README: doesn't seem supported but I may be wrong
           partOtherHeaderSupport = false
         ).tests() ++ additionalTests() ++
-        new ServerStreamingTests(createServerTest, ZioStreams).tests() ++
+        new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(ZioStreams)(drainZStream) ++
         new ServerWebSocketTests(createServerTest, ZioStreams) {
           override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = in => in.map(f)
           override def emptyPipe[A, B]: streams.Pipe[A, B] = _ => ZStream.empty

--- a/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/streams/ZStreamTest.scala
+++ b/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/streams/ZStreamTest.scala
@@ -124,7 +124,7 @@ class ZStreamTest extends AsyncFlatSpec with Matchers {
     val opts = options.copy(maxQueueSizeForReadStream = 128)
     val count = 100
     val readStream = new FakeStream()
-    val stream = zioReadStreamCompatible(opts)(runtime).fromReadStream(readStream)
+    val stream = zioReadStreamCompatible(opts)(runtime).fromReadStream(readStream, None)
     unsafeToFuture(for {
       resultFiber <- ZIO
         .scoped(
@@ -154,7 +154,7 @@ class ZStreamTest extends AsyncFlatSpec with Matchers {
     val opts = options.copy(maxQueueSizeForReadStream = 4)
     val count = 100
     val readStream = new FakeStream()
-    val stream = zioReadStreamCompatible(opts)(runtime).fromReadStream(readStream)
+    val stream = zioReadStreamCompatible(opts)(runtime).fromReadStream(readStream, None)
     unsafeToFuture(for {
       resultFiber <- ZIO
         .scoped(
@@ -188,7 +188,7 @@ class ZStreamTest extends AsyncFlatSpec with Matchers {
     val opts = options.copy(maxQueueSizeForReadStream = 4)
     val count = 50
     val readStream = new FakeStream()
-    val stream = zioReadStreamCompatible(opts)(runtime).fromReadStream(readStream)
+    val stream = zioReadStreamCompatible(opts)(runtime).fromReadStream(readStream, None)
     unsafeToFuture(for {
       resultFiber <- ZIO
         .scoped(

--- a/server/vertx-server/zio1/src/main/scala/sttp/tapir/server/vertx/zio/streams/zio.scala
+++ b/server/vertx-server/zio1/src/main/scala/sttp/tapir/server/vertx/zio/streams/zio.scala
@@ -119,8 +119,9 @@ package object streams {
         .toEither
         .fold(throw _, identity)
 
-    override def fromReadStream(readStream: ReadStream[Buffer]): Stream[Throwable, Byte] =
+    override def fromReadStream(readStream: ReadStream[Buffer], maxBytes: Option[Long]): Stream[Throwable, Byte] = {
       fromReadStreamInternal(readStream).mapConcatChunk(buffer => Chunk.fromArray(buffer.getBytes))
+    }
 
     private def fromReadStreamInternal[T](readStream: ReadStream[T]): Stream[Throwable, T] =
       runtime

--- a/server/vertx-server/zio1/src/test/scala/sttp/tapir/server/vertx/zio/ZioVertxServerTest.scala
+++ b/server/vertx-server/zio1/src/test/scala/sttp/tapir/server/vertx/zio/ZioVertxServerTest.scala
@@ -10,6 +10,7 @@ import _root_.zio.RIO
 import _root_.zio.blocking.Blocking
 import sttp.tapir.ztapir.RIOMonadError
 import zio.stream.ZStream
+import zio.Task
 
 class ZioVertxServerTest extends TestSuite {
   def vertxResource: Resource[IO, Vertx] =
@@ -27,7 +28,7 @@ class ZioVertxServerTest extends TestSuite {
           partContentTypeHeaderSupport = false, // README: doesn't seem supported but I may be wrong
           partOtherHeaderSupport = false
         ).tests() ++
-        new ServerStreamingTests(createServerTest, ZioStreams).tests() ++
+        new ServerStreamingTests(createServerTest, maxLengthSupported = false).tests(ZioStreams)(_ => Task.unit) ++
         new ServerWebSocketTests(createServerTest, ZioStreams) {
           override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = in => in.map(f)
           override def emptyPipe[A, B]: streams.Pipe[A, B] = _ => ZStream.empty

--- a/server/vertx-server/zio1/src/test/scala/sttp/tapir/server/vertx/zio/streams/ZStreamTest.scala
+++ b/server/vertx-server/zio1/src/test/scala/sttp/tapir/server/vertx/zio/streams/ZStreamTest.scala
@@ -131,7 +131,7 @@ class ZStreamTest extends AsyncFlatSpec with Matchers {
     val opts = options.copy(maxQueueSizeForReadStream = 128)
     val count = 100
     val readStream = new FakeStream()
-    val stream = zioReadStreamCompatible(opts)(runtime).fromReadStream(readStream)
+    val stream = zioReadStreamCompatible(opts)(runtime).fromReadStream(readStream, maxBytes = None)
     runtime
       .unsafeRunToFuture(for {
         resultFiber <- stream
@@ -160,7 +160,7 @@ class ZStreamTest extends AsyncFlatSpec with Matchers {
     val opts = options.copy(maxQueueSizeForReadStream = 4)
     val count = 100
     val readStream = new FakeStream()
-    val stream = zioReadStreamCompatible(opts)(runtime).fromReadStream(readStream)
+    val stream = zioReadStreamCompatible(opts)(runtime).fromReadStream(readStream, maxBytes = None)
     runtime
       .unsafeRunToFuture(for {
         resultFiber <- stream
@@ -193,7 +193,7 @@ class ZStreamTest extends AsyncFlatSpec with Matchers {
     val opts = options.copy(maxQueueSizeForReadStream = 4)
     val count = 50
     val readStream = new FakeStream()
-    val stream = zioReadStreamCompatible(opts)(runtime).fromReadStream(readStream)
+    val stream = zioReadStreamCompatible(opts)(runtime).fromReadStream(readStream, maxBytes = None)
     runtime
       .unsafeRunToFuture(for {
         resultFiber <- stream

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpRequestBody.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpRequestBody.scala
@@ -29,7 +29,10 @@ class ZioHttpRequestBody[R](serverOptions: ZioHttpServerOptions[R]) extends Requ
     case RawBodyType.MultipartBody(_, _) => ZIO.fail(new UnsupportedOperationException("Multipart is not supported"))
   }
 
-  override def toStream(serverRequest: ServerRequest): streams.BinaryStream = stream(serverRequest).asInstanceOf[streams.BinaryStream]
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = {
+    val inputStream = stream(serverRequest)
+    maxBytes.map(ZioStreams.limitBytes(inputStream, _)).getOrElse(inputStream).asInstanceOf[streams.BinaryStream]
+  }
 
   private def stream(serverRequest: ServerRequest): Stream[Throwable, Byte] =
     zioHttpRequest(serverRequest).body.asStream

--- a/server/zio1-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
+++ b/server/zio1-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
@@ -54,7 +54,7 @@ class ZioHttpServerTest extends TestSuite {
           // Cause: java.io.IOException: parsing HTTP/1.1 status line, receiving [f2 content], parser state [STATUS_LINE]
           new AllServerTests(createServerTest, interpreter, backend, basic = false, staticContent = false, multipart = false, file = true)
             .tests() ++
-          new ServerStreamingTests(createServerTest, ZioStreams).tests() ++
+          new ServerStreamingTests(createServerTest, maxLengthSupported = false).tests(ZioStreams)(_ => Task.unit) ++
           new ZioHttpCompositionTest(createServerTest).tests() // ++
         // TODO: only works with zio2
         // additionalTests()

--- a/serverless/aws/lambda-core/src/main/scala/sttp/tapir/serverless/aws/lambda/AwsRequestBody.scala
+++ b/serverless/aws/lambda-core/src/main/scala/sttp/tapir/serverless/aws/lambda/AwsRequestBody.scala
@@ -33,7 +33,8 @@ private[lambda] class AwsRequestBody[F[_]: MonadError]() extends RequestBody[F, 
     }).asInstanceOf[RawValue[R]].unit
   }
 
-  override def toStream(serverRequest: ServerRequest): streams.BinaryStream = throw new UnsupportedOperationException
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream =
+    throw new UnsupportedOperationException
 
   private def awsRequest(serverRequest: ServerRequest) = serverRequest.underlying.asInstanceOf[AwsRequest]
 }

--- a/tests/src/main/scala/sttp/tapir/tests/Streaming.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/Streaming.scala
@@ -12,6 +12,10 @@ object Streaming {
     endpoint.post.in("api" / "echo").in(sb).out(sb)
   }
 
+  def in_stream_out_string[S](s: Streams[S]): PublicEndpoint[s.BinaryStream, Unit, String, S] = {
+    endpoint.post.in("api" / "echo").in(streamTextBody(s)(CodecFormat.TextPlain(), Some(StandardCharsets.UTF_8))).out(stringBody)
+  }
+
   def in_stream_out_stream_with_content_length[S](
       s: Streams[S]
   ): PublicEndpoint[(Long, s.BinaryStream), Unit, (Long, s.BinaryStream), S] = {


### PR DESCRIPTION
Started as a solution to https://github.com/softwaremill/tapir/issues/3056 for Netty, but addresses more backends in general.
This PR introduces a possibility to add a `MaxContentLength` attribute to any endpoint. When set, decoding `RequestBody` in supported backends prevents loading too much into memory, and fails if the limit is exceeded.
As a result, `DefaultExceptionHandler` returns `HTTP 413 Payload Too Large`.

*Streaming only*
This is only a part of the full feature. The PR covers streaming support for streaming request body, excluding:
- Armeria streams
- Vertx streams
- zio1 streams

In a follow-up PR, I'll add:
- Support for non-streaming body (direct byte arrays, files) 
- Documentation
- API extension to allow writing `endpoint.maxContentLength(x)` instead of setting an attribute.