### PR TITLE
Use setup-node to install npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,10 @@ jobs:
         sam --version
     - name: Install NPM
       if: matrix.java == '11'
-      run: |
-        sudo apt install npm
-        npm --version
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18
+    - run: npm --version
     - name: Install AWS CDK
       if: matrix.java == '11'
       run: |


### PR DESCRIPTION
Installing Node.js using `sudo apt install npm` fails due to https://github.com/actions/runner-images/issues/8779
As per recommendations in the announcement, I'm switching to `actions/setup-node`.