### PR TITLE
[CI] Compile tests in compileScoped

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -345,7 +345,7 @@ lazy val rootProject = (project in file("."))
     testFinatra := (Test / test).all(filterProject(p => p.contains("finatra"))).value,
     compileScoped := Def.inputTaskDyn {
       val args = spaceDelimited("<arg>").parsed
-      Def.taskDyn((Compile / compile).all(filterByVersionAndPlatform(args.head, args(1))))
+      Def.taskDyn((Test / compile).all(filterByVersionAndPlatform(args.head, args(1))))
     }.evaluated,
     testScoped := Def.inputTaskDyn {
       val args = spaceDelimited("<arg>").parsed


### PR DESCRIPTION
With only `Compile / compile` in `compileScoped`, the tests are compiled later in the `Test` step. The `Test` step is wrapped in retries, which causes unnecessary long retries in case of failing test compilation.