### PR TITLE
[CI] Tune test timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,8 @@ jobs:
       if: matrix.target-platform != 'JS'
       uses: nick-fields/retry@v2
       with:
-        timeout_minutes: 45
-        max_attempts: 3
+        timeout_minutes: 15
+        max_attempts: 4
         command: sbt $SBT_JAVA_OPTS -v "testScoped ${{ matrix.scala-version }} ${{ matrix.target-platform }}"
     # The finatra tests take a really long time (1/3 of the build duration); hence, they are disabled and need to be run separately
     #- name: Test finatra


### PR DESCRIPTION
Here's another attempt to make this better.
After recent change which  moves test compilation to the `compileScoped` step (https://github.com/softwaremill/tapir/pull/3336), I noticed that the `Test` step takes much less time (yay!). It's now a matter of minutes, usually far less than 10m if successful.
Because of this, I propose:
1. Reducing timeout: if tests freeze, let's retry after 15 minutes instead of 45 minutes
2. Increasing number of retries: let's bump this a bit, from 3 to 4