### PR TITLE
Http4s max content length

### DIFF
--- a/doc/endpoint/security.md
+++ b/doc/endpoint/security.md
@@ -52,7 +52,7 @@ Optional and multiple authentication inputs have some additional rules as to how
 ## Limiting request body length
 
 *Supported backends*: 
-Feature enabled only for Netty-based servers. More backends will be added in the near future.
+This feature is available for backends based on http4s, jdkhttp, Netty, and Play. More backends will be added in the near future.
 
 Individual endpoints can be annotated with content length limit:
 

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestBody.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestBody.scala
@@ -19,8 +19,7 @@ private[http4s] class Http4sRequestBody[F[_]: Async](
 ) extends RequestBody[F, Fs2Streams[F]] {
   override val streams: Fs2Streams[F] = Fs2Streams[F]
   override def toRaw[R](serverRequest: ServerRequest, bodyType: RawBodyType[R], maxBytes: Option[Long]): F[RawValue[R]] = {
-    val r = http4sRequest(serverRequest)
-    toRawFromStream(serverRequest, r.body, bodyType, r.charset)
+    toRawFromStream(serverRequest, toStream(serverRequest, maxBytes), bodyType, http4sRequest(serverRequest).charset)
   }
   override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = {
     val stream = http4sRequest(serverRequest).body

--- a/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerTest.scala
+++ b/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerTest.scala
@@ -136,7 +136,7 @@ class Http4sServerTest[R >: Fs2Streams[IO] with WebSockets] extends TestSuite wi
     def drainFs2(stream: Fs2Streams[IO]#BinaryStream): IO[Unit] =
       stream.compile.drain.void
 
-    new AllServerTests(createServerTest, interpreter, backend).tests() ++
+    new AllServerTests(createServerTest, interpreter, backend, maxContentLength = true).tests() ++
       new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(Fs2Streams[IO])(drainFs2) ++
       new ServerWebSocketTests(createServerTest, Fs2Streams[IO]) {
         override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = in => in.map(f)

--- a/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerTest.scala
+++ b/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sServerTest.scala
@@ -53,8 +53,8 @@ class ZHttp4sServerTest extends TestSuite with OptionValues {
     def drainZStream(zStream: ZioStreams.BinaryStream): Task[Unit] =
       zStream.run(ZSink.drain)
 
-    new AllServerTests(createServerTest, interpreter, backend).tests() ++
-    new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(ZioStreams)(drainZStream) ++
+    new AllServerTests(createServerTest, interpreter, backend, maxContentLength = true).tests() ++
+      new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(ZioStreams)(drainZStream) ++
       new ServerWebSocketTests(createServerTest, ZioStreams) {
         override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = in => in.map(f)
         override def emptyPipe[A, B]: streams.Pipe[A, B] = _ => ZStream.empty

--- a/server/jdkhttp-server/src/main/scala/sttp/tapir/server/jdkhttp/internal/JdkHttpToResponseBody.scala
+++ b/server/jdkhttp-server/src/main/scala/sttp/tapir/server/jdkhttp/internal/JdkHttpToResponseBody.scala
@@ -133,12 +133,3 @@ private class ByteBufferBackedInputStream(buf: ByteBuffer) extends InputStream {
   }
 }
 
-private class LimitedInputStream(delegate: InputStream, var limit: Long) extends InputStream {
-  override def read(): Int = {
-    if (limit == 0L) -1
-    else {
-      limit -= 1
-      delegate.read()
-    }
-  }
-}

--- a/server/jdkhttp-server/src/main/scala/sttp/tapir/server/jdkhttp/internal/LimitedInputStream.scala
+++ b/server/jdkhttp-server/src/main/scala/sttp/tapir/server/jdkhttp/internal/LimitedInputStream.scala
@@ -1,0 +1,78 @@
+package sttp.tapir.server.jdkhttp.internal
+
+import sttp.capabilities.StreamMaxLengthExceededException
+import java.io.FilterInputStream
+import java.io.InputStream
+import java.io.IOException
+
+class FailingLimitedInputStream(in: InputStream, limit: Long) extends LimitedInputStream(in, limit) {
+  override def onLimit: Int = {
+    throw new StreamMaxLengthExceededException(limit)
+  }
+}
+
+/** Based on Guava's https://github.com/google/guava/blob/master/guava/src/com/google/common/io/ByteStreams.java
+  */
+class LimitedInputStream(in: InputStream, limit: Long) extends FilterInputStream(in) {
+  protected var left: Long = limit
+  private var mark: Long = -1L
+
+  override def available(): Int = Math.min(in.available(), left.toInt)
+
+  override def mark(readLimit: Int): Unit = this.synchronized {
+    in.mark(readLimit)
+    mark = left
+  }
+
+  override def read(): Int = this.synchronized {
+    if (left == 0) {
+      onLimit
+    } else {
+      val result = in.read()
+      if (result != -1) {
+        left -= 1
+      }
+      result
+    }
+  }
+
+  override def read(b: Array[Byte], off: Int, len: Int): Int = this.synchronized {
+    if (left == 0) {
+      // Temporarily perform a read to check if more bytes are available
+      val checkRead = in.read()
+      if (checkRead == -1) {
+        -1 // No more bytes available in the stream
+      } else {
+        onLimit
+      }
+    } else {
+      val adjustedLen = Math.min(len, left.toInt)
+      val result = in.read(b, off, adjustedLen)
+      if (result != -1) {
+        left -= result
+      }
+      result
+    }
+  }
+
+  override def reset(): Unit = this.synchronized {
+    if (!in.markSupported) {
+      throw new IOException("Mark not supported")
+    }
+    if (mark == -1) {
+      throw new IOException("Mark not set")
+    }
+
+    in.reset()
+    left = mark
+  }
+
+  override def skip(n: Long): Long = this.synchronized {
+    val toSkip = Math.min(n, left)
+    val skipped = in.skip(toSkip)
+    left -= skipped
+    skipped
+  }
+
+  protected def onLimit: Int = -1
+}

--- a/server/jdkhttp-server/src/test/scala/sttp/tapir/server/jdkhttp/JdkHttpServerTest.scala
+++ b/server/jdkhttp-server/src/test/scala/sttp/tapir/server/jdkhttp/JdkHttpServerTest.scala
@@ -14,7 +14,7 @@ class JdkHttpServerTest extends TestSuite with EitherValues {
           val interpreter = new JdkHttpTestServerInterpreter()
           val createServerTest = new DefaultCreateServerTest(backend, interpreter)
 
-          new ServerBasicTests(createServerTest, interpreter, invulnerableToUnsanitizedHeaders = false).tests() ++
+          new ServerBasicTests(createServerTest, interpreter, invulnerableToUnsanitizedHeaders = false, maxContentLength = true).tests() ++
             new AllServerTests(createServerTest, interpreter, backend, basic = false).tests()
         })
     }

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
@@ -27,7 +27,7 @@ private[play] class PlayRequestBody(serverOptions: PlayServerOptions)(implicit
     import mat.executionContext
     val request = playRequest(serverRequest)
     val charset = request.charset.map(Charset.forName)
-    toRaw(request, bodyType, charset, () => request.body, None)
+    toRaw(request, bodyType, charset, () => toStream(serverRequest, maxBytes), None)
   }
 
   override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = {

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
@@ -1,7 +1,6 @@
 package sttp.tapir.server.play
 
 import org.apache.pekko.actor.ActorSystem
-import enumeratum._
 import org.apache.pekko.stream.scaladsl.{Flow, Sink, Source}
 import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
@@ -17,8 +16,6 @@ import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
 
 import scala.concurrent.Future
-import sttp.tapir.codec.enumeratum.TapirCodecEnumeratum
-import sttp.tapir.server.interceptor.decodefailure.DefaultDecodeFailureHandler
 
 class PlayServerTest extends TestSuite {
 
@@ -112,10 +109,18 @@ class PlayServerTest extends TestSuite {
         interpreter,
         multipleValueHeaderSupport = false,
         inputStreamSupport = false,
-        invulnerableToUnsanitizedHeaders = false
+        invulnerableToUnsanitizedHeaders = false,
+        maxContentLength = true
       ).tests() ++
         new ServerMultipartTests(createServerTest, partOtherHeaderSupport = false).tests() ++
-        new AllServerTests(createServerTest, interpreter, backend, basic = false, multipart = false, options = false).tests() ++
+        new AllServerTests(
+          createServerTest,
+          interpreter,
+          backend,
+          basic = false,
+          multipart = false,
+          options = false
+        ).tests() ++
         new ServerStreamingTests(createServerTest, maxLengthSupported = true).tests(PekkoStreams)(drainPekko) ++
         new PlayServerWithContextTest(backend).tests() ++
         new ServerWebSocketTests(createServerTest, PekkoStreams) {

--- a/server/play29-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
+++ b/server/play29-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
@@ -27,7 +27,7 @@ private[play] class PlayRequestBody(serverOptions: PlayServerOptions)(implicit
     import mat.executionContext
     val request = playRequest(serverRequest)
     val charset = request.charset.map(Charset.forName)
-    toRaw(request, bodyType, charset, () => request.body, None)
+    toRaw(request, bodyType, charset, () => toStream(serverRequest, maxBytes), None)
   }
 
   override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = {

--- a/server/play29-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
+++ b/server/play29-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
@@ -111,7 +111,8 @@ class PlayServerTest extends TestSuite {
         interpreter,
         multipleValueHeaderSupport = false,
         inputStreamSupport = false,
-        invulnerableToUnsanitizedHeaders = false
+        invulnerableToUnsanitizedHeaders = false,
+        maxContentLength = true
       ).tests() ++
         new ServerMultipartTests(createServerTest, partOtherHeaderSupport = false).tests() ++
         new AllServerTests(createServerTest, interpreter, backend, basic = false, multipart = false, options = false).tests() ++

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -752,7 +752,7 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
       maxLength: Int
   ) = testServer(
     testedEndpoint.maxRequestBodyLength(maxLength.toLong),
-    "returns 413 on exceeded max content length (request)"
+    "checks payload limit and returns 413 on exceeded max content length (request)"
   )(i => pureResult(i.asRight[Unit])) { (backend, baseUri) =>
     val tooLargeBody: String = List.fill(maxLength + 1)('x').mkString
     basicRequest.post(uri"$baseUri/api/echo").body(tooLargeBody).send(backend).map(_.code shouldBe StatusCode.PayloadTooLarge)
@@ -762,7 +762,7 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
       maxLength: Int
   ) = testServer(
     testedEndpoint.attribute(AttributeKey[MaxContentLength], MaxContentLength(maxLength.toLong)),
-    "returns OK on content length  below or equal max (request)"
+    "checks payload limit and returns OK on content length  below or equal max (request)"
   )(i => pureResult(i.asRight[Unit])) { (backend, baseUri) =>
     val fineBody: String = List.fill(maxLength)('x').mkString
     basicRequest.post(uri"$baseUri/api/echo").body(fineBody).send(backend).map(_.code shouldBe StatusCode.Ok)

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -10,6 +10,7 @@ import sttp.client3._
 import sttp.model._
 import sttp.model.headers.{CookieValueWithMeta, CookieWithMeta}
 import sttp.monad.MonadError
+import sttp.monad.syntax._
 import sttp.tapir._
 import sttp.tapir.codec.enumeratum.TapirCodecEnumeratum
 import sttp.tapir.generic.auto._
@@ -774,10 +775,33 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
       testPayloadTooLarge(in_string_out_string, maxLength),
       testPayloadTooLarge(in_byte_array_out_byte_array, maxLength),
       testPayloadTooLarge(in_file_out_file, maxLength),
-      testPayloadTooLarge(in_input_stream_out_input_stream, maxLength),
+      testServer(
+        in_input_stream_out_input_stream.maxRequestBodyLength(maxLength.toLong),
+        "checks payload limit and returns 413 on exceeded max content length (request)"
+      )(i => {
+        // Forcing server logic to try to drain the InputStream
+        suspendResult(i.readAllBytes()).map(_ => new ByteArrayInputStream(Array.empty[Byte]).asRight[Unit])
+      }) { (backend, baseUri) =>
+        val tooLargeBody: String = List.fill(maxLength + 1)('x').mkString
+        basicRequest.post(uri"$baseUri/api/echo").body(tooLargeBody).response(asByteArray).send(backend).map { r =>
+          r.code shouldBe StatusCode.PayloadTooLarge
+        }
+      },
+
       testPayloadTooLarge(in_byte_buffer_out_byte_buffer, maxLength),
       testPayloadWithinLimit(in_string_out_string, maxLength),
-      testPayloadWithinLimit(in_input_stream_out_input_stream, maxLength),
+      testServer(
+        in_input_stream_out_input_stream.maxRequestBodyLength(maxLength.toLong),
+        "checks payload limit and returns OK on content length  below or equal max (request)"
+      )(i => {
+        // Forcing server logic to drain the InputStream
+        suspendResult(i.readAllBytes()).map(_ => new ByteArrayInputStream(Array.empty[Byte]).asRight[Unit])
+      }) { (backend, baseUri) =>
+        val tooLargeBody: String = List.fill(maxLength)('x').mkString
+        basicRequest.post(uri"$baseUri/api/echo").body(tooLargeBody).response(asByteArray).send(backend).map { r =>
+          r.code shouldBe StatusCode.Ok
+        }
+      },
       testPayloadWithinLimit(in_byte_array_out_byte_array, maxLength),
       testPayloadWithinLimit(in_file_out_file, maxLength),
       testPayloadWithinLimit(in_byte_buffer_out_byte_buffer, maxLength)


### PR DESCRIPTION
A follow-up to #3337 

Enables MaxContentLength checks for raw request body in:

* tapir-http4s-server
* tapir-http4s-server-zio
* tapir-jdkhttp-server
* tapir-play-server
* tapir-play29-server