### PR TITLE
Fix: ContentType is not set for multipart file upload in VertxServer

### DIFF
--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/decoders/VertxRequestBody.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/decoders/VertxRequestBody.scala
@@ -3,7 +3,7 @@ package sttp.tapir.server.vertx.decoders
 import io.vertx.core.Future
 import io.vertx.ext.web.{FileUpload, RoutingContext}
 import sttp.capabilities.Streams
-import sttp.model.Part
+import sttp.model.{MediaType, Part}
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.{FileRange, InputStreamRange, RawBodyType}
 import sttp.tapir.server.interpreter.{RawValue, RequestBody}
@@ -85,7 +85,9 @@ class VertxRequestBody[F[_], S <: Streams[S]](
             .map { fu =>
               mp.partType(fu.name())
                 .flatMap(rawBodyType => extractFilePart(fu, rawBodyType))
-                .map(body => Part(fu.name(), body, fileName = Option(fu.fileName())))
+                .map(body =>
+                  Part(fu.name(), body, contentType = MediaType.parse(fu.contentType()).toOption, fileName = Option(fu.fileName()))
+                )
             }
             .toList
             .flatten

--- a/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxServerTest.scala
+++ b/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxServerTest.scala
@@ -25,7 +25,7 @@ class VertxServerTest extends TestSuite {
       new AllServerTests(createServerTest, interpreter, backend, multipart = false, reject = false, options = false).tests() ++
         new ServerMultipartTests(
           createServerTest,
-          partContentTypeHeaderSupport = false, // README: doesn't seem supported but I may be wrong
+          partContentTypeHeaderSupport = true,
           partOtherHeaderSupport = false
         ).tests() ++ new ServerStreamingTests(createServerTest, maxLengthSupported = false).tests(VertxStreams)(_ => Future.unit) ++
         (new ServerWebSocketTests(createServerTest, VertxStreams) {


### PR DESCRIPTION
Hi.

I am using VertxServerInterpreter.
I did a file upload with multipart and the `Part.contentType` was set to None and the ContentType of the request was not set.

Since `io.vertx.ext.web.FileUpload` in Vert.x has a `contentType` method, I thought I could simply set it if it was valid as MediaType, so I fixed it.