### PR TITLE
fix(server): proper path segment decoding

### DIFF
--- a/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraServerRequest.scala
+++ b/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraServerRequest.scala
@@ -17,7 +17,8 @@ case class FinatraServerRequest(request: Request, attributes: AttributeMap = Att
   override lazy val queryParameters: QueryParams =
     QueryParams.fromMultiMap(request.params.keys.toList.map(k => k -> request.params.getAll(k).toList).toMap)
   override lazy val pathSegments: List[String] = {
-    val segments = request.path.dropWhile(_ == '/').split("/").toList.map(QueryStringDecoder.decodeComponent)
+    val segments =
+      request.path.dropWhile(_ == '/').split("/").view.map(s => QueryStringDecoder.decodeComponent(s.replace("+", "%2B"))).toList
     if (segments == List("")) Nil else segments // representing the root path as an empty list
   }
   override def underlying: Any = request

--- a/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraServerRequest.scala
+++ b/server/finatra-server/src/main/scala/sttp/tapir/server/finatra/FinatraServerRequest.scala
@@ -1,7 +1,6 @@
 package sttp.tapir.server.finatra
 
 import com.twitter.finagle.http.Request
-import io.netty.handler.codec.http.QueryStringDecoder
 import sttp.model.{Header, Method, QueryParams, Uri}
 import sttp.tapir.{AttributeKey, AttributeMap}
 import sttp.tapir.model.{ConnectionInfo, ServerRequest}
@@ -17,8 +16,7 @@ case class FinatraServerRequest(request: Request, attributes: AttributeMap = Att
   override lazy val queryParameters: QueryParams =
     QueryParams.fromMultiMap(request.params.keys.toList.map(k => k -> request.params.getAll(k).toList).toMap)
   override lazy val pathSegments: List[String] = {
-    val segments =
-      request.path.dropWhile(_ == '/').split("/").view.map(s => QueryStringDecoder.decodeComponent(s.replace("+", "%2B"))).toList
+    val segments = uri.pathSegments.segments.map(_.v).filter(_.nonEmpty).toList
     if (segments == List("")) Nil else segments // representing the root path as an empty list
   }
   override def underlying: Any = request

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/decoders/VertxServerRequest.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/decoders/VertxServerRequest.scala
@@ -1,7 +1,5 @@
 package sttp.tapir.server.vertx.decoders
 
-import io.netty.handler.codec.http.QueryStringDecoder
-
 import java.net.InetSocketAddress
 import io.vertx.core.net.SocketAddress
 import io.vertx.ext.web.RoutingContext
@@ -28,8 +26,7 @@ private[vertx] case class VertxServerRequest(rc: RoutingContext, attributes: Att
   override lazy val headers: Seq[Header] = rc.request.headers.entries.asScala.iterator.map(e => Header(e.getKey, e.getValue)).toList
   override lazy val queryParameters: QueryParams = Uri.unsafeParse(rc.request.uri()).params
   override lazy val pathSegments: List[String] = {
-    val path = Option(rc.request.path).getOrElse("")
-    val segments = path.dropWhile(_ == '/').split("/").view.map(s => QueryStringDecoder.decodeComponent(s.replace("+", "%2B"))).toList
+    val segments = uri.pathSegments.segments.map(_.v).filter(_.nonEmpty).toList
     if (segments == List("")) Nil else segments // representing the root path as an empty list
   }
 

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/decoders/VertxServerRequest.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/decoders/VertxServerRequest.scala
@@ -29,7 +29,7 @@ private[vertx] case class VertxServerRequest(rc: RoutingContext, attributes: Att
   override lazy val queryParameters: QueryParams = Uri.unsafeParse(rc.request.uri()).params
   override lazy val pathSegments: List[String] = {
     val path = Option(rc.request.path).getOrElse("")
-    val segments = path.dropWhile(_ == '/').split("/").toList.map(QueryStringDecoder.decodeComponent)
+    val segments = path.dropWhile(_ == '/').split("/").view.map(s => QueryStringDecoder.decodeComponent(s.replace("+", "%2B"))).toList
     if (segments == List("")) Nil else segments // representing the root path as an empty list
   }
 

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerRequest.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerRequest.scala
@@ -1,9 +1,9 @@
 package sttp.tapir.server.ziohttp
 
+import io.netty.handler.codec.http.QueryStringDecoder
 import sttp.model.{QueryParams, Uri, Header => SttpHeader, Method => SttpMethod}
 import sttp.tapir.{AttributeKey, AttributeMap}
 import sttp.tapir.model.{ConnectionInfo, ServerRequest}
-import zio.http.Path
 import zio.http.Request
 
 import java.net.InetSocketAddress
@@ -18,7 +18,8 @@ case class ZioHttpServerRequest(req: Request, attributes: AttributeMap = Attribu
       None
     )
   override def underlying: Any = req
-  override lazy val pathSegments: List[String] = req.url.path.segments.toList
+  override lazy val pathSegments: List[String] =
+    req.url.path.segments.view.map(s => QueryStringDecoder.decodeComponent(s.replace("+", "%2B"))).toList
   override lazy val queryParameters: QueryParams = QueryParams.fromMultiMap(req.url.queryParams.map)
   override lazy val method: SttpMethod = SttpMethod(req.method.name.toUpperCase)
   override lazy val uri: Uri = Uri.unsafeParse(req.url.encode)

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerRequest.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerRequest.scala
@@ -1,6 +1,5 @@
 package sttp.tapir.server.ziohttp
 
-import io.netty.handler.codec.http.QueryStringDecoder
 import sttp.model.{QueryParams, Uri, Header => SttpHeader, Method => SttpMethod}
 import sttp.tapir.{AttributeKey, AttributeMap}
 import sttp.tapir.model.{ConnectionInfo, ServerRequest}
@@ -18,8 +17,7 @@ case class ZioHttpServerRequest(req: Request, attributes: AttributeMap = Attribu
       None
     )
   override def underlying: Any = req
-  override lazy val pathSegments: List[String] =
-    req.url.path.segments.view.map(s => QueryStringDecoder.decodeComponent(s.replace("+", "%2B"))).toList
+  override lazy val pathSegments: List[String] = uri.pathSegments.segments.map(_.v).filter(_.nonEmpty).toList
   override lazy val queryParameters: QueryParams = QueryParams.fromMultiMap(req.url.queryParams.map)
   override lazy val method: SttpMethod = SttpMethod(req.method.name.toUpperCase)
   override lazy val uri: Uri = Uri.unsafeParse(req.url.encode)

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
@@ -250,7 +250,6 @@ class ZioHttpServerTest extends TestSuite {
           createServerTest,
           interpreter,
           multipleValueHeaderSupport = false,
-          supportsUrlEncodedPathSegments = false,
           supportsMultipleSetCookieHeaders = false,
           invulnerableToUnsanitizedHeaders = false
         ).tests() ++


### PR DESCRIPTION
Fixes #3384

Inspired by how Vert.x does this: https://github.com/vert-x3/vertx-web/pull/443/files#diff-1ddd6931545856eae625d256298d4252ce3c89150ad3ee83db5c9d985427b79bR255