### PR TITLE
Fix codegen method parsing

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -195,7 +195,7 @@ object OpenapiModels {
         .downField("parameters")
         .as[Option[Seq[Resolvable[OpenapiParameter]]]]
         .map(_.getOrElse(Nil))
-      methods <- List("get", "put", "post", "delete", "options", "head", "patch", "patch", "connect")
+      methods <- List("get", "put", "post", "delete", "options", "head", "patch", "connect", "trace")
         .traverse(method => c.downField(method).as[Option[OpenapiPathMethod]].map(_.map(_.copy(methodType = method))))
     } yield OpenapiPath("--partial--", methods.flatten, parameters)
   }


### PR DESCRIPTION
Endpoint using `patch` method is generated twice and not at all when using `trace`.