### PR TITLE
Fix Circe Yaml

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,6 +1,7 @@
 updates.ignore = [
   {groupId = "org.scala-lang", artifactId = "scala-compiler", version = "2.12."},
   {groupId = "org.scala-lang", artifactId = "scala-compiler", version = "2.13."},
-  {groupId = "org.scala-lang", artifactId = "scala-compiler", version = "3."}
+  {groupId = "org.scala-lang", artifactId = "scala-compiler", version = "3."},
+  {groupId = "io.circe", artifactId="circe-yaml", version="1.15.0" }
 ]
 updates.pin = [{ groupId = "com.typesafe.akka", version = "2.6." }]

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -6,7 +6,7 @@ object Versions {
   val catsEffect = "3.5.2"
   val circe = "0.14.6"
   val circeGenericExtras = "0.14.3"
-  val circeYaml = "1.15.0"
+  val circeYaml = "0.15.1"
   val helidon = "4.0.0"
   val sttp = "3.9.1"
   val sttpModel = "1.7.6"


### PR DESCRIPTION
Circe Yaml 1.15.0 was released by mistake ([see circe-yaml](https://github.com/circe/circe-yaml/releases/tag/mistake-v1.15.0)).

- Replaced circe-yaml version with 0.15.1 ([see circe-yaml release](https://github.com/circe/circe-yaml/releases/tag/v0.15.1))
- Add ignore for circe 1.15.0 in scala-steward conf.