### PR TITLE
Support MaxContentLength for zio-http, fix file upload

### DIFF
--- a/doc/endpoint/security.md
+++ b/doc/endpoint/security.md
@@ -52,7 +52,7 @@ Optional and multiple authentication inputs have some additional rules as to how
 ## Limiting request body length
 
 *Unsupported backends*: 
-This feature is available for all server backends *except*: `akka-grpc`, `Armeria`, `Finatra`, `Helidon Nima`, `pekko-grpc`, `zio-http`. 
+This feature is available for all server backends *except*: `akka-grpc`, `Armeria`, `Finatra`, `Helidon Nima`, `pekko-grpc`. 
 
 Individual endpoints can be annotated with content length limit:
 

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpRequestBody.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpRequestBody.scala
@@ -2,14 +2,12 @@ package sttp.tapir.server.ziohttp
 
 import sttp.capabilities
 import sttp.capabilities.zio.ZioStreams
-import sttp.tapir.{FileRange, InputStreamRange}
-import sttp.tapir.RawBodyType
 import sttp.tapir.model.ServerRequest
-import sttp.tapir.server.interpreter.RawValue
-import sttp.tapir.server.interpreter.RequestBody
+import sttp.tapir.server.interpreter.{RawValue, RequestBody}
+import sttp.tapir.{FileRange, InputStreamRange, RawBodyType}
 import zio.http.Request
+import zio.stream.{Stream, ZSink, ZStream}
 import zio.{RIO, Task, ZIO}
-import zio.stream.Stream
 
 import java.io.ByteArrayInputStream
 import java.nio.ByteBuffer
@@ -17,16 +15,25 @@ import java.nio.ByteBuffer
 class ZioHttpRequestBody[R](serverOptions: ZioHttpServerOptions[R]) extends RequestBody[RIO[R, *], ZioStreams] {
   override val streams: capabilities.Streams[ZioStreams] = ZioStreams
 
-  override def toRaw[RAW](serverRequest: ServerRequest, bodyType: RawBodyType[RAW], maxBytes: Option[Long]): Task[RawValue[RAW]] = bodyType match {
-    case RawBodyType.StringBody(defaultCharset) => asByteArray(serverRequest).map(new String(_, defaultCharset)).map(RawValue(_))
-    case RawBodyType.ByteArrayBody              => asByteArray(serverRequest).map(RawValue(_))
-    case RawBodyType.ByteBufferBody             => asByteArray(serverRequest).map(bytes => ByteBuffer.wrap(bytes)).map(RawValue(_))
-    case RawBodyType.InputStreamBody            => asByteArray(serverRequest).map(new ByteArrayInputStream(_)).map(RawValue(_))
-    case RawBodyType.InputStreamRangeBody =>
-      asByteArray(serverRequest).map(bytes => new InputStreamRange(() => new ByteArrayInputStream(bytes))).map(RawValue(_))
-    case RawBodyType.FileBody =>
-      serverOptions.createFile(serverRequest).map(d => FileRange(d)).flatMap(file => ZIO.succeed(RawValue(file, Seq(file))))
-    case RawBodyType.MultipartBody(_, _) => ZIO.fail(new UnsupportedOperationException("Multipart is not supported"))
+  override def toRaw[RAW](serverRequest: ServerRequest, bodyType: RawBodyType[RAW], maxBytes: Option[Long]): Task[RawValue[RAW]] = {
+
+    def asByteArray: Task[Array[Byte]] =
+      (toStream(serverRequest, maxBytes).asInstanceOf[ZStream[Any, Throwable, Byte]]).runCollect.map(_.toArray)
+
+    bodyType match {
+      case RawBodyType.StringBody(defaultCharset) => asByteArray.map(new String(_, defaultCharset)).map(RawValue(_))
+      case RawBodyType.ByteArrayBody              => asByteArray.map(RawValue(_))
+      case RawBodyType.ByteBufferBody             => asByteArray.map(bytes => ByteBuffer.wrap(bytes)).map(RawValue(_))
+      case RawBodyType.InputStreamBody            => asByteArray.map(new ByteArrayInputStream(_)).map(RawValue(_))
+      case RawBodyType.InputStreamRangeBody =>
+        asByteArray.map(bytes => new InputStreamRange(() => new ByteArrayInputStream(bytes))).map(RawValue(_))
+      case RawBodyType.FileBody =>
+        for {
+          file <- serverOptions.createFile(serverRequest)
+          _ <- (toStream(serverRequest, maxBytes).asInstanceOf[ZStream[Any, Throwable, Byte]]).run(ZSink.fromFile(file)).map(_ => ())
+        } yield RawValue(FileRange(file), Seq(FileRange(file)))
+      case RawBodyType.MultipartBody(_, _) => ZIO.fail(new UnsupportedOperationException("Multipart is not supported"))
+    }
   }
 
   override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = {
@@ -37,7 +44,6 @@ class ZioHttpRequestBody[R](serverOptions: ZioHttpServerOptions[R]) extends Requ
   private def stream(serverRequest: ServerRequest): Stream[Throwable, Byte] =
     zioHttpRequest(serverRequest).body.asStream
 
-  private def asByteArray(serverRequest: ServerRequest): Task[Array[Byte]] = zioHttpRequest(serverRequest).body.asArray
-
   private def zioHttpRequest(serverRequest: ServerRequest) = serverRequest.underlying.asInstanceOf[Request]
 }
+

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
@@ -252,18 +252,16 @@ class ZioHttpServerTest extends TestSuite {
           multipleValueHeaderSupport = false,
           supportsMultipleSetCookieHeaders = false,
           invulnerableToUnsanitizedHeaders = false,
-          maxContentLength = false
+          maxContentLength = true
         ).tests() ++
-          // TODO: re-enable static content once a newer zio http is available. Currently these tests often fail with:
-          // Cause: java.io.IOException: parsing HTTP/1.1 status line, receiving [f2 content], parser state [STATUS_LINE]
           new AllServerTests(
             createServerTest,
             interpreter,
             backend,
             basic = false,
-            staticContent = false,
+            staticContent = true,
             multipart = false,
-            file = false,
+            file = true,
             options = false
           ).tests() ++
           new ServerStreamingTests(createServerTest).tests(ZioStreams)(drainZStream) ++


### PR DESCRIPTION
This PR enables max request body checks for `zio-http` for raw requests (which are streaming requests underneath anyway).
It also fixes handling of `FileBody`, which wasn't writing anything to the file. From now on, static content and file upload tests are enabled as well.