### PR TITLE
Fix Json Schema meta schema ID

### DIFF
--- a/doc/docs/json-schema.md
+++ b/doc/docs/json-schema.md
@@ -71,7 +71,7 @@ You can also disable generation of default title fields by setting an option `ad
 
 ```json
 {
-  "$schema" : "https://json-schema.org/draft-04/schema#",
+  "$schema" : "http://json-schema.org/draft-04/schema#",
   "required" : [
     "innerChildField",
     "childDetails"

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/MetaSchema.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/schema/MetaSchema.scala
@@ -5,5 +5,5 @@ sealed trait MetaSchema {
 }
 
 case object MetaSchemaDraft04 extends MetaSchema {
-  override lazy val schemaId: String = "https://json-schema.org/draft-04/schema#"
+  override lazy val schemaId: String = "http://json-schema.org/draft-04/schema#"
 }

--- a/docs/apispec-docs/src/test/scala/sttp/tapir/docs/apispec/schema/TapirSchemaToJsonSchemaTest.scala
+++ b/docs/apispec-docs/src/test/scala/sttp/tapir/docs/apispec/schema/TapirSchemaToJsonSchemaTest.scala
@@ -26,7 +26,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val result: ASchema = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true)
 
     // then
-    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}},"$$defs":{"Child":{"title":"Child","required":["childId"],"type":"object","properties":{"childId":{"type":"string"},"childNames":{"type":"array","items":{"type":"string"}}}}}}"""
+    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"http://json-schema.org/draft-04/schema#","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}},"$$defs":{"Child":{"title":"Child","required":["childId"],"type":"object","properties":{"childId":{"type":"string"},"childNames":{"type":"array","items":{"type":"string"}}}}}}"""
 
   }
 
@@ -38,7 +38,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true)
 
     // then
-    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","type":"array","items":{"type":"integer","format":"int32"}}"""
+    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"http://json-schema.org/draft-04/schema#","type":"array","items":{"type":"integer","format":"int32"}}"""
   }
 
   it should "handle repeated type names" in {
@@ -54,7 +54,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true)
 
     // then
-    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","required":["innerChildField","childDetails"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"},"childDetails":{"$$ref":"#/$$defs/Child1"}},"$$defs":{"Child":{"title":"Child","required":["childName"],"type":"object","properties":{"childName":{"type":"string"}}},"Child1":{"title":"Child1","required":["age"],"type":"object","properties":{"age":{"type":"integer","format":"int32"},"height":{"type":["integer", "null"],"format":"int32"}}}}}"""
+    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"http://json-schema.org/draft-04/schema#","required":["innerChildField","childDetails"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"},"childDetails":{"$$ref":"#/$$defs/Child1"}},"$$defs":{"Child":{"title":"Child","required":["childName"],"type":"object","properties":{"childName":{"type":"string"}}},"Child1":{"title":"Child1","required":["age"],"type":"object","properties":{"age":{"type":"integer","format":"int32"},"height":{"type":["integer", "null"],"format":"int32"}}}}}"""
   }
 
   it should "handle options as not nullable" in {
@@ -67,7 +67,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = false)
 
     // then
-    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}},"$$defs":{"Child":{"title":"Child","type":"object","properties":{"childName":{"type":"string"}}}}}"""
+    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"http://json-schema.org/draft-04/schema#","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}},"$$defs":{"Child":{"title":"Child","type":"object","properties":{"childName":{"type":"string"}}}}}"""
 
   }
 
@@ -81,7 +81,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true)
 
     // then
-    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}},"$$defs":{"Child":{"title":"Child","type":"object","properties":{"childName":{"type":["string","null"]}}}}}"""
+    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"http://json-schema.org/draft-04/schema#","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}},"$$defs":{"Child":{"title":"Child","type":"object","properties":{"childName":{"type":["string","null"]}}}}}"""
   }
 
   it should "use title from annotation or ref name" in {
@@ -100,7 +100,7 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true)
 
     // then
-    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","title":"MyOwnTitle1","required":["inner"],"type":"object","properties":{"inner":{"$$ref":"#/$$defs/Parent"}},"$$defs":{"Parent":{"title":"Parent","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}}},"Child":{"title":"MyOwnTitle3","type":"object","properties":{"childName":{"type":["string","null"]}}}}}"""
+    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"http://json-schema.org/draft-04/schema#","title":"MyOwnTitle1","required":["inner"],"type":"object","properties":{"inner":{"$$ref":"#/$$defs/Parent"}},"$$defs":{"Parent":{"title":"Parent","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}}},"Child":{"title":"MyOwnTitle3","type":"object","properties":{"childName":{"type":["string","null"]}}}}}"""
   }
 
   it should "NOT use generate default titles if disabled" in {
@@ -116,6 +116,6 @@ class JsonSchemasTest extends AnyFlatSpec with Matchers with OptionValues with E
     val result = TapirSchemaToJsonSchema(tSchema, markOptionsAsNullable = true, addTitleToDefs = false)
 
     // then
-    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"https://json-schema.org/draft-04/schema#","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}},"$$defs":{"Child":{"title":"MyChild","type":"object","properties":{"childName":{"type":["string","null"]}}}}}"""
+    result.asJson.deepDropNullValues shouldBe json"""{"$$schema":"http://json-schema.org/draft-04/schema#","required":["innerChildField"],"type":"object","properties":{"innerChildField":{"$$ref":"#/$$defs/Child"}},"$$defs":{"Child":{"title":"MyChild","type":"object","properties":{"childName":{"type":["string","null"]}}}}}"""
   }
 }


### PR DESCRIPTION
The meta schema ID for Draft 4 uses `http`, not `https`, according to https://json-schema.org/understanding-json-schema/reference/schema. Having it as `https` causes some parsers to reject the schema ID, even though it's also available there.