### PR TITLE
[bugfix] Close the DefaultEventExecutor on shutdown

### DIFF
--- a/server/netty-server/loom/src/main/scala/sttp/tapir/server/netty/loom/NettyIdServer.scala
+++ b/server/netty-server/loom/src/main/scala/sttp/tapir/server/netty/loom/NettyIdServer.scala
@@ -87,7 +87,8 @@ case class NettyIdServer(routes: Vector[IdRoute], options: NettyIdServerOptions,
         }
       )
     }
-    val channelGroup = new DefaultChannelGroup(new DefaultEventExecutor()) // thread safe
+    val eventExecutor = new DefaultEventExecutor()
+    val channelGroup = new DefaultChannelGroup(eventExecutor) // thread safe
     val isShuttingDown: AtomicBoolean = new AtomicBoolean(false)
 
     val channelIdFuture = NettyBootstrap(
@@ -106,7 +107,7 @@ case class NettyIdServer(routes: Vector[IdRoute], options: NettyIdServerOptions,
 
     (
       channelId.localAddress().asInstanceOf[SA],
-      () => stop(channelId, eventLoopGroup, channelGroup, isShuttingDown, config.gracefulShutdownTimeout)
+      () => stop(channelId, eventLoopGroup, channelGroup, eventExecutor, isShuttingDown, config.gracefulShutdownTimeout)
     )
   }
 
@@ -124,6 +125,7 @@ case class NettyIdServer(routes: Vector[IdRoute], options: NettyIdServerOptions,
       ch: Channel,
       eventLoopGroup: EventLoopGroup,
       channelGroup: ChannelGroup,
+      eventExecutor: DefaultEventExecutor,
       isShuttingDown: AtomicBoolean,
       gracefulShutdownTimeout: Option[FiniteDuration]
   ): Unit = {
@@ -135,7 +137,8 @@ case class NettyIdServer(routes: Vector[IdRoute], options: NettyIdServerOptions,
     )
     ch.close().get()
     if (config.shutdownEventLoopGroupOnClose) {
-      val _ = eventLoopGroup.shutdownGracefully().get()
+      eventLoopGroup.shutdownGracefully().get(): Unit
+      eventExecutor.shutdownGracefully().get(): Unit
     }
   }
 }

--- a/server/netty-server/loom/src/main/scala/sttp/tapir/server/netty/loom/NettyIdServer.scala
+++ b/server/netty-server/loom/src/main/scala/sttp/tapir/server/netty/loom/NettyIdServer.scala
@@ -137,8 +137,8 @@ case class NettyIdServer(routes: Vector[IdRoute], options: NettyIdServerOptions,
     )
     ch.close().get()
     if (config.shutdownEventLoopGroupOnClose) {
-      eventLoopGroup.shutdownGracefully().get(): Unit
-      eventExecutor.shutdownGracefully().get(): Unit
+      val _ = eventLoopGroup.shutdownGracefully().get()
+      val _ = eventExecutor.shutdownGracefully().get()
     }
   }
 }


### PR DESCRIPTION
Netty's `DefaultEventExecutor` has to be explicitly shut down, otherwise it may leave a hanging thread, preventing JVM from closing.