### PR TITLE
[bugfix] Release Netty buffers

### DIFF
--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/FileWriterSubscriber.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/FileWriterSubscriber.scala
@@ -42,11 +42,13 @@ class FileWriterSubscriber(path: Path) extends PromisingSubscriber[Unit, HttpCon
       (),
       new java.nio.channels.CompletionHandler[Integer, Unit] {
         override def completed(result: Integer, attachment: Unit): Unit = {
+          httpContent.release()
           position += result
           subscription.request(1)
         }
 
         override def failed(exc: Throwable, attachment: Unit): Unit = {
+          httpContent.release()
           subscription.cancel()
           onError(exc)
         }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/SimpleSubscriber.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/SimpleSubscriber.scala
@@ -25,9 +25,10 @@ private[netty] class SimpleSubscriber() extends PromisingSubscriber[Array[Byte],
   }
 
   override def onNext(content: HttpContent): Unit = {
-    val a = ByteBufUtil.getBytes(content.content())
-    size += a.length
-    chunks.add(a)
+    val array = ByteBufUtil.getBytes(content.content())
+    content.release()
+    size += array.length
+    chunks.add(array)
     subscription.request(1)
   }
       


### PR DESCRIPTION
During performance tests of Netty servers (https://github.com/softwaremill/tapir/pull/3434) I noticed log entries like:

```
[info] 2024-01-22 11:04:21,657 [epollEventLoopGroup-2-4] ERROR io.netty.util.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
[info] Recent access records:
[info] Created at:
[info]  io.netty.buffer.SimpleLeakAwareByteBuf.unwrappedDerived(SimpleLeakAwareByteBuf.java:144)
```

This fix adds explicit release of resources, which makes the problematic logs go away. We'll look deeper into memory consumption with a profiler using performance tests.