### PR TITLE
Add Scala 3 support to sttp-mock-server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,15 +3,15 @@ import com.softwaremill.SbtSoftwareMillBrowserTestJS._
 import com.softwaremill.SbtSoftwareMillCommon.commonSmlBuildSettings
 import com.softwaremill.UpdateVersionInDocs
 import com.typesafe.tools.mima.core.{Problem, ProblemFilters}
+import complete.DefaultParsers._
 import sbt.Reference.display
 import sbt.internal.ProjectMatrix
+// explicit import to avoid clash with gatling plugin
 import sbtassembly.AssemblyPlugin.autoImport.assembly
 
 import java.net.URL
 import scala.concurrent.duration.DurationInt
 import scala.sys.process.Process
-
-import complete.DefaultParsers._
 
 val scala2_12 = "2.12.18"
 val scala2_13 = "2.13.12"

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ import com.typesafe.tools.mima.core.{Problem, ProblemFilters}
 import complete.DefaultParsers._
 import sbt.Reference.display
 import sbt.internal.ProjectMatrix
+
 // explicit import to avoid clash with gatling plugin
 import sbtassembly.AssemblyPlugin.autoImport.assembly
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,16 +3,15 @@ import com.softwaremill.SbtSoftwareMillBrowserTestJS._
 import com.softwaremill.SbtSoftwareMillCommon.commonSmlBuildSettings
 import com.softwaremill.UpdateVersionInDocs
 import com.typesafe.tools.mima.core.{Problem, ProblemFilters}
-import complete.DefaultParsers._
 import sbt.Reference.display
 import sbt.internal.ProjectMatrix
-
-// explicit import to avoid clash with gatling plugin
 import sbtassembly.AssemblyPlugin.autoImport.assembly
 
 import java.net.URL
 import scala.concurrent.duration.DurationInt
 import scala.sys.process.Process
+
+import complete.DefaultParsers._
 
 val scala2_12 = "2.12.18"
 val scala2_13 = "2.13.12"
@@ -1330,7 +1329,7 @@ lazy val sttpMockServer: ProjectMatrix = (projectMatrix in file("server/sttp-moc
       "org.mock-server" % "mockserver-netty" % Versions.mockServer % Test
     )
   )
-  .jvmPlatform(scalaVersions = scala2Versions)
+  .jvmPlatform(scalaVersions = scala2And3Versions)
   .dependsOn(serverCore, serverTests % "test", sttpClient)
 
 lazy val finatraServer: ProjectMatrix = (projectMatrix in file("server/finatra-server"))

--- a/server/sttp-mock-server/src/main/scala/sttp/tapir/server/mockserver/impl/JsonCodecs.scala
+++ b/server/sttp-mock-server/src/main/scala/sttp/tapir/server/mockserver/impl/JsonCodecs.scala
@@ -1,10 +1,8 @@
 package sttp.tapir.server.mockserver.impl
 
-import io.circe.generic.codec.DerivedAsObjectCodec
-import io.circe.{Codec, CursorOp, Decoder, DecodingFailure, Encoder, Json, JsonObject}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax._
-import shapeless.Lazy
+import io.circe.{CursorOp, Decoder, DecodingFailure, Encoder, Json, JsonObject}
 import sttp.model.{MediaType, Method, StatusCode, Uri}
 import sttp.tapir.server.mockserver.ExpectationBodyDefinition.JsonMatchType
 import sttp.tapir.server.mockserver.{
@@ -83,19 +81,21 @@ private[mockserver] object JsonCodecs {
       }
   }
 
-  private def deriveCodecDropNull[A](implicit codec: Lazy[DerivedAsObjectCodec[A]]): Codec[A] =
-    Codec.from(codec.value, codec.value.mapJson(_.dropNullValues))
-
-  private implicit val expectationRequestDefinitionCodec: Codec[ExpectationRequestDefinition] =
-    deriveCodecDropNull[ExpectationRequestDefinition]
-  private implicit val expectationResponseDefinitionCodec: Codec[ExpectationResponseDefinition] =
-    deriveCodecDropNull[ExpectationResponseDefinition]
-  private implicit val expectationTimesCodec: Codec[ExpectationTimes] = deriveCodecDropNull[ExpectationTimes]
-  private implicit val expectationTimeToLiveCodec: Codec[ExpectationTimeToLive] = deriveCodecDropNull[ExpectationTimeToLive]
-  private implicit val verificationTimesDefinitionCodec: Codec[VerificationTimesDefinition] =
-    deriveCodecDropNull[VerificationTimesDefinition]
+  private implicit val expectationRequestDefinitionEncoder: Encoder[ExpectationRequestDefinition] =
+    deriveEncoder[ExpectationRequestDefinition].mapJson(_.dropNullValues)
+  private implicit val expectationResponseDefinitionEncoder: Encoder[ExpectationResponseDefinition] =
+    deriveEncoder[ExpectationResponseDefinition].mapJson(_.dropNullValues)
+  private implicit val verificationTimesDefinitionEncoder: Encoder[VerificationTimesDefinition] =
+    deriveEncoder[VerificationTimesDefinition].mapJson(_.dropNullValues)
 
   implicit val createExpectationRequestEncoder: Encoder[CreateExpectationRequest] = deriveEncoder[CreateExpectationRequest]
   implicit val verifyExpectationRequestEncoder: Encoder[VerifyExpectationRequest] = deriveEncoder[VerifyExpectationRequest]
+
+  private implicit val expectationRequestDefinitionDecoder: Decoder[ExpectationRequestDefinition] =
+    deriveDecoder[ExpectationRequestDefinition]
+  private implicit val expectationResponseDefinitionDecoder: Decoder[ExpectationResponseDefinition] =
+    deriveDecoder[ExpectationResponseDefinition]
+  private implicit val expectationTimesDecoder: Decoder[ExpectationTimes] = deriveDecoder[ExpectationTimes]
+  private implicit val expectationTimeToLiveDecoder: Decoder[ExpectationTimeToLive] = deriveDecoder[ExpectationTimeToLive]
   implicit val expectationDecoder: Decoder[Expectation] = deriveDecoder[Expectation]
 }


### PR DESCRIPTION
Closes #3477

Adding extra Circe Encoder/Decoder Boilerplate to remove the need to use Shapeless and thus supporting Scala 3 for sttp-mock-server