### PR TITLE
Release netty buffers after use

### DIFF
--- a/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/internal/ZioStreamCompatible.scala
+++ b/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/internal/ZioStreamCompatible.scala
@@ -50,7 +50,11 @@ private[zio] object ZioStreamCompatible {
         val stream =
           Adapters
             .publisherToStream(publisher, bufferSize = 2)
-            .map(httpContent => Chunk.fromByteBuffer(httpContent.content.nioBuffer()))
+            .map { httpContent =>
+              val bytes = Chunk.fromByteBuffer(httpContent.content.nioBuffer())
+              httpContent.release()
+              bytes
+            }
             .flattenChunks
         maxBytes.map(ZioStreams.limitBytes(stream, _)).getOrElse(stream)
       }


### PR DESCRIPTION
Without an explicit release, the netty leak detector occasionally complains of leakage like this:
ERROR i.n.u.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information. This change immediately 
releases the buffer after conversion to Chunk and silences the leak detector.
