### PR TITLE
[bugfix] Fix memory leak of Netty byte buffer in netty.cats server

### DIFF
--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/internal/Fs2StreamCompatible.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/internal/Fs2StreamCompatible.scala
@@ -55,7 +55,7 @@ object Fs2StreamCompatible {
           .flatMap(httpContent =>
             fs2.Stream.chunk {
               val fs2Chunk = Chunk.byteBuffer(httpContent.content.nioBuffer())
-              httpContent.release() // https://netty.io/wiki/reference-counted-oubjects.html
+              httpContent.release() // https://netty.io/wiki/reference-counted-objects.html
               fs2Chunk
             }
           )


### PR DESCRIPTION
Inspired by https://github.com/softwaremill/tapir/pull/3485

Tested with
```
perfTests/Test/runMain sttp.tapir.perf.PerfTestSuiteRunner -s netty.cats.Tapir -m PostBytes,PostLongBytes -d 25 -u 15
```