### PR TITLE
Improve CSV reports for perf tests

### DIFF
--- a/perf-tests/src/test/scala/sttp/tapir/perf/CsvReportPrinter.scala
+++ b/perf-tests/src/test/scala/sttp/tapir/perf/CsvReportPrinter.scala
@@ -1,10 +1,11 @@
 package sttp.tapir.perf
 
 object CsvReportPrinter {
-  def print(results: List[GatlingSimulationResult]): String = {
+  def print(results: List[GatlingSimulationResult], initialSimOrdering: List[String]): String = {
 
     val groupedResults = results.groupBy(_.simulationName)
-    val headers = "Simulation" :: groupedResults.values.head.flatMap(r => {
+    val orderedResults = initialSimOrdering.flatMap(simName => groupedResults.get(simName).map(simName -> _))
+    val headers = "Simulation" :: orderedResults.head._2.flatMap(r => {
       val server = r.serverName
       List(
         s"$server-ops/sec",
@@ -14,7 +15,7 @@ object CsvReportPrinter {
         s"$server-latency-p50"
       )
     })
-    val rows: List[String] = groupedResults.toList.map { case (simName, serverResults) =>
+    val rows: List[String] = orderedResults.map { case (simName, serverResults) =>
       (simName :: serverResults.flatMap(singleResult =>
         List(
           singleResult.meanReqsPerSec.toString,

--- a/perf-tests/src/test/scala/sttp/tapir/perf/CsvReportPrinter.scala
+++ b/perf-tests/src/test/scala/sttp/tapir/perf/CsvReportPrinter.scala
@@ -8,11 +8,11 @@ object CsvReportPrinter {
     val headers = "Simulation" :: orderedResults.head._2.flatMap(r => {
       val server = r.serverName
       List(
-        s"$server-ops/sec",
-        s"$server-latency-p99",
-        s"$server-latency-p95",
-        s"$server-latency-p75",
-        s"$server-latency-p50"
+        s"$server reqs/s",
+        s"$server latency-p99",
+        s"$server latency-p95",
+        s"$server latency-p75",
+        s"$server latency-p50"
       )
     })
     val rows: List[String] = orderedResults.map { case (simName, serverResults) =>

--- a/perf-tests/src/test/scala/sttp/tapir/perf/PerfTestSuiteRunner.scala
+++ b/perf-tests/src/test/scala/sttp/tapir/perf/PerfTestSuiteRunner.scala
@@ -40,7 +40,7 @@ object PerfTestSuiteRunner extends IOApp {
       .traverse { case ((simulationName, shortSimulationName), (serverName, shortServerName)) =>
         for {
           serverKillSwitch <- startServerByTypeName(serverName)
-          _ <- IO.println(s"Running server $shortServerName")
+          _ <- IO.println(s"Running server $shortServerName, simulation $simulationName")
           _ <- (for {
             _ <- IO.println("======================== WARM-UP ===============================================")
             _ = setSimulationParams(users = WarmupUsers, duration = WarmupDuration, warmup = true)
@@ -55,7 +55,7 @@ object PerfTestSuiteRunner extends IOApp {
           _ <- IO.println(serverSimulationResult)
         } yield (serverSimulationResult)
       }
-      .flatTap(writeCsvReport(currentTime))
+      .flatTap(writeCsvReport(currentTime, params.simulationNames.map(_._2)))
       .flatTap(writeHtmlReport(currentTime))
       .as(ExitCode.Success)
   }
@@ -78,11 +78,11 @@ object PerfTestSuiteRunner extends IOApp {
   private def setSimulationParams(users: Int, duration: FiniteDuration, warmup: Boolean): Unit = {
     System.setProperty("tapir.perf.user-count", users.toString)
     System.setProperty("tapir.perf.duration-seconds", duration.toSeconds.toString)
-    System.setProperty("tapir.perf.is-warm-up", warmup.toString) : Unit
+    System.setProperty("tapir.perf.is-warm-up", warmup.toString): Unit
   }
 
-  private def writeCsvReport(currentTime: String)(results: List[GatlingSimulationResult]): IO[Unit] = {
-    val csv = CsvReportPrinter.print(results)
+  private def writeCsvReport(currentTime: String, initialSimOrdering: List[String])(results: List[GatlingSimulationResult]): IO[Unit] = {
+    val csv = CsvReportPrinter.print(results, initialSimOrdering)
     writeReportFile(csv, "csv", currentTime)
   }
 


### PR DESCRIPTION
When specifying test order in the command, columns in the report should be in the same order, so that it's easier and faster to copy the results into a sheet which generates charts.