### PR TITLE
Pin scopt 3.7.1

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -4,4 +4,8 @@ updates.ignore = [
   {groupId = "org.scala-lang", artifactId = "scala-compiler", version = "3."},
   {groupId = "io.circe", artifactId="circe-yaml", version="1.15.0" }
 ]
-updates.pin = [{ groupId = "com.typesafe.akka", version = "2.6." }]
+updates.pin = [
+  {groupId = "com.typesafe.akka", version = "2.6."},
+  # Gatling uses scopt 3.7.1 and fails on Gatling/testOnly for scopt 4.x
+  {groupId = "com.github.scopt", artifactId = "scopt", version = "3.7.1"}
+]


### PR DESCRIPTION
Gatling uses scopt 3.7.1 and fails on Gatling/testOnly for scopt 4.x