### PR TITLE
Codegen form-data support

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -4,6 +4,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaAny,
   OpenapiSchemaBoolean,
+  OpenapiSchemaBinary,
   OpenapiSchemaDateTime,
   OpenapiSchemaDouble,
   OpenapiSchemaEnum,
@@ -70,6 +71,8 @@ object BasicGenerator {
         ("String", nb)
       case OpenapiSchemaBoolean(nb) =>
         ("Boolean", nb)
+      case OpenapiSchemaBinary(nb) =>
+        ("sttp.model.Part[java.io.File]", nb)
       case OpenapiSchemaAny(nb) =>
         ("io.circe.Json", nb)
       case OpenapiSchemaRef(t) =>


### PR DESCRIPTION
Adds multipart body support for codegen.

```yaml
paths:
  /files:
    post:
      requestBody:
        content:
          multipart/form-data:
            schema:
              $ref: '#/components/schemas/UploadInput'
        required: true

components:
  schemas:
    UploadInput:
      type: object
      properties:
        name:
          type: string
        file:
          type: string
          format: binary
      required:
      - name
      - file
```