### PR TITLE
Perf test: WebSockets (http4s)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -516,7 +516,7 @@ lazy val perfTests: ProjectMatrix = (projectMatrix in file("perf-tests"))
       "nl.grons" %% "metrics4-scala" % Versions.metrics4Scala % Test,
       "com.lihaoyi" %% "scalatags" % Versions.scalaTags % Test,
       // Needs to match version used by Gatling
-      "com.github.scopt" %% "scopt" % "4.1.0",
+      "com.github.scopt" %% "scopt" % "3.7.1",
       "io.github.classgraph" % "classgraph" % "4.8.165" % Test,
       "org.http4s" %% "http4s-core" % Versions.http4s,
       "org.http4s" %% "http4s-dsl" % Versions.http4s,

--- a/perf-tests/README.md
+++ b/perf-tests/README.md
@@ -82,9 +82,22 @@ p99, p95, p75, and p50 percentiles for latencies of all requests sent during the
 To add a new server, go to `src/main/scala` and put an object extending `sttp.tapir.perf.apis.ServerRunner` in a subpackage of `sttp.tapir.perf`. 
 It should be automatically resoled by the `TypeScanner` utility used by the `PerfTestSuiteRunner`.
 
-Similarly with simulations. Go to `src/test/scala` and a class extending `io.gatling.core.Predef.Simulation` under `sttp.tapir.perf`. See the `Simulations.scala` 
+Similarly with simulations. Go to `src/test/scala` and a class extending `sttp.tapir.perf.PerfTestSuiteRunnerSimulation` under `sttp.tapir.perf`. See the `Simulations.scala` 
 file for examples.
 
 ## Testing WebSockets
 
-TODO
+`WebSocketsSimulation` cannot be executed using `PerfTestSuiteRunner`, as it requires special warmup and injection setup, it also won't store gatling log in a format expected by our report builder.
+For WebSockets we want to measure latency distribution, not throughput, so use given instructions to run it and read the report:
+
+1. Adjust simulation parameters in the `sttp.tapir.perf.WebSocketsSimulation` class
+2. Start a server using `ServerRunner`, for example:
+```
+perfTests/runMain sttp.tapir.perf.apis.ServerRunner http4s.Tapir
+```
+3. Run the simulation using Gatling's task:
+```
+perfTests/Gatling/testOnly sttp.tapir.perf.WebSocketsSimulation 
+```
+4. Read the histogram report generated in the end in your stdout.
+5. Stop the server manually.

--- a/perf-tests/README.md
+++ b/perf-tests/README.md
@@ -84,3 +84,7 @@ It should be automatically resoled by the `TypeScanner` utility used by the `Per
 
 Similarly with simulations. Go to `src/test/scala` and a class extending `io.gatling.core.Predef.Simulation` under `sttp.tapir.perf`. See the `Simulations.scala` 
 file for examples.
+
+## Testing WebSockets
+
+TODO

--- a/perf-tests/README.md
+++ b/perf-tests/README.md
@@ -99,5 +99,6 @@ perfTests/runMain sttp.tapir.perf.apis.ServerRunner http4s.Tapir
 ```
 perfTests/Gatling/testOnly sttp.tapir.perf.WebSocketsSimulation 
 ```
-4. Read the histogram report generated in the end in your stdout.
+4. A HdrHistogram report will be printed to stdout and to a file. Check output for the full path.
 5. Stop the server manually.
+6. Use [HDR Histogram Plotter](https://hdrhistogram.github.io/HdrHistogram/plotFiles.html) to plot histogram file(s)

--- a/perf-tests/src/main/scala/sttp/tapir/perf/Common.scala
+++ b/perf-tests/src/main/scala/sttp/tapir/perf/Common.scala
@@ -16,9 +16,11 @@ object Common {
   val Port = 8080
   val TmpDir: File = new java.io.File(System.getProperty("java.io.tmpdir")).getAbsoluteFile
   def newTempFilePath(): Path = TmpDir.toPath.resolve(s"tapir-${new Date().getTime}-${Random.nextLong()}")
-  def buildOptions[F[_], O](customiseInterceptors: CustomiseInterceptors[F, O],  withServerLog: Boolean): O = 
+  def buildOptions[F[_], O](customiseInterceptors: CustomiseInterceptors[F, O], withServerLog: Boolean): O =
     (if (withServerLog == false)
-      customiseInterceptors.serverLog(None)
-    else
-      customiseInterceptors).options
+       customiseInterceptors.serverLog(None)
+     else
+       customiseInterceptors).options
+  val WebSocketRequestsPerUser = 600
+  val WebSocketSingleResponseLag = 100.millis
 }

--- a/perf-tests/src/main/scala/sttp/tapir/perf/http4s/Http4s.scala
+++ b/perf-tests/src/main/scala/sttp/tapir/perf/http4s/Http4s.scala
@@ -18,9 +18,10 @@ import sttp.tapir.perf.apis._
 import sttp.tapir.server.http4s.{Http4sServerInterpreter, Http4sServerOptions}
 import sttp.tapir.{CodecFormat, endpoint, webSocketBody}
 
-import scala.concurrent.duration._
-
 object Http4sCommon {
+  // Websocket response is returned with a lag, so that we can have more concurrent users talking to the server.
+  // This lag is not relevant for measurements, because the server returns a timestamp after having a response ready to send back,
+  // so the client can measure only the latency of the server stack handling the response.
   val wsResponseStream = Stream.fixedRate[IO](WebSocketSingleResponseLag, dampen = false)
 }
 

--- a/perf-tests/src/main/scala/sttp/tapir/perf/http4s/Http4s.scala
+++ b/perf-tests/src/main/scala/sttp/tapir/perf/http4s/Http4s.scala
@@ -108,11 +108,15 @@ object Tapir extends Endpoints {
 }
 
 object server {
+  val maxConnections = 65536
+  val connectorPoolSize: Int = Math.max(2, Runtime.getRuntime.availableProcessors() / 4)
   def runServer(router: HttpRoutes[IO], webSocketApp: WebSocketBuilder2[IO] => HttpApp[IO]): IO[ServerRunner.KillSwitch] =
     BlazeServerBuilder[IO]
       .bindHttp(Port, "localhost")
       .withHttpApp(router.orNotFound)
       .withHttpWebSocketApp(webSocketApp)
+      .withMaxConnections(maxConnections)
+      .withConnectorPoolSize(connectorPoolSize)
       .resource
       .allocated
       .map(_._2)

--- a/perf-tests/src/main/scala/sttp/tapir/perf/http4s/Http4s.scala
+++ b/perf-tests/src/main/scala/sttp/tapir/perf/http4s/Http4s.scala
@@ -1,18 +1,28 @@
 package sttp.tapir.perf.http4s
 
 import cats.effect._
+import fs2._
 import fs2.io.file.{Files, Path => Fs2Path}
 import org.http4s._
 import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.dsl._
 import org.http4s.implicits._
 import org.http4s.server.Router
+import org.http4s.server.websocket.WebSocketBuilder2
+import org.http4s.websocket.WebSocketFrame
+import sttp.capabilities.fs2.Fs2Streams
 import sttp.monad.MonadError
 import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.perf.Common._
 import sttp.tapir.perf.apis._
-import sttp.tapir.server.http4s.Http4sServerInterpreter
-import sttp.tapir.server.http4s.Http4sServerOptions
+import sttp.tapir.server.http4s.{Http4sServerInterpreter, Http4sServerOptions}
+import sttp.tapir.{CodecFormat, endpoint, webSocketBody}
+
+import scala.concurrent.duration._
+
+object Http4sCommon {
+  val wsResponseStream = Stream.fixedRate[IO](100.millis, dampen = false)
+}
 
 object Vanilla {
   val router: Int => HttpRoutes[IO] = (nRoutes: Int) =>
@@ -44,11 +54,34 @@ object Vanilla {
         }
       ): _*
     )
+
+  def webSocketApp(wsb: WebSocketBuilder2[IO]): HttpApp[IO] = {
+    val dsl = new Http4sDsl[IO] {}
+    import dsl._
+    val receive: Pipe[IO, WebSocketFrame, Unit] = _.as(())
+    val responseStream = Http4sCommon.wsResponseStream.evalMap(_ => IO.realTime.map(ts => WebSocketFrame.Text(s"${ts.toMillis}")))
+
+    HttpRoutes
+      .of[IO] { case GET -> Root / "ws" / "ts" =>
+        wsb.withFilterPingPongs(true).build(responseStream, receive)
+      }
+      .orNotFound
+  }
 }
 
 object Tapir extends Endpoints {
 
   implicit val mErr: MonadError[IO] = new CatsMonadError[IO]
+
+  private val wsEndpoint = endpoint.get
+    .in("ts")
+    .out(
+      webSocketBody[Long, CodecFormat.TextPlain, Long, CodecFormat.TextPlain](Fs2Streams[IO])
+        .concatenateFragmentedFrames(false)
+        .autoPongOnPing(false)
+        .ignorePong(false)
+        .autoPing(None)
+    )
 
   def router(nRoutes: Int, withServerLog: Boolean = false): HttpRoutes[IO] = {
     val serverOptions = buildOptions(Http4sServerOptions.customiseInterceptors[IO], withServerLog)
@@ -58,13 +91,28 @@ object Tapir extends Endpoints {
       )
     })
   }
+
+  def wsApp(withServerLog: Boolean = false): WebSocketBuilder2[IO] => HttpApp[IO] = { wsb =>
+    val serverOptions = buildOptions(Http4sServerOptions.customiseInterceptors[IO], withServerLog)
+    Router("/ws" -> {
+      Http4sServerInterpreter[IO](serverOptions)
+        .toWebSocketRoutes(
+          wsEndpoint.serverLogicSuccess(_ =>
+            IO.pure { (in: Stream[IO, Long]) =>
+              Http4sCommon.wsResponseStream.evalMap(_ => IO.realTime.map(_.toMillis)).concurrently(in.as(()))
+            }
+          )
+        )(wsb)
+    }).orNotFound
+  }
 }
 
 object server {
-  def runServer(router: HttpRoutes[IO]): IO[ServerRunner.KillSwitch] =
+  def runServer(router: HttpRoutes[IO], webSocketApp: WebSocketBuilder2[IO] => HttpApp[IO]): IO[ServerRunner.KillSwitch] =
     BlazeServerBuilder[IO]
       .bindHttp(Port, "localhost")
       .withHttpApp(router.orNotFound)
+      .withHttpWebSocketApp(webSocketApp)
       .resource
       .allocated
       .map(_._2)
@@ -73,8 +121,10 @@ object server {
       })
 }
 
-object TapirServer extends ServerRunner { override def start = server.runServer(Tapir.router(1)) }
-object TapirMultiServer extends ServerRunner { override def start = server.runServer(Tapir.router(128)) }
-object TapirInterceptorMultiServer extends ServerRunner { override def start = server.runServer(Tapir.router(128, withServerLog = true)) }
-object VanillaServer extends ServerRunner { override def start = server.runServer(Vanilla.router(1)) }
-object VanillaMultiServer extends ServerRunner { override def start = server.runServer(Vanilla.router(128)) }
+object TapirServer extends ServerRunner { override def start = server.runServer(Tapir.router(1), Tapir.wsApp()) }
+object TapirMultiServer extends ServerRunner { override def start = server.runServer(Tapir.router(128), Tapir.wsApp()) }
+object TapirInterceptorMultiServer extends ServerRunner {
+  override def start = server.runServer(Tapir.router(128, withServerLog = true), Tapir.wsApp(withServerLog = true))
+}
+object VanillaServer extends ServerRunner { override def start = server.runServer(Vanilla.router(1), Vanilla.webSocketApp) }
+object VanillaMultiServer extends ServerRunner { override def start = server.runServer(Vanilla.router(128), Vanilla.webSocketApp) }

--- a/perf-tests/src/main/scala/sttp/tapir/perf/http4s/Http4s.scala
+++ b/perf-tests/src/main/scala/sttp/tapir/perf/http4s/Http4s.scala
@@ -21,7 +21,7 @@ import sttp.tapir.{CodecFormat, endpoint, webSocketBody}
 import scala.concurrent.duration._
 
 object Http4sCommon {
-  val wsResponseStream = Stream.fixedRate[IO](100.millis, dampen = false)
+  val wsResponseStream = Stream.fixedRate[IO](WebSocketSingleResponseLag, dampen = false)
 }
 
 object Vanilla {

--- a/perf-tests/src/test/scala/sttp/tapir/perf/Simulations.scala
+++ b/perf-tests/src/test/scala/sttp/tapir/perf/Simulations.scala
@@ -125,35 +125,38 @@ object CommonSimulations {
 
 import CommonSimulations._
 
-class SimpleGetSimulation extends Simulation {
+abstract class PerfTestSuiteRunnerSimulation extends Simulation
+
+class SimpleGetSimulation extends PerfTestSuiteRunnerSimulation {
   setUp(scenario_simple_get(0)): Unit
 }
 
-class SimpleGetMultiRouteSimulation extends Simulation {
+class SimpleGetMultiRouteSimulation extends PerfTestSuiteRunnerSimulation {
   setUp(scenario_simple_get(127)): Unit
 }
 
-class PostBytesSimulation extends Simulation {
+class PostBytesSimulation extends PerfTestSuiteRunnerSimulation {
   setUp(scenario_post_bytes(0)): Unit
 }
 
-class PostLongBytesSimulation extends Simulation {
+class PostLongBytesSimulation extends PerfTestSuiteRunnerSimulation {
   setUp(scenario_post_long_bytes(0)): Unit
 }
 
-class PostFileSimulation extends Simulation {
+class PostFileSimulation extends PerfTestSuiteRunnerSimulation {
   setUp(scenario_post_file(0)): Unit
 }
 
-class PostStringSimulation extends Simulation {
+class PostStringSimulation extends PerfTestSuiteRunnerSimulation {
   setUp(scenario_post_string(0)): Unit
 }
 
-class PostLongStringSimulation extends Simulation {
+class PostLongStringSimulation extends PerfTestSuiteRunnerSimulation {
   setUp(scenario_post_long_string(0)): Unit
 }
 
 /** Based on https://github.com/kamilkloch/websocket-benchmark/
+ *  Can't be executed using PerfTestSuiteRunner, see perfTests/README.md
   */
 class WebSocketsSimulation extends Simulation {
   private val numOfMessagesPerUser = 60 * 10 // for websocket scenario: 60 seconds with 10 msg/sec

--- a/perf-tests/src/test/scala/sttp/tapir/perf/TypeScanner.scala
+++ b/perf-tests/src/test/scala/sttp/tapir/perf/TypeScanner.scala
@@ -1,6 +1,5 @@
 package sttp.tapir.perf
 
-import io.gatling.core.scenario.Simulation
 import io.github.classgraph.ClassGraph
 import sttp.tapir.perf.apis.ServerRunner
 
@@ -40,7 +39,7 @@ object TypeScanner {
       .map(c => c.stripPrefix(s"${rootPackage}.").stripSuffix("Server$"))
 
   lazy val allSimulations: List[String] =
-    findAllImplementations[Simulation](rootPackage)
+    findAllImplementations[PerfTestSuiteRunnerSimulation](rootPackage)
       .map(_.getName)
       .map(c => c.stripPrefix(s"${rootPackage}.").stripSuffix("Simulation"))
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -60,7 +60,7 @@ object Versions {
   val openTelemetry = "1.35.0"
   val mockServer = "5.15.0"
   val dogstatsdClient = "4.3.0"
-  val nettyAll = "4.1.106.Final"
+  val nettyAll = "4.1.107.Final"
   val logback = "1.4.14"
   val slf4j = "2.0.12"
 }


### PR DESCRIPTION
This PR adds an endpoint for performance tests of WebSockets: `ws://127.0.0.1:8080/ws/ts`, returning current timestamp.
A special simulation called `WebSocketsSimulation` can then be executed. It would build a histogram reporting latency percentiles.
This simulation cannot be configured and run using standard way (`PerfTestSuiteRunner`), so the process is described in `perfTests/README.md`.

Based on https://github.com/kamilkloch/websocket-benchmark
WS endpoint will be added to other servers in separate PRs.