### PR TITLE
Avoid generic type in Netty's RunAsync

### DIFF
--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
@@ -23,7 +23,7 @@ trait NettyCatsServerInterpreter[F[_]] {
 
     implicit val monad: MonadError[F] = new CatsMonadError[F]
     val runAsync = new RunAsync[F] {
-      override def apply[T](f: => F[T]): Unit = nettyServerOptions.dispatcher.unsafeRunAndForget(f)
+      override def apply(f: => F[Unit]): Unit = nettyServerOptions.dispatcher.unsafeRunAndForget(f)
     }
     implicit val bodyListener: BodyListener[F, NettyResponse] = new NettyBodyListener(runAsync)
 

--- a/server/netty-server/loom/src/main/scala/sttp/tapir/server/netty/loom/NettyIdServerInterpreter.scala
+++ b/server/netty-server/loom/src/main/scala/sttp/tapir/server/netty/loom/NettyIdServerInterpreter.scala
@@ -16,7 +16,7 @@ trait NettyIdServerInterpreter {
       new NettyToResponseBody[Id],
       nettyServerOptions.deleteFile,
       new RunAsync[Id] {
-        override def apply[T](f: => Id[T]): Unit = {
+        override def apply(f: => Id[Unit]): Unit = {
           val _ = f
           ()
         }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServerInterpreter.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServerInterpreter.scala
@@ -37,6 +37,6 @@ object NettyFutureServerInterpreter {
   }
 
   private object FutureRunAsync extends RunAsync[Future] {
-    override def apply[T](f: => Future[T]): Unit = f
+    override def apply(f: => Future[Unit]): Unit = f
   }
 }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/RunAsync.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/RunAsync.scala
@@ -1,5 +1,5 @@
 package sttp.tapir.server.netty.internal
 
 trait RunAsync[F[_]] {
-  def apply[T](f: => F[T]): Unit
+  def apply(f: => F[Unit]): Unit
 }

--- a/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/NettyZioServerInterpreter.scala
+++ b/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/NettyZioServerInterpreter.scala
@@ -59,6 +59,6 @@ object NettyZioServerInterpreter {
   }
 
   private[netty] class ZioRunAsync[R](runtime: Runtime[R]) extends RunAsync[RIO[R, *]] {
-    override def apply[T](f: => RIO[R, T]): Unit = Unsafe.unsafe(implicit u => runtime.unsafe.runToFuture(f))
+    override def apply(f: => RIO[R, Unit]): Unit = Unsafe.unsafe(implicit u => runtime.unsafe.runToFuture(f))
   }
 }


### PR DESCRIPTION
## Problem

The `apply` method in `RunAsync` takes an unnecessary type parameter. Kyo allows nesting of effects for composition but it's necessary to prove that a computation isn't nested to invoke methods that handle effects, which is necessary for `RunAsync`'s implementation. I'm currently using [an unsafe flat check](https://github.com/getkyo/kyo/blob/7985576fafa45d58088573653fab647c50f7fee7/kyo-tapir/src/main/scala/kyo/server/NettyKyoServer.scala#L135) to work this around. 

## Solution

Modify `RunAsync.apply` to take a an `F` fixed to `Unit`, which Kyo is able to prove as flat and matches the usage in `NettyBodyListener`.

## Notes

- I imagine this isn't considered a breaking change since the trait is internal.
- I'd like to keep the integration with Tapir in Kyo's repository, which is why I'm using internal APIs. Is there an interest in providing first-class support for external integrations? 
- I had trouble to run the tests locally, I see odd errors like `Referring to non-existent class sttp.apispec.SchemaType` but I imagine isn't related to the change.