### PR TITLE
Record HdrHistogram for standard REST perf tests

### DIFF
--- a/perf-tests/README.md
+++ b/perf-tests/README.md
@@ -27,7 +27,7 @@ which displays help similar to:
 [error]   -d, --duration <value>  Single simulation duration in seconds, default is 10
 [error]   -g, --gatling-reports   Generate Gatling reports for individuals sims, may significantly affect total time (disabled by default)
 ```
-
+Generating Gatling reports is useful if you want to verify additional data like latency or throughput distribution over time.
 If you want to run a test server separately from simulations, use a separate sbt session and start it using `ServerRunner`:
 
 ```
@@ -64,8 +64,16 @@ perfTest/Test/runMain sttp.tapir.perf.PerfTestSuiteRunner -m PostBytes,PostLongB
 
 ## Reports
 
-After all tests finish successfully, your console output will point to report files, 
-containing aggregated results from the entire suite:
+Each single simulation results in a latency HDR Histogram report printed to stdout as well as a file:
+
+```
+[info] ******* Histogram saved to /home/kc/code/oss/tapir/.sbt/matrix/perfTests/SimpleGetSimulation-2024-02-26_10_30_22
+```
+
+You can use [HDR Histogram Plotter](https://hdrhistogram.github.io/HdrHistogram/plotFiles.html) to plot a set of such files.
+
+The main report is generated after all tests, and contains results for standard Gatling latencies and mean throughput in a table combining
+all servers and tests. They will be printed to a HTML and a CSV file after the suite finishes:
 ```
 [info] ******* Test Suite report saved to /home/alice/projects/tapir/.sbt/matrix/perfTests/tapir-perf-tests-2024-01-22_16_33_14.csv
 [info] ******* Test Suite report saved to /home/alice/projects/tapir/.sbt/matrix/perfTests/tapir-perf-tests-2024-01-22_16_33_14.html

--- a/perf-tests/src/test/scala/sttp/tapir/perf/HistogramPrinter.scala
+++ b/perf-tests/src/test/scala/sttp/tapir/perf/HistogramPrinter.scala
@@ -5,11 +5,16 @@ import org.HdrHistogram.Histogram
 import java.io.{FileOutputStream, PrintStream}
 import java.nio.file.Paths
 import scala.util.{Failure, Success, Using}
+import java.time.format.DateTimeFormatter
+import java.time.LocalDateTime
 
 object HistogramPrinter {
+  val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH_mm_ss")
+
   def saveToFile(histogram: Histogram, histogramName: String): Unit = {
+    val currentTime = LocalDateTime.now().format(formatter)
     val baseDir = System.getProperty("user.dir")
-    val targetFilePath = Paths.get(baseDir).resolve(s"$histogramName-${System.currentTimeMillis()}")
+    val targetFilePath = Paths.get(baseDir).resolve(s"$histogramName-$currentTime")
     Using.Manager { use =>
       val fos = use(new FileOutputStream(targetFilePath.toFile))
       val ps = use(new PrintStream(fos))

--- a/perf-tests/src/test/scala/sttp/tapir/perf/HistogramPrinter.scala
+++ b/perf-tests/src/test/scala/sttp/tapir/perf/HistogramPrinter.scala
@@ -1,0 +1,25 @@
+package sttp.tapir.perf
+
+import org.HdrHistogram.Histogram
+
+import java.io.{FileOutputStream, PrintStream}
+import java.nio.file.Paths
+import scala.util.{Failure, Success, Using}
+
+object HistogramPrinter {
+  def saveToFile(histogram: Histogram, histogramName: String): Unit = {
+    val baseDir = System.getProperty("user.dir")
+    val targetFilePath = Paths.get(baseDir).resolve(s"$histogramName-${System.currentTimeMillis()}")
+    Using.Manager { use =>
+      val fos = use(new FileOutputStream(targetFilePath.toFile))
+      val ps = use(new PrintStream(fos))
+      histogram.outputPercentileDistribution(System.out, 1.0)
+      histogram.outputPercentileDistribution(ps, 1.0)
+    } match {
+      case Success(_) =>
+        println(s"******* Histogram saved to $targetFilePath")
+      case Failure(ex) =>
+        ex.printStackTrace
+    }
+  }
+}


### PR DESCRIPTION
Similarly to what we do in `WebSocketsSimulation`, I added recording HdrHistogram response times for other tests: SimpleGet, SimpleGetMultiRoute, PostBytes, PostString, PostLongBytes.
Gatling records only p99 latency, while some interesting bottlenecks can be observed in higher percentiles, even 99.999+

P.S. The PostFile test is omitted, because I have doubts if we want to have this test at all.