### PR TITLE
Optimize Http4sServerRequest.uri

### DIFF
--- a/core/src/main/scala/sttp/tapir/Endpoint.scala
+++ b/core/src/main/scala/sttp/tapir/Endpoint.scala
@@ -220,10 +220,10 @@ trait EndpointErrorOutputVariantsOps[A, I, E, O, -R] {
   def errorOutVariantPrepend[E2 >: E](o: OneOfVariant[_ <: E2]): EndpointType[A, I, E2, O, R] =
     withErrorOutputVariant(oneOf[E2](o, oneOfDefaultVariant(errorOutput)), identity)
 
-   /** Same as [[errorOutVariantPrepend]], but allows appending multiple variants in one go. */
+  /** Same as [[errorOutVariantPrepend]], but allows appending multiple variants in one go. */
   def errorOutVariantsPrepend[E2 >: E](first: OneOfVariant[_ <: E2], other: OneOfVariant[_ <: E2]*): EndpointType[A, I, E2, O, R] =
     withErrorOutputVariant(oneOf[E2](oneOfDefaultVariant(errorOutput), first +: other: _*), identity)
- 
+
   /** Same as [[errorOutVariant]], but allows appending multiple variants in one go. */
   def errorOutVariants[E2 >: E](first: OneOfVariant[_ <: E2], other: OneOfVariant[_ <: E2]*)(implicit
       ct: ClassTag[E],
@@ -339,7 +339,7 @@ trait EndpointMetaOps {
   /** Shortened information about the endpoint. If the endpoint is named, returns the name, e.g. `[my endpoint]`. Otherwise, returns the
     * string representation of the method (if any) and path, e.g. `POST /books/add`
     */
-  def showShort: String = info.name match {
+  lazy val showShort: String = info.name match {
     case None       => s"${method.map(_.toString()).getOrElse("*")} ${showPathTemplate(showQueryParam = None)}"
     case Some(name) => s"[$name]"
   }
@@ -347,7 +347,7 @@ trait EndpointMetaOps {
   /** Basic information about the endpoint, excluding mapping information, with inputs sorted (first the method, then path, etc.). E.g.:
     * `POST /books /add {header Authorization} {body as application/json (UTF-8)} -> {body as text/plain (UTF-8)}/-`
     */
-  def show: String = {
+  lazy val show: String = {
     def showOutputs(o: EndpointOutput[_]): String = showOneOf(o.asBasicOutputsList.map(os => showMultiple(os.sortByType)))
 
     val namePrefix = info.name.map("[" + _ + "] ").getOrElse("")
@@ -401,7 +401,7 @@ trait EndpointMetaOps {
   /** The method defined in a fixed method input in this endpoint, if any (using e.g. [[EndpointInputsOps.get]] or
     * [[EndpointInputsOps.post]]).
     */
-  def method: Option[Method] = {
+  lazy val method: Option[Method] = {
     import sttp.tapir.internal._
     input.method.orElse(securityInput.method)
   }

--- a/core/src/main/scala/sttp/tapir/Endpoint.scala
+++ b/core/src/main/scala/sttp/tapir/Endpoint.scala
@@ -220,10 +220,10 @@ trait EndpointErrorOutputVariantsOps[A, I, E, O, -R] {
   def errorOutVariantPrepend[E2 >: E](o: OneOfVariant[_ <: E2]): EndpointType[A, I, E2, O, R] =
     withErrorOutputVariant(oneOf[E2](o, oneOfDefaultVariant(errorOutput)), identity)
 
-  /** Same as [[errorOutVariantPrepend]], but allows appending multiple variants in one go. */
+   /** Same as [[errorOutVariantPrepend]], but allows appending multiple variants in one go. */
   def errorOutVariantsPrepend[E2 >: E](first: OneOfVariant[_ <: E2], other: OneOfVariant[_ <: E2]*): EndpointType[A, I, E2, O, R] =
     withErrorOutputVariant(oneOf[E2](oneOfDefaultVariant(errorOutput), first +: other: _*), identity)
-
+ 
   /** Same as [[errorOutVariant]], but allows appending multiple variants in one go. */
   def errorOutVariants[E2 >: E](first: OneOfVariant[_ <: E2], other: OneOfVariant[_ <: E2]*)(implicit
       ct: ClassTag[E],
@@ -339,7 +339,7 @@ trait EndpointMetaOps {
   /** Shortened information about the endpoint. If the endpoint is named, returns the name, e.g. `[my endpoint]`. Otherwise, returns the
     * string representation of the method (if any) and path, e.g. `POST /books/add`
     */
-  lazy val showShort: String = info.name match {
+  def showShort: String = info.name match {
     case None       => s"${method.map(_.toString()).getOrElse("*")} ${showPathTemplate(showQueryParam = None)}"
     case Some(name) => s"[$name]"
   }
@@ -347,7 +347,7 @@ trait EndpointMetaOps {
   /** Basic information about the endpoint, excluding mapping information, with inputs sorted (first the method, then path, etc.). E.g.:
     * `POST /books /add {header Authorization} {body as application/json (UTF-8)} -> {body as text/plain (UTF-8)}/-`
     */
-  lazy val show: String = {
+  def show: String = {
     def showOutputs(o: EndpointOutput[_]): String = showOneOf(o.asBasicOutputsList.map(os => showMultiple(os.sortByType)))
 
     val namePrefix = info.name.map("[" + _ + "] ").getOrElse("")
@@ -401,7 +401,7 @@ trait EndpointMetaOps {
   /** The method defined in a fixed method input in this endpoint, if any (using e.g. [[EndpointInputsOps.get]] or
     * [[EndpointInputsOps.post]]).
     */
-  lazy val method: Option[Method] = {
+  def method: Option[Method] = {
     import sttp.tapir.internal._
     input.method.orElse(securityInput.method)
   }

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerRequest.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerRequest.scala
@@ -25,7 +25,6 @@ private[http4s] case class Http4sServerRequest[F[_]](req: Request[F], attributes
   override lazy val queryParameters: QueryParams = QueryParams.fromMultiMap(req.multiParams)
 
   override def method: Method = Method(req.method.name.toUpperCase)
-  // override def uri: Uri = Uri.unsafeParse(req.uri.toString())
   override lazy val uri: Uri =
     Uri.apply(
       req.uri.scheme.map(_.value),

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerRequest.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerRequest.scala
@@ -31,7 +31,7 @@ private[http4s] case class Http4sServerRequest[F[_]](req: Request[F], attributes
       req.uri.scheme.map(_.value),
       req.uri.authority.map(a => Authority(a.userInfo.map(u => UserInfo(u.username, u.password)), HostSegment(a.host.value), a.port)),
       PathSegments.absoluteOrEmptyS(req.uri.path.segments.map(_.decoded()) ++ (if (req.uri.path.endsWithSlash) Seq("") else Nil)),
-      req.uri.query.pairs.map(kv => QuerySegment.KeyValue(kv._1, kv._2.getOrElse(""))),
+      req.uri.query.pairs.map(kv => kv._2.map(v => QuerySegment.KeyValue(kv._1, v)).getOrElse(QuerySegment.Value(kv._1))),
       req.uri.fragment.map(f => FragmentSegment(f))
     )
   override lazy val headers: Seq[Header] = req.headers.headers.map(h => Header(h.name.toString, h.value))

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerRequest.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerRequest.scala
@@ -1,9 +1,10 @@
 package sttp.tapir.server.http4s
 
 import org.http4s.Request
+import sttp.model.Uri.{Authority, FragmentSegment, HostSegment, PathSegments, QuerySegment, UserInfo}
 import sttp.model.{Header, Method, QueryParams, Uri}
-import sttp.tapir.{AttributeKey, AttributeMap}
 import sttp.tapir.model.{ConnectionInfo, ServerRequest}
+import sttp.tapir.{AttributeKey, AttributeMap}
 
 import scala.collection.immutable.Seq
 
@@ -24,7 +25,15 @@ private[http4s] case class Http4sServerRequest[F[_]](req: Request[F], attributes
   override lazy val queryParameters: QueryParams = QueryParams.fromMultiMap(req.multiParams)
 
   override def method: Method = Method(req.method.name.toUpperCase)
-  override def uri: Uri = Uri.unsafeParse(req.uri.toString())
+  // override def uri: Uri = Uri.unsafeParse(req.uri.toString())
+  override lazy val uri: Uri =
+    Uri.apply(
+      req.uri.scheme.map(_.value),
+      req.uri.authority.map(a => Authority(a.userInfo.map(u => UserInfo(u.username, u.password)), HostSegment(a.host.value), a.port)),
+      PathSegments.absoluteOrEmptyS(req.uri.path.segments.map(_.decoded()) ++ (if (req.uri.path.endsWithSlash) Seq("") else Nil)),
+      req.uri.query.pairs.map(kv => QuerySegment.KeyValue(kv._1, kv._2.getOrElse(""))),
+      req.uri.fragment.map(f => FragmentSegment(f))
+    )
   override lazy val headers: Seq[Header] = req.headers.headers.map(h => Header(h.name.toString, h.value))
 
   override def attribute[T](k: AttributeKey[T]): Option[T] = attributes.get(k)


### PR DESCRIPTION
Fixes https://github.com/softwaremill/tapir/issues/3546
This PR makes the `Http4sServerRequest.uri` create the `Uri` object manually to avoid expensive toString and parsing.