### PR TITLE
optimize channel closing to avoid allocations when flushing pending responses

### DIFF
--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyServerHandler.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyServerHandler.scala
@@ -85,7 +85,9 @@ class NettyServerHandler[F[_]](
             pendingResponses.length
           )
         }
-        pendingResponses.foreach(_.apply())
+        while(pendingResponses.nonEmpty) {
+          pendingResponses.dequeue().apply()
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem

Scala's `foreach` is quite difficult for the JIT to optimize. The use of shared abstract implementations in Scala's collections makes call sides become highly polymorphic and simple cases like this one end up requiring allocations and interface dispatches.

## Solution

Use a `while` since `pendingResponses` is a mutable queue and can efficiently dequeue elements.

## Notes

- This is part of https://github.com/softwaremill/tapir/issues/3552
- This issue isn't present in my benchmark [implementation](https://github.com/fwbrasil/rinha-2024-q1) anymore because I've fixed the nginx config to use keepalive but I thought it was still worth sending the patch.