### PR TITLE
avoid allocation in Validator.All.contramap

### DIFF
--- a/core/src/main/scala/sttp/tapir/Validator.scala
+++ b/core/src/main/scala/sttp/tapir/Validator.scala
@@ -242,7 +242,7 @@ object Validator extends ValidatorMacros {
   case class All[T](validators: immutable.Seq[Validator[T]]) extends Validator[T] {
     override def apply(t: T): List[ValidationError[_]] = validators.flatMap(_.apply(t)).toList
 
-    override def contramap[TT](g: TT => T): Validator[TT] = if (validators.isEmpty) All(Nil) else super.contramap(g)
+    override def contramap[TT](g: TT => T): Validator[TT] = if (validators.isEmpty) this.asInstanceOf[Validator[TT]] else super.contramap(g)
     override def and(other: Validator[T]): Validator[T] = if (validators.isEmpty) other else All(validators :+ other)
   }
 


### PR DESCRIPTION
## Problem

Tapir uses a default `Validatator.All` instance with an empty validator sequence and calls `contramap` on each request handling as part of the value decoding (the call comes from `Schema.map`)

## Solution

Cast the current instance and return it instead of allocating a new one.

## Notes

- This is part of https://github.com/softwaremill/tapir/issues/3552
- The cast seems safe since the class is immutable and the empty sequence should have the same behavior regardless of the type parameter.