### PR TITLE
Optimize parsing headers for pekko-http and akka-http

### DIFF
--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaModel.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaModel.scala
@@ -13,8 +13,8 @@ private[akkahttp] object AkkaModel {
 
   def parseHeadersOrThrowWithoutContentHeaders(hs: HasHeaders): Seq[HttpHeader] =
     hs.headers
-      .map(parseHeaderOrThrow)
       .filterNot(h => h.is(ctHeaderNameLowerCase) || h.is(clHeaderNameLowerCase) || h.is(teHeaderNameLowerCase))
+      .map(parseHeaderOrThrow)
 
   def parseHeaderOrThrow(h: Header): HttpHeader =
     HttpHeader.parse(h.name, h.value) match {

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaToResponseBody.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaToResponseBody.scala
@@ -132,7 +132,7 @@ private[akkahttp] class AkkaToResponseBody(implicit m: Materializer, ec: Executi
   }
 
   private def parseContentType(ct: String): ContentType =
-    ContentType.parse(ct).getOrElse(throw new IllegalArgumentException(s"Cannot parse content type: $ct"))
+    ContentTypeCache.getOrParse(ct)
 
   private def charsetToHttpCharset(charset: Charset): HttpCharset = HttpCharset.custom(charset.name())
 

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/ContentTypeCache.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/ContentTypeCache.scala
@@ -21,7 +21,8 @@ private[akkahttp] object ContentTypeCache {
       case None =>
         val contentType =
           ContentType.parse(headerValue).getOrElse(throw new IllegalArgumentException(s"Cannot parse content type: $headerValue"))
-        if (cache.size <= Limit) cache.putIfAbsent(headerValue, contentType) else ()
+        // We don't want to fill the cache with parameterized media types (BTW charset does not appear in params)
+        val _ = if (cache.size <= Limit && contentType.mediaType.params.isEmpty) cache.putIfAbsent(headerValue, contentType)
         contentType
     }
   }

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/ContentTypeCache.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/ContentTypeCache.scala
@@ -1,0 +1,28 @@
+package sttp.tapir.server.akkahttp
+
+import akka.http.scaladsl.model.ContentType
+import scala.collection.concurrent.TrieMap
+
+/** Pekko-specific ConentType has to be created if an endpoint overrides it, but we want to reduce overhead of the expensive
+  * ContentType.parse operation if possible. Parsing may also happen for cases not listed explictly in
+  * PekkoToResponseBody.formatToContentType. This cache doesn't have to save atomically, because the worst case scenario is that we parse he
+  * same header a few times before it's saved. The cache is not cleared, because the number of different content types is limited and the
+  * cache is not expected to grow too much. The only exception is when there is a boundary in the header, but in such situation the endpoint
+  * contentType shouldn't be overriden. Just in case this happens, we limit the cache size.
+  */
+private[akkahttp] object ContentTypeCache {
+  private val cache = TrieMap[String, ContentType]()
+  private val Limit = 100
+
+  def getOrParse(headerValue: String): ContentType = {
+    cache.get(headerValue) match {
+      case Some(contentType) =>
+        contentType
+      case None =>
+        val contentType =
+          ContentType.parse(headerValue).getOrElse(throw new IllegalArgumentException(s"Cannot parse content type: $headerValue"))
+        if (cache.size <= Limit) cache.putIfAbsent(headerValue, contentType) else ()
+        contentType
+    }
+  }
+}

--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/ContentTypeCache.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/ContentTypeCache.scala
@@ -1,0 +1,28 @@
+package sttp.tapir.server.pekkohttp
+
+import org.apache.pekko.http.scaladsl.model.ContentType
+import scala.collection.concurrent.TrieMap
+
+/** Pekko-specific ConentType has to be created if an endpoint overrides it, but we want to reduce overhead of the expensive
+  * ContentType.parse operation if possible. Parsing may also happen for cases not listed explictly in
+  * PekkoToResponseBody.formatToContentType. This cache doesn't have to save atomically, because the worst case scenario is that we parse he
+  * same header a few times before it's saved. The cache is not cleared, because the number of different content types is limited and the
+  * cache is not expected to grow too much. The only exception is when there is a boundary in the header, but in such situation the endpoint
+  * contentType shouldn't be overriden. Just in case this happens, we limit the cache size.
+  */
+private[pekkohttp] object ContentTypeCache {
+  private val cache = TrieMap[String, ContentType]()
+  private val Limit = 100
+
+  def getOrParse(headerValue: String): ContentType = {
+    cache.get(headerValue) match {
+      case Some(contentType) =>
+        contentType
+      case None =>
+        val contentType =
+          ContentType.parse(headerValue).getOrElse(throw new IllegalArgumentException(s"Cannot parse content type: $headerValue"))
+        if (cache.size <= Limit) cache.putIfAbsent(headerValue, contentType) else ()
+        contentType
+    }
+  }
+}

--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/ContentTypeCache.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/ContentTypeCache.scala
@@ -21,7 +21,8 @@ private[pekkohttp] object ContentTypeCache {
       case None =>
         val contentType =
           ContentType.parse(headerValue).getOrElse(throw new IllegalArgumentException(s"Cannot parse content type: $headerValue"))
-        if (cache.size <= Limit) cache.putIfAbsent(headerValue, contentType) else ()
+        // We don't want to fill the cache with parameterized media types (BTW charset does not appear in params)
+        val _ = if (cache.size <= Limit && contentType.mediaType.params.isEmpty) cache.putIfAbsent(headerValue, contentType)
         contentType
     }
   }

--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoModel.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoModel.scala
@@ -13,8 +13,8 @@ private[pekkohttp] object PekkoModel {
 
   def parseHeadersOrThrowWithoutContentHeaders(hs: HasHeaders): Seq[HttpHeader] =
     hs.headers
-      .map(parseHeaderOrThrow)
       .filterNot(h => h.is(ctHeaderNameLowerCase) || h.is(clHeaderNameLowerCase) || h.is(teHeaderNameLowerCase))
+      .map(parseHeaderOrThrow)
 
   def parseHeaderOrThrow(h: Header): HttpHeader =
     HttpHeader.parse(h.name, h.value) match {

--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoToResponseBody.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoToResponseBody.scala
@@ -132,7 +132,7 @@ private[pekkohttp] class PekkoToResponseBody(implicit m: Materializer, ec: Execu
   }
 
   private def parseContentType(ct: String): ContentType =
-    ContentType.parse(ct).getOrElse(throw new IllegalArgumentException(s"Cannot parse content type: $ct"))
+    ContentTypeCache.getOrParse(ct)
 
   private def charsetToHttpCharset(charset: Charset): HttpCharset = HttpCharset.custom(charset.name())
 


### PR DESCRIPTION
Fixes https://github.com/softwaremill/tapir/issues/3544

CPU samples registered in profiler:
Before:
```
sttp.tapir.server.pekkohttp.PekkoToResponseBody.parseContentType(String) 3.53%
sttp.tapir.server.pekkohttp.PekkoModel$.parseHeadersOrThrowWithoutContentHeaders(HasHeaders) 2.13%
```
After:
```
sttp.tapir.server.pekkohttp.PekkoToResponseBody.parseContentType(String) 0.18%
sttp.tapir.server.pekkohttp.PekkoModel$.parseHeadersOrThrowWithoutContentHeaders(HasHeaders) 0.14%
```

Throughput in `SimpleGet` Simulation for 128 users:
Before:
![image](https://github.com/softwaremill/tapir/assets/1413553/38ddb01e-d6f6-470d-8bd0-cc053aa44925)
After:
![image](https://github.com/softwaremill/tapir/assets/1413553/87d60e44-39f8-4dfc-a2e3-344bc72974b5)
(Yes, the timestamps are OK, I ran the test on the optimized server first :))
Note:
The issue mentions one more hot frame:
```
sttp.tapir.server.pekkohttp.PekkoServerRequest.acceptsContentTypes() 2.4%
```

It's a common issue caused by the base `ServerRequest.acceptContentTypes` calling `Accepts.parse` from `sttp-model`, involving some pattern matching. I tried two approaches, without great results:

1. A low-level string-based parser instead of using sttp-model. This lowered CPU samples to ~1.8%, which isn't a great gain, while the code was pretty complex and didn't cover some error corner cases.
2. Switching to Pekko's `HttpHeader.parse` which is more efficient, then repacking Pekko datatypes to Tapir's. This lowered the load to ~1.9%. Again, doesn't seem worthwhile, the repacking was also pretty complex and error prone, it probably involved unnecessary allocations as well. `HttpHeader.parse` is not very efficient by itself, because [internally it calls](https://github.com/apache/incubator-pekko-http/blob/6ccdc742747ba0ead83bc6e2b45554be412691e3/http-core/src/main/scala/org/apache/pekko/http/scaladsl/model/HttpHeader.scala#L91)
```scala
val parser = new HeaderParser(value, settings)
```
every time. The full power of `HeaderParser` could be leveraged if the parser was instantiated once and reused within a connection, then passed to new connections once the connection is closed (it has its own internal cache). This is what happens underneath if one uses raw pekko-http.