### PR TITLE
disable connection linger timeout by default

### DIFF
--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
@@ -107,7 +107,7 @@ object NettyConfig {
     socketKeepAlive = true,
     requestTimeout = Some(20.seconds),
     connectionTimeout = Some(10.seconds),
-    lingerTimeout = None,
+    lingerTimeout = None, // see #3576
     gracefulShutdownTimeout = Some(10.seconds),
     maxConnections = None,
     addLoggingHandler = false,

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
@@ -114,7 +114,7 @@ object NettyConfig {
     requestTimeout = Some(20.seconds),
     connectionTimeout = Some(10.seconds),
     socketTimeout = Some(60.seconds),
-    lingerTimeout = Some(60.seconds),
+    lingerTimeout = None,
     gracefulShutdownTimeout = Some(10.seconds),
     maxConnections = None,
     addLoggingHandler = false,


### PR DESCRIPTION
## Problem

Tapir sets the `SO_LINGER` socket option by default. This config holds the connection for some time after it's closed and Netty uses a global thread pool (`GlobalEventExecutor`) with a single ephemeral thread to delay the connection close. Netty doesn't set this config by default and I couldn't identify a mechanism to make it use another thread pool.

I noticed this issue when benchmarking with a high rate of short-lived connections, which ended up generating a backlog in this thread pool and memory pressure. The `GlobalEventExecutor` also keeps constantly tearing down its thread and creating new ones, which introduces additional overhead.

## Solution

Don't set the configuration by default.

## Notes

- There can be cases where the config makes sense but I'd say it's important that it is done by an expert considering the characteristics of specific systems.