### PR TITLE
Optimize SimpleSubscriber for Netty

### DIFF
--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/internal/NettyCatsRequestBody.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/internal/NettyCatsRequestBody.scala
@@ -20,7 +20,7 @@ private[cats] class NettyCatsRequestBody[F[_]: Async](
 
   override implicit val monad: MonadError[F] = new CatsMonadError()
 
-  override def publisherToBytes(publisher: Publisher[HttpContent], maxBytes: Option[Long]): F[Array[Byte]] =
+  override def publisherToBytes(publisher: Publisher[HttpContent], contentLength: Option[Int], maxBytes: Option[Long]): F[Array[Byte]] =
     streamCompatible.fromPublisher(publisher, maxBytes).compile.to(Chunk).map(_.toArray[Byte])
 
   override def writeToFile(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): F[Unit] =

--- a/server/netty-server/loom/src/main/scala/sttp/tapir/server/netty/loom/NettyIdRequestBody.scala
+++ b/server/netty-server/loom/src/main/scala/sttp/tapir/server/netty/loom/NettyIdRequestBody.scala
@@ -16,8 +16,8 @@ private[netty] class NettyIdRequestBody(val createFile: ServerRequest => TapirFi
   override implicit val monad: MonadError[Id] = idMonad
   override val streams: capabilities.Streams[NoStreams] = NoStreams
 
-  override def publisherToBytes(publisher: Publisher[HttpContent], maxBytes: Option[Long]): Array[Byte] =
-    SimpleSubscriber.processAllBlocking(publisher, maxBytes)
+  override def publisherToBytes(publisher: Publisher[HttpContent], contentLength: Option[Int], maxBytes: Option[Long]): Array[Byte] =
+    SimpleSubscriber.processAllBlocking(publisher, contentLength, maxBytes)
 
   override def writeToFile(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): Unit =
     serverRequest.underlying match {

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyFutureRequestBody.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyFutureRequestBody.scala
@@ -18,8 +18,8 @@ private[netty] class NettyFutureRequestBody(val createFile: ServerRequest => Fut
   override val streams: capabilities.Streams[NoStreams] = NoStreams
   override implicit val monad: MonadError[Future] = new FutureMonad()
 
-  override def publisherToBytes(publisher: Publisher[HttpContent], maxBytes: Option[Long]): Future[Array[Byte]] =
-    SimpleSubscriber.processAll(publisher, maxBytes)
+  override def publisherToBytes(publisher: Publisher[HttpContent], contentLength: Option[Int], maxBytes: Option[Long]): Future[Array[Byte]] =
+    SimpleSubscriber.processAll(publisher, contentLength, maxBytes)
 
   override def writeToFile(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): Future[Unit] =
     serverRequest.underlying match {

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/SimpleSubscriber.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/SimpleSubscriber.scala
@@ -1,18 +1,12 @@
 package sttp.tapir.server.netty.internal.reactivestreams
 
-import io.netty.buffer.ByteBufUtil
+import io.netty.buffer.{ByteBuf, ByteBufUtil}
 import io.netty.handler.codec.http.HttpContent
 import org.reactivestreams.{Publisher, Subscription}
-
-import java.util.concurrent.ConcurrentLinkedQueue
-import scala.collection.JavaConverters._
-import scala.concurrent.{Future, Promise}
-import java.util.concurrent.LinkedBlockingQueue
 import sttp.capabilities.StreamMaxLengthExceededException
-import io.netty.buffer.Unpooled
-import io.netty.buffer.ByteBuf
-import io.netty.buffer.CompositeByteBuf
-import scala.collection.mutable
+
+import java.util.concurrent.{ConcurrentLinkedQueue, LinkedBlockingQueue}
+import scala.concurrent.{Future, Promise}
 
 private[netty] class SimpleSubscriber(contentLength: Option[Int]) extends PromisingSubscriber[Array[Byte], HttpContent] {
   private var subscription: Subscription = _

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/SimpleSubscriber.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/SimpleSubscriber.scala
@@ -31,7 +31,7 @@ private[netty] class SimpleSubscriber(contentLength: Option[Int]) extends Promis
 
   override def onNext(content: HttpContent): Unit = {
     val byteBuf = content.content()
-    if (contentLength.exists(_ == byteBuf.readableBytes())) {
+    if (contentLength.contains(byteBuf.readableBytes())) {
       val finalArray = ByteBufUtil.getBytes(byteBuf)
       byteBuf.release()
       resultBlockingQueue.add(Right(finalArray))

--- a/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/internal/NettyZioRequestBody.scala
+++ b/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/internal/NettyZioRequestBody.scala
@@ -19,7 +19,11 @@ private[zio] class NettyZioRequestBody[Env](
   override val streams: ZioStreams = ZioStreams
   override implicit val monad: MonadError[RIO[Env, *]] = new RIOMonadError[Env]
 
-  override def publisherToBytes(publisher: Publisher[HttpContent], maxBytes: Option[Long]): RIO[Env, Array[Byte]] =
+  override def publisherToBytes(
+      publisher: Publisher[HttpContent],
+      contentLength: Option[Int],
+      maxBytes: Option[Long]
+  ): RIO[Env, Array[Byte]] =
     streamCompatible.fromPublisher(publisher, maxBytes).run(ZSink.collectAll[Byte]).map(_.toArray)
 
   override def writeToFile(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): RIO[Env, Unit] =


### PR DESCRIPTION
Fixes #3548 

This PR updates the `SimpleSubscriber` with following improvements:
1. If there is only one chunk of data (by default for body length < 8192), read it from the buffer and return immediately, requiring only one array allocation
2. If there are multiple chunks, collect all Netty `ByteBufs` without rewriting them into arrays, then copy them into the final array in `onComplete`. Disclaimer: initially I wanted to cover this case with Netty's `CompositeByteBuf`, but it turned out to be bad idea. It does some reallocations to resize internal representation underneath, resulting in making the overall performance significantly worse.

Results:
`PostBytes` Simulation
|                          |      Before |  After   |
|---------------------|:-------------:|-----------:|
| CPU samples  |  30.86%   | 29.73% |
| throughput    |    44738    |   56955 |

Latency improvement:
![latency-postbytes](https://github.com/softwaremill/tapir/assets/1413553/c1dbe569-f2d6-4475-9dca-e7d2845e3674)

`PostLongBytes` Simulation
|                          |      Before |  After   |
|---------------------|:-------------:|-----------:|
| CPU samples  |  48.8%    | 38.69% |
| throughput    |    363       |  454       |

Latency improvement:
![latency-postlongbytes](https://github.com/softwaremill/tapir/assets/1413553/44d43bf8-86b3-4c93-96a1-51130e9c6296)

I haven't measured it, but there should be also noteworthy gains in memory allocations.
