### PR TITLE
Codegen: Add new `useHeadTagForObjectNames` flag to permit splitting generated endpoint objects by tag

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -35,13 +35,14 @@ defined case-classes and endpoint definitions.
 The generator currently supports these settings, you can override them in the `build.sbt`;
 
 ```eval_rst
-=================== ==================================== ===========================================
-setting             default value                        description                             
-=================== ==================================== ===========================================
-openapiSwaggerFile  baseDirectory.value / "swagger.yaml" The swagger file with the api definitions.
-openapiPackage      sttp.tapir.generated                 The name for the generated package.
-openapiObject       TapirGeneratedEndpoints              The name for the generated object.
-=================== ==================================== ===========================================
+=============================== ==================================== =====================================================================
+setting                         default value                        description
+=============================== ==================================== =====================================================================
+openapiSwaggerFile              baseDirectory.value / "swagger.yaml" The swagger file with the api definitions.
+openapiPackage                  sttp.tapir.generated                 The name for the generated package.
+openapiObject                   TapirGeneratedEndpoints              The name for the generated object.
+openapiUseHeadTagForObjectName  false                                If true, put endpoints in separate files based on first declared tag.
+=============================== ==================================== =====================================================================
 ```
 
 The general usage is;

--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -55,6 +55,33 @@ import sttp.tapir.docs.openapi._
 val docs = TapirGeneratedEndpoints.generatedEndpoints.toOpenAPI("My Bookshop", "1.0")
 ```
 
+### Output files
+
+To expand on the `openapiUseHeadTagForObjectName` setting a little more, suppose we have the following endpoints:
+```yaml
+paths:
+  /foo:
+    get:
+      tags:
+        - Baz
+        - Foo
+    put:
+      tags: []
+  /bar:
+    get:
+      tags:
+        - Baz
+        - Bar
+```
+In this case 'head' tag for `GET /foo` and `GET /bar` would be 'Baz', and `PUT /foo` has no tags (and thus no 'head' tag).
+
+If `openapiUseHeadTagForObjectName = false` (assuming default settings for the other flags) then all endpoint definitions
+will be output to the `TapirGeneratedEndpoints.scala` file, which will contain a single `object TapirGeneratedEndpoints`.
+
+If `openapiUseHeadTagForObjectName = true`, then the  `GET /foo` and `GET /bar` endpoints would be output to a
+`Baz.scala` file, containing a single `object Baz` with those endpoint definitions; the `PUT /foo` endpoint, by dint of
+having no tags, would be output to the `TapirGeneratedEndpoints` file, along with any schema and parameter definitions.
+
 ### Limitations
 
 Currently, the generated code depends on `"io.circe" %% "circe-generic"`. In the future probably we will make the encoder/decoder json lib configurable (PRs welcome).

--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -64,11 +64,11 @@ object GenScala {
         val objectName = maybeObjectName.getOrElse(DefaultObjectName)
 
         def generateCode(doc: OpenapiDocument): IO[Unit] = for {
-          content <- IO.pure(
-            BasicGenerator.generateObjects(doc, packageName, objectName, targetScala3, headTagForNames)(objectName)
+          contents <- IO.pure(
+            BasicGenerator.generateObjects(doc, packageName, objectName, targetScala3, headTagForNames)
           )
-          destFile <- writeGeneratedFile(destDir, objectName, content)
-          _ <- IO.println(s"Generated endpoints written to: $destFile")
+          destFiles <- contents.traverse{ case (fileName, content) => writeGeneratedFile(destDir, objectName, content) }
+          _ <- IO.println(s"Generated endpoints written to: ${destFiles.mkString(", ")}")
         } yield ()
 
         for {

--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -67,7 +67,7 @@ object GenScala {
           contents <- IO.pure(
             BasicGenerator.generateObjects(doc, packageName, objectName, targetScala3, headTagForNames)
           )
-          destFiles <- contents.traverse{ case (fileName, content) => writeGeneratedFile(destDir, objectName, content) }
+          destFiles <- contents.traverse{ case (fileName, content) => writeGeneratedFile(destDir, fileName, content) }
           _ <- IO.println(s"Generated endpoints written to: ${destFiles.mkString(", ")}")
         } yield ()
 

--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -67,7 +67,7 @@ object GenScala {
           contents <- IO.pure(
             BasicGenerator.generateObjects(doc, packageName, objectName, targetScala3, headTagForNames)
           )
-          destFiles <- contents.traverse{ case (fileName, content) => writeGeneratedFile(destDir, fileName, content) }
+          destFiles <- contents.toVector.traverse{ case (fileName, content) => writeGeneratedFile(destDir, fileName, content) }
           _ <- IO.println(s"Generated endpoints written to: ${destFiles.mkString(", ")}")
         } yield ()
 

--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -40,6 +40,12 @@ object GenScala {
       )
       .orNone
 
+  private val targetScala3Opt: Opts[Boolean] =
+    Opts.flag("scala3", "Whether to generate Scala 3 code", "3").orFalse
+
+  private val headTagForNamesOpt: Opts[Boolean] =
+    Opts.flag("headTagForNames", "Whether to group generated endpoints by first declared tag", "t").orFalse
+
   private val destDirOpt: Opts[File] =
     Opts
       .option[String]("destdir", "Destination directory", "d")
@@ -53,22 +59,25 @@ object GenScala {
       }
 
   val cmd: Command[IO[ExitCode]] = Command("genscala", "Generate Scala classes", helpFlag = true) {
-    (fileOpt, packageNameOpt, destDirOpt, objectNameOpt).mapN { case (file, packageName, destDir, maybeObjectName) =>
-      val objectName = maybeObjectName.getOrElse(DefaultObjectName)
+    (fileOpt, packageNameOpt, destDirOpt, objectNameOpt, targetScala3Opt, headTagForNamesOpt).mapN {
+      case (file, packageName, destDir, maybeObjectName, targetScala3, headTagForNames) =>
+        val objectName = maybeObjectName.getOrElse(DefaultObjectName)
 
-      def generateCode(doc: OpenapiDocument): IO[Unit] = for {
-        content <- IO.pure(BasicGenerator.generateObjects(doc, packageName, objectName, false))
-        destFile <- writeGeneratedFile(destDir, objectName, content)
-        _ <- IO.println(s"Generated endpoints written to: $destFile")
-      } yield ()
+        def generateCode(doc: OpenapiDocument): IO[Unit] = for {
+          content <- IO.pure(
+            BasicGenerator.generateObjects(doc, packageName, objectName, targetScala3, headTagForNames)(objectName)
+          )
+          destFile <- writeGeneratedFile(destDir, objectName, content)
+          _ <- IO.println(s"Generated endpoints written to: $destFile")
+        } yield ()
 
-      for {
-        parsed <- readFile(file).map(YamlParser.parseFile)
-        exitCode <- parsed match {
-          case Left(err)  => IO.println(s"Invalid YAML file: ${err.getMessage}").as(ExitCode.Error)
-          case Right(doc) => generateCode(doc).as(ExitCode.Success)
-        }
-      } yield exitCode
+        for {
+          parsed <- readFile(file).map(YamlParser.parseFile)
+          exitCode <- parsed match {
+            case Left(err)  => IO.println(s"Invalid YAML file: ${err.getMessage}").as(ExitCode.Error)
+            case Right(doc) => generateCode(doc).as(ExitCode.Success)
+          }
+        } yield exitCode
     }
   }
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -22,11 +22,33 @@ object BasicGenerator {
   val classGenerator = new ClassDefinitionGenerator()
   val endpointGenerator = new EndpointGenerator()
 
-  def generateObjects(doc: OpenapiDocument, packagePath: String, objName: String, targetScala3: Boolean): String = {
+  def generateObjects(
+      doc: OpenapiDocument,
+      packagePath: String,
+      objName: String,
+      targetScala3: Boolean,
+      useHeadTagForObjectNames: Boolean
+  ): Map[String, String] = {
     val enumImport =
       if (!targetScala3 && doc.components.toSeq.flatMap(_.schemas).exists(_._2.isInstanceOf[OpenapiSchemaEnum])) "\n  import enumeratum._"
       else ""
-    s"""|
+
+    val endpointsByTag = endpointGenerator.endpointDefs(doc, useHeadTagForObjectNames)
+    val taggedObjs = endpointsByTag.collect {
+      case (Some(headTag), body) if body.nonEmpty =>
+        val taggedObj =
+          s"""package $packagePath
+           |
+           |import $objName._
+           |
+           |object $headTag {
+           |
+           |${indent(2)(body)}
+           |
+           |}""".stripMargin
+        headTag -> taggedObj
+    }
+    val mainObj = s"""|
         |package $packagePath
         |
         |object $objName {
@@ -35,10 +57,11 @@ object BasicGenerator {
         |
         |${indent(2)(classGenerator.classDefs(doc, targetScala3).getOrElse(""))}
         |
-        |${indent(2)(endpointGenerator.endpointDefs(doc))}
+        |${indent(2)(endpointsByTag.getOrElse(None, ""))}
         |
         |}
         |""".stripMargin
+    taggedObjs + (objName -> mainObj)
   }
 
   private[codegen] def imports: String =

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -43,6 +43,8 @@ object BasicGenerator {
            |
            |object $headTag {
            |
+           |${indent(2)(imports)}
+           |
            |${indent(2)(body)}
            |
            |}""".stripMargin

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
@@ -14,4 +14,25 @@ class BasicGeneratorSpec extends CompileCheckTestBase {
     )("TapirGeneratedEndpoints") shouldCompile ()
   }
 
+  it should "split outputs by tag if useHeadTagForObjectNames = true" in {
+    val generated = BasicGenerator.generateObjects(
+      TestHelpers.myBookshopDoc,
+      "sttp.tapir.generated",
+      "TapirGeneratedEndpoints",
+      targetScala3 = false,
+      useHeadTagForObjectNames = true
+    )
+    val schemas = generated("TapirGeneratedEndpoints")
+    val endpoints = generated("Bookshop")
+    // schema file on its own should compile
+    schemas shouldCompile ()
+    // schema file should contain no endpoint definitions
+    schemas.linesIterator.count(_.matches("""^\s*endpoint""")) shouldEqual 0
+    // Bookshop file should contain all endpoint definitions
+    endpoints.linesIterator.count(_.matches("""^\s*endpoint""")) shouldEqual 3
+    // endpoint file depends on schema file. For simplicity of testing, just strip the package declaration from the
+    // endpoint file, and concat the two, before testing for compilation
+    (schemas + "\n" + (endpoints.linesIterator.filterNot(_ startsWith "package").mkString("\n"))) shouldCompile ()
+  }
+
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
@@ -9,8 +9,9 @@ class BasicGeneratorSpec extends CompileCheckTestBase {
       TestHelpers.myBookshopDoc,
       "sttp.tapir.generated",
       "TapirGeneratedEndpoints",
-      targetScala3 = false
-    ) shouldCompile ()
+      targetScala3 = false,
+      useHeadTagForObjectNames = false
+    )("TapirGeneratedEndpoints") shouldCompile ()
   }
 
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -344,7 +344,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
 
     val res: String = parserRes match {
       case Left(value) => throw new Exception(value)
-      case Right(doc)  => new EndpointGenerator().endpointDefs(doc)
+      case Right(doc)  => new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false)(None)
     }
 
     val compileUnit =

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -56,7 +56,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       ),
       null
     )
-    val generatedCode = BasicGenerator.imports ++ new EndpointGenerator().endpointDefs(doc)
+    val generatedCode = BasicGenerator.imports ++ new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false)(None)
     generatedCode should include("val getTestAsdId =")
     generatedCode shouldCompile ()
   }
@@ -131,7 +131,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       )
     )
     BasicGenerator.imports ++
-      new EndpointGenerator().endpointDefs(doc) shouldCompile ()
+      new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false)(None) shouldCompile ()
   }
 
   it should "handle status codes" in {
@@ -174,7 +174,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       ),
       null
     )
-    val generatedCode = BasicGenerator.imports ++ new EndpointGenerator().endpointDefs(doc)
+    val generatedCode = BasicGenerator.imports ++ new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false)(None)
     generatedCode should include(
       """.out(stringBody.description("Processing").and(statusCode(sttp.model.StatusCode(202))))"""
     ) // status code with body
@@ -230,7 +230,13 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
         )
       )
     )
-    val generatedCode = BasicGenerator.generateObjects(doc, "sttp.tapir.generated", "TapirGeneratedEndpoints", targetScala3 = false)
+    val generatedCode = BasicGenerator.generateObjects(
+      doc,
+      "sttp.tapir.generated",
+      "TapirGeneratedEndpoints",
+      targetScala3 = false,
+      useHeadTagForObjectNames = false
+    )("TapirGeneratedEndpoints")
     generatedCode should include(
       """file: sttp.model.Part[java.io.File]"""
     )

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -6,6 +6,9 @@ trait OpenapiCodegenKeys {
   lazy val openapiSwaggerFile = settingKey[File]("The swagger file with the api definitions.")
   lazy val openapiPackage = settingKey[String]("The name for the generated package.")
   lazy val openapiObject = settingKey[String]("The name for the generated object.")
+  lazy val openapiUseHeadTagForObjectName = settingKey[Boolean](
+    "If true, any tagged endpoints will be defined in an object with a name based on the first tag, instead of on the default generated object."
+  )
 
   lazy val generateTapirDefinitions = taskKey[Unit]("The task that generates tapir definitions based on the input swagger file.")
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -18,14 +18,15 @@ object OpenapiCodegenPlugin extends AutoPlugin {
   def openapiCodegenScopedSettings(conf: Configuration): Seq[Setting[_]] = inConfig(conf)(
     Seq(
       generateTapirDefinitions := codegen.value,
-      sourceGenerators += (codegen.taskValue).map(_.map(_.toPath.toFile))
+      sourceGenerators += (codegen.taskValue).map(_.flatMap(_.map(_.toPath.toFile)))
     )
   )
 
   def openapiCodegenDefaultSettings: Seq[Setting[_]] = Seq(
     openapiSwaggerFile := baseDirectory.value / "swagger.yaml",
     openapiPackage := "sttp.tapir.generated",
-    openapiObject := "TapirGeneratedEndpoints"
+    openapiObject := "TapirGeneratedEndpoints",
+    openapiUseHeadTagForObjectName := false
   )
 
   private def codegen = Def.task {
@@ -35,6 +36,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
       openapiSwaggerFile,
       openapiPackage,
       openapiObject,
+      openapiUseHeadTagForObjectName,
       sourceManaged,
       streams,
       scalaVersion
@@ -43,11 +45,12 @@ object OpenapiCodegenPlugin extends AutoPlugin {
           swaggerFile: File,
           packageName: String,
           objectName: String,
+          useHeadTagForObjectName: Boolean,
           srcDir: File,
           taskStreams: TaskStreams,
           sv: String
       ) =>
-        OpenapiCodegenTask(swaggerFile, packageName, objectName, srcDir, taskStreams.cacheDirectory, sv.startsWith("3")).file
+        OpenapiCodegenTask(swaggerFile, packageName, objectName, useHeadTagForObjectName, srcDir, taskStreams.cacheDirectory, sv.startsWith("3")).file
     }) map (Seq(_))).value
   }
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -23,7 +23,7 @@ case class OpenapiCodegenTask(
   def file: Task[Seq[File]] = {
     makeFiles(tempDirectory) map { files =>
       files.map { tempFile =>
-        val outFile = outDirectory / s"$objectName.scala"
+        val outFile = outDirectory / tempFile.getName
         cachedCopyFile(tempFile, outFile)(hash(tempFile))
         outFile
       }


### PR DESCRIPTION
I've been thinking about this for ages and finally got around to it. If autogenerating files for a very large spec, it's possible to hit the JVM limits on class size since all definitions go into the same object; so from a purely technical perspective, this does enable working with certain specs that would otherwise require some fudging (such as calling the codegen cli on multiple input files); although I confess to also just finding it a bit tidier. This pr adds a new flag `useHeadTagForObjectNames` (defaulting to false, to preserve existing behaviour). If this flag is true then the generated endpoints are grouped by the first tag, and each group put into a new file+object with the same name as that tag. All types/enums/classes generated from schemas remain in the default object model as before, and if an endpoint has no tags at all, it is placed into the default object (i.e. a spec with no tags would see no change as a result of this pr, regardless of whether the flag were set to true or not) 