### PR TITLE
Codegen: Generate attributes on endpoints for any specification extensions defined on path or operation objects

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -63,24 +63,22 @@ object BasicGenerator {
         headTag -> taggedObj
     }
 
-    val specificationExtensions = doc.paths
+    val maybeSpecificationExtensionKeys = doc.paths
       .flatMap { p =>
         p.specificationExtensions.toSeq ++ p.methods.flatMap(_.specificationExtensions.toSeq)
       }
       .groupBy(_._1)
-    val specificationExtensionWrapper = if (specificationExtensions.isEmpty) "" else "case class XSpecificationExtension[T](value: T)\n"
-    val maybeSpecificationExtensionKeys = specificationExtensions
       .map { case (keyName, pairs) =>
         val values = pairs.map(_._2)
         val `type` = SpecificationExtensionRenderer.renderCombinedType(values)
         val name = strippedToCamelCase(keyName)
         val uncapitalisedName = name.head.toLower + name.tail
         val capitalisedName = name.head.toUpper + name.tail
-        s"""type ${capitalisedName}X = ${`type`}
-           |val ${uncapitalisedName}XKey = new sttp.tapir.AttributeKey[XSpecificationExtension[${capitalisedName}X]]("$packagePath.$objName.XSpecificationExtension[$packagePath.$objName.${capitalisedName}X]")
+        s"""type ${capitalisedName}Extension = ${`type`}
+           |val ${uncapitalisedName}ExtensionKey = new sttp.tapir.AttributeKey[${capitalisedName}Extension]("$packagePath.$objName.${capitalisedName}Extension")
            |""".stripMargin
       }
-      .mkString(specificationExtensionWrapper, "\n", "")
+      .mkString("\n")
 
     val mainObj = s"""|
         |package $packagePath

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -3,8 +3,8 @@ package sttp.tapir.codegen
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaAny,
-  OpenapiSchemaBoolean,
   OpenapiSchemaBinary,
+  OpenapiSchemaBoolean,
   OpenapiSchemaDateTime,
   OpenapiSchemaDouble,
   OpenapiSchemaFloat,
@@ -15,6 +15,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaString,
   OpenapiSchemaUUID
 }
+import sttp.tapir.codegen.openapi.models.SpecificationExtensionRenderer
 
 object JsonSerdeLib extends Enumeration {
   val Circe, Jsoniter = Value
@@ -69,12 +70,7 @@ object BasicGenerator {
       .groupBy(_._1)
       .map { case (keyName, pairs) =>
         val values = pairs.map(_._2)
-        val distinctTypes = values.map(_.tpe).distinct
-        if (distinctTypes.size != 1)
-          throw new IllegalArgumentException(
-            s"specification extensions with the same key are expected to all have the same type. Found $distinctTypes for $keyName"
-          )
-        val `type` = distinctTypes.head
+        val `type` = SpecificationExtensionRenderer.renderCombinedType(values)
         val name = strippedToCamelCase(keyName)
         val uncapitalisedName = name.head.toLower + name.tail
         val capitalisedName = name.head.toUpper + name.tail

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -1,9 +1,8 @@
 package sttp.tapir.codegen
 
-import io.circe.Json
 import sttp.tapir.codegen.BasicGenerator.{indent, mapSchemaSimpleTypeToType}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
-import sttp.tapir.codegen.openapi.models.{OpenapiSchemaType, Renderer}
+import sttp.tapir.codegen.openapi.models.{OpenapiSchemaType, DefaultValueRenderer}
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
 
 import scala.annotation.tailrec
@@ -267,7 +266,8 @@ class ClassDefinitionGenerator {
         val tpe = mapSchemaTypeToType(name, key, obj.required.contains(key), schemaType, isJson)
         val fixedKey = fixKey(key)
         val optional = schemaType.nullable || !obj.required.contains(key)
-        val maybeExplicitDefault = maybeDefault.map(" = " + Renderer.render(allModels = allSchemas, thisType = schemaType, optional)(_))
+        val maybeExplicitDefault =
+          maybeDefault.map(" = " + DefaultValueRenderer.render(allModels = allSchemas, thisType = schemaType, optional)(_))
         val default = maybeExplicitDefault getOrElse (if (optional) " = None" else "")
         s"$fixedKey: $tpe$default"
       }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -209,7 +209,9 @@ class EndpointGenerator {
       .map { case (k, v) =>
         val camelCaseK = strippedToCamelCase(k)
         val uncapitalisedName = camelCaseK.head.toLower + camelCaseK.tail
-        s""".attribute[${camelCaseK.capitalize}Extension](${uncapitalisedName}ExtensionKey, ${SpecificationExtensionRenderer.renderValue(v)})"""
+        val extensionType = s"${camelCaseK.capitalize}X"
+        val wrappedValue = s"XSpecificationExtension[$extensionType](${SpecificationExtensionRenderer.renderValue(v)})"
+        s""".attribute[XSpecificationExtension[$extensionType]](${uncapitalisedName}XKey, $wrappedValue)"""
       }
       .mkString("\n")
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -1,21 +1,15 @@
 package sttp.tapir.codegen
+import io.circe.Json
 import sttp.tapir.codegen.BasicGenerator.{indent, mapSchemaSimpleTypeToType, strippedToCamelCase}
-import sttp.tapir.codegen.openapi.models.OpenapiModels.{
-  OpenapiDocument,
-  OpenapiParameter,
-  OpenapiPath,
-  OpenapiRequestBody,
-  OpenapiResponse,
-  SpecificationExtensionValue
-}
+import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiDocument, OpenapiParameter, OpenapiPath, OpenapiRequestBody, OpenapiResponse}
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
+  OpenapiSchemaAny,
   OpenapiSchemaArray,
   OpenapiSchemaBinary,
   OpenapiSchemaRef,
-  OpenapiSchemaAny,
   OpenapiSchemaSimpleType
 }
-import sttp.tapir.codegen.openapi.models.{OpenapiComponent, OpenapiSchemaType, OpenapiSecuritySchemeType}
+import sttp.tapir.codegen.openapi.models.{OpenapiComponent, OpenapiSchemaType, OpenapiSecuritySchemeType, SpecificationExtensionRenderer}
 import sttp.tapir.codegen.util.JavaEscape
 
 case class Location(path: String, method: String) {
@@ -210,12 +204,12 @@ class EndpointGenerator {
     openapiTags.map(_.distinct.mkString(".tags(List(\"", "\", \"", "\"))")).mkString
   }
 
-  private def attributes(atts: Map[String, SpecificationExtensionValue]): Option[String] = if (atts.nonEmpty) Some {
+  private def attributes(atts: Map[String, Json]): Option[String] = if (atts.nonEmpty) Some {
     atts
       .map { case (k, v) =>
         val camelCaseK = strippedToCamelCase(k)
         val uncapitalisedName = camelCaseK.head.toLower + camelCaseK.tail
-        s""".attribute(${uncapitalisedName}ExtensionKey, ${v.render})"""
+        s""".attribute[${camelCaseK.capitalize}Extension](${uncapitalisedName}ExtensionKey, ${SpecificationExtensionRenderer.renderValue(v)})"""
       }
       .mkString("\n")
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -209,9 +209,7 @@ class EndpointGenerator {
       .map { case (k, v) =>
         val camelCaseK = strippedToCamelCase(k)
         val uncapitalisedName = camelCaseK.head.toLower + camelCaseK.tail
-        val extensionType = s"${camelCaseK.capitalize}X"
-        val wrappedValue = s"XSpecificationExtension[$extensionType](${SpecificationExtensionRenderer.renderValue(v)})"
-        s""".attribute[XSpecificationExtension[$extensionType]](${uncapitalisedName}XKey, $wrappedValue)"""
+        s""".attribute[${camelCaseK.capitalize}Extension](${uncapitalisedName}ExtensionKey, ${SpecificationExtensionRenderer.renderValue(v)})"""
       }
       .mkString("\n")
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/DefaultValueRenderer.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/DefaultValueRenderer.scala
@@ -18,7 +18,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaUUID
 }
 
-object Renderer {
+object DefaultValueRenderer {
   private def lookup(allModels: Map[String, OpenapiSchemaType], ref: OpenapiSchemaRef): OpenapiSchemaType = allModels(
     ref.name.stripPrefix("#/components/schemas/")
   )

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/SpecificationExtensionRenderer.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/SpecificationExtensionRenderer.scala
@@ -1,0 +1,48 @@
+package sttp.tapir.codegen.openapi.models
+
+import io.circe.Json
+
+object SpecificationExtensionRenderer {
+
+  def renderCombinedType(jsons: Seq[Json]): String = {
+    // permit nulls for any type, but specify type as null if every value is null
+    val nonNull = jsons.filterNot(_.isNull)
+    if (jsons.isEmpty) "Nothing"
+    else if (nonNull.isEmpty) "Null"
+    else {
+      val groupedByBaseType = nonNull.groupBy(j =>
+        if (j.isBoolean) "Boolean"
+        else if (j.isNumber) "Number"
+        else if (j.isString) "String"
+        else if (j.isArray) "Array"
+        else if (j.isObject) "Object"
+        else throw new IllegalStateException("json must be one of boolean, number, string, array or object")
+      )
+      // Cannot resolve types if totally different...
+      if (groupedByBaseType.size > 1) "Any"
+      else
+        groupedByBaseType.head match {
+          case (t @ ("Boolean" | "String"), _) => t
+          case ("Number", vs)                  => if (vs.forall(_.asNumber.flatMap(_.toLong).isDefined)) "Long" else "Double"
+          case ("Array", vs) =>
+            val t = renderCombinedType(vs.flatMap(_.asArray).flatten)
+            s"Seq[$t]"
+          case ("Object", kvs) =>
+            val t = renderCombinedType(kvs.flatMap(_.asObject).flatMap(_.toMap.values))
+            s"Map[String, $t]"
+          case (x, _) => throw new IllegalStateException(s"No such group $x")
+        }
+    }
+  }
+
+  def renderValue(json: Json): String = json.fold(
+    "null",
+    bool => bool.toString,
+    n => n.toLong.map(l => s"${l}L") getOrElse s"${n.toDouble}d", // the long repr is fine even if type expanded to Double
+    s => '"' +: s :+ '"',
+    arr => if (arr.isEmpty) "Vector.empty" else s"Vector(${arr.map(renderValue).mkString(", ")})",
+    obj =>
+      if (obj.isEmpty) "Map.empty[String, Nothing]"
+      else s"Map(${obj.toMap.map { case (k, v) => s""""$k" -> ${renderValue(v)}""" }.mkString(", ")})"
+  )
+}

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -260,19 +260,23 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       useHeadTagForObjectNames = false,
       jsonSerdeLib = "circe"
     )("TapirGeneratedEndpoints")
-    generatedCode should include(
-      """.attribute[String](new AttributeKey[String]("custom-string-extension-on-path"), "foobar")"""
-    )
-    generatedCode should include(
-      """.attribute[String](new AttributeKey[String]("custom-string-extension-on-operation"), "bazquux")"""
-    )
-    generatedCode should include(
-      """.attribute[Seq[String]](new AttributeKey[Seq[String]]("custom-list-extension-on-operation"), Vector("baz", "quux"))"""
-    )
-    generatedCode should include(
-      """.attribute[Map[String, Any]](new AttributeKey[Map[String, Any]]("custom-map-extension-on-path"), Map("bazkey" -> "bazval", "quuxkey" -> Vector("quux1", "quux2"))"""
-    )
     generatedCode shouldCompile ()
+    generatedCode should include(
+      """.attribute(customStringExtensionOnPathExtensionKey, "foobar")"""
+    )
+    generatedCode should include(
+      """.attribute(customStringExtensionOnOperationExtensionKey, "bazquux")"""
+    )
+    generatedCode should include(
+      """.attribute(customListExtensionOnOperationExtensionKey, Vector("baz", "quux"))"""
+    )
+    generatedCode should include(
+      """.attribute(customMapExtensionOnPathExtensionKey, Map("bazkey" -> "bazval", "quuxkey" -> Vector("quux1", "quux2"))"""
+    )
+    generatedCode should include("""type CustomMapExtensionOnOperationExtension = Map[String, Any]""")
+    generatedCode should include(
+      """val customMapExtensionOnOperationExtensionKey = new sttp.tapir.AttributeKey[CustomMapExtensionOnOperationExtension]("sttp.tapir.generated.TapirGeneratedEndpoints.CustomMapExtensionOnOperationExtension")""".stripMargin
+    )
   }
 
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -265,7 +265,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       """.attribute[CustomStringExtensionOnPathExtension](customStringExtensionOnPathExtensionKey, "another string")""",
       """.attribute[CustomStringExtensionOnOperationExtension](customStringExtensionOnOperationExtensionKey, "bazquux")""",
       """.attribute[CustomListExtensionOnOperationExtension](customListExtensionOnOperationExtensionKey, Vector("baz", "quux"))""",
-      """.attribute[CustomMapExtensionOnPathExtension](customMapExtensionOnPathExtensionKey, Map("bazkey" -> "bazval", "quuxkey" -> Vector("quux1", "quux2"))"""
+      """.attribute[CustomMapExtensionOnPathExtension](customMapExtensionOnPathExtensionKey, Map("bazkey" -> "bazval", "quuxkey" -> Vector("quux1", "quux2"))""",
+      """.attribute[CustomStringExtensionOnPathDoubleTypeExtension](customStringExtensionOnPathDoubleTypeExtensionKey, 123L)"""
     )
     expectedAttrDecls foreach (decl => generatedCode should include(decl))
     generatedCode should include(

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -250,4 +250,29 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
     generatedCode shouldCompile ()
   }
 
+  it should "generate attributes for specification extensions on path and operation objects" in {
+    val doc = TestHelpers.specificationExtensionDocs
+    val generatedCode = BasicGenerator.generateObjects(
+      doc,
+      "sttp.tapir.generated",
+      "TapirGeneratedEndpoints",
+      targetScala3 = false,
+      useHeadTagForObjectNames = false,
+      jsonSerdeLib = "circe"
+    )("TapirGeneratedEndpoints")
+    generatedCode should include(
+      """.attribute[String](new AttributeKey[String]("custom-string-extension-on-path"), "foobar")"""
+    )
+    generatedCode should include(
+      """.attribute[String](new AttributeKey[String]("custom-string-extension-on-operation"), "bazquux")"""
+    )
+    generatedCode should include(
+      """.attribute[Seq[String]](new AttributeKey[Seq[String]]("custom-list-extension-on-operation"), Vector("baz", "quux"))"""
+    )
+    generatedCode should include(
+      """.attribute[Map[String, Any]](new AttributeKey[Map[String, Any]]("custom-map-extension-on-path"), Map("bazkey" -> "bazval", "quuxkey" -> Vector("quux1", "quux2"))"""
+    )
+    generatedCode shouldCompile ()
+  }
+
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -261,22 +261,27 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       jsonSerdeLib = "circe"
     )("TapirGeneratedEndpoints")
     generatedCode shouldCompile ()
-    generatedCode should include(
-      """.attribute(customStringExtensionOnPathExtensionKey, "foobar")"""
+    val expectedAttrDecls = Seq(
+      """.attribute[CustomStringExtensionOnPathExtension](customStringExtensionOnPathExtensionKey, "another string")""",
+      """.attribute[CustomStringExtensionOnOperationExtension](customStringExtensionOnOperationExtensionKey, "bazquux")""",
+      """.attribute[CustomListExtensionOnOperationExtension](customListExtensionOnOperationExtensionKey, Vector("baz", "quux"))""",
+      """.attribute[CustomMapExtensionOnPathExtension](customMapExtensionOnPathExtensionKey, Map("bazkey" -> "bazval", "quuxkey" -> Vector("quux1", "quux2"))"""
     )
-    generatedCode should include(
-      """.attribute(customStringExtensionOnOperationExtensionKey, "bazquux")"""
-    )
-    generatedCode should include(
-      """.attribute(customListExtensionOnOperationExtensionKey, Vector("baz", "quux"))"""
-    )
-    generatedCode should include(
-      """.attribute(customMapExtensionOnPathExtensionKey, Map("bazkey" -> "bazval", "quuxkey" -> Vector("quux1", "quux2"))"""
-    )
-    generatedCode should include("""type CustomMapExtensionOnOperationExtension = Map[String, Any]""")
+    expectedAttrDecls foreach (decl => generatedCode should include(decl))
     generatedCode should include(
       """val customMapExtensionOnOperationExtensionKey = new sttp.tapir.AttributeKey[CustomMapExtensionOnOperationExtension]("sttp.tapir.generated.TapirGeneratedEndpoints.CustomMapExtensionOnOperationExtension")""".stripMargin
     )
+    val expectedKeyDeclarations = Seq(
+      """type CustomMapExtensionOnOperationExtension = Map[String, Any]""",
+      """type CustomListExtensionOnPathAnyTypeExtension = Seq[Any]""",
+      """type CustomMapExtensionOnPathSingleValueTypeExtension = Map[String, String]""",
+      """type CustomListExtensionOnOperationExtension = Seq[String]""",
+      """type CustomStringExtensionOnPathAnyTypeExtension = Any""",
+      """type CustomStringExtensionOnPathDoubleTypeExtension = Double""",
+      """type CustomListExtensionOnPathExtension = Seq[String]""",
+      """type CustomStringExtensionOnPathExtension = String"""
+    )
+    expectedKeyDeclarations foreach (decl => generatedCode should include(decl))
   }
 
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -262,25 +262,25 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
     )("TapirGeneratedEndpoints")
     generatedCode shouldCompile ()
     val expectedAttrDecls = Seq(
-      """.attribute[CustomStringExtensionOnPathExtension](customStringExtensionOnPathExtensionKey, "another string")""",
-      """.attribute[CustomStringExtensionOnOperationExtension](customStringExtensionOnOperationExtensionKey, "bazquux")""",
-      """.attribute[CustomListExtensionOnOperationExtension](customListExtensionOnOperationExtensionKey, Vector("baz", "quux"))""",
-      """.attribute[CustomMapExtensionOnPathExtension](customMapExtensionOnPathExtensionKey, Map("bazkey" -> "bazval", "quuxkey" -> Vector("quux1", "quux2"))""",
-      """.attribute[CustomStringExtensionOnPathDoubleTypeExtension](customStringExtensionOnPathDoubleTypeExtensionKey, 123L)"""
+      """.attribute[XSpecificationExtension[CustomStringExtensionOnPathX]](customStringExtensionOnPathXKey, XSpecificationExtension[CustomStringExtensionOnPathX]("another string"))""",
+      """.attribute[XSpecificationExtension[CustomStringExtensionOnOperationX]](customStringExtensionOnOperationXKey, XSpecificationExtension[CustomStringExtensionOnOperationX]("bazquux"))""",
+      """.attribute[XSpecificationExtension[CustomListExtensionOnOperationX]](customListExtensionOnOperationXKey, XSpecificationExtension[CustomListExtensionOnOperationX](Vector("baz", "quux")))""",
+      """.attribute[XSpecificationExtension[CustomMapExtensionOnPathX]](customMapExtensionOnPathXKey, XSpecificationExtension[CustomMapExtensionOnPathX](Map("bazkey" -> "bazval", "quuxkey" -> Vector("quux1", "quux2")))""",
+      """.attribute[XSpecificationExtension[CustomStringExtensionOnPathDoubleTypeX]](customStringExtensionOnPathDoubleTypeXKey, XSpecificationExtension[CustomStringExtensionOnPathDoubleTypeX](123L))"""
     )
     expectedAttrDecls foreach (decl => generatedCode should include(decl))
     generatedCode should include(
-      """val customMapExtensionOnOperationExtensionKey = new sttp.tapir.AttributeKey[CustomMapExtensionOnOperationExtension]("sttp.tapir.generated.TapirGeneratedEndpoints.CustomMapExtensionOnOperationExtension")""".stripMargin
+      """val customMapExtensionOnOperationXKey = new sttp.tapir.AttributeKey[XSpecificationExtension[CustomMapExtensionOnOperationX]]("sttp.tapir.generated.TapirGeneratedEndpoints.XSpecificationExtension[sttp.tapir.generated.TapirGeneratedEndpoints.CustomMapExtensionOnOperationX]")""".stripMargin
     )
     val expectedKeyDeclarations = Seq(
-      """type CustomMapExtensionOnOperationExtension = Map[String, Any]""",
-      """type CustomListExtensionOnPathAnyTypeExtension = Seq[Any]""",
-      """type CustomMapExtensionOnPathSingleValueTypeExtension = Map[String, String]""",
-      """type CustomListExtensionOnOperationExtension = Seq[String]""",
-      """type CustomStringExtensionOnPathAnyTypeExtension = Any""",
-      """type CustomStringExtensionOnPathDoubleTypeExtension = Double""",
-      """type CustomListExtensionOnPathExtension = Seq[String]""",
-      """type CustomStringExtensionOnPathExtension = String"""
+      """type CustomMapExtensionOnOperationX = Map[String, Any]""",
+      """type CustomListExtensionOnPathAnyTypeX = Seq[Any]""",
+      """type CustomMapExtensionOnPathSingleValueTypeX = Map[String, String]""",
+      """type CustomListExtensionOnOperationX = Seq[String]""",
+      """type CustomStringExtensionOnPathAnyTypeX = Any""",
+      """type CustomStringExtensionOnPathDoubleTypeX = Double""",
+      """type CustomListExtensionOnPathX = Seq[String]""",
+      """type CustomStringExtensionOnPathX = String"""
     )
     expectedKeyDeclarations foreach (decl => generatedCode should include(decl))
   }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -262,25 +262,25 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
     )("TapirGeneratedEndpoints")
     generatedCode shouldCompile ()
     val expectedAttrDecls = Seq(
-      """.attribute[XSpecificationExtension[CustomStringExtensionOnPathX]](customStringExtensionOnPathXKey, XSpecificationExtension[CustomStringExtensionOnPathX]("another string"))""",
-      """.attribute[XSpecificationExtension[CustomStringExtensionOnOperationX]](customStringExtensionOnOperationXKey, XSpecificationExtension[CustomStringExtensionOnOperationX]("bazquux"))""",
-      """.attribute[XSpecificationExtension[CustomListExtensionOnOperationX]](customListExtensionOnOperationXKey, XSpecificationExtension[CustomListExtensionOnOperationX](Vector("baz", "quux")))""",
-      """.attribute[XSpecificationExtension[CustomMapExtensionOnPathX]](customMapExtensionOnPathXKey, XSpecificationExtension[CustomMapExtensionOnPathX](Map("bazkey" -> "bazval", "quuxkey" -> Vector("quux1", "quux2")))""",
-      """.attribute[XSpecificationExtension[CustomStringExtensionOnPathDoubleTypeX]](customStringExtensionOnPathDoubleTypeXKey, XSpecificationExtension[CustomStringExtensionOnPathDoubleTypeX](123L))"""
+      """.attribute[CustomStringExtensionOnPathExtension](customStringExtensionOnPathExtensionKey, "another string")""",
+      """.attribute[CustomStringExtensionOnOperationExtension](customStringExtensionOnOperationExtensionKey, "bazquux")""",
+      """.attribute[CustomListExtensionOnOperationExtension](customListExtensionOnOperationExtensionKey, Vector("baz", "quux"))""",
+      """.attribute[CustomMapExtensionOnPathExtension](customMapExtensionOnPathExtensionKey, Map("bazkey" -> "bazval", "quuxkey" -> Vector("quux1", "quux2"))""",
+      """.attribute[CustomStringExtensionOnPathDoubleTypeExtension](customStringExtensionOnPathDoubleTypeExtensionKey, 123L)"""
     )
     expectedAttrDecls foreach (decl => generatedCode should include(decl))
     generatedCode should include(
-      """val customMapExtensionOnOperationXKey = new sttp.tapir.AttributeKey[XSpecificationExtension[CustomMapExtensionOnOperationX]]("sttp.tapir.generated.TapirGeneratedEndpoints.XSpecificationExtension[sttp.tapir.generated.TapirGeneratedEndpoints.CustomMapExtensionOnOperationX]")""".stripMargin
+      """val customMapExtensionOnOperationExtensionKey = new sttp.tapir.AttributeKey[CustomMapExtensionOnOperationExtension]("sttp.tapir.generated.TapirGeneratedEndpoints.CustomMapExtensionOnOperationExtension")""".stripMargin
     )
     val expectedKeyDeclarations = Seq(
-      """type CustomMapExtensionOnOperationX = Map[String, Any]""",
-      """type CustomListExtensionOnPathAnyTypeX = Seq[Any]""",
-      """type CustomMapExtensionOnPathSingleValueTypeX = Map[String, String]""",
-      """type CustomListExtensionOnOperationX = Seq[String]""",
-      """type CustomStringExtensionOnPathAnyTypeX = Any""",
-      """type CustomStringExtensionOnPathDoubleTypeX = Double""",
-      """type CustomListExtensionOnPathX = Seq[String]""",
-      """type CustomStringExtensionOnPathX = String"""
+      """type CustomMapExtensionOnOperationExtension = Map[String, Any]""",
+      """type CustomListExtensionOnPathAnyTypeExtension = Seq[Any]""",
+      """type CustomMapExtensionOnPathSingleValueTypeExtension = Map[String, String]""",
+      """type CustomListExtensionOnOperationExtension = Seq[String]""",
+      """type CustomStringExtensionOnPathAnyTypeExtension = Any""",
+      """type CustomStringExtensionOnPathDoubleTypeExtension = Double""",
+      """type CustomListExtensionOnPathExtension = Seq[String]""",
+      """type CustomStringExtensionOnPathExtension = String"""
     )
     expectedKeyDeclarations foreach (decl => generatedCode should include(decl))
   }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.codegen
 
 import io.circe.Json
-import sttp.tapir.codegen.openapi.models._
+import sttp.tapir.codegen.openapi.models.OpenapiComponent
 import sttp.tapir.codegen.openapi.models.OpenapiModels._
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaArray,
@@ -762,5 +762,88 @@ object TestHelpers {
         Map()
       )
     )
+  )
+
+  val specificationExtensionYaml =
+    """
+     |openapi: 3.1.0
+     |info:
+     |  title: hello goodbye
+     |  version: '1.0'
+     |paths:
+     |  /hello:
+     |    x-custom-string-extension-on-path: foobar
+     |    x-custom-list-extension-on-path:
+     |      - foo
+     |      - bar
+     |    x-custom-map-extension-on-path:
+     |      bazkey: bazval
+     |      quuxkey:
+     |        - quux1
+     |        - quux2
+     |    post:
+     |      responses: {}
+     |  /goodbye:
+     |    delete:
+     |      x-custom-string-extension-on-operation: bazquux
+     |      x-custom-list-extension-on-operation:
+     |        - baz
+     |        - quux
+     |      x-custom-map-extension-on-operation:
+     |        bazkey: bazval
+     |        quuxkey:
+     |          - quux1
+     |          - quux2
+     |      responses: {}""".stripMargin
+
+  val specificationExtensionDocs = OpenapiDocument(
+    "3.1.0",
+    OpenapiInfo("hello goodbye", "1.0"),
+    Seq(
+      OpenapiPath(
+        url = "/hello",
+        methods = Seq(OpenapiPathMethod(methodType = "post", parameters = Seq(), responses = Seq(), requestBody = None)),
+        specificationExtensions = Map(
+          "custom-string-extension-on-path" -> SpecificationExtensionValueString("foobar"),
+          "custom-list-extension-on-path" -> SpecificationExtensionValueList(
+            Vector(SpecificationExtensionValueString("foo"), SpecificationExtensionValueString("bar"))
+          ),
+          "custom-map-extension-on-path" -> SpecificationExtensionValueMap(
+            Map(
+              "bazkey" -> SpecificationExtensionValueString("bazval"),
+              "quuxkey" -> SpecificationExtensionValueList(
+                Vector(SpecificationExtensionValueString("quux1"), SpecificationExtensionValueString("quux2"))
+              )
+            )
+          )
+        )
+      ),
+      OpenapiPath(
+        url = "/goodbye",
+        methods = Seq(
+          OpenapiPathMethod(
+            methodType = "delete",
+            parameters = Seq(),
+            responses = Seq(),
+            requestBody = None,
+            specificationExtensions = Map(
+              "custom-string-extension-on-operation" -> SpecificationExtensionValueString("bazquux"),
+              "custom-list-extension-on-operation" -> SpecificationExtensionValueList(
+                Vector(SpecificationExtensionValueString("baz"), SpecificationExtensionValueString("quux"))
+              ),
+              "custom-map-extension-on-operation" -> SpecificationExtensionValueMap(
+                Map(
+                  "bazkey" -> SpecificationExtensionValueString("bazval"),
+                  "quuxkey" -> SpecificationExtensionValueList(
+                    Vector(SpecificationExtensionValueString("quux1"), SpecificationExtensionValueString("quux2"))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    ),
+    None
   )
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -772,10 +772,14 @@ object TestHelpers {
      |  version: '1.0'
      |paths:
      |  /hello:
-     |    x-custom-string-extension-on-path: foobar
+     |    x-custom-string-extension-on-path-any-type: foobar
+     |    x-custom-string-extension-on-path-double-type: 123
+     |    x-custom-string-extension-on-path: null
      |    x-custom-list-extension-on-path:
      |      - foo
      |      - bar
+     |    x-custom-list-extension-on-path-any-type:
+     |      - string
      |    x-custom-map-extension-on-path:
      |      bazkey: bazval
      |      quuxkey:
@@ -784,6 +788,16 @@ object TestHelpers {
      |    post:
      |      responses: {}
      |  /goodbye:
+     |    x-custom-string-extension-on-path-any-type: 123
+     |    x-custom-string-extension-on-path-double-type: 123.456
+     |    x-custom-string-extension-on-path: another string
+     |    x-custom-list-extension-on-path: []
+     |    x-custom-list-extension-on-path-any-type:
+     |      - 123
+     |    x-custom-map-extension-on-path: {}
+     |    x-custom-map-extension-on-path-single-value-type:
+     |      bazkey: bazval
+     |      quuxkey: quuxval
      |    delete:
      |      x-custom-string-extension-on-operation: bazquux
      |      x-custom-list-extension-on-operation:
@@ -804,15 +818,17 @@ object TestHelpers {
         url = "/hello",
         methods = Seq(OpenapiPathMethod(methodType = "post", parameters = Seq(), responses = Seq(), requestBody = None)),
         specificationExtensions = Map(
-          "custom-string-extension-on-path" -> SpecificationExtensionValueString("foobar"),
-          "custom-list-extension-on-path" -> SpecificationExtensionValueList(
-            Vector(SpecificationExtensionValueString("foo"), SpecificationExtensionValueString("bar"))
+          "custom-string-extension-on-path-any-type" -> Json.fromString("foobar"),
+          "custom-string-extension-on-path-double-type" -> Json.fromLong(123L),
+          "custom-list-extension-on-path" -> Json.fromValues(
+            Vector(Json.fromString("foo"), Json.fromString("bar"))
           ),
-          "custom-map-extension-on-path" -> SpecificationExtensionValueMap(
+          "custom-list-extension-on-path-any-type" -> Json.arr(Json.fromString("string")),
+          "custom-map-extension-on-path" -> Json.fromFields(
             Map(
-              "bazkey" -> SpecificationExtensionValueString("bazval"),
-              "quuxkey" -> SpecificationExtensionValueList(
-                Vector(SpecificationExtensionValueString("quux1"), SpecificationExtensionValueString("quux2"))
+              "bazkey" -> Json.fromString("bazval"),
+              "quuxkey" -> Json.fromValues(
+                Vector(Json.fromString("quux1"), Json.fromString("quux2"))
               )
             )
           )
@@ -827,18 +843,32 @@ object TestHelpers {
             responses = Seq(),
             requestBody = None,
             specificationExtensions = Map(
-              "custom-string-extension-on-operation" -> SpecificationExtensionValueString("bazquux"),
-              "custom-list-extension-on-operation" -> SpecificationExtensionValueList(
-                Vector(SpecificationExtensionValueString("baz"), SpecificationExtensionValueString("quux"))
+              "custom-string-extension-on-operation" -> Json.fromString("bazquux"),
+              "custom-list-extension-on-operation" -> Json.fromValues(
+                Vector(Json.fromString("baz"), Json.fromString("quux"))
               ),
-              "custom-map-extension-on-operation" -> SpecificationExtensionValueMap(
+              "custom-map-extension-on-operation" -> Json.fromFields(
                 Map(
-                  "bazkey" -> SpecificationExtensionValueString("bazval"),
-                  "quuxkey" -> SpecificationExtensionValueList(
-                    Vector(SpecificationExtensionValueString("quux1"), SpecificationExtensionValueString("quux2"))
+                  "bazkey" -> Json.fromString("bazval"),
+                  "quuxkey" -> Json.fromValues(
+                    Vector(Json.fromString("quux1"), Json.fromString("quux2"))
                   )
                 )
               )
+            )
+          )
+        ),
+        specificationExtensions = Map(
+          "custom-string-extension-on-path-any-type" -> Json.fromLong(123L),
+          "custom-string-extension-on-path-double-type" -> Json.fromDouble(123.456d).get,
+          "custom-string-extension-on-path" -> Json.fromString("another string"),
+          "custom-list-extension-on-path" -> Json.arr(),
+          "custom-list-extension-on-path-any-type" -> Json.arr(Json.fromLong(123L)),
+          "custom-map-extension-on-path" -> Json.fromFields(Map.empty),
+          "custom-map-extension-on-path-single-value-type" -> Json.fromFields(
+            Map(
+              "bazkey" -> Json.fromString("bazval"),
+              "quuxkey" -> Json.fromString("quuxval")
             )
           )
         )

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
@@ -178,4 +178,15 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers {
       TestHelpers.withDefaultsDocs
     ))
   }
+
+  it should "parse endpoint with simple specification extensions" in {
+    val res = parser
+      .parse(TestHelpers.specificationExtensionYaml)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[OpenapiDocument])
+
+    res shouldBe (Right(
+      TestHelpers.specificationExtensionDocs
+    ))
+  }
 }


### PR DESCRIPTION
The OpenApi spec permits defining [Specification Extensions](https://swagger.io/specification/#specification-extensions) on a large number of components. Not all of those have any kind of obvious mapping into the tapir model; however it feels natural to map extensions on path and operation definitions into `.attribute` declarations on generated endpoints, thus making this metadata accessible at runtime for $variousSundryPurposes


For context, this would enable me to implement some specific authorization guards cleanly at the implementation layer without having to hack around with tags. I don't think tapir would currently emit any specification extensions when generating the openapi from an endpoint with attributes, so I guess there's a break in idempotency there? But since we currently ignore extensions anyway I don't consider that a new issue and think this should be ok... Happy to engage in alternatives to solve the same problem! But I do think this is the most sensible route 

