### PR TITLE
codegen: support enum query params

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -87,7 +87,7 @@ having no tags, would be output to the `TapirGeneratedEndpoints` file, along wit
 Currently, the generated code depends on `"io.circe" %% "circe-generic"`. In the future probably we will make the encoder/decoder json lib configurable (PRs welcome).
 
 String-like enums in Scala 2 depend on both `"com.beachape" %% "enumeratum"` and `"com.beachape" %% "enumeratum-circe"`.
-For Scala 3 we derive native enums, and depend instead on `"org.latestbit" %% "circe-tagged-adt-codec"`.
+For Scala 3 we derive native enums, and depend on `"org.latestbit" %% "circe-tagged-adt-codec"` for json serdes and `"io.github.bishabosha" %% "enum-extensions"` for query param serdes.
 Other forms of OpenApi enum are not currently supported.
 
 We currently miss a lot of OpenApi features like:

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -33,7 +33,7 @@ object BasicGenerator {
       if (!targetScala3 && doc.components.toSeq.flatMap(_.schemas).exists(_._2.isInstanceOf[OpenapiSchemaEnum])) "\n  import enumeratum._"
       else ""
 
-    val endpointsByTag = endpointGenerator.endpointDefs(doc, useHeadTagForObjectNames)
+    val EndpointDefs(endpointsByTag, queryParamRefs) = endpointGenerator.endpointDefs(doc, useHeadTagForObjectNames)
     val taggedObjs = endpointsByTag.collect {
       case (Some(headTag), body) if body.nonEmpty =>
         val taggedObj =
@@ -57,7 +57,7 @@ object BasicGenerator {
         |
         |${indent(2)(imports)}$enumImport
         |
-        |${indent(2)(classGenerator.classDefs(doc, targetScala3).getOrElse(""))}
+        |${indent(2)(classGenerator.classDefs(doc, targetScala3, queryParamRefs).getOrElse(""))}
         |
         |${indent(2)(endpointsByTag.getOrElse(None, ""))}
         |

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -7,7 +7,6 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaBinary,
   OpenapiSchemaDateTime,
   OpenapiSchemaDouble,
-  OpenapiSchemaEnum,
   OpenapiSchemaFloat,
   OpenapiSchemaInt,
   OpenapiSchemaLong,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -29,10 +29,6 @@ object BasicGenerator {
       targetScala3: Boolean,
       useHeadTagForObjectNames: Boolean
   ): Map[String, String] = {
-    val enumImport =
-      if (!targetScala3 && doc.components.toSeq.flatMap(_.schemas).exists(_._2.isInstanceOf[OpenapiSchemaEnum])) "\n  import enumeratum._"
-      else ""
-
     val EndpointDefs(endpointsByTag, queryParamRefs) = endpointGenerator.endpointDefs(doc, useHeadTagForObjectNames)
     val taggedObjs = endpointsByTag.collect {
       case (Some(headTag), body) if body.nonEmpty =>
@@ -55,7 +51,7 @@ object BasicGenerator {
         |
         |object $objName {
         |
-        |${indent(2)(imports)}$enumImport
+        |${indent(2)(imports)}
         |
         |${indent(2)(classGenerator.classDefs(doc, targetScala3, queryParamRefs).getOrElse(""))}
         |

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -5,7 +5,6 @@ import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaArray,
-  OpenapiSchemaConstantString,
   OpenapiSchemaEnum,
   OpenapiSchemaMap,
   OpenapiSchemaObject,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -33,7 +33,7 @@ class ClassDefinitionGenerator {
           |    .mapDecode(s =>
           |      // Case-insensitive mapping
           |      scala.util
-          |        .Try(enumMap[T](using enumextensions.EnumMirror[T])(s.toUpperCase)) 
+          |        .Try(enumMap[T](using enumextensions.EnumMirror[T])(s.toUpperCase))
           |        .fold(
           |          _ =>
           |            sttp.tapir.DecodeResult.Error(

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -33,8 +33,17 @@ class ClassDefinitionGenerator {
           |    .mapDecode(s =>
           |      // Case-insensitive mapping
           |      scala.util
-          |        .Try(enumMap[T](using enumextensions.EnumMirror[T])(s.toUpperCase)) // TODO a nicer error on the stack trace instead of java.util.NoSuchElementException: key not found
-          |        .fold(sttp.tapir.DecodeResult.Error(s, _), sttp.tapir.DecodeResult.Value(_))
+          |        .Try(enumMap[T](using enumextensions.EnumMirror[T])(s.toUpperCase)) 
+          |        .fold(
+          |          _ =>
+          |            sttp.tapir.DecodeResult.Error(
+          |              s,
+          |              new NoSuchElementException(
+          |                s"Could not find value $s for enum ${enumextensions.EnumMirror[T].mirroredName}, available values: ${enumextensions.EnumMirror[T].values.mkString(", ")}"
+          |              )
+          |            ),
+          |          sttp.tapir.DecodeResult.Value(_)
+          |        )
           |    )(_.name)
           |""".stripMargin
       else

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -23,7 +23,7 @@ class ClassDefinitionGenerator {
       if (!generatesQueryParamEnums) ""
       else if (targetScala3) "" // TODO
       else
-        """  def makeQueryCodecForEnum[T <: EnumEntry](T: Enum[T] with CirceEnum[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] =
+        """  def makeQueryCodecForEnum[T <: enumeratum.EnumEntry](T: enumeratum.Enum[T] with enumeratum.CirceEnum[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] =
           |    sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
           |      .mapDecode(s =>
           |        // Case-insensitive mapping
@@ -70,8 +70,8 @@ class ClassDefinitionGenerator {
        |  implicit val ${name.head.toLower +: name.tail}Codec: sttp.tapir.Codec[List[String], ${name}, sttp.tapir.CodecFormat.TextPlain] =
        |    makeQueryCodecForEnum(${name})""".stripMargin
       else ""
-    s"""|sealed trait $name extends EnumEntry
-        |object $name extends Enum[$name] with CirceEnum[$name] {
+    s"""|sealed trait $name extends enumeratum.EnumEntry
+        |object $name extends enumeratum.Enum[$name] with enumeratum.CirceEnum[$name] {
         |  val values = findValues
         |${indent(2)(members.mkString("\n"))}$maybeQueryCodecDefn
         |}""".stripMargin :: Nil

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -50,19 +50,19 @@ class ClassDefinitionGenerator {
         """def makeQueryCodecForEnum[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] =
           |  sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
           |    .mapDecode(s =>
-          |        // Case-insensitive mapping
-          |        scala.util.Try(T.upperCaseNameValuesToMap(s.toUpperCase))
-          |          .fold(
-          |            _ =>
-          |              sttp.tapir.DecodeResult.Error(
-          |                s,
-          |                new NoSuchElementException(
-          |                  s"Could not find value $s for enum ${enumName}, available values: ${T.values.mkString(", ")}"
-          |                )
-          |              ),
-          |            sttp.tapir.DecodeResult.Value(_)
-          |          )
-          |      )(_.entryName)
+          |      // Case-insensitive mapping
+          |      scala.util.Try(T.upperCaseNameValuesToMap(s.toUpperCase))
+          |        .fold(
+          |          _ =>
+          |            sttp.tapir.DecodeResult.Error(
+          |              s,
+          |              new NoSuchElementException(
+          |                s"Could not find value $s for enum ${enumName}, available values: ${T.values.mkString(", ")}"
+          |              )
+          |            ),
+          |          sttp.tapir.DecodeResult.Value(_)
+          |        )
+          |    )(_.entryName)
           |""".stripMargin
     val defns = doc.components
       .map(_.schemas.flatMap {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -4,7 +4,6 @@ import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiDocument, Openapi
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaArray,
   OpenapiSchemaBinary,
-  OpenapiSchemaEnum,
   OpenapiSchemaRef,
   OpenapiSchemaSimpleType
 }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -4,6 +4,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiDocument, Openapi
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaArray,
   OpenapiSchemaBinary,
+  OpenapiSchemaEnum,
   OpenapiSchemaRef,
   OpenapiSchemaSimpleType
 }
@@ -14,16 +15,25 @@ case class Location(path: String, method: String) {
   override def toString: String = s"${method.toUpperCase} ${path}"
 }
 
+case class GeneratedEndpoints(namesAndBodies: Seq[(Option[String], Seq[(String, String)])], queryParamRefs: Set[String]) {
+  def merge(that: GeneratedEndpoints): GeneratedEndpoints =
+    GeneratedEndpoints(
+      (namesAndBodies ++ that.namesAndBodies).groupBy(_._1).mapValues(_.map(_._2).reduce(_ ++ _)).toSeq,
+      queryParamRefs ++ that.queryParamRefs
+    )
+}
+case class EndpointDefs(endpointDecls: Map[Option[String], String], queryParamRefs: Set[String])
+
 class EndpointGenerator {
   private def bail(msg: String)(implicit location: Location): Nothing = throw new NotImplementedError(s"$msg at $location")
 
   private[codegen] def allEndpoints: String = "generatedEndpoints"
 
-  def endpointDefs(doc: OpenapiDocument, useHeadTagForObjectNames: Boolean): Map[Option[String], String] = {
+  def endpointDefs(doc: OpenapiDocument, useHeadTagForObjectNames: Boolean): EndpointDefs = {
     val components = Option(doc.components).flatten
-    val geMap =
-      doc.paths.flatMap(generatedEndpoints(components, useHeadTagForObjectNames)).groupBy(_._1).mapValues(_.map(_._2).reduce(_ ++ _))
-    geMap.mapValues { ge =>
+    val GeneratedEndpoints(geMap, queryParamRefs) =
+      doc.paths.map(generatedEndpoints(components, useHeadTagForObjectNames)).foldLeft(GeneratedEndpoints(Nil, Set.empty))(_ merge _)
+    val endpointDecls = geMap.map { case (k, ge) =>
       val definitions = ge
         .map { case (name, definition) =>
           s"""|lazy val $name =
@@ -33,20 +43,21 @@ class EndpointGenerator {
         .mkString("\n")
       val allEP = s"lazy val $allEndpoints = List(${ge.map(_._1).mkString(", ")})"
 
-      s"""|$definitions
+      k -> s"""|$definitions
           |
           |$allEP
           |""".stripMargin
     }.toMap
+    EndpointDefs(endpointDecls, queryParamRefs)
   }
 
   private[codegen] def generatedEndpoints(components: Option[OpenapiComponent], useHeadTagForObjectNames: Boolean)(
       p: OpenapiPath
-  ): Seq[(Option[String], Seq[(String, String)])] = {
+  ): GeneratedEndpoints = {
     val parameters = components.map(_.parameters).getOrElse(Map.empty)
     val securitySchemes = components.map(_.securitySchemes).getOrElse(Map.empty)
 
-    p.methods
+    val (fileNamesAndParams, unflattenedQueryParamRefs) = p.methods
       .map(_.withResolvedParentParameters(parameters, p.parameters))
       .map { m =>
         implicit val location: Location = Location(p.url, m.methodType)
@@ -68,11 +79,18 @@ class EndpointGenerator {
           .map { case (part, 0) => part; case (part, _) => part.capitalize }
           .mkString
         val maybeTargetFileName = if (useHeadTagForObjectNames) m.tags.flatMap(_.headOption) else None
-        (maybeTargetFileName, (name, definition))
+        val queryParamRefs = m.resolvedParameters
+          .collect { case queryParam: OpenapiParameter if queryParam.in == "query" => queryParam.schema }
+          .collect { case OpenapiSchemaRef(ref) if ref.startsWith("#/components/schemas/") => ref.stripPrefix("#/components/schemas/") }
+          .toSet
+        (maybeTargetFileName, (name, definition)) -> queryParamRefs
       }
+      .unzip
+    val namesAndParamsByFile = fileNamesAndParams
       .groupBy(_._1)
       .toSeq
       .map { case (maybeTargetFileName, defns) => maybeTargetFileName -> defns.map(_._2) }
+    GeneratedEndpoints(namesAndParamsByFile, unflattenedQueryParamRefs.foldLeft(Set.empty[String])(_ ++ _))
   }
 
   private def urlMapper(url: String, parameters: Seq[OpenapiParameter])(implicit location: Location): String = {

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
@@ -40,8 +40,9 @@ class BasicGeneratorSpec extends CompileCheckTestBase {
       TestHelpers.enumQueryParamDocs,
       "sttp.tapir.generated",
       "TapirGeneratedEndpoints",
-      targetScala3 = false
-    ) shouldCompile ()
+      targetScala3 = false,
+      useHeadTagForObjectNames = false
+    )("TapirGeneratedEndpoints") shouldCompile ()
   }
 
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
@@ -35,4 +35,14 @@ class BasicGeneratorSpec extends CompileCheckTestBase {
     (schemas + "\n" + (endpoints.linesIterator.filterNot(_ startsWith "package").mkString("\n"))) shouldCompile ()
   }
 
+  it should "compile endpoints with enum query params" in {
+    BasicGenerator.generateObjects(
+      TestHelpers.enumQueryParamDocs,
+      "sttp.tapir.generated",
+      "TapirGeneratedEndpoints",
+      targetScala3 = false,
+      useHeadTagForObjectNames = false
+    )("TapirGeneratedEndpoints") shouldCompile ()
+  }
+
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
@@ -40,9 +40,8 @@ class BasicGeneratorSpec extends CompileCheckTestBase {
       TestHelpers.enumQueryParamDocs,
       "sttp.tapir.generated",
       "TapirGeneratedEndpoints",
-      targetScala3 = false,
-      useHeadTagForObjectNames = false
-    )("TapirGeneratedEndpoints") shouldCompile ()
+      targetScala3 = false
+    ) shouldCompile ()
   }
 
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -344,7 +344,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
 
     val res: String = parserRes match {
       case Left(value) => throw new Exception(value)
-      case Right(doc)  => new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false)(None)
+      case Right(doc)  => new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false).endpointDecls(None)
     }
 
     val compileUnit =

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -355,7 +355,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
          |  $res
          |}
          |  """.stripMargin
-    println(compileUnit)
+
     compileUnit shouldCompile ()
 
   }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -55,7 +55,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       )
     )
     // the enumeratum import should be included by the BasicGenerator iff we generated enums
-    "import enumeratum._;" + (new ClassDefinitionGenerator().classDefs(doc).get) shouldCompile ()
+    new ClassDefinitionGenerator().classDefs(doc).get shouldCompile ()
   }
 
   it should "generate simple class with reserved propName" in {
@@ -305,8 +305,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     )
 
     val gen = new ClassDefinitionGenerator()
-    val res = gen.classDefs(doc, false)
-    "import enumeratum._;" + res.get shouldCompile ()
+    gen.classDefs(doc, false).get shouldCompile ()
   }
 
   import cats.implicits._

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -298,8 +298,17 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       |    .mapDecode(s =>
       |      // Case-insensitive mapping
       |      scala.util
-      |        .Try(enumMap[T](using enumextensions.EnumMirror[T])(s.toUpperCase)) // TODO a nicer error on the stack trace instead of java.util.NoSuchElementException: key not found
-      |        .fold(sttp.tapir.DecodeResult.Error(s, _), sttp.tapir.DecodeResult.Value(_))
+      |        .Try(enumMap[T](using enumextensions.EnumMirror[T])(s.toUpperCase))
+      |        .fold(
+      |          _ =>
+      |            sttp.tapir.DecodeResult.Error(
+      |              s,
+      |              new NoSuchElementException(
+      |                s"Could not find value $s for enum ${enumextensions.EnumMirror[T].mirroredName}, available values: ${enumextensions.EnumMirror[T].values.mkString(", ")}"
+      |              )
+      |            ),
+      |          sttp.tapir.DecodeResult.Value(_)
+      |        )
       |    )(_.name)
       |
       |object Test {

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -56,7 +56,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       ),
       null
     )
-    val generatedCode = BasicGenerator.imports ++ new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false)(None)
+    val generatedCode =
+      BasicGenerator.imports ++ new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false).endpointDecls(None)
     generatedCode should include("val getTestAsdId =")
     generatedCode shouldCompile ()
   }
@@ -131,7 +132,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       )
     )
     BasicGenerator.imports ++
-      new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false)(None) shouldCompile ()
+      new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false).endpointDecls(None) shouldCompile ()
   }
 
   it should "handle status codes" in {
@@ -174,7 +175,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       ),
       null
     )
-    val generatedCode = BasicGenerator.imports ++ new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false)(None)
+    val generatedCode =
+      BasicGenerator.imports ++ new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false).endpointDecls(None)
     generatedCode should include(
       """.out(stringBody.description("Processing").and(statusCode(sttp.model.StatusCode(202))))"""
     ) // status code with body

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -16,6 +16,8 @@ import sttp.tapir.codegen.openapi.models.OpenapiModels.{
 }
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaArray,
+  OpenapiSchemaConstantString,
+  OpenapiSchemaEnum,
   OpenapiSchemaInt,
   OpenapiSchemaObject,
   OpenapiSchemaRef,
@@ -512,5 +514,66 @@ object TestHelpers {
       )
     ),
     None
+  )
+
+  val enumQueryParamYaml =
+    """
+      |openapi: 3.1.0
+      |info:
+      |  title: enum query test
+      |  version: '1.0'
+      |paths:
+      |  /queryTest:
+      |    parameters:
+      |      - name: test
+      |        in: query
+      |        required: false
+      |        schema:
+      |          $ref: '#/components/schemas/Test'
+      |    post:
+      |      responses: {}
+      |
+      |schemas:
+      |  Test:
+      |    title: Test
+      |    type: string
+      |    enum:
+      |      - paperback
+      |      - hardback
+      |""".stripMargin
+
+  val enumQueryParamDocs = OpenapiDocument(
+    "3.1.0",
+    OpenapiInfo("enum query test", "1.0"),
+    Seq(
+      OpenapiPath(
+        "/queryTest",
+        Seq(
+          OpenapiPathMethod(
+            methodType = "post",
+            parameters = Seq(),
+            responses = Seq(),
+            requestBody = None,
+            summary = None,
+            tags = None,
+            operationId = None
+          )
+        ),
+        parameters = Seq(
+          Resolved(OpenapiParameter("test", "query", None, None, OpenapiSchemaRef("#/components/schemas/Test")))
+        )
+      )
+    ),
+    Some(
+      OpenapiComponent(
+        Map(
+          "Test" -> OpenapiSchemaEnum(
+            "string",
+            Seq(OpenapiSchemaConstantString("paperback"), OpenapiSchemaConstantString("hardback")),
+            false
+          )
+        )
+      )
+    )
   )
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -533,13 +533,14 @@ object TestHelpers {
       |    post:
       |      responses: {}
       |
-      |schemas:
-      |  Test:
-      |    title: Test
-      |    type: string
-      |    enum:
-      |      - paperback
-      |      - hardback
+      |components:
+      |  schemas:
+      |    Test:
+      |      title: Test
+      |      type: string
+      |      enum:
+      |        - paperback
+      |        - hardback
       |""".stripMargin
 
   val enumQueryParamDocs = OpenapiDocument(


### PR DESCRIPTION
Support for enum query params in codegen. I've gone for case-insensitive decoding here, but arguably case-sensitive would be the better option; it should be very easy to change or make configurable later on.