### PR TITLE
codegen: Jsoniter support (#840)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1971,10 +1971,12 @@ lazy val openapiCodegenCore: ProjectMatrix = (projectMatrix in file("openapi-cod
       scalaOrganization.value % "scala-reflect" % scalaVersion.value,
       scalaOrganization.value % "scala-compiler" % scalaVersion.value % Test,
       "com.beachape" %% "enumeratum" % "1.7.3" % Test,
-      "com.beachape" %% "enumeratum-circe" % "1.7.3" % Test
+      "com.beachape" %% "enumeratum-circe" % "1.7.3" % Test,
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.28.2" % Test,
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.28.2" % Provided
     )
   )
-  .dependsOn(core % Test, circeJson % Test)
+  .dependsOn(core % Test, circeJson % Test, jsoniterScala % Test)
 
 lazy val openapiCodegenSbt: ProjectMatrix = (projectMatrix in file("openapi-codegen/sbt-plugin"))
   .enablePlugins(SbtPlugin)

--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -26,8 +26,8 @@ Add your OpenApi file to the project, and override the `openapiSwaggerFile` sett
 openapiSwaggerFile := baseDirectory.value / "swagger.yaml"
 ```
 
-At this point your compile step will try to generate the endpoint definitions 
-to the `sttp.tapir.generated.TapirGeneratedEndpoints` object, where you can access the 
+At this point your compile step will try to generate the endpoint definitions
+to the `sttp.tapir.generated.TapirGeneratedEndpoints` object, where you can access the
 defined case-classes and endpoint definitions.
 
 ## Usage and options
@@ -58,6 +58,7 @@ val docs = TapirGeneratedEndpoints.generatedEndpoints.toOpenAPI("My Bookshop", "
 ### Output files
 
 To expand on the `openapiUseHeadTagForObjectName` setting a little more, suppose we have the following endpoints:
+
 ```yaml
 paths:
   /foo:
@@ -66,17 +67,21 @@ paths:
         - Baz
         - Foo
     put:
-      tags: []
+      tags: [ ]
   /bar:
     get:
       tags:
         - Baz
         - Bar
 ```
-In this case 'head' tag for `GET /foo` and `GET /bar` would be 'Baz', and `PUT /foo` has no tags (and thus no 'head' tag).
 
-If `openapiUseHeadTagForObjectName = false` (assuming default settings for the other flags) then all endpoint definitions
-will be output to the `TapirGeneratedEndpoints.scala` file, which will contain a single `object TapirGeneratedEndpoints`.
+In this case 'head' tag for `GET /foo` and `GET /bar` would be 'Baz', and `PUT /foo` has no tags (and thus no 'head'
+tag).
+
+If `openapiUseHeadTagForObjectName = false` (assuming default settings for the other flags) then all endpoint
+definitions
+will be output to the `TapirGeneratedEndpoints.scala` file, which will contain a
+single `object TapirGeneratedEndpoints`.
 
 If `openapiUseHeadTagForObjectName = true`, then the  `GET /foo` and `GET /bar` endpoints would be output to a
 `Baz.scala` file, containing a single `object Baz` with those endpoint definitions; the `PUT /foo` endpoint, by dint of
@@ -84,15 +89,19 @@ having no tags, would be output to the `TapirGeneratedEndpoints` file, along wit
 
 ### Limitations
 
-Currently, the generated code depends on `"io.circe" %% "circe-generic"`. In the future probably we will make the encoder/decoder json lib configurable (PRs welcome).
+Currently, the generated code depends on `"io.circe" %% "circe-generic"`. In the future probably we will make the
+encoder/decoder json lib configurable (PRs welcome).
 
 String-like enums in Scala 2 depend on both `"com.beachape" %% "enumeratum"` and `"com.beachape" %% "enumeratum-circe"`.
-For Scala 3 we derive native enums, and depend on `"org.latestbit" %% "circe-tagged-adt-codec"` for json serdes and `"io.github.bishabosha" %% "enum-extensions"` for query param serdes.
+For Scala 3 we derive native enums, and depend on `"org.latestbit" %% "circe-tagged-adt-codec"` for json serdes
+and `"io.github.bishabosha" %% "enum-extensions"` for query param serdes.
 Other forms of OpenApi enum are not currently supported.
 
+Models containing binary data cannot be re-used between json and multi-part form endpoints, due to having different
+representation types for the binary data
+
 We currently miss a lot of OpenApi features like:
- - tags
- - ADTs
- - missing model types and meta descriptions (like date, minLength)
- - file handling
+
+- ADTs
+- missing model types and meta descriptions (like date, minLength)
 

--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -42,6 +42,7 @@ openapiSwaggerFile              baseDirectory.value / "swagger.yaml" The swagger
 openapiPackage                  sttp.tapir.generated                 The name for the generated package.
 openapiObject                   TapirGeneratedEndpoints              The name for the generated object.
 openapiUseHeadTagForObjectName  false                                If true, put endpoints in separate files based on first declared tag.
+openapiJsonSerdeLib             circe                                The json serde library to use.
 =============================== ==================================== =====================================================================
 ```
 
@@ -87,14 +88,24 @@ If `openapiUseHeadTagForObjectName = true`, then the  `GET /foo` and `GET /bar` 
 `Baz.scala` file, containing a single `object Baz` with those endpoint definitions; the `PUT /foo` endpoint, by dint of
 having no tags, would be output to the `TapirGeneratedEndpoints` file, along with any schema and parameter definitions.
 
+### Json Support
+
+```eval_rst
+===================== ================================================================== ===================================================================
+ openapiJsonSerdeLib         required dependencies                                       Conditional requirements
+===================== ================================================================== ===================================================================
+circe                 "io.circe" %% "circe-core"                                         "com.beachape" %% "enumeratum-circe" (scala 2 enum support).
+                      "io.circe" %% "circe-generic"                                      "org.latestbit" %% "circe-tagged-adt-codec" (scala 3 enum support).
+jsoniter              "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"
+                      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros"
+===================== ================================================================== ===================================================================
+```
+
 ### Limitations
 
-Currently, the generated code depends on `"io.circe" %% "circe-generic"`. In the future probably we will make the
-encoder/decoder json lib configurable (PRs welcome).
-
-String-like enums in Scala 2 depend on both `"com.beachape" %% "enumeratum"` and `"com.beachape" %% "enumeratum-circe"`.
-For Scala 3 we derive native enums, and depend on `"org.latestbit" %% "circe-tagged-adt-codec"` for json serdes
-and `"io.github.bishabosha" %% "enum-extensions"` for query param serdes.
+Currently, string-like enums in Scala 2 depend upon the enumeratum library (`"com.beachape" %% "enumeratum"`).
+For Scala 3 we derive native enums, and depend on `"io.github.bishabosha" %% "enum-extensions"` for generating query
+param serdes.
 Other forms of OpenApi enum are not currently supported.
 
 Models containing binary data cannot be re-used between json and multi-part form endpoints, due to having different
@@ -102,6 +113,8 @@ representation types for the binary data
 
 We currently miss a lot of OpenApi features like:
 
+- tags
 - ADTs
 - missing model types and meta descriptions (like date, minLength)
+- file handling
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -80,8 +80,6 @@ object BasicGenerator {
   private[codegen] def imports(jsonSerdeLib: JsonSerdeLib.JsonSerdeLib): String = {
     val jsonImports = jsonSerdeLib match {
       case JsonSerdeLib.Circe =>
-        // Note: all schema models have explicit decoders and encoders defined using semiauto; however, it can happen
-        // that other types are pulled into
         """import sttp.tapir.json.circe._
           |import io.circe.generic.semiauto._""".stripMargin
       case JsonSerdeLib.Jsoniter =>

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -16,6 +16,11 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaUUID
 }
 
+object JsonSerdeLib extends Enumeration {
+  val Circe, Jsoniter = Value
+  type JsonSerdeLib = Value
+}
+
 object BasicGenerator {
 
   val classGenerator = new ClassDefinitionGenerator()
@@ -26,9 +31,20 @@ object BasicGenerator {
       packagePath: String,
       objName: String,
       targetScala3: Boolean,
-      useHeadTagForObjectNames: Boolean
+      useHeadTagForObjectNames: Boolean,
+      jsonSerdeLib: String
   ): Map[String, String] = {
-    val EndpointDefs(endpointsByTag, queryParamRefs) = endpointGenerator.endpointDefs(doc, useHeadTagForObjectNames)
+    val normalisedJsonLib = jsonSerdeLib.toLowerCase match {
+      case "circe"    => JsonSerdeLib.Circe
+      case "jsoniter" => JsonSerdeLib.Jsoniter
+      case _ =>
+        System.err.println(
+          s"!!! Unrecognised value $jsonSerdeLib for json serde lib -- should be one of circe, jsoniter. Defaulting to circe !!!"
+        )
+        JsonSerdeLib.Circe
+    }
+
+    val EndpointDefs(endpointsByTag, queryParamRefs, jsonParamRefs) = endpointGenerator.endpointDefs(doc, useHeadTagForObjectNames)
     val taggedObjs = endpointsByTag.collect {
       case (Some(headTag), body) if body.nonEmpty =>
         val taggedObj =
@@ -38,7 +54,7 @@ object BasicGenerator {
            |
            |object $headTag {
            |
-           |${indent(2)(imports)}
+           |${indent(2)(imports(normalisedJsonLib))}
            |
            |${indent(2)(body)}
            |
@@ -50,9 +66,9 @@ object BasicGenerator {
         |
         |object $objName {
         |
-        |${indent(2)(imports)}
+        |${indent(2)(imports(normalisedJsonLib))}
         |
-        |${indent(2)(classGenerator.classDefs(doc, targetScala3, queryParamRefs).getOrElse(""))}
+        |${indent(2)(classGenerator.classDefs(doc, targetScala3, queryParamRefs, normalisedJsonLib, jsonParamRefs).getOrElse(""))}
         |
         |${indent(2)(endpointsByTag.getOrElse(None, ""))}
         |
@@ -61,19 +77,30 @@ object BasicGenerator {
     taggedObjs + (objName -> mainObj)
   }
 
-  private[codegen] def imports: String =
-    """import sttp.tapir._
-      |import sttp.tapir.model._
-      |import sttp.tapir.json.circe._
-      |import sttp.tapir.generic.auto._
-      |import io.circe.generic.auto._
-      |""".stripMargin
+  private[codegen] def imports(jsonSerdeLib: JsonSerdeLib.JsonSerdeLib): String = {
+    val jsonImports = jsonSerdeLib match {
+      case JsonSerdeLib.Circe =>
+        // Note: all schema models have explicit decoders and encoders defined using semiauto; however, it can happen
+        // that other types are pulled into
+        """import sttp.tapir.json.circe._
+          |import io.circe.generic.semiauto._""".stripMargin
+      case JsonSerdeLib.Jsoniter =>
+        """import sttp.tapir.json.jsoniter._
+          |import com.github.plokhotnyuk.jsoniter_scala.macros._
+          |import com.github.plokhotnyuk.jsoniter_scala.core._""".stripMargin
+    }
+    s"""import sttp.tapir._
+       |import sttp.tapir.model._
+       |import sttp.tapir.generic.auto._
+       |$jsonImports
+       |""".stripMargin
+  }
 
   def indent(i: Int)(str: String): String = {
     str.linesIterator.map(" " * i + _).mkString("\n")
   }
 
-  def mapSchemaSimpleTypeToType(osst: OpenapiSchemaSimpleType): (String, Boolean) = {
+  def mapSchemaSimpleTypeToType(osst: OpenapiSchemaSimpleType, multipartForm: Boolean = false): (String, Boolean) = {
     osst match {
       case OpenapiSchemaDouble(nb) =>
         ("Double", nb)
@@ -91,8 +118,10 @@ object BasicGenerator {
         ("String", nb)
       case OpenapiSchemaBoolean(nb) =>
         ("Boolean", nb)
-      case OpenapiSchemaBinary(nb) =>
+      case OpenapiSchemaBinary(nb) if multipartForm =>
         ("sttp.model.Part[java.io.File]", nb)
+      case OpenapiSchemaBinary(nb) =>
+        ("Array[Byte]", nb)
       case OpenapiSchemaAny(nb) =>
         ("io.circe.Json", nb)
       case OpenapiSchemaRef(t) =>

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -114,7 +114,7 @@ class ClassDefinitionGenerator {
       |""".stripMargin
 
   @tailrec
-  private def recursiveFindAllReferencedSchemaTypes(
+  final def recursiveFindAllReferencedSchemaTypes(
       allSchemas: Map[String, OpenapiSchemaType]
   )(toCheck: OpenapiSchemaType, checked: Set[String], tail: Seq[OpenapiSchemaType]): Set[String] = {
     def nextParamsFromTypeSeq(types: Seq[OpenapiSchemaType]) = types match {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -3,21 +3,107 @@ package sttp.tapir.codegen
 import sttp.tapir.codegen.BasicGenerator.{indent, mapSchemaSimpleTypeToType}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  OpenapiSchemaArray,
-  OpenapiSchemaEnum,
-  OpenapiSchemaMap,
-  OpenapiSchemaObject,
-  OpenapiSchemaSimpleType
-}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
+
+import scala.annotation.tailrec
 
 class ClassDefinitionGenerator {
 
-  def classDefs(doc: OpenapiDocument, targetScala3: Boolean = false, queryParamRefs: Set[String] = Set.empty): Option[String] = {
+  def classDefs(
+      doc: OpenapiDocument,
+      targetScala3: Boolean = false,
+      queryParamRefs: Set[String] = Set.empty,
+      jsonSerdeLib: JsonSerdeLib.JsonSerdeLib = JsonSerdeLib.Circe,
+      jsonParamRefs: Set[String] = Set.empty
+  ): Option[String] = {
+    val allSchemas: Map[String, OpenapiSchemaType] = doc.components.toSeq.flatMap(_.schemas).toMap
     val generatesQueryParamEnums =
-      doc.components.toSeq
-        .flatMap(_.schemas.collect { case (name, _: OpenapiSchemaEnum) => name })
+      allSchemas
+        .collect { case (name, _: OpenapiSchemaEnum) => name }
         .exists(queryParamRefs.contains)
+
+    def fetchJsonParamRefs(initialSet: Set[String], toCheck: Seq[OpenapiSchemaType]): Set[String] = toCheck match {
+      case Nil          => initialSet
+      case head +: tail => defJsonParamRefs(head, initialSet, tail)
+    }
+
+    @tailrec
+    def defJsonParamRefs(toCheck: OpenapiSchemaType, checked: Set[String], tail: Seq[OpenapiSchemaType]): Set[String] = {
+      // We sadly cannot use this because it spoils the @tailrec check
+//      def recurseOnTail = tail match {
+//        case Nil          => checked
+//        case next +: rest => defJsonParamRefs(next, checked, rest)
+//      }
+      toCheck match {
+        case OpenapiSchemaRef(ref) if ref.startsWith("#/components/schemas/") =>
+          val name = ref.stripPrefix("#/components/schemas/")
+          val maybeAppended = if (checked contains name) None else allSchemas.get(name)
+          (tail ++ maybeAppended) match {
+            case Nil          => checked
+            case next +: rest => defJsonParamRefs(next, checked + name, rest)
+          }
+        case OpenapiSchemaArray(items, _) => defJsonParamRefs(items, checked, tail)
+        case OpenapiSchemaNot(items)      => defJsonParamRefs(items, checked, tail)
+        case OpenapiSchemaMap(items, _)   => defJsonParamRefs(items, checked, tail)
+        case OpenapiSchemaOneOf(types) =>
+          types match {
+            case Nil =>
+              tail match {
+                case Nil          => checked
+                case next +: rest => defJsonParamRefs(next, checked, rest)
+              }
+            case next +: rest => defJsonParamRefs(next, checked, rest ++ tail)
+          }
+        case OpenapiSchemaAnyOf(types) =>
+          types match {
+            case Nil =>
+              tail match {
+                case Nil          => checked
+                case next +: rest => defJsonParamRefs(next, checked, rest)
+              }
+            case next +: rest => defJsonParamRefs(next, checked, rest ++ tail)
+          }
+        case OpenapiSchemaAllOf(types) =>
+          types match {
+            case Nil =>
+              tail match {
+                case Nil          => checked
+                case next +: rest => defJsonParamRefs(next, checked, rest)
+              }
+            case next +: rest => defJsonParamRefs(next, checked, rest ++ tail)
+          }
+
+        case OpenapiSchemaObject(properties, _, _) if properties.isEmpty =>
+          tail match {
+            case Nil          => checked
+            case next +: rest => defJsonParamRefs(next, checked, rest)
+          }
+        case OpenapiSchemaObject(properties, required, nullable) =>
+          val propToCheck = properties.head
+          val (propToCheckName, propToCheckType) = propToCheck
+          defJsonParamRefs(propToCheckType, checked, OpenapiSchemaObject(properties - propToCheckName, required, nullable) +: tail)
+
+        case _ =>
+          tail match {
+            case Nil          => checked
+            case next +: rest => defJsonParamRefs(next, checked, rest)
+          }
+      }
+    }
+
+    val allTransitiveJsonParamRefs = fetchJsonParamRefs(
+      jsonParamRefs,
+      jsonParamRefs.toSeq.flatMap(ref => allSchemas.get(ref.stripPrefix("#/components/schemas/")))
+    )
+
+    val maybeJsonSerdeHelpers =
+      if (jsonParamRefs.nonEmpty && jsonSerdeLib == JsonSerdeLib.Jsoniter)
+        """implicit def seqCodec[T: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec]: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[List[T]] =
+        |  com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[List[T]]
+        |implicit def optionCodec[T: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec]: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[Option[T]] =
+        |  com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[Option[T]]
+        |""".stripMargin
+      else ""
     val enumQuerySerdeHelper =
       if (!generatesQueryParamEnums) ""
       else if (targetScala3)
@@ -64,25 +150,53 @@ class ClassDefinitionGenerator {
           |        )
           |    )(_.entryName)
           |""".stripMargin
+    val additionalExplicitSerdes = jsonParamRefs.toSeq
+      .filter(x => !allSchemas.contains(x) && !x.contains("java.io.File"))
+      .map(s =>
+        jsonSerdeLib match {
+          case JsonSerdeLib.Jsoniter =>
+            val name = s.replace("[", "_").replace("]", "_").replace(".", "_") + "JsonCodec"
+            s"""implicit lazy val $name: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[$s] =
+            |  com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[$s]""".stripMargin
+          case _ => ""
+        }
+      )
+      .mkString("", "\n", "\n")
     val defns = doc.components
       .map(_.schemas.flatMap {
         case (name, obj: OpenapiSchemaObject) =>
-          generateClass(name, obj)
+          generateClass(name, obj, jsonSerdeLib, allTransitiveJsonParamRefs)
         case (name, obj: OpenapiSchemaEnum) =>
-          generateEnum(name, obj, targetScala3, queryParamRefs)
-        case (name, OpenapiSchemaMap(valueSchema, _)) => generateMap(name, valueSchema)
+          generateEnum(name, obj, targetScala3, queryParamRefs, jsonSerdeLib, allTransitiveJsonParamRefs)
+        case (name, OpenapiSchemaMap(valueSchema, _)) => generateMap(name, valueSchema, jsonSerdeLib, allTransitiveJsonParamRefs)
         case (n, x) => throw new NotImplementedError(s"Only objects, enums and maps supported! (for $n found ${x})")
       })
       .map(_.mkString("\n"))
-    defns.map(enumQuerySerdeHelper + _)
+    defns.map(additionalExplicitSerdes + maybeJsonSerdeHelpers + enumQuerySerdeHelper + _)
   }
 
-  private[codegen] def generateMap(name: String, valueSchema: OpenapiSchemaType): Seq[String] = {
+  private[codegen] def generateMap(
+      name: String,
+      valueSchema: OpenapiSchemaType,
+      jsonSerdeLib: JsonSerdeLib.JsonSerdeLib,
+      jsonParamRefs: Set[String]
+  ): Seq[String] = {
     val valueSchemaName = valueSchema match {
       case simpleType: OpenapiSchemaSimpleType => BasicGenerator.mapSchemaSimpleTypeToType(simpleType)._1
       case otherType => throw new NotImplementedError(s"Only simple value types and refs are implemented for named maps (found $otherType)")
     }
-    Seq(s"""type $name = Map[String, $valueSchemaName]""")
+    val uncapitalisedName = name.head.toLower +: name.tail
+    val maybeJsonCodecDefn = jsonSerdeLib match {
+      case _ if !jsonParamRefs.contains(name) => ""
+      case JsonSerdeLib.Circe =>
+        s"""
+           |implicit lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] = io.circe.Decoder.decodeMap[String, $valueSchemaName]
+           |implicit lazy val ${uncapitalisedName}JsonEncoder: io.circe.Encoder[$name] = io.circe.Encoder.encodeMap[String, $valueSchemaName]""".stripMargin
+      case JsonSerdeLib.Jsoniter =>
+        s"""
+           |implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[$name] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make""".stripMargin
+    }
+    Seq(s"""type $name = Map[String, $valueSchemaName]$maybeJsonCodecDefn""")
   }
 
   // Uses enumeratum for scala 2, but generates scala 3 enums instead where it can
@@ -90,9 +204,10 @@ class ClassDefinitionGenerator {
       name: String,
       obj: OpenapiSchemaEnum,
       targetScala3: Boolean,
-      queryParamRefs: Set[String]
+      queryParamRefs: Set[String],
+      jsonSerdeLib: JsonSerdeLib.JsonSerdeLib,
+      jsonParamRefs: Set[String]
   ): Seq[String] = if (targetScala3) {
-    val maybeQueryParamSerdeDerivation = if (queryParamRefs contains name) ", enumextensions.EnumMirror" else ""
     val maybeCompanion =
       if (queryParamRefs contains name)
         s"""
@@ -101,26 +216,53 @@ class ClassDefinitionGenerator {
         |    makeQueryCodecForEnum[$name]
         |}""".stripMargin
       else ""
+    val maybeCodecExtensions = jsonSerdeLib match {
+      case _ if !jsonParamRefs.contains(name) && !queryParamRefs.contains(name) => ""
+      case _ if !jsonParamRefs.contains(name)                                   => " derives enumextensions.EnumMirror"
+      case JsonSerdeLib.Circe if !queryParamRefs.contains(name) => " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec"
+      case JsonSerdeLib.Circe => " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec, enumextensions.EnumMirror"
+      case JsonSerdeLib.Jsoniter if !queryParamRefs.contains(name) => s" extends java.lang.Enum[$name]"
+      case JsonSerdeLib.Jsoniter                                   => s" extends java.lang.Enum[$name] derives enumextensions.EnumMirror"
+    }
     s"""$maybeCompanion
-       |enum $name derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec$maybeQueryParamSerdeDerivation {
+       |enum $name$maybeCodecExtensions {
        |  case ${obj.items.map(_.value).mkString(", ")}
        |}""".stripMargin :: Nil
   } else {
+    val uncapitalisedName = name.head.toLower +: name.tail
     val members = obj.items.map { i => s"case object ${i.value} extends $name" }
+    val maybeJsonCodecDefn = jsonSerdeLib match {
+      case _ if !jsonParamRefs.contains(name) => ""
+      case JsonSerdeLib.Circe                 => ""
+      case JsonSerdeLib.Jsoniter =>
+        s"""
+           |  implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make""".stripMargin
+    }
+    val maybeCodecExtension = jsonSerdeLib match {
+      case _ if !jsonParamRefs.contains(name) && !queryParamRefs.contains(name) => ""
+      case JsonSerdeLib.Circe                                                   => s" with enumeratum.CirceEnum[$name]"
+      case JsonSerdeLib.Jsoniter                                                => ""
+    }
     val maybeQueryCodecDefn =
       if (queryParamRefs contains name)
         s"""
-       |  implicit val ${name.head.toLower +: name.tail}Codec: sttp.tapir.Codec[List[String], ${name}, sttp.tapir.CodecFormat.TextPlain] =
+       |  implicit val ${uncapitalisedName}QueryCodec: sttp.tapir.Codec[List[String], ${name}, sttp.tapir.CodecFormat.TextPlain] =
        |    makeQueryCodecForEnum("${name}", ${name})""".stripMargin
       else ""
     s"""|sealed trait $name extends enumeratum.EnumEntry
-        |object $name extends enumeratum.Enum[$name] with enumeratum.CirceEnum[$name] {
-        |  val values = findValues
+        |object $name extends enumeratum.Enum[$name]$maybeCodecExtension {
+        |  val values = findValues$maybeJsonCodecDefn
         |${indent(2)(members.mkString("\n"))}$maybeQueryCodecDefn
         |}""".stripMargin :: Nil
   }
 
-  private[codegen] def generateClass(name: String, obj: OpenapiSchemaObject): Seq[String] = {
+  private[codegen] def generateClass(
+      name: String,
+      obj: OpenapiSchemaObject,
+      jsonSerdeLib: JsonSerdeLib.JsonSerdeLib,
+      jsonParamRefs: Set[String]
+  ): Seq[String] = {
+    val isJson = jsonParamRefs contains name
     def rec(name: String, obj: OpenapiSchemaObject, acc: List[String]): Seq[String] = {
       val innerClasses = obj.properties
         .collect {
@@ -140,12 +282,29 @@ class ClassDefinitionGenerator {
         .toList
 
       val properties = obj.properties.map { case (key, schemaType) =>
-        val tpe = mapSchemaTypeToType(name, key, obj.required.contains(key), schemaType)
+        val tpe = mapSchemaTypeToType(name, key, obj.required.contains(key), schemaType, isJson)
         val fixedKey = fixKey(key)
         s"$fixedKey: $tpe"
       }
 
-      s"""|case class $name (
+      val uncapitalisedName = name.head.toLower +: name.tail
+      def jsonCodec = jsonSerdeLib match {
+        case JsonSerdeLib.Circe =>
+          s"""implicit lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] = io.circe.generic.semiauto.deriveDecoder[$name]
+             |implicit lazy val ${uncapitalisedName}JsonEncoder: io.circe.Encoder[$name] = io.circe.generic.semiauto.deriveEncoder[$name]""".stripMargin
+        case JsonSerdeLib.Jsoniter =>
+          s"""implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make"""
+      }
+      val maybeCompanion =
+        if (isJson)
+          s"""
+          |object $name {
+          |${indent(2)(jsonCodec)}
+          |}"""
+        else ""
+
+      s"""|$maybeCompanion
+          |case class $name (
           |${indent(2)(properties.mkString(",\n"))}
           |)""".stripMargin :: innerClasses ::: acc
     }
@@ -153,20 +312,20 @@ class ClassDefinitionGenerator {
     rec(addName("", name), obj, Nil)
   }
 
-  private def mapSchemaTypeToType(parentName: String, key: String, required: Boolean, schemaType: OpenapiSchemaType): String = {
+  private def mapSchemaTypeToType(parentName: String, key: String, required: Boolean, schemaType: OpenapiSchemaType, isJson: Boolean): String = {
     val (tpe, optional) = schemaType match {
       case simpleType: OpenapiSchemaSimpleType =>
-        mapSchemaSimpleTypeToType(simpleType)
+        mapSchemaSimpleTypeToType(simpleType, multipartForm = !isJson)
 
       case objectType: OpenapiSchemaObject =>
         addName(parentName, key) -> objectType.nullable
 
       case mapType: OpenapiSchemaMap =>
-        val innerType = mapSchemaTypeToType(addName(parentName, key), "item", required = true, mapType.items)
+        val innerType = mapSchemaTypeToType(addName(parentName, key), "item", required = true, mapType.items, isJson = isJson)
         s"Map[String, $innerType]" -> mapType.nullable
 
       case arrayType: OpenapiSchemaArray =>
-        val innerType = mapSchemaTypeToType(addName(parentName, key), "item", required = true, arrayType.items)
+        val innerType = mapSchemaTypeToType(addName(parentName, key), "item", required = true, arrayType.items, isJson = isJson)
         s"Seq[$innerType]" -> arrayType.nullable
 
       case _ =>

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -271,7 +271,7 @@ class ClassDefinitionGenerator {
           s"""implicit lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] = io.circe.generic.semiauto.deriveDecoder[$name]
              |implicit lazy val ${uncapitalisedName}JsonEncoder: io.circe.Encoder[$name] = io.circe.generic.semiauto.deriveEncoder[$name]""".stripMargin
         case JsonSerdeLib.Jsoniter =>
-          s"""implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make"""
+          s"""implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true))"""
       }
       val maybeCompanion =
         if (isJson)

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
@@ -3,46 +3,52 @@ package sttp.tapir.codegen
 import sttp.tapir.codegen.testutils.CompileCheckTestBase
 
 class BasicGeneratorSpec extends CompileCheckTestBase {
+  def testJsonLib(jsonSerdeLib: String) = {
+    it should s"generate the bookshop example using ${jsonSerdeLib} serdes" in {
+      BasicGenerator.generateObjects(
+        TestHelpers.myBookshopDoc,
+        "sttp.tapir.generated",
+        "TapirGeneratedEndpoints",
+        targetScala3 = false,
+        useHeadTagForObjectNames = false,
+        jsonSerdeLib = jsonSerdeLib
+      )("TapirGeneratedEndpoints") shouldCompile ()
+    }
 
-  it should "generate the bookshop example" in {
-    BasicGenerator.generateObjects(
-      TestHelpers.myBookshopDoc,
-      "sttp.tapir.generated",
-      "TapirGeneratedEndpoints",
-      targetScala3 = false,
-      useHeadTagForObjectNames = false
-    )("TapirGeneratedEndpoints") shouldCompile ()
-  }
+    it should s"split outputs by tag if useHeadTagForObjectNames = true using ${jsonSerdeLib} serdes" in {
+      val generated = BasicGenerator.generateObjects(
+        TestHelpers.myBookshopDoc,
+        "sttp.tapir.generated",
+        "TapirGeneratedEndpoints",
+        targetScala3 = false,
+        useHeadTagForObjectNames = true,
+        jsonSerdeLib = jsonSerdeLib
+      )
+      val schemas = generated("TapirGeneratedEndpoints")
+      val endpoints = generated("Bookshop")
+      // schema file on its own should compile
+      schemas shouldCompile ()
+      // schema file should contain no endpoint definitions
+      schemas.linesIterator.count(_.matches("""^\s*endpoint""")) shouldEqual 0
+      // Bookshop file should contain all endpoint definitions
+      endpoints.linesIterator.count(_.matches("""^\s*endpoint""")) shouldEqual 3
+      // endpoint file depends on schema file. For simplicity of testing, just strip the package declaration from the
+      // endpoint file, and concat the two, before testing for compilation
+      (schemas + "\n" + (endpoints.linesIterator.filterNot(_ startsWith "package").mkString("\n"))) shouldCompile ()
+    }
 
-  it should "split outputs by tag if useHeadTagForObjectNames = true" in {
-    val generated = BasicGenerator.generateObjects(
-      TestHelpers.myBookshopDoc,
-      "sttp.tapir.generated",
-      "TapirGeneratedEndpoints",
-      targetScala3 = false,
-      useHeadTagForObjectNames = true
-    )
-    val schemas = generated("TapirGeneratedEndpoints")
-    val endpoints = generated("Bookshop")
-    // schema file on its own should compile
-    schemas shouldCompile ()
-    // schema file should contain no endpoint definitions
-    schemas.linesIterator.count(_.matches("""^\s*endpoint""")) shouldEqual 0
-    // Bookshop file should contain all endpoint definitions
-    endpoints.linesIterator.count(_.matches("""^\s*endpoint""")) shouldEqual 3
-    // endpoint file depends on schema file. For simplicity of testing, just strip the package declaration from the
-    // endpoint file, and concat the two, before testing for compilation
-    (schemas + "\n" + (endpoints.linesIterator.filterNot(_ startsWith "package").mkString("\n"))) shouldCompile ()
-  }
+    it should s"compile endpoints with enum query params using ${jsonSerdeLib} serdes" in {
+      BasicGenerator.generateObjects(
+        TestHelpers.enumQueryParamDocs,
+        "sttp.tapir.generated",
+        "TapirGeneratedEndpoints",
+        targetScala3 = false,
+        useHeadTagForObjectNames = false,
+        jsonSerdeLib = jsonSerdeLib
+      )("TapirGeneratedEndpoints") shouldCompile ()
+    }
 
-  it should "compile endpoints with enum query params" in {
-    BasicGenerator.generateObjects(
-      TestHelpers.enumQueryParamDocs,
-      "sttp.tapir.generated",
-      "TapirGeneratedEndpoints",
-      targetScala3 = false,
-      useHeadTagForObjectNames = false
-    )("TapirGeneratedEndpoints") shouldCompile ()
   }
+  Seq("circe", "jsoniter") foreach testJsonLib
 
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -2,16 +2,8 @@ package sttp.tapir.codegen
 
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  OpenapiSchemaAny,
-  OpenapiSchemaArray,
-  OpenapiSchemaConstantString,
-  OpenapiSchemaEnum,
-  OpenapiSchemaMap,
-  OpenapiSchemaObject,
-  OpenapiSchemaRef,
-  OpenapiSchemaString
-}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
 import sttp.tapir.codegen.testutils.CompileCheckTestBase
 
 class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
@@ -348,7 +340,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
   import io.circe._
   import io.circe.yaml.parser
 
-  it should "" in {
+  it should "correctly handle quoted strings" in {
     val quotedString = """a "quoted" string"""
     val yaml =
       s"""
@@ -392,6 +384,59 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
          |  """.stripMargin
 
     compileUnit shouldCompile ()
+
+  }
+
+  it should "be able to find all types referenced by schema" in {
+    val allSchemas = Map(
+      "TopMap" -> OpenapiSchemaMap(OpenapiSchemaRef("#/components/schemas/MapType"), false),
+      "MapType" -> OpenapiSchemaRef("#/components/schemas/MapValue"),
+      "MapValue" -> OpenapiSchemaArray(OpenapiSchemaDateTime(false), false),
+      "TopArray" -> OpenapiSchemaMap(OpenapiSchemaRef("#/components/schemas/ArrayType"), false),
+      "ArrayType" -> OpenapiSchemaRef("#/components/schemas/ArrayValue"),
+      "ArrayValue" -> OpenapiSchemaArray(OpenapiSchemaByte(false), false),
+      "TopOneOf" -> OpenapiSchemaOneOf(
+        Seq(
+          OpenapiSchemaRef("#/components/schemas/TopMap"),
+          OpenapiSchemaRef("#/components/schemas/TopArray"),
+          OpenapiSchemaRef("#/components/schemas/OneOfValue")
+        )
+      ),
+      "OneOfValue" -> OpenapiSchemaArray(OpenapiSchemaBinary(false), false),
+      "TopObject" -> OpenapiSchemaObject(
+        Map(
+          "innerMap" -> OpenapiSchemaRef("#/components/schemas/TopMap"),
+          "innerArray" -> OpenapiSchemaRef("#/components/schemas/TopArray"),
+          "innerOneOf" -> OpenapiSchemaRef("#/components/schemas/TopOneOf"),
+          "innerBoolean" -> OpenapiSchemaBoolean(false),
+          "recursiveEntry" -> OpenapiSchemaRef("#/components/schemas/TopObject")
+        ),
+        Nil,
+        false
+      )
+    )
+    def fetchJsonParamRefs(initialSet: Set[String], toCheck: Seq[OpenapiSchemaType]): Set[String] = toCheck match {
+      case Nil          => initialSet
+      case head +: tail => new ClassDefinitionGenerator().recursiveFindAllReferencedSchemaTypes(allSchemas)(head, initialSet, tail)
+    }
+    fetchJsonParamRefs(Set("MapType"), Seq(allSchemas("MapType"))) shouldEqual Set("MapType", "MapValue")
+    fetchJsonParamRefs(Set("TopMap"), Seq(allSchemas("TopMap"))) shouldEqual Set("TopMap", "MapType", "MapValue")
+    fetchJsonParamRefs(Set("TopArray"), Seq(allSchemas("TopArray"))) shouldEqual Set("TopArray", "ArrayType", "ArrayValue")
+    fetchJsonParamRefs(Set("TopOneOf"), Seq(allSchemas("TopOneOf"))) shouldEqual Set(
+      "TopOneOf",
+      "OneOfValue",
+      "TopMap",
+      "MapType",
+      "MapValue",
+      "TopArray",
+      "ArrayType",
+      "ArrayValue"
+    )
+    fetchJsonParamRefs(Set("TopObject"), Seq(allSchemas("TopObject"))) shouldEqual allSchemas.keySet
+    fetchJsonParamRefs(
+      Set("TopMap", "TopArray", "TopObject"),
+      Seq(allSchemas("TopMap"), allSchemas("TopArray"), allSchemas("TopObject"))
+    ) shouldEqual allSchemas.keySet
 
   }
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -279,14 +279,16 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     )
 
     val gen = new ClassDefinitionGenerator()
-    val res = gen.classDefs(doc, true)
-    val resWithQueryParamCodec = gen.classDefs(doc, true, queryParamRefs = Set("Test"))
+    val res = gen.classDefs(doc, true, jsonParamRefs = Set("Test"))
+    val resWithQueryParamCodec = gen.classDefs(doc, true, queryParamRefs = Set("Test"), jsonParamRefs = Set("Test"))
     // can't just check whether these compile, because our tests only run on scala 2.12 - so instead just eyeball it...
     res shouldBe Some("""
+      |
       |enum Test derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec {
       |  case enum1, enum2
       |}""".stripMargin)
     resWithQueryParamCodec shouldBe Some("""
+      |
       |def enumMap[E: enumextensions.EnumMirror]: Map[String, E] =
       |  Map.from(
       |    for e <- enumextensions.EnumMirror[E].values yield e.name.toUpperCase -> e

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -56,8 +56,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       ),
       null
     )
-    val generatedCode =
-      BasicGenerator.imports ++ new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false).endpointDecls(None)
+    val generatedCode = BasicGenerator.imports(JsonSerdeLib.Circe) ++
+      new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false).endpointDecls(None)
     generatedCode should include("val getTestAsdId =")
     generatedCode shouldCompile ()
   }
@@ -131,7 +131,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
         )
       )
     )
-    BasicGenerator.imports ++
+    BasicGenerator.imports(JsonSerdeLib.Circe) ++
       new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false).endpointDecls(None) shouldCompile ()
   }
 
@@ -175,8 +175,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       ),
       null
     )
-    val generatedCode =
-      BasicGenerator.imports ++ new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false).endpointDecls(None)
+    val generatedCode = BasicGenerator.imports(JsonSerdeLib.Circe) ++
+      new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false).endpointDecls(None)
     generatedCode should include(
       """.out(stringBody.description("Processing").and(statusCode(sttp.model.StatusCode(202))))"""
     ) // status code with body
@@ -237,7 +237,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       "sttp.tapir.generated",
       "TapirGeneratedEndpoints",
       targetScala3 = false,
-      useHeadTagForObjectNames = false
+      useHeadTagForObjectNames = false,
+      jsonSerdeLib = "circe"
     )("TapirGeneratedEndpoints")
     generatedCode should include(
       """file: sttp.model.Part[java.io.File]"""
@@ -247,4 +248,5 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
     )
     generatedCode shouldCompile ()
   }
+
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -9,6 +9,7 @@ trait OpenapiCodegenKeys {
   lazy val openapiUseHeadTagForObjectName = settingKey[Boolean](
     "If true, any tagged endpoints will be defined in an object with a name based on the first tag, instead of on the default generated object."
   )
+  lazy val openapiJsonSerdeLib = settingKey[String]("The lib to use for json serdes. Supports 'circe' and 'jsoniter'.")
 
   lazy val generateTapirDefinitions = taskKey[Unit]("The task that generates tapir definitions based on the input swagger file.")
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -26,7 +26,8 @@ object OpenapiCodegenPlugin extends AutoPlugin {
     openapiSwaggerFile := baseDirectory.value / "swagger.yaml",
     openapiPackage := "sttp.tapir.generated",
     openapiObject := "TapirGeneratedEndpoints",
-    openapiUseHeadTagForObjectName := false
+    openapiUseHeadTagForObjectName := false,
+    openapiJsonSerdeLib := "circe"
   )
 
   private def codegen = Def.task {
@@ -37,6 +38,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
       openapiPackage,
       openapiObject,
       openapiUseHeadTagForObjectName,
+      openapiJsonSerdeLib,
       sourceManaged,
       streams,
       scalaVersion
@@ -46,11 +48,21 @@ object OpenapiCodegenPlugin extends AutoPlugin {
           packageName: String,
           objectName: String,
           useHeadTagForObjectName: Boolean,
+          jsonSerdeLib,
           srcDir: File,
           taskStreams: TaskStreams,
           sv: String
       ) =>
-        OpenapiCodegenTask(swaggerFile, packageName, objectName, useHeadTagForObjectName, srcDir, taskStreams.cacheDirectory, sv.startsWith("3")).file
+        OpenapiCodegenTask(
+          swaggerFile,
+          packageName,
+          objectName,
+          useHeadTagForObjectName,
+          jsonSerdeLib,
+          srcDir,
+          taskStreams.cacheDirectory,
+          sv.startsWith("3")
+        ).file
     }) map (Seq(_))).value
   }
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -10,6 +10,7 @@ case class OpenapiCodegenTask(
     packageName: String,
     objectName: String,
     useHeadTagForObjectName: Boolean,
+    jsonSerdeLib: String,
     dir: File,
     cacheDir: File,
     targetScala3: Boolean
@@ -43,13 +44,15 @@ case class OpenapiCodegenTask(
         .parseFile(IO.readLines(inputYaml).mkString("\n"))
         .left
         .map(d => new RuntimeException(_root_.io.circe.Error.showError.show(d)))
-      BasicGenerator.generateObjects(parsed.toTry.get, packageName, objectName, targetScala3, useHeadTagForObjectName).map {
-        case (objectName, fileBody) =>
+      BasicGenerator
+        .generateObjects(parsed.toTry.get, packageName, objectName, targetScala3, useHeadTagForObjectName, jsonSerdeLib)
+        .map { case (objectName, fileBody) =>
           val file = directory / s"$objectName.scala"
           val lines = fileBody.linesIterator.toSeq
           IO.writeLines(file, lines, IO.utf8)
           file
-      }.toSeq
+        }
+        .toSeq
     }
   }
 }


### PR DESCRIPTION
Starts to address https://github.com/softwaremill/tapir/issues/840

Adds support for jsoniter serdes in codegen.

Since, in order to support jsoniter, it became necessary to explicitly define the desired serdes, I've also moved from `io.circe.generic.auto._` to `io.circe.generic.semiauto._`; the latter of which has the notable benefit that if it's going to fail to compile, it doesn't take until the heat death of the universe to do so.

I've also modified the model generation. When multipart file support was initially added, the generated type for `format: binary` strings was changed to `sttp.model.Part[java.io.File]`, which notably does not work with json serialisation. In order to retain that support, I've added a check so that if a schema is _not_ used in any application/json content we'll retain the File model, and otherwise use Array[Byte]. This means that a model defining a binary string type cannot be reused between `multipart/form-data` and `application/json` contexts, but I honestly have no idea how to avoid that limitation.

Extra edit: it turns out supporting adt serialisation with jsoniter-scala requires that the adt serdes be in a separate ~module~ file to the class declarations, so I'm immediately regretting this when trying to implement oneOf support but hey ho