### PR TITLE
Performance tests for loom-based backends

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -256,13 +256,13 @@ lazy val allAggregates: Seq[ProjectReference] = {
   }
   if (sys.env.isDefinedAt("ONLY_LOOM")) {
     println("[info] ONLY_LOOM defined, including only loom-based projects")
-    filteredByNative.filter(p => (p.toString.contains("Loom") || p.toString.contains("nima")))
+    filteredByNative.filter(p => (p.toString.contains("Loom") || p.toString.contains("nima") || p.toString.contains("perf-tests")))
   } else if (sys.env.isDefinedAt("ALSO_LOOM")) {
     println("[info] ALSO_LOOM defined, including also loom-based projects")
     filteredByNative
   } else {
     println("[info] ONLY_LOOM *not* defined, *not* including loom-based-projects")
-    filteredByNative.filterNot(p => (p.toString.contains("Loom") || p.toString.contains("nima")))
+    filteredByNative.filterNot(p => (p.toString.contains("Loom") || p.toString.contains("nima") || p.toString.contains("perf-tests")))
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -538,7 +538,7 @@ lazy val perfTests: ProjectMatrix = (projectMatrix in file("perf-tests"))
     Test / run / javaOptions --= perfServerJavaOptions
   )
   .jvmPlatform(scalaVersions = List(scala2_13))
-  .dependsOn(core, pekkoHttpServer, http4sServer, nettyServer, nettyServerCats, playServer, vertxServer, vertxServerCats)
+  .dependsOn(core, pekkoHttpServer, http4sServer, nettyServer, nettyServerCats, nettyServerLoom, playServer, vertxServer, vertxServerCats)
 
 // integrations
 

--- a/build.sbt
+++ b/build.sbt
@@ -256,13 +256,13 @@ lazy val allAggregates: Seq[ProjectReference] = {
   }
   if (sys.env.isDefinedAt("ONLY_LOOM")) {
     println("[info] ONLY_LOOM defined, including only loom-based projects")
-    filteredByNative.filter(p => (p.toString.contains("Loom") || p.toString.contains("nima") || p.toString.contains("perf-tests")))
+    filteredByNative.filter(p => (p.toString.contains("Loom") || p.toString.contains("nima") || p.toString.contains("perfTests")))
   } else if (sys.env.isDefinedAt("ALSO_LOOM")) {
     println("[info] ALSO_LOOM defined, including also loom-based projects")
     filteredByNative
   } else {
     println("[info] ONLY_LOOM *not* defined, *not* including loom-based-projects")
-    filteredByNative.filterNot(p => (p.toString.contains("Loom") || p.toString.contains("nima") || p.toString.contains("perf-tests")))
+    filteredByNative.filterNot(p => (p.toString.contains("Loom") || p.toString.contains("nima") || p.toString.contains("perfTests")))
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -538,7 +538,18 @@ lazy val perfTests: ProjectMatrix = (projectMatrix in file("perf-tests"))
     Test / run / javaOptions --= perfServerJavaOptions
   )
   .jvmPlatform(scalaVersions = List(scala2_13))
-  .dependsOn(core, pekkoHttpServer, http4sServer, nettyServer, nettyServerCats, nettyServerLoom, playServer, vertxServer, vertxServerCats)
+  .dependsOn(
+    core,
+    pekkoHttpServer,
+    http4sServer,
+    nettyServer,
+    nettyServerCats,
+    nettyServerLoom,
+    playServer,
+    vertxServer,
+    vertxServerCats,
+    nimaServer
+  )
 
 // integrations
 

--- a/perf-tests/README.md
+++ b/perf-tests/README.md
@@ -1,5 +1,7 @@
 # Performance tests
 
+To work with performance tests, make sure you are running JDK 21+, and that the `ALSO_LOOM` environment variable is set, because the `perf-tests` project includes `tapir-netty-loom` and `tapir-nima`, which require Loom JDK feature to be available.
+
 Performance tests are executed by running `PerfTestSuiteRunner`, which is a standard "Main" Scala application, configured by command line parameters. It executes a sequence of tests, where
 each test consist of:
 

--- a/perf-tests/src/main/scala/sttp/tapir/perf/apis/Endpoints.scala
+++ b/perf-tests/src/main/scala/sttp/tapir/perf/apis/Endpoints.scala
@@ -3,6 +3,7 @@ package sttp.tapir.perf.apis
 import cats.effect.IO
 import sttp.tapir._
 import sttp.tapir.perf.Common._
+import sttp.tapir.server.netty.loom.Id
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.model.EndpointExtensions._
 
@@ -66,4 +67,5 @@ trait Endpoints {
 
   def genEndpointsFuture(count: Int): List[ServerEndpoint[Any, Future]] = genServerEndpoints(count)(Future.successful)
   def genEndpointsIO(count: Int): List[ServerEndpoint[Any, IO]] = genServerEndpoints(count)(IO.pure)
+  def genEndpointsId(count: Int): List[ServerEndpoint[Any, Id]] = genServerEndpoints[Id](count)(x  => x: Id[String])
 }

--- a/perf-tests/src/main/scala/sttp/tapir/perf/netty/loom/NettyId.scala
+++ b/perf-tests/src/main/scala/sttp/tapir/perf/netty/loom/NettyId.scala
@@ -6,10 +6,6 @@ import sttp.tapir.perf.Common._
 import sttp.tapir.server.netty.loom._
 import sttp.tapir.server.ServerEndpoint
 
-import scala.concurrent.ExecutionContext
-import ExecutionContext.Implicits.global
-import scala.concurrent.Future
-
 object Tapir extends Endpoints
 
 object NettyId {

--- a/perf-tests/src/main/scala/sttp/tapir/perf/netty/loom/NettyId.scala
+++ b/perf-tests/src/main/scala/sttp/tapir/perf/netty/loom/NettyId.scala
@@ -1,0 +1,36 @@
+package sttp.tapir.perf.netty.loom
+
+import cats.effect.IO
+import sttp.tapir.perf.apis._
+import sttp.tapir.perf.Common._
+import sttp.tapir.server.netty.loom._
+import sttp.tapir.server.ServerEndpoint
+
+import scala.concurrent.ExecutionContext
+import ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+object Tapir extends Endpoints
+
+object NettyId {
+
+  def runServer(endpoints: List[ServerEndpoint[Any, Id]], withServerLog: Boolean = false): IO[ServerRunner.KillSwitch] = {
+    val declaredPort = Port
+    val declaredHost = "0.0.0.0"
+    val serverOptions = buildOptions(NettyIdServerOptions.customiseInterceptors, withServerLog)
+    // Starting netty server
+    val serverBinding: NettyIdServerBinding =
+      NettyIdServer(serverOptions)
+        .port(declaredPort)
+        .host(declaredHost)
+        .addEndpoints(endpoints)
+        .start()
+    IO(IO(serverBinding.stop()))
+  }
+}
+
+object TapirServer extends ServerRunner { override def start = NettyId.runServer(Tapir.genEndpointsId(1)) }
+object TapirMultiServer extends ServerRunner { override def start = NettyId.runServer(Tapir.genEndpointsId(128)) }
+object TapirInterceptorMultiServer extends ServerRunner {
+  override def start = NettyId.runServer(Tapir.genEndpointsId(128), withServerLog = true)
+}

--- a/perf-tests/src/main/scala/sttp/tapir/perf/nima/Nima.scala
+++ b/perf-tests/src/main/scala/sttp/tapir/perf/nima/Nima.scala
@@ -1,0 +1,44 @@
+package sttp.tapir.perf.nima
+
+import cats.effect.IO
+import sttp.tapir.perf.apis._
+import sttp.tapir.perf.Common._
+import io.helidon.webserver.WebServer
+import sttp.tapir.server.nima.{Id, NimaServerInterpreter, NimaServerOptions}
+import sttp.tapir.server.ServerEndpoint
+
+import scala.concurrent.ExecutionContext
+import ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+object Tapir extends Endpoints {
+  def genEndpointsNId(count: Int): List[ServerEndpoint[Any, Id]] = genServerEndpoints[Id](count)(x => x: Id[String])
+}
+
+object Nima {
+
+  def runServer(endpoints: List[ServerEndpoint[Any, Id]], withServerLog: Boolean = false): IO[ServerRunner.KillSwitch] = {
+    val declaredPort = Port
+    val declaredHost = "0.0.0.0"
+    val serverOptions = buildOptions(NimaServerOptions.customiseInterceptors, withServerLog)
+    // Starting Nima server
+
+    val handler = NimaServerInterpreter(serverOptions).toHandler(endpoints)
+    val server = WebServer
+      .builder()
+      .routing { builder =>
+        builder.any(handler)
+        ()
+      }
+      .port(declaredPort)
+      .build()
+      .start()
+    IO(IO(server.stop()))
+  }
+}
+
+object TapirServer extends ServerRunner { override def start = Nima.runServer(Tapir.genEndpointsNId(1)) }
+object TapirMultiServer extends ServerRunner { override def start = Nima.runServer(Tapir.genEndpointsNId(128)) }
+object TapirInterceptorMultiServer extends ServerRunner {
+  override def start = Nima.runServer(Tapir.genEndpointsNId(128), withServerLog = true)
+}

--- a/perf-tests/src/main/scala/sttp/tapir/perf/nima/Nima.scala
+++ b/perf-tests/src/main/scala/sttp/tapir/perf/nima/Nima.scala
@@ -1,15 +1,11 @@
 package sttp.tapir.perf.nima
 
 import cats.effect.IO
+import io.helidon.webserver.WebServer
 import sttp.tapir.perf.apis._
 import sttp.tapir.perf.Common._
-import io.helidon.webserver.WebServer
 import sttp.tapir.server.nima.{Id, NimaServerInterpreter, NimaServerOptions}
 import sttp.tapir.server.ServerEndpoint
-
-import scala.concurrent.ExecutionContext
-import ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 object Tapir extends Endpoints {
   def genEndpointsNId(count: Int): List[ServerEndpoint[Any, Id]] = genServerEndpoints[Id](count)(x => x: Id[String])
@@ -19,7 +15,6 @@ object Nima {
 
   def runServer(endpoints: List[ServerEndpoint[Any, Id]], withServerLog: Boolean = false): IO[ServerRunner.KillSwitch] = {
     val declaredPort = Port
-    val declaredHost = "0.0.0.0"
     val serverOptions = buildOptions(NimaServerOptions.customiseInterceptors, withServerLog)
     // Starting Nima server
 
@@ -33,7 +28,7 @@ object Nima {
       .port(declaredPort)
       .build()
       .start()
-    IO(IO(server.stop()))
+    IO(IO { val _ = server.stop() })
   }
 }
 


### PR DESCRIPTION
This PR adds Loom-based backends to performance tests. These backends were used for the "Benchmarking Tapir: Part 3 (Loom)" blog post.