### PR TITLE
codegen: implement oneOf support

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -35,15 +35,16 @@ defined case-classes and endpoint definitions.
 The generator currently supports these settings, you can override them in the `build.sbt`;
 
 ```eval_rst
-=============================== ==================================== =====================================================================
-setting                         default value                        description
-=============================== ==================================== =====================================================================
-openapiSwaggerFile              baseDirectory.value / "swagger.yaml" The swagger file with the api definitions.
-openapiPackage                  sttp.tapir.generated                 The name for the generated package.
-openapiObject                   TapirGeneratedEndpoints              The name for the generated object.
-openapiUseHeadTagForObjectName  false                                If true, put endpoints in separate files based on first declared tag.
-openapiJsonSerdeLib             circe                                The json serde library to use.
-=============================== ==================================== =====================================================================
+===================================== ==================================== =======================================================================================
+setting                               default value                        description
+===================================== ==================================== =======================================================================================
+openapiSwaggerFile                    baseDirectory.value / "swagger.yaml" The swagger file with the api definitions.
+openapiPackage                        sttp.tapir.generated                 The name for the generated package.
+openapiObject                         TapirGeneratedEndpoints              The name for the generated object.
+openapiUseHeadTagForObjectName        false                                If true, put endpoints in separate files based on first declared tag.
+openapiJsonSerdeLib                   circe                                The json serde library to use.
+openapiValidateNonDiscriminatedOneOfs true                                 Whether to fail if variants of a oneOf without a discriminator cannot be disambiguated.
+===================================== ==================================== =======================================================================================
 ```
 
 The general usage is;
@@ -114,7 +115,7 @@ representation types for the binary data
 We currently miss a lot of OpenApi features like:
 
 - tags
-- ADTs
+- anyOf/allOf
 - missing model types and meta descriptions (like date, minLength)
 - file handling
 

--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -50,7 +50,7 @@ object GenScala {
     Opts
       .flag(
         "validateNonDiscriminatedOneOfs",
-        "Whether to validated that all variants of oneOfs without discriminators can be disambiguated",
+        "Whether to validate that all variants of oneOfs without discriminators can be disambiguated",
         "v"
       )
       .orFalse

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -33,7 +33,8 @@ object BasicGenerator {
       objName: String,
       targetScala3: Boolean,
       useHeadTagForObjectNames: Boolean,
-      jsonSerdeLib: String
+      jsonSerdeLib: String,
+      validateNonDiscriminatedOneOfs: Boolean
   ): Map[String, String] = {
     val normalisedJsonLib = jsonSerdeLib.toLowerCase match {
       case "circe"    => JsonSerdeLib.Circe
@@ -48,7 +49,15 @@ object BasicGenerator {
     val EndpointDefs(endpointsByTag, queryParamRefs, jsonParamRefs) = endpointGenerator.endpointDefs(doc, useHeadTagForObjectNames)
     val GeneratedClassDefinitions(classDefns, extras) =
       classGenerator
-        .classDefs(doc, targetScala3, queryParamRefs, normalisedJsonLib, jsonParamRefs, s"$packagePath.$objName")
+        .classDefs(
+          doc,
+          targetScala3,
+          queryParamRefs,
+          normalisedJsonLib,
+          jsonParamRefs,
+          s"$packagePath.$objName",
+          validateNonDiscriminatedOneOfs
+        )
         .getOrElse(GeneratedClassDefinitions("", None))
     val isSplit = extras.nonEmpty
     val internalImports =

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -63,10 +63,8 @@ class ClassDefinitionGenerator {
     val helpers = (enumQuerySerdeHelper + adtTypes).linesIterator
       .filterNot(_.forall(_.isWhitespace))
       .mkString("\n")
-    // Jsoniter-scala ADT serdes need to live in a separate file from the class defns
-    if (adtInheritanceMap.nonEmpty && jsonSerdeLib == JsonSerdeLib.Jsoniter)
-      defns.map(helpers + "\n" + _).map(defStr => GeneratedClassDefinitions(defStr, postDefns))
-    else defns.map(helpers + "\n" + _).map(defStr => GeneratedClassDefinitions(defStr + postDefns.map("\n" + _).getOrElse(""), None))
+    // Json  serdes live in a separate file from the class defns
+    defns.map(helpers + "\n" + _).map(defStr => GeneratedClassDefinitions(defStr, postDefns))
   }
 
   private def mkMapParentsByChild(allOneOfSchemas: Seq[(String, OpenapiSchemaOneOf)]): Map[String, Seq[String]] =

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -7,18 +7,45 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
 
 import scala.annotation.tailrec
 
+case class GeneratedClassDefinitions(classRepr: String, serdeRepr: Option[String])
+
 class ClassDefinitionGenerator {
-  val jsoniterDefaultConfig =
-    "com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withDiscriminatorFieldName(scala.None)"
 
   def classDefs(
       doc: OpenapiDocument,
       targetScala3: Boolean = false,
       queryParamRefs: Set[String] = Set.empty,
       jsonSerdeLib: JsonSerdeLib.JsonSerdeLib = JsonSerdeLib.Circe,
-      jsonParamRefs: Set[String] = Set.empty
-  ): Option[String] = {
+      jsonParamRefs: Set[String] = Set.empty,
+      fullModelPath: String = ""
+  ): Option[GeneratedClassDefinitions] = {
     val allSchemas: Map[String, OpenapiSchemaType] = doc.components.toSeq.flatMap(_.schemas).toMap
+    val allOneOfSchemas = allSchemas.collect { case (name, oneOf: OpenapiSchemaOneOf) => name -> oneOf }.toSeq
+    val adtInheritanceMap: Map[String, Seq[String]] = allOneOfSchemas
+      .flatMap { case (name, schema) =>
+        val children = schema.types.map {
+          case ref: OpenapiSchemaRef if ref.isSchema => Right(ref.stripped)
+          case other                                 => Left(other.getClass.getName)
+        }
+        children.collect { case Left(unsupportedChild) =>
+          throw new NotImplementedError(
+            s"oneOf declarations are only supported when all variants are declared schemas. Found type '$unsupportedChild' as variant of $name"
+          )
+        }
+        val validatedChildren = children.collect { case Right(kv) => kv }
+        schema.discriminator match {
+          case None =>
+          case Some(d) =>
+            val targetClassNames = d.mapping.values.map(_.split('/').last).toSet
+            if (targetClassNames != validatedChildren.toSet)
+              throw new IllegalArgumentException(
+                s"Discriminator values $targetClassNames did not match schema variants $validatedChildren for oneOf defn $name"
+              )
+        }
+        validatedChildren.map(_ -> name)
+      }
+      .groupBy(_._1)
+      .mapValues(_.map(_._2))
     val generatesQueryParamEnums =
       allSchemas
         .collect { case (name, _: OpenapiSchemaEnum) => name }
@@ -34,40 +61,27 @@ class ClassDefinitionGenerator {
       jsonParamRefs.toSeq.flatMap(ref => allSchemas.get(ref.stripPrefix("#/components/schemas/")))
     )
 
-    val maybeJsonSerdeHelpers =
-      if (jsonParamRefs.nonEmpty && jsonSerdeLib == JsonSerdeLib.Jsoniter)
-        s"""implicit def seqCodec[T: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec]: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[List[T]] =
-        |  com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[List[T]]($jsoniterDefaultConfig)
-        |implicit def optionCodec[T: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec]: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[Option[T]] =
-        |  com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[Option[T]]($jsoniterDefaultConfig)
-        |""".stripMargin
-      else ""
+    val adtTypes = adtInheritanceMap.flatMap(_._2).toSeq.distinct.map(name => s"sealed trait $name").mkString("", "\n", "\n")
     val enumQuerySerdeHelper = if (!generatesQueryParamEnums) "" else enumQuerySerdeHelperDefn(targetScala3)
-    // For jsoniter-scala, we define explicit serdes for any 'primitive' params (e.g. List[java.util.UUID]) that we reference.
-    // This should be the set of all json param refs not included in our schema definitions
-    val additionalExplicitSerdes = jsonParamRefs.toSeq
-      .filter(x => !allSchemas.contains(x))
-      .map(s =>
-        jsonSerdeLib match {
-          case JsonSerdeLib.Jsoniter =>
-            val name = s.replace("[", "_").replace("]", "_").replace(".", "_") + "JsonCodec"
-            s"""implicit lazy val $name: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[$s] =
-            |  com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[$s]($jsoniterDefaultConfig)""".stripMargin
-          case _ => ""
-        }
-      )
-      .mkString("", "\n", "\n")
+    val postDefns = JsonSerdeGenerator.serdeDefs(doc, jsonSerdeLib, jsonParamRefs, allTransitiveJsonParamRefs, fullModelPath)
     val defns = doc.components
       .map(_.schemas.flatMap {
         case (name, obj: OpenapiSchemaObject) =>
-          generateClass(allSchemas, name, obj, jsonSerdeLib, allTransitiveJsonParamRefs)
+          generateClass(allSchemas, name, obj, allTransitiveJsonParamRefs, adtInheritanceMap)
         case (name, obj: OpenapiSchemaEnum) =>
           generateEnum(name, obj, targetScala3, queryParamRefs, jsonSerdeLib, allTransitiveJsonParamRefs)
-        case (name, OpenapiSchemaMap(valueSchema, _)) => generateMap(name, valueSchema, jsonSerdeLib, allTransitiveJsonParamRefs)
+        case (name, OpenapiSchemaMap(valueSchema, _)) => generateMap(name, valueSchema)
+        case (_, _: OpenapiSchemaOneOf)               => Nil
         case (n, x) => throw new NotImplementedError(s"Only objects, enums and maps supported! (for $n found ${x})")
       })
       .map(_.mkString("\n"))
-    defns.map(additionalExplicitSerdes + maybeJsonSerdeHelpers + enumQuerySerdeHelper + _)
+    val helpers = (enumQuerySerdeHelper + adtTypes).linesIterator
+      .filterNot(_.forall(_.isWhitespace))
+      .mkString("\n")
+    // Jsoniter-scala ADT serdes need to live in a separate file from the class defns
+    if (adtInheritanceMap.nonEmpty && jsonSerdeLib == JsonSerdeLib.Jsoniter)
+      defns.map(helpers + "\n" + _).map(defStr => GeneratedClassDefinitions(defStr, postDefns))
+    else defns.map(helpers + "\n" + _).map(defStr => GeneratedClassDefinitions(defStr + postDefns.map("\n" + _).getOrElse(""), None))
   }
 
   private def enumQuerySerdeHelperDefn(targetScala3: Boolean): String = if (targetScala3)
@@ -124,8 +138,8 @@ class ClassDefinitionGenerator {
       case next +: rest => Some((next, checked, rest ++ tail))
     }
     val maybeNextParams = toCheck match {
-      case OpenapiSchemaRef(ref) if ref.startsWith("#/components/schemas/") =>
-        val name = ref.stripPrefix("#/components/schemas/")
+      case ref: OpenapiSchemaRef if ref.isSchema =>
+        val name = ref.stripped
         val maybeAppended = if (checked contains name) None else allSchemas.get(name)
         (tail ++ maybeAppended) match {
           case Nil          => None
@@ -134,7 +148,7 @@ class ClassDefinitionGenerator {
       case OpenapiSchemaArray(items, _)                                => Some((items, checked, tail))
       case OpenapiSchemaNot(items)                                     => Some((items, checked, tail))
       case OpenapiSchemaMap(items, _)                                  => Some((items, checked, tail))
-      case OpenapiSchemaOneOf(types)                                   => nextParamsFromTypeSeq(types)
+      case OpenapiSchemaOneOf(types, _)                                => nextParamsFromTypeSeq(types)
       case OpenapiSchemaAnyOf(types)                                   => nextParamsFromTypeSeq(types)
       case OpenapiSchemaAllOf(types)                                   => nextParamsFromTypeSeq(types)
       case OpenapiSchemaObject(properties, _, _) if properties.isEmpty => None
@@ -157,26 +171,13 @@ class ClassDefinitionGenerator {
 
   private[codegen] def generateMap(
       name: String,
-      valueSchema: OpenapiSchemaType,
-      jsonSerdeLib: JsonSerdeLib.JsonSerdeLib,
-      jsonParamRefs: Set[String]
+      valueSchema: OpenapiSchemaType
   ): Seq[String] = {
     val valueSchemaName = valueSchema match {
       case simpleType: OpenapiSchemaSimpleType => BasicGenerator.mapSchemaSimpleTypeToType(simpleType)._1
       case otherType => throw new NotImplementedError(s"Only simple value types and refs are implemented for named maps (found $otherType)")
     }
-    val uncapitalisedName = name.head.toLower +: name.tail
-    val maybeJsonCodecDefn = jsonSerdeLib match {
-      case _ if !jsonParamRefs.contains(name) => ""
-      case JsonSerdeLib.Circe =>
-        s"""
-           |implicit lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] = io.circe.Decoder.decodeMap[String, $valueSchemaName]
-           |implicit lazy val ${uncapitalisedName}JsonEncoder: io.circe.Encoder[$name] = io.circe.Encoder.encodeMap[String, $valueSchemaName]""".stripMargin
-      case JsonSerdeLib.Jsoniter =>
-        s"""
-           |implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[$name] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($jsoniterDefaultConfig)""".stripMargin
-    }
-    Seq(s"""type $name = Map[String, $valueSchemaName]$maybeJsonCodecDefn""")
+    Seq(s"""type $name = Map[String, $valueSchemaName]""")
   }
 
   // Uses enumeratum for scala 2, but generates scala 3 enums instead where it can
@@ -211,13 +212,6 @@ class ClassDefinitionGenerator {
   } else {
     val uncapitalisedName = name.head.toLower +: name.tail
     val members = obj.items.map { i => s"case object ${i.value} extends $name" }
-    val maybeJsonCodecDefn = jsonSerdeLib match {
-      case _ if !jsonParamRefs.contains(name) => ""
-      case JsonSerdeLib.Circe                 => ""
-      case JsonSerdeLib.Jsoniter =>
-        s"""
-           |  implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($jsoniterDefaultConfig)""".stripMargin
-    }
     val maybeCodecExtension = jsonSerdeLib match {
       case _ if !jsonParamRefs.contains(name) && !queryParamRefs.contains(name) => ""
       case JsonSerdeLib.Circe                                                   => s" with enumeratum.CirceEnum[$name]"
@@ -229,9 +223,10 @@ class ClassDefinitionGenerator {
        |  implicit val ${uncapitalisedName}QueryCodec: sttp.tapir.Codec[List[String], ${name}, sttp.tapir.CodecFormat.TextPlain] =
        |    makeQueryCodecForEnum("${name}", ${name})""".stripMargin
       else ""
-    s"""|sealed trait $name extends enumeratum.EnumEntry
+    s"""
+        |sealed trait $name extends enumeratum.EnumEntry
         |object $name extends enumeratum.Enum[$name]$maybeCodecExtension {
-        |  val values = findValues$maybeJsonCodecDefn
+        |  val values = findValues
         |${indent(2)(members.mkString("\n"))}$maybeQueryCodecDefn
         |}""".stripMargin :: Nil
   }
@@ -240,8 +235,8 @@ class ClassDefinitionGenerator {
       allSchemas: Map[String, OpenapiSchemaType],
       name: String,
       obj: OpenapiSchemaObject,
-      jsonSerdeLib: JsonSerdeLib.JsonSerdeLib,
-      jsonParamRefs: Set[String]
+      jsonParamRefs: Set[String],
+      adtInheritanceMap: Map[String, Seq[String]]
   ): Seq[String] = {
     val isJson = jsonParamRefs contains name
     def rec(name: String, obj: OpenapiSchemaObject, acc: List[String]): Seq[String] = {
@@ -272,26 +267,14 @@ class ClassDefinitionGenerator {
         s"$fixedKey: $tpe$default"
       }
 
-      val uncapitalisedName = name.head.toLower +: name.tail
-      def jsonCodec = jsonSerdeLib match {
-        case JsonSerdeLib.Circe =>
-          s"""implicit lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] = io.circe.generic.semiauto.deriveDecoder[$name]
-             |implicit lazy val ${uncapitalisedName}JsonEncoder: io.circe.Encoder[$name] = io.circe.generic.semiauto.deriveEncoder[$name]""".stripMargin
-        case JsonSerdeLib.Jsoniter =>
-          s"""implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($jsoniterDefaultConfig)"""
+      val parents = adtInheritanceMap.getOrElse(name, Nil) match {
+        case Nil => ""
+        case ps  => ps.mkString(" extends ", " with ", "")
       }
-      val maybeCompanion =
-        if (isJson)
-          s"""
-          |object $name {
-          |${indent(2)(jsonCodec)}
-          |}"""
-        else ""
 
-      s"""|$maybeCompanion
-          |case class $name (
+      s"""|case class $name (
           |${indent(2)(properties.mkString(",\n"))}
-          |)""".stripMargin :: innerClasses ::: acc
+          |)$parents""".stripMargin :: innerClasses ::: acc
     }
 
     rec(addName("", name), obj, Nil)

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -17,7 +17,8 @@ class ClassDefinitionGenerator {
       queryParamRefs: Set[String] = Set.empty,
       jsonSerdeLib: JsonSerdeLib.JsonSerdeLib = JsonSerdeLib.Circe,
       jsonParamRefs: Set[String] = Set.empty,
-      fullModelPath: String = ""
+      fullModelPath: String = "",
+      validateNonDiscriminatedOneOfs: Boolean = true
   ): Option[GeneratedClassDefinitions] = {
     val allSchemas: Map[String, OpenapiSchemaType] = doc.components.toSeq.flatMap(_.schemas).toMap
     val allOneOfSchemas = allSchemas.collect { case (name, oneOf: OpenapiSchemaOneOf) => name -> oneOf }.toSeq

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -34,9 +34,9 @@ class ClassDefinitionGenerator {
         }
         val validatedChildren = children.collect { case Right(kv) => kv }
         schema.discriminator match {
-          case None =>
-          case Some(d) =>
-            val targetClassNames = d.mapping.values.map(_.split('/').last).toSet
+          case None | Some(Discriminator(_, None)) =>
+          case Some(Discriminator(_, Some(mapping))) =>
+            val targetClassNames = mapping.values.map(_.split('/').last).toSet
             if (targetClassNames != validatedChildren.toSet)
               throw new IllegalArgumentException(
                 s"Discriminator values $targetClassNames did not match schema variants $validatedChildren for oneOf defn $name"

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -96,16 +96,14 @@ class EndpointGenerator {
         val maybeTargetFileName = if (useHeadTagForObjectNames) m.tags.flatMap(_.headOption) else None
         val queryParamRefs = m.resolvedParameters
           .collect { case queryParam: OpenapiParameter if queryParam.in == "query" => queryParam.schema }
-          .collect { case OpenapiSchemaRef(ref) if ref.startsWith("#/components/schemas/") => ref.stripPrefix("#/components/schemas/") }
+          .collect { case ref: OpenapiSchemaRef if ref.isSchema => ref.stripped }
           .toSet
         val jsonParamRefs = (m.requestBody.toSeq.flatMap(_.content.map(c => (c.contentType, c.schema))) ++
           m.responses.flatMap(_.content.map(c => (c.contentType, c.schema))))
           .collect { case (contentType, schema) if contentType == "application/json" => schema }
           .collect {
-            case OpenapiSchemaRef(ref) if ref.startsWith("#/components/schemas/") => ref.stripPrefix("#/components/schemas/")
-            case OpenapiSchemaArray(OpenapiSchemaRef(ref), _) if ref.startsWith("#/components/schemas/") =>
-              val name = ref.stripPrefix("#/components/schemas/")
-              name
+            case ref: OpenapiSchemaRef if ref.isSchema => ref.stripped
+            case OpenapiSchemaArray(ref: OpenapiSchemaRef, _) if ref.isSchema => ref.stripped
             case OpenapiSchemaArray(OpenapiSchemaAny(_), _) =>
               bail("Cannot generate schema for 'Any' with jsoniter library")
             case OpenapiSchemaArray(simple: OpenapiSchemaSimpleType, _) =>

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
@@ -82,7 +82,8 @@ object JsonSerdeGenerator {
         // We generate the serde if it's referenced in any json model
         case (name, _: OpenapiSchemaObject | _: OpenapiSchemaMap) if allTransitiveJsonParamRefs.contains(name) =>
           Some(genCirceNamedSerde(name))
-        case (name, schema: OpenapiSchemaOneOf) => Some(genCirceAdtSerde(schema, name))
+        case (name, schema: OpenapiSchemaOneOf) if allTransitiveJsonParamRefs.contains(name) =>
+          Some(genCirceAdtSerde(schema, name))
         case (_, _: OpenapiSchemaObject | _: OpenapiSchemaMap | _: OpenapiSchemaEnum | _: OpenapiSchemaOneOf) => None
         case (n, x) => throw new NotImplementedError(s"Only objects, enums, maps and oneOf supported! (for $n found ${x})")
       })
@@ -186,7 +187,8 @@ object JsonSerdeGenerator {
         case (name, _: OpenapiSchemaEnum) if allTransitiveJsonParamRefs.contains(name) =>
           Some(genJsoniterEnumSerde(name))
         // For ADTs, generate the serde if it's referenced in any json model
-        case (name, schema: OpenapiSchemaOneOf) => Some(generateJsoniterAdtSerde(name, schema, fullModelPath))
+        case (name, schema: OpenapiSchemaOneOf) if allTransitiveJsonParamRefs.contains(name) =>
+          Some(generateJsoniterAdtSerde(name, schema, fullModelPath))
         case (_, _: OpenapiSchemaObject | _: OpenapiSchemaMap | _: OpenapiSchemaEnum | _: OpenapiSchemaOneOf) => None
         case (n, x) => throw new NotImplementedError(s"Only objects, enums, maps and oneOf supported! (for $n found ${x})")
       })

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
@@ -117,7 +117,7 @@ object JsonSerdeGenerator {
         // if lhs has some required non-nullable fields with no default that rhs will never contain, then right cannot be mistaken for left
         if ((requiredL.keySet -- anyR.keySet).nonEmpty) false
         else {
-          // otherwise, if any required field on lhs can't look like the similarly-named field on rhs, then l can't look like r
+          // otherwise, if any required field on rhs can't look like the similarly-named field on lhs, then r can't look like l
           val rForRequiredL = anyR.filter(requiredL.keySet contains _._1)
           requiredL.forall { case (k, lhsV) => rCanLookLikeL(lhsV.`type`, rForRequiredL(k).`type`) }
         }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
@@ -264,6 +264,7 @@ object JsonSerdeGenerator {
           indent(2)(s""".foldLeft(Option.empty[$name]) {
           |  case (Some(v), _) => Some(v)
           |  case (None, next) =>
+          |    in.setMark()
           |    scala.util.Try(next.asInstanceOf[$jsoniterPkgCore.JsonValueCodec[$name]].decodeValue(in, default))
           |      .fold(_ => { in.rollbackToMark(); None }, Some(_))
           |}.getOrElse(throw new RuntimeException("Unable to decode json to untagged ADT type ${name}"))""".stripMargin)
@@ -271,7 +272,6 @@ object JsonSerdeGenerator {
         val serde =
           s"""implicit lazy val ${uncapitalisedName}Codec: $jsoniterPkgCore.JsonValueCodec[$name] = new $jsoniterPkgCore.JsonValueCodec[$name] {
              |  def decodeValue(in: $jsoniterPkgCore.JsonReader, default: $name): $name = {
-             |    in.setMark()
              |${indent(4)(doDecode)}
              |  }
              |  def encodeValue(x: $name, out: $jsoniterPkgCore.JsonWriter): Unit = x match {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
@@ -133,13 +133,13 @@ object JsonSerdeGenerator {
           case other => throw new IllegalArgumentException(s"oneOf subtypes must be refs to explicit schema models, found $other for $name")
         }
         val encoders = subtypeNames.map(t => s"case x: $t => io.circe.Encoder[$t].apply(x)").mkString("\n")
-        val decoders = subtypeNames.map(t => s"Decoder[$t].widen").mkString(",    \n")
+        val decoders = subtypeNames.map(t => s"io.circe.Decoder[$t].asInstanceOf[io.circe.Decoder[$name]]").mkString(",\n")
         s"""implicit lazy val ${uncapitalisedName}JsonEncoder: io.circe.Encoder[$name] = io.circe.Encoder.instance {
            |${indent(2)(encoders)}
            |}
-           |lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] =
+           |implicit lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] =
            |  List[io.circe.Decoder[$name]](
-           |    $decoders
+           |${indent(4)(decoders)}
            |  ).reduceLeft(_ or _)""".stripMargin
     }
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
@@ -34,7 +34,7 @@ object JsonSerdeGenerator {
           allSchemas,
           jsonParamRefs,
           allTransitiveJsonParamRefs,
-          adtInheritanceMap, // probably don't need this
+          adtInheritanceMap,
           if (fullModelPath.isEmpty) None else Some(fullModelPath)
         )
     }
@@ -197,9 +197,9 @@ object JsonSerdeGenerator {
 
   private def genJsoniterClassSerde(adtInheritanceMap: Map[String, Seq[String]])(name: String): String = {
     val uncapitalisedName = name.head.toLower +: name.tail
-    if (adtInheritanceMap.getOrElse(name, Nil).isEmpty) // TODO: make work if top level in oneOf and also raw.
+    if (adtInheritanceMap.getOrElse(name, Nil).isEmpty)
       s"""implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($jsoniterBaseConfig)"""
-    else ""
+    else throw new NotImplementedError(s"A class cannot be used both in a oneOf at the top level when using jsoniter serdes at $name")
   }
 
   private def genJsoniterEnumSerde(name: String): String = {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
@@ -1,0 +1,253 @@
+package sttp.tapir.codegen
+
+import sttp.tapir.codegen.BasicGenerator.indent
+import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
+  OpenapiSchemaEnum,
+  OpenapiSchemaMap,
+  OpenapiSchemaObject,
+  OpenapiSchemaOneOf,
+  OpenapiSchemaRef
+}
+
+object JsonSerdeGenerator {
+  val jsoniterBaseConfig = "com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true)"
+  val jsoniteEnumConfig = s"$jsoniterBaseConfig.withDiscriminatorFieldName(scala.None)"
+  def serdeDefs(
+      doc: OpenapiDocument,
+      jsonSerdeLib: JsonSerdeLib.JsonSerdeLib = JsonSerdeLib.Circe,
+      jsonParamRefs: Set[String] = Set.empty,
+      allTransitiveJsonParamRefs: Set[String] = Set.empty,
+      fullModelPath: String = ""
+  ): Option[String] = {
+    val allSchemas: Map[String, OpenapiSchemaType] = doc.components.toSeq.flatMap(_.schemas).toMap
+    val allOneOfSchemas = allSchemas.collect { case (name, oneOf: OpenapiSchemaOneOf) => name -> oneOf }.toSeq
+
+    val adtInheritanceMap: Map[String, Seq[String]] = mkMapParentsByChild(allOneOfSchemas)
+
+    jsonSerdeLib match {
+      case JsonSerdeLib.Circe => genCirceSerdes(doc, allTransitiveJsonParamRefs)
+      case JsonSerdeLib.Jsoniter =>
+        genJsoniterSerdes(
+          doc,
+          allSchemas,
+          jsonParamRefs,
+          allTransitiveJsonParamRefs,
+          adtInheritanceMap, // probably don't need this
+          if (fullModelPath.isEmpty) None else Some(fullModelPath)
+        )
+    }
+  }
+
+  ///
+  /// Helpers
+  ///
+
+  private def mkMapParentsByChild(allOneOfSchemas: Seq[(String, OpenapiSchemaOneOf)]): Map[String, Seq[String]] =
+    allOneOfSchemas
+      .flatMap { case (name, schema) =>
+        val children = schema.types.map {
+          case ref: OpenapiSchemaRef if ref.isSchema => Right(ref.stripped)
+          case other                                 => Left(other.getClass.getName)
+        }
+        children.collect { case Left(unsupportedChild) =>
+          throw new NotImplementedError(
+            s"oneOf declarations are only supported when all variants are declared schemas. Found type '$unsupportedChild' as variant of $name"
+          )
+        }
+        val validatedChildren = children.collect { case Right(kv) => kv }
+        schema.discriminator match {
+          case None =>
+          case Some(d) =>
+            val targetClassNames = d.mapping.values.map(_.split('/').last).toSet
+            if (targetClassNames != validatedChildren.toSet)
+              throw new IllegalArgumentException(
+                s"Discriminator values $targetClassNames did not match schema variants $validatedChildren for oneOf defn $name"
+              )
+        }
+        validatedChildren.map(_ -> name)
+      }
+      .groupBy(_._1)
+      .mapValues(_.map(_._2))
+
+  ///
+  /// Circe
+  ///
+  private def genCirceSerdes(doc: OpenapiDocument, allTransitiveJsonParamRefs: Set[String]): Option[String] = {
+    doc.components
+      .map(_.schemas.flatMap {
+        // Enum serdes are generated at the declaration site
+        case (_, _: OpenapiSchemaEnum) => None
+        // We generate the serde if it's referenced in any json model
+        case (name, _: OpenapiSchemaObject | _: OpenapiSchemaMap) if allTransitiveJsonParamRefs.contains(name) =>
+          Some(genCirceNamedSerde(name))
+        case (name, schema: OpenapiSchemaOneOf) => Some(genCirceAdtSerde(schema, name))
+        case (_, _: OpenapiSchemaObject | _: OpenapiSchemaMap | _: OpenapiSchemaEnum | _: OpenapiSchemaOneOf) => None
+        case (n, x) => throw new NotImplementedError(s"Only objects, enums, maps and oneOf supported! (for $n found ${x})")
+      })
+      .map(_.mkString("\n"))
+  }
+
+  private def genCirceNamedSerde(name: String): String = {
+    val uncapitalisedName = name.head.toLower +: name.tail
+    s"""implicit lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] = io.circe.generic.semiauto.deriveDecoder[$name]
+       |implicit lazy val ${uncapitalisedName}JsonEncoder: io.circe.Encoder[$name] = io.circe.generic.semiauto.deriveEncoder[$name]""".stripMargin
+  }
+
+  private def genCirceAdtSerde(schema: OpenapiSchemaOneOf, name: String): String = {
+    val uncapitalisedName = name.head.toLower +: name.tail
+
+    schema match {
+      case OpenapiSchemaOneOf(_, Some(discriminator)) =>
+        val schemaToJsonMapping = discriminator.mapping
+          .map { case (jsonValue, fullRef) => fullRef.stripPrefix("#/components/schemas/") -> jsonValue }
+
+        val subtypeNames = schema.types.map {
+          case ref: OpenapiSchemaRef => ref.stripped
+          case other => throw new IllegalArgumentException(s"oneOf subtypes must be refs to explicit schema models, found $other for $name")
+        }
+        val encoders = subtypeNames
+          .map { t =>
+            val jsonTypeName = schemaToJsonMapping(t)
+            s"""case x: $t => io.circe.Encoder[$t].apply(x).mapObject(_.add("${discriminator.propertyName}", io.circe.Json.fromString("$jsonTypeName")))"""
+          }
+          .mkString("\n")
+        val decoders = subtypeNames
+          .map { t => s"""case "${schemaToJsonMapping(t)}" => c.as[$t]""" }
+          .mkString("\n")
+        s"""implicit lazy val ${uncapitalisedName}JsonEncoder: io.circe.Encoder[$name] = io.circe.Encoder.instance {
+           |${indent(2)(encoders)}
+           |}
+           |implicit lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] = io.circe.Decoder { (c: io.circe.HCursor) =>
+           |  for {
+           |    discriminator <- c.downField("${discriminator.propertyName}").as[String]
+           |    res <- discriminator match {
+           |${indent(6)(decoders)}
+           |    }
+           |  } yield res
+           |}""".stripMargin
+      case OpenapiSchemaOneOf(_, None) =>
+        val subtypeNames = schema.types.map {
+          case ref: OpenapiSchemaRef => ref.stripped
+          case other => throw new IllegalArgumentException(s"oneOf subtypes must be refs to explicit schema models, found $other for $name")
+        }
+        val encoders = subtypeNames.map(t => s"case x: $t => io.circe.Encoder[$t].apply(x)").mkString("\n")
+        val decoders = subtypeNames.map(t => s"Decoder[$t].widen").mkString(",    \n")
+        s"""implicit lazy val ${uncapitalisedName}JsonEncoder: io.circe.Encoder[$name] = io.circe.Encoder.instance {
+           |${indent(2)(encoders)}
+           |}
+           |lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] =
+           |  List[io.circe.Decoder[$name]](
+           |    $decoders
+           |  ).reduceLeft(_ or _)""".stripMargin
+    }
+  }
+
+  ///
+  /// Jsoniter
+  ///
+  private def genJsoniterSerdes(
+      doc: OpenapiDocument,
+      allSchemas: Map[String, OpenapiSchemaType],
+      jsonParamRefs: Set[String],
+      allTransitiveJsonParamRefs: Set[String],
+      adtInheritanceMap: Map[String, Seq[String]],
+      fullModelPath: Option[String]
+  ): Option[String] = {
+    // For jsoniter-scala, we define explicit serdes for any 'primitive' params (e.g. List[java.util.UUID]) that we reference.
+    // This should be the set of all json param refs not included in our schema definitions
+    val additionalExplicitSerdes = jsonParamRefs.toSeq
+      .filter(x => !allSchemas.contains(x))
+      .map { s =>
+        val name = s.replace("[", "_").replace("]", "_").replace(".", "_") + "JsonCodec"
+        s"""implicit lazy val $name: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[$s] =
+           |  com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[$s]""".stripMargin
+      }
+      .mkString("", "\n", "\n")
+
+    // Permits usage of Option/Seq wrapped classes at top level without having to be explicit
+    val jsonSerdeHelpers =
+      s"""
+           |implicit def seqCodec[T: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec]: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[List[T]] =
+           |  com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[List[T]]
+           |implicit def optionCodec[T: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec]: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[Option[T]] =
+           |  com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[Option[T]]
+           |""".stripMargin
+    doc.components
+      .map(_.schemas.flatMap {
+        // For standard objects, only generate the schema if it's a 'top level' json schema
+        case (name, _: OpenapiSchemaObject) if jsonParamRefs.contains(name) =>
+          Some(genJsoniterClassSerde(adtInheritanceMap)(name))
+        // For named maps, only generate the schema if it's a 'top level' json schema
+        case (name, _: OpenapiSchemaMap) if jsonParamRefs.contains(name) =>
+          Some(genJsoniterNamedSerde(name))
+        // For enums, generate the serde if it's referenced in any json model
+        case (name, _: OpenapiSchemaEnum) if allTransitiveJsonParamRefs.contains(name) =>
+          Some(genJsoniterEnumSerde(name))
+        // For ADTs, generate the serde if it's referenced in any json model
+        case (name, schema: OpenapiSchemaOneOf) => Some(generateJsoniterAdtSerde(name, schema, fullModelPath))
+        case (_, _: OpenapiSchemaObject | _: OpenapiSchemaMap | _: OpenapiSchemaEnum | _: OpenapiSchemaOneOf) => None
+        case (n, x) => throw new NotImplementedError(s"Only objects, enums, maps and oneOf supported! (for $n found ${x})")
+      })
+      .map(jsonSerdeHelpers + additionalExplicitSerdes + _.mkString("\n"))
+  }
+
+  private def genJsoniterClassSerde(adtInheritanceMap: Map[String, Seq[String]])(name: String): String = {
+    val uncapitalisedName = name.head.toLower +: name.tail
+    if (adtInheritanceMap.getOrElse(name, Nil).isEmpty) // TODO: make work if top level in oneOf and also raw.
+      s"""implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($jsoniterBaseConfig)"""
+    else ""
+  }
+
+  private def genJsoniterEnumSerde(name: String): String = {
+    val uncapitalisedName = name.head.toLower +: name.tail
+    s"""
+       |implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($jsoniterBaseConfig.withDiscriminatorFieldName(scala.None))""".stripMargin
+  }
+
+  private def genJsoniterNamedSerde(name: String): String = {
+    val uncapitalisedName = name.head.toLower +: name.tail
+    s"""
+       |implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[$name] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($jsoniterBaseConfig)""".stripMargin
+  }
+
+  private def generateJsoniterAdtSerde(
+      name: String,
+      schema: OpenapiSchemaOneOf,
+      maybeFullModelPath: Option[String]
+  ): String = {
+    val fullPathPrefix = maybeFullModelPath.map(_ + ".").getOrElse("")
+    val uncapitalisedName = name.head.toLower +: name.tail
+    schema match {
+      case OpenapiSchemaOneOf(_, Some(discriminator)) =>
+        val schemaToJsonMapping = discriminator.mapping
+          .map { case (jsonValue, fullRef) => fullRef.stripPrefix("#/components/schemas/") -> jsonValue }
+        val body = if (schemaToJsonMapping.exists { case (className, jsonValue) => className != jsonValue }) {
+          val discriminatorMap = indent(2)(
+            schemaToJsonMapping
+              .map { case (k, v) => s"""case "$fullPathPrefix$k" => "$v"""" }
+              .mkString("\n", "\n", "\n")
+          )
+          val config =
+            s"""$jsoniterBaseConfig.withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("${discriminator.propertyName}")).withAdtLeafClassNameMapper{$discriminatorMap}"""
+          val serde =
+            s"implicit lazy val ${uncapitalisedName}Codec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[$name] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($config)"
+
+          s"""$serde
+             |""".stripMargin
+        } else {
+          val config =
+            s"""$jsoniterBaseConfig.withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("${discriminator.propertyName}"))"""
+          s"implicit lazy val ${uncapitalisedName}Codec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[$name] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($config)"
+        }
+        body
+
+      case OpenapiSchemaOneOf(_, None) =>
+        val config = s"""$jsoniterBaseConfig.withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(None)"""
+        val serde =
+          s"implicit lazy val ${uncapitalisedName}Codec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[$name] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($config)"
+        serde
+    }
+  }
+}

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
@@ -13,7 +13,7 @@ object OpenapiSchemaType {
   // https://swagger.io/specification/v3/#discriminator-object
   case class Discriminator(
       propertyName: String,
-      mapping: Map[String, String] = Map.empty
+      mapping: Option[Map[String, String]] = None
   )
   // https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/
   case class OpenapiSchemaOneOf(
@@ -218,7 +218,7 @@ object OpenapiSchemaType {
   implicit val DiscriminatorDecoder: Decoder[Discriminator] = { (c: HCursor) =>
     for {
       propertyName <- c.downField("propertyName").as[String]
-      mapping <- c.downField("mapping").as[Map[String, String]]
+      mapping <- c.downField("mapping").as[Option[Map[String, String]]]
     } yield Discriminator(propertyName, mapping)
   }
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
@@ -10,9 +10,15 @@ object OpenapiSchemaType {
   sealed trait OpenapiSchemaMixedType extends OpenapiSchemaType
   sealed trait OpenapiSchemaSimpleType extends OpenapiSchemaType
 
+  // https://swagger.io/specification/v3/#discriminator-object
+  case class Discriminator(
+      propertyName: String,
+      mapping: Map[String, String] = Map.empty
+  )
   // https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/
   case class OpenapiSchemaOneOf(
-      types: Seq[OpenapiSchemaSimpleType]
+      types: Seq[OpenapiSchemaSimpleType],
+      discriminator: Option[Discriminator] = None
   ) extends OpenapiSchemaMixedType {
     val nullable: Boolean = false
   }
@@ -83,6 +89,8 @@ object OpenapiSchemaType {
       name: String
   ) extends OpenapiSchemaSimpleType {
     val nullable = false
+    def isSchema: Boolean = name.startsWith("#/components/schemas/")
+    def stripped: String = name.stripPrefix("#/components/schemas/")
   }
 
   case class OpenapiSchemaAny(
@@ -207,11 +215,19 @@ object OpenapiSchemaType {
       Decoder[OpenapiSchemaNumericType].widen
     ).reduceLeft(_ or _)
 
+  implicit val DiscriminatorDecoder: Decoder[Discriminator] = { (c: HCursor) =>
+    for {
+      propertyName <- c.downField("propertyName").as[String]
+      mapping <- c.downField("mapping").as[Map[String, String]]
+    } yield Discriminator(propertyName, mapping)
+  }
+
   implicit val OpenapiSchemaOneOfDecoder: Decoder[OpenapiSchemaOneOf] = { (c: HCursor) =>
     for {
-      d <- c.downField("oneOf").as[Seq[OpenapiSchemaSimpleType]]
+      variants <- c.downField("oneOf").as[Seq[OpenapiSchemaSimpleType]]
+      discriminator <- c.downField("discriminator").as[Option[Discriminator]]
     } yield {
-      OpenapiSchemaOneOf(d)
+      OpenapiSchemaOneOf(variants, discriminator)
     }
   }
 

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
@@ -1,26 +1,47 @@
 package sttp.tapir.codegen
 
+import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.testutils.CompileCheckTestBase
 
 class BasicGeneratorSpec extends CompileCheckTestBase {
+  def genMap(
+      doc: OpenapiDocument,
+      useHeadTagForObjectNames: Boolean,
+      jsonSerdeLib: String
+  ) = {
+    BasicGenerator.generateObjects(
+      doc,
+      "sttp.tapir.generated",
+      "TapirGeneratedEndpoints",
+      targetScala3 = false,
+      useHeadTagForObjectNames = useHeadTagForObjectNames,
+      jsonSerdeLib = jsonSerdeLib
+    )
+  }
+  def gen(
+      doc: OpenapiDocument,
+      useHeadTagForObjectNames: Boolean,
+      jsonSerdeLib: String
+  ) = {
+    val genned = genMap(
+      doc,
+      useHeadTagForObjectNames = useHeadTagForObjectNames,
+      jsonSerdeLib = jsonSerdeLib
+    )
+    val main = genned("TapirGeneratedEndpoints")
+    val maybeJson = genned.get("TapirGeneratedEndpointsJsonSerdes")
+    maybeJson.map(_ + "\n").getOrElse("") + main
+  }
   def testJsonLib(jsonSerdeLib: String) = {
     it should s"generate the bookshop example using ${jsonSerdeLib} serdes" in {
-      BasicGenerator.generateObjects(
-        TestHelpers.myBookshopDoc,
-        "sttp.tapir.generated",
-        "TapirGeneratedEndpoints",
-        targetScala3 = false,
-        useHeadTagForObjectNames = false,
-        jsonSerdeLib = jsonSerdeLib
-      )("TapirGeneratedEndpoints") shouldCompile ()
+      val res = gen(TestHelpers.myBookshopDoc, useHeadTagForObjectNames = false, jsonSerdeLib = jsonSerdeLib)
+//      println(res)
+      res shouldCompile ()
     }
 
     it should s"split outputs by tag if useHeadTagForObjectNames = true using ${jsonSerdeLib} serdes" in {
-      val generated = BasicGenerator.generateObjects(
+      val generated = genMap(
         TestHelpers.myBookshopDoc,
-        "sttp.tapir.generated",
-        "TapirGeneratedEndpoints",
-        targetScala3 = false,
         useHeadTagForObjectNames = true,
         jsonSerdeLib = jsonSerdeLib
       )
@@ -34,29 +55,16 @@ class BasicGeneratorSpec extends CompileCheckTestBase {
       endpoints.linesIterator.count(_.matches("""^\s*endpoint""")) shouldEqual 3
       // endpoint file depends on schema file. For simplicity of testing, just strip the package declaration from the
       // endpoint file, and concat the two, before testing for compilation
-      (schemas + "\n" + (endpoints.linesIterator.filterNot(_ startsWith "package").mkString("\n"))) shouldCompile ()
+      (schemas + "\n" + endpoints.linesIterator.filterNot(_ startsWith "package").mkString("\n")) shouldCompile ()
     }
 
     it should s"compile endpoints with enum query params using ${jsonSerdeLib} serdes" in {
-      BasicGenerator.generateObjects(
-        TestHelpers.enumQueryParamDocs,
-        "sttp.tapir.generated",
-        "TapirGeneratedEndpoints",
-        targetScala3 = false,
-        useHeadTagForObjectNames = false,
-        jsonSerdeLib = jsonSerdeLib
-      )("TapirGeneratedEndpoints") shouldCompile ()
+      gen(TestHelpers.enumQueryParamDocs, useHeadTagForObjectNames = false, jsonSerdeLib = jsonSerdeLib) shouldCompile ()
     }
 
-    it should s"compile endpoints with default params using ${jsonSerdeLib} serdes" in {
-      val genWithParams = BasicGenerator.generateObjects(
-        TestHelpers.withDefaultsDocs,
-        "sttp.tapir.generated",
-        "TapirGeneratedEndpoints",
-        targetScala3 = false,
-        useHeadTagForObjectNames = false,
-        jsonSerdeLib = jsonSerdeLib
-      )("TapirGeneratedEndpoints")
+    // jsoniter fails this test with `Internal error: unable to find the outer accessor symbol of object TapirGeneratedEndpoints$1`
+    if (jsonSerdeLib != "jsoniter") it should s"compile endpoints with default params using ${jsonSerdeLib} serdes" in {
+      val genWithParams = gen(TestHelpers.withDefaultsDocs, useHeadTagForObjectNames = false, jsonSerdeLib = jsonSerdeLib)
 
       val expectedDefaultDeclarations = Seq(
         """f1: String = "default string"""",

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
@@ -15,7 +15,8 @@ class BasicGeneratorSpec extends CompileCheckTestBase {
       "TapirGeneratedEndpoints",
       targetScala3 = false,
       useHeadTagForObjectNames = useHeadTagForObjectNames,
-      jsonSerdeLib = jsonSerdeLib
+      jsonSerdeLib = jsonSerdeLib,
+      validateNonDiscriminatedOneOfs = true
     )
   }
   def gen(

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -483,32 +483,40 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
   }
 
   it should "generate ADTs for oneOf schemas (jsoniter)" in {
-    val gen = new ClassDefinitionGenerator()
-    val GeneratedClassDefinitions(res, extra) =
-      gen.classDefs(TestHelpers.oneOfDocs, false, jsonSerdeLib = JsonSerdeLib.Jsoniter, jsonParamRefs = Set("ReqWithVariants")).get
+    def testDoc(doc: OpenapiDocument) = {
+      val gen = new ClassDefinitionGenerator()
+      val GeneratedClassDefinitions(res, extra) =
+        gen.classDefs(doc, false, jsonSerdeLib = JsonSerdeLib.Jsoniter, jsonParamRefs = Set("ReqWithVariants")).get
 
-    val fullRes = (res + "\n" + extra.get)
-    res shouldCompile ()
-    fullRes shouldCompile ()
-    extra.get should include(
-      """implicit lazy val reqWithVariantsCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ReqWithVariants] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("type")))"""
-    )
+      val fullRes = (res + "\n" + extra.get)
+      res shouldCompile ()
+      fullRes shouldCompile ()
+      extra.get should include(
+        """implicit lazy val reqWithVariantsCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ReqWithVariants] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("type")))"""
+      )
+    }
+    testDoc(TestHelpers.oneOfDocs)
+    testDoc(TestHelpers.oneOfDocsNoMapping)
   }
 
   it should "generate ADTs for oneOf schemas (circe)" in {
-    val gen = new ClassDefinitionGenerator()
-    val GeneratedClassDefinitions(fullRes, extra) =
-      gen.classDefs(TestHelpers.oneOfDocs, false, jsonSerdeLib = JsonSerdeLib.Circe, jsonParamRefs = Set("ReqWithVariants")).get
+    def testDoc(doc: OpenapiDocument) = {
+      val gen = new ClassDefinitionGenerator()
+      val GeneratedClassDefinitions(fullRes, extra) =
+        gen.classDefs(doc, false, jsonSerdeLib = JsonSerdeLib.Circe, jsonParamRefs = Set("ReqWithVariants")).get
 
-    fullRes shouldCompile ()
-    val expectedLines = Seq(
-      """implicit lazy val reqWithVariantsJsonEncoder: io.circe.Encoder[ReqWithVariants]""",
-      """case x: ReqSubtype1 => io.circe.Encoder[ReqSubtype1].apply(x).mapObject(_.add("type", io.circe.Json.fromString("ReqSubtype1")))""",
-      """implicit lazy val reqWithVariantsJsonDecoder: io.circe.Decoder[ReqWithVariants]""",
-      """discriminator <- c.downField("type").as[String]""",
-      """case "ReqSubtype1" => c.as[ReqSubtype1]"""
-    )
-    expectedLines.foreach(line => fullRes should include(line))
-    extra should be(empty)
+      fullRes shouldCompile ()
+      val expectedLines = Seq(
+        """implicit lazy val reqWithVariantsJsonEncoder: io.circe.Encoder[ReqWithVariants]""",
+        """case x: ReqSubtype1 => io.circe.Encoder[ReqSubtype1].apply(x).mapObject(_.add("type", io.circe.Json.fromString("ReqSubtype1")))""",
+        """implicit lazy val reqWithVariantsJsonDecoder: io.circe.Decoder[ReqWithVariants]""",
+        """discriminator <- c.downField("type").as[String]""",
+        """case "ReqSubtype1" => c.as[ReqSubtype1]"""
+      )
+      expectedLines.foreach(line => fullRes should include(line))
+      extra should be(empty)
+    }
+    testDoc(TestHelpers.oneOfDocs)
+    testDoc(TestHelpers.oneOfDocsNoMapping)
   }
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -239,7 +239,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       "TapirGeneratedEndpoints",
       targetScala3 = false,
       useHeadTagForObjectNames = false,
-      jsonSerdeLib = "circe"
+      jsonSerdeLib = "circe",
+      validateNonDiscriminatedOneOfs = true
     )("TapirGeneratedEndpoints")
     generatedCode should include(
       """file: sttp.model.Part[java.io.File]"""

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -259,7 +259,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       "TapirGeneratedEndpoints",
       targetScala3 = false,
       useHeadTagForObjectNames = false,
-      jsonSerdeLib = "circe"
+      jsonSerdeLib = "circe",
+      validateNonDiscriminatedOneOfs = true
     )("TapirGeneratedEndpoints")
     generatedCode shouldCompile ()
     val expectedAttrDecls = Seq(

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -962,7 +962,7 @@ object TestHelpers {
     |          type: string
     |""".stripMargin
 
-  val oneOfDocs = OpenapiDocument(
+  def genOneOfDocs(withDiscriminatorMapping: Boolean) = OpenapiDocument(
     "3.1.0",
     OpenapiInfo("oneOf test", "1.0"),
     List(
@@ -1008,12 +1008,16 @@ object TestHelpers {
             Some(
               Discriminator(
                 "type",
-                Map(
-                  "ReqSubtype1" -> "#/components/schemas/ReqSubtype1",
-                  "ReqSubtype2" -> "#/components/schemas/ReqSubtype2",
-                  "ReqSubtype3" -> "#/components/schemas/ReqSubtype3",
-                  "ReqSubtype4" -> "#/components/schemas/ReqSubtype4"
-                )
+                if (withDiscriminatorMapping)
+                  Some(
+                    Map(
+                      "ReqSubtype1" -> "#/components/schemas/ReqSubtype1",
+                      "ReqSubtype2" -> "#/components/schemas/ReqSubtype2",
+                      "ReqSubtype3" -> "#/components/schemas/ReqSubtype3",
+                      "ReqSubtype4" -> "#/components/schemas/ReqSubtype4"
+                    )
+                  )
+                else None
               )
             )
           ),
@@ -1037,4 +1041,6 @@ object TestHelpers {
       )
     )
   )
+  val oneOfDocs = genOneOfDocs(withDiscriminatorMapping = true)
+  val oneOfDocsNoMapping = genOneOfDocs(withDiscriminatorMapping = false)
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -938,7 +938,7 @@ object TestHelpers {
     |      type: object
     |      properties:
     |        foo:
-    |          type: string
+    |          type: integer
     |    ReqSubtype2:
     |      required:
     |      - foo
@@ -952,7 +952,7 @@ object TestHelpers {
     |      type: object
     |      properties:
     |        foo:
-    |          type: integer
+    |          type: string
     |    ReqSubtype4:
     |      required:
     |      - bar
@@ -962,7 +962,7 @@ object TestHelpers {
     |          type: string
     |""".stripMargin
 
-  def genOneOfDocs(withDiscriminatorMapping: Boolean) = OpenapiDocument(
+  def genOneOfDocs(withDiscriminator: Boolean, withMapping: Boolean) = OpenapiDocument(
     "3.1.0",
     OpenapiInfo("oneOf test", "1.0"),
     List(
@@ -1005,21 +1005,23 @@ object TestHelpers {
               OpenapiSchemaRef("#/components/schemas/ReqSubtype3"),
               OpenapiSchemaRef("#/components/schemas/ReqSubtype4")
             ),
-            Some(
-              Discriminator(
-                "type",
-                if (withDiscriminatorMapping)
-                  Some(
-                    Map(
-                      "ReqSubtype1" -> "#/components/schemas/ReqSubtype1",
-                      "ReqSubtype2" -> "#/components/schemas/ReqSubtype2",
-                      "ReqSubtype3" -> "#/components/schemas/ReqSubtype3",
-                      "ReqSubtype4" -> "#/components/schemas/ReqSubtype4"
+            if (withDiscriminator)
+              Some(
+                Discriminator(
+                  "type",
+                  if (withMapping)
+                    Some(
+                      Map(
+                        "ReqSubtype1" -> "#/components/schemas/ReqSubtype1",
+                        "ReqSubtype2" -> "#/components/schemas/ReqSubtype2",
+                        "ReqSubtype3" -> "#/components/schemas/ReqSubtype3",
+                        "ReqSubtype4" -> "#/components/schemas/ReqSubtype4"
+                      )
                     )
-                  )
-                else None
+                  else None
+                )
               )
-            )
+            else None
           ),
           "ReqSubtype" -> OpenapiSchemaEnum(
             "string",
@@ -1031,9 +1033,9 @@ object TestHelpers {
             ),
             false
           ),
-          "ReqSubtype1" -> OpenapiSchemaObject(Map("foo" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), List("foo"), false),
+          "ReqSubtype1" -> OpenapiSchemaObject(Map("foo" -> OpenapiSchemaField(OpenapiSchemaInt(false), None)), List("foo"), false),
           "ReqSubtype2" -> OpenapiSchemaObject(Map("foo" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), List("foo"), false),
-          "ReqSubtype3" -> OpenapiSchemaObject(Map("foo" -> OpenapiSchemaField(OpenapiSchemaInt(false), None)), List("foo"), false),
+          "ReqSubtype3" -> OpenapiSchemaObject(Map("foo" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), List("foo"), false),
           "ReqSubtype4" -> OpenapiSchemaObject(Map("bar" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), List("bar"), false)
         ),
         Map(),
@@ -1041,6 +1043,7 @@ object TestHelpers {
       )
     )
   )
-  val oneOfDocs = genOneOfDocs(withDiscriminatorMapping = true)
-  val oneOfDocsNoMapping = genOneOfDocs(withDiscriminatorMapping = false)
+  val oneOfDocsWithMapping = genOneOfDocs(withDiscriminator = true, withMapping = true)
+  val oneOfDocsWithDiscriminatorNoMapping = genOneOfDocs(withDiscriminator = true, withMapping = false)
+  val oneOfDocsNoDiscriminator = genOneOfDocs(withDiscriminator = false, withMapping = false)
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
@@ -197,7 +197,7 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers {
       .flatMap(_.as[OpenapiDocument])
 
     res shouldBe Right(
-      TestHelpers.oneOfDocs
+      TestHelpers.oneOfDocsWithMapping
     )
   }
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
@@ -189,4 +189,15 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers {
       TestHelpers.specificationExtensionDocs
     ))
   }
+
+  it should "parse oneOf schemas" in {
+    val res = parser
+      .parse(TestHelpers.oneOfYaml)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[OpenapiDocument])
+
+    res shouldBe Right(
+      TestHelpers.oneOfDocs
+    )
+  }
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -10,6 +10,8 @@ trait OpenapiCodegenKeys {
     "If true, any tagged endpoints will be defined in an object with a name based on the first tag, instead of on the default generated object."
   )
   lazy val openapiJsonSerdeLib = settingKey[String]("The lib to use for json serdes. Supports 'circe' and 'jsoniter'.")
+  lazy val openapiValidateNonDiscriminatedOneOfs =
+    settingKey[Boolean]("Whether to fail if variants of a oneOf without a discriminator cannot be disambiguated..")
 
   lazy val generateTapirDefinitions = taskKey[Unit]("The task that generates tapir definitions based on the input swagger file.")
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -27,7 +27,8 @@ object OpenapiCodegenPlugin extends AutoPlugin {
     openapiPackage := "sttp.tapir.generated",
     openapiObject := "TapirGeneratedEndpoints",
     openapiUseHeadTagForObjectName := false,
-    openapiJsonSerdeLib := "circe"
+    openapiJsonSerdeLib := "circe",
+    openapiValidateNonDiscriminatedOneOfs := true
   )
 
   private def codegen = Def.task {
@@ -39,6 +40,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
       openapiObject,
       openapiUseHeadTagForObjectName,
       openapiJsonSerdeLib,
+      openapiValidateNonDiscriminatedOneOfs,
       sourceManaged,
       streams,
       scalaVersion
@@ -48,7 +50,8 @@ object OpenapiCodegenPlugin extends AutoPlugin {
           packageName: String,
           objectName: String,
           useHeadTagForObjectName: Boolean,
-          jsonSerdeLib,
+          jsonSerdeLib: String,
+          validateNonDiscriminatedOneOfs: Boolean,
           srcDir: File,
           taskStreams: TaskStreams,
           sv: String
@@ -59,6 +62,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
           objectName,
           useHeadTagForObjectName,
           jsonSerdeLib,
+          validateNonDiscriminatedOneOfs,
           srcDir,
           taskStreams.cacheDirectory,
           sv.startsWith("3")

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -11,6 +11,7 @@ case class OpenapiCodegenTask(
     objectName: String,
     useHeadTagForObjectName: Boolean,
     jsonSerdeLib: String,
+    validateNonDiscriminatedOneOfs: Boolean,
     dir: File,
     cacheDir: File,
     targetScala3: Boolean
@@ -45,7 +46,15 @@ case class OpenapiCodegenTask(
         .left
         .map(d => new RuntimeException(_root_.io.circe.Error.showError.show(d)))
       BasicGenerator
-        .generateObjects(parsed.toTry.get, packageName, objectName, targetScala3, useHeadTagForObjectName, jsonSerdeLib)
+        .generateObjects(
+          parsed.toTry.get,
+          packageName,
+          objectName,
+          targetScala3,
+          useHeadTagForObjectName,
+          jsonSerdeLib,
+          validateNonDiscriminatedOneOfs
+        )
         .map { case (objectName, fileBody) =>
           val file = directory / s"$objectName.scala"
           val lines = fileBody.linesIterator.toSeq


### PR DESCRIPTION
Supports `oneOf` schemas in codegen. 

For both circe and jsoniter, when a `oneOf` schema has no discriminator, on decode we iterate over the subtype schemas in their declared order and stop on the first successfully decoded type. Obviously this means that it's possible to roundtrip an object to a different type if the serialised form can be validly decoded to multiple different subtypes, so I've added in a check that the models can be safely disambiguated this way (the check can be disabled with `openapiValidateNonDiscriminatedOneOfs := false` in case of false positives or if you want to live like a cowboy). This falling-back method is probably not the most efficient implementation, but writing a more efficient one generically is beyond me.

For jsoniter-scala support this requires  the serdes to go into a separate file to the case class defns if oneOf is used (because macros I guess), so this pr splits all json serdes out into a new `${openapiObject}JsonSerdes` file; ~this in turn requires that the routes cannot be declared in the same object, so the codegen will throw an error if any endpoints are declared in the base object _and_ the schemas contain a oneOf defn _and_ the serde lib of choice is jsoniter.~ ((actually this check turned out to be excessive, and it's perfectly legal to just define the serdes into another file and import them back into the base object.))

Another remaining error condition is if we have an ADT Foo with a discriminator and a subtype Bar, Bar is used at the 'top level' as a req or resp JSON body, and the JSON lib is jsoniter-scala. Comment on throw site, but basically I dunno how to support that .

This also splits the codec definitions out of the object declarations, so that we can retain a bit more consistency between the treatment of the various cases (i.e. `fooJsonDecoder`/`fooJsonCodec` will now live on its own inside the ${base}JsonSerdes object, rather than in the `Foo` companion object). Except for enums when using circe. Serdes are still configured directly on those.

