### PR TITLE
Fix tapir on scala 3.4.0: an incorrect form of a tuple type being generated

### DIFF
--- a/core/src/main/scala-3/sttp/tapir/typelevel/IntersectionTypeMirror.scala
+++ b/core/src/main/scala-3/sttp/tapir/typelevel/IntersectionTypeMirror.scala
@@ -20,7 +20,8 @@ object IntersectionTypeMirror {
   private def derivedImpl[A](using Quotes, Type[A]): Expr[IntersectionTypeMirror[A]] = {
     import quotes.reflect.*
 
-    val tplPrependType = TypeRepr.of[? *: ?]
+    val tplPrependType = TypeRepr.of[? *: ?] match
+      case AppliedType(tycon, _) => tycon
     val tplConcatType = TypeRepr.of[Tuple.Concat]
 
     def prependTypes(head: TypeRepr, tail: TypeRepr): TypeRepr =

--- a/core/src/main/scala-3/sttp/tapir/typelevel/UnionTypeMirror.scala
+++ b/core/src/main/scala-3/sttp/tapir/typelevel/UnionTypeMirror.scala
@@ -21,7 +21,8 @@ object UnionTypeMirror {
   private def derivedImpl[A](using Quotes, Type[A]): Expr[UnionTypeMirror[A]] = {
     import quotes.reflect.*
 
-    val tplPrependType = TypeRepr.of[? *: ?]
+    val tplPrependType = TypeRepr.of[? *: ?] match
+      case AppliedType(tycon, _) => tycon
     val tplConcatType = TypeRepr.of[Tuple.Concat]
 
     def prependTypes(head: TypeRepr, tail: TypeRepr): TypeRepr =


### PR DESCRIPTION
The issue was found by the scala 3 open community build, and caused the macro expansion of the tests to fail compilation on scala 3.4.0. The previous implementation generated types which then later could not be "inline matched" by the newer compiler (generating new compile time errors), but somehow managed to go through the cracks of the older compiler. Those types would have shape like:

```scala
scala.*:[_ >: scala.Nothing <: scala.Any, _ >: scala.Nothing <: scala.Any][scala.Some[scala.Any], scala.Tuple$package.EmptyTuple]
```
(a type applied with wildcards, and also applied with correct types).

This PR fixes the implementation, so that the macro expansion will be successful for users using tapir on scala 3.4.0.
Underlying issue and fix found by @nicolasstucki

More information: https://github.com/scala/scala3/issues/19458
