### PR TITLE
Remove log4s usage in http4s-server integration

### DIFF
--- a/client/testserver/src/main/scala/sttp/tapir/client/tests/HttpServer.scala
+++ b/client/testserver/src/main/scala/sttp/tapir/client/tests/HttpServer.scala
@@ -12,7 +12,8 @@ import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.server.middleware._
 import org.http4s.server.websocket.WebSocketBuilder2
 import org.http4s.websocket.WebSocketFrame
-import org.http4s.{multipart, _}
+import org.http4s._
+import org.slf4j.LoggerFactory
 import org.typelevel.ci.CIString
 import scodec.bits.ByteVector
 import sttp.tapir.client.tests.HttpServer._
@@ -30,7 +31,7 @@ object HttpServer {
 
 class HttpServer(port: Port) {
 
-  private val logger = org.log4s.getLogger
+  private val logger = LoggerFactory.getLogger(getClass)
 
   private var stopServer: IO[Unit] = _
 


### PR DESCRIPTION
Hi, it's me about logging again.
I noticed the http4s server integration was using log4s, [which will be removed in http4s 1.0](https://github.com/http4s/http4s/commit/3b553ccd98bb7e74b44f42aca1306976696f73e9).

Http4s now uses log4cats internally.