### PR TITLE
codegen: Semiauto schema derivation

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -35,16 +35,17 @@ defined case-classes and endpoint definitions.
 The generator currently supports these settings, you can override them in the `build.sbt`;
 
 ```eval_rst
-===================================== ==================================== =======================================================================================
+===================================== ==================================== ==================================================================================================
 setting                               default value                        description
-===================================== ==================================== =======================================================================================
+===================================== ==================================== ==================================================================================================
 openapiSwaggerFile                    baseDirectory.value / "swagger.yaml" The swagger file with the api definitions.
 openapiPackage                        sttp.tapir.generated                 The name for the generated package.
 openapiObject                         TapirGeneratedEndpoints              The name for the generated object.
 openapiUseHeadTagForObjectName        false                                If true, put endpoints in separate files based on first declared tag.
 openapiJsonSerdeLib                   circe                                The json serde library to use.
 openapiValidateNonDiscriminatedOneOfs true                                 Whether to fail if variants of a oneOf without a discriminator cannot be disambiguated.
-===================================== ==================================== =======================================================================================
+openapiMaxSchemasPerFile              400                                  Maximum number of schemas to generate in a single file (tweak if hitting javac class size limits).
+===================================== ==================================== ==================================================================================================
 ```
 
 The general usage is;

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
@@ -1,0 +1,227 @@
+package sttp.tapir.codegen
+
+import sttp.tapir.codegen.BasicGenerator.indent
+import sttp.tapir.codegen.JsonSerdeLib.JsonSerdeLib
+import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
+  Discriminator,
+  OpenapiSchemaAllOf,
+  OpenapiSchemaAny,
+  OpenapiSchemaAnyOf,
+  OpenapiSchemaArray,
+  OpenapiSchemaConstantString,
+  OpenapiSchemaEnum,
+  OpenapiSchemaField,
+  OpenapiSchemaMap,
+  OpenapiSchemaNot,
+  OpenapiSchemaObject,
+  OpenapiSchemaOneOf,
+  OpenapiSchemaRef,
+  OpenapiSchemaSimpleType
+}
+
+import scala.collection.mutable
+
+object SchemaGenerator {
+
+  def generateSchemas(
+      doc: OpenapiDocument,
+      allSchemas: Map[String, OpenapiSchemaType],
+      fullModelPath: String,
+      jsonSerdeLib: JsonSerdeLib,
+      maxSchemasPerFile: Int
+  ): Seq[String] = {
+    def schemaContainsAny(schema: OpenapiSchemaType): Boolean = schema match {
+      case _: OpenapiSchemaAny           => true
+      case OpenapiSchemaArray(items, _)  => schemaContainsAny(items)
+      case OpenapiSchemaMap(items, _)    => schemaContainsAny(items)
+      case OpenapiSchemaObject(fs, _, _) => fs.values.map(_.`type`).exists(schemaContainsAny)
+      case OpenapiSchemaOneOf(types, _)  => types.exists(schemaContainsAny)
+      case OpenapiSchemaAllOf(types)     => types.exists(schemaContainsAny)
+      case OpenapiSchemaAnyOf(types)     => types.exists(schemaContainsAny)
+      case OpenapiSchemaNot(item)        => schemaContainsAny(item)
+      case _: OpenapiSchemaSimpleType | _: OpenapiSchemaEnum | _: OpenapiSchemaConstantString | _: OpenapiSchemaRef => false
+    }
+    val schemasWithAny = allSchemas.filter { case (_, schema) =>
+      schemaContainsAny(schema)
+    }
+    val maybeAnySchema: Option[(OpenapiSchemaType, String)] =
+      if (schemasWithAny.isEmpty) None
+      else if (jsonSerdeLib == JsonSerdeLib.Circe)
+        Some(
+          OpenapiSchemaAny(
+            false
+          ) -> "implicit lazy val anyTapirSchema: sttp.tapir.Schema[io.circe.Json] = sttp.tapir.Schema.any[io.circe.Json]"
+        )
+      else throw new NotImplementedError("any not implemented for json libs other than circe")
+    val openApiSchemasWithTapirSchemas = doc.components
+      .map(_.schemas.map {
+        case (name, _: OpenapiSchemaEnum) =>
+          name -> s"implicit lazy val ${BasicGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
+        case (name, obj: OpenapiSchemaObject) => name -> schemaForObject(name, obj)
+        case (name, schema: OpenapiSchemaMap) => name -> schemaForMap(name, schema)
+        case (name, schema: OpenapiSchemaOneOf) =>
+          name -> genADTSchema(name, schema, if (fullModelPath.isEmpty) None else Some(fullModelPath))
+        case (n, x) => throw new NotImplementedError(s"Only objects, enums, maps and oneOf supported! (for $n found ${x})")
+      })
+      .toSeq
+      .flatMap(maybeAnySchema.toSeq ++ _)
+      .toMap
+
+    val groupedByRing = constructRings(allSchemas)
+    val orderedLayers = orderLayers(groupedByRing)
+    val foldedLayers = foldLayers(maxSchemasPerFile)(orderedLayers)
+    maybeAnySchema.map(_._2).toSeq ++ foldedLayers.map(ring => ring.map(openApiSchemasWithTapirSchemas apply _._1).mkString("\n"))
+  }
+  // Group files into chunks
+  private def foldLayers(maxSchemasPerFile: Int)(layers: Seq[Seq[(String, OpenapiSchemaType)]]): Seq[Seq[(String, OpenapiSchemaType)]] = {
+    val maxLayerSize = maxSchemasPerFile
+    layers.foldLeft(Seq.empty[Seq[(String, OpenapiSchemaType)]]) { (acc, next) =>
+      if (acc.isEmpty) Seq(next)
+      else if (acc.last.size + next.size >= maxLayerSize) acc :+ next
+      else {
+        val first :+ last = acc
+        first :+ (last ++ next)
+      }
+    }
+  }
+  // Need to order rings so that leaf schemas are defined before parents
+  private def orderLayers(layers: Seq[Seq[(String, OpenapiSchemaType)]]): Seq[Seq[(String, OpenapiSchemaType)]] = {
+    def getDirectChildren(schema: OpenapiSchemaType): Set[String] = schema match {
+      case r: OpenapiSchemaRef                                                                => Set(r.stripped)
+      case _: OpenapiSchemaSimpleType | _: OpenapiSchemaEnum | _: OpenapiSchemaConstantString => Set.empty[String]
+      case OpenapiSchemaArray(items, _)                                                       => getDirectChildren(items)
+      case OpenapiSchemaNot(items)                                                            => getDirectChildren(items)
+      case OpenapiSchemaMap(items, _)                                                         => getDirectChildren(items)
+      case OpenapiSchemaOneOf(items, _)                                                       => items.flatMap(getDirectChildren).toSet
+      case OpenapiSchemaAnyOf(items)                                                          => items.flatMap(getDirectChildren).toSet
+      case OpenapiSchemaAllOf(items)                                                          => items.flatMap(getDirectChildren).toSet
+      case OpenapiSchemaObject(kvs, _, _) => kvs.values.flatMap(f => getDirectChildren(f.`type`)).toSet
+    }
+    val withDirectChildren = layers.map { layer =>
+      layer.map { case (k, v) => (k, v, getDirectChildren(v)) }
+    }
+    val initialSet: mutable.Set[Seq[(String, OpenapiSchemaType, Set[String])]] = mutable.Set(withDirectChildren: _*)
+    val acquired = mutable.Set.empty[String]
+    val res = mutable.ArrayBuffer.empty[Seq[(String, OpenapiSchemaType, Set[String])]]
+    while (initialSet.nonEmpty) {
+      val nextLayers = initialSet.filter(g => g.forall(_._3.forall(c => acquired.contains(c) || g.map(_._1).contains(c))))
+
+      initialSet --= nextLayers
+      res ++= nextLayers
+      acquired ++= nextLayers.flatMap(_.map(_._1)).toSet
+      if (initialSet.nonEmpty && nextLayers.isEmpty)
+        throw new IllegalStateException("Cannot order layers until mutually-recursive references have been resolved.")
+    }
+
+    res.map(_.map { case (k, v, _) => k -> v })
+  }
+  // finds all recursive and mutually-recursive references, grouping mutually-recursive schemas into a single 'layer' seq
+  private def constructRings(allSchemas: Map[String, OpenapiSchemaType]): Seq[Seq[(String, OpenapiSchemaType)]] = {
+    val initialSet: mutable.Set[(String, OpenapiSchemaType)] = mutable.Set(allSchemas.toSeq: _*)
+    val res = mutable.ArrayBuffer.empty[Seq[(String, OpenapiSchemaType)]]
+    while (initialSet.nonEmpty) {
+      val nextRing = mutable.ArrayBuffer.empty[(String, OpenapiSchemaType)]
+      def recurse(next: (String, OpenapiSchemaType)): Unit = {
+        val (nextName, nextSchema) = next
+        nextRing += next
+        initialSet -= next
+        val refs = getReferencesToXInY(allSchemas, nextName, nextSchema, Set.empty, Seq(nextName))
+        val newRefs = refs.flatMap(r => initialSet.find(_._1 == r))
+        newRefs foreach recurse
+      }
+      // need to check oneOfs first because the children don't know they have parents. Order lexicographically for stable output
+      val next = initialSet.filter(_._2.isInstanceOf[OpenapiSchemaOneOf]).toSeq.sortBy(_._1).headOption getOrElse initialSet.minBy(_._1)
+      recurse(next)
+      res += nextRing
+    }
+    res.toSeq
+  }
+  // finds recursive and mutually-recursive references to a single schema
+  private def getReferencesToXInY(
+      allSchemas: Map[String, OpenapiSchemaType],
+      schemaX: String,
+      schemaY: OpenapiSchemaType,
+      checked: Set[String],
+      maybeRefs: Seq[String]
+  ): Set[String] = schemaY match {
+    case ref: OpenapiSchemaRef =>
+      val stripped = ref.stripped
+      if (stripped == schemaX) maybeRefs.toSet
+      else if (checked contains stripped) Set.empty
+      else {
+        allSchemas
+          .get(ref.stripped)
+          .map(getReferencesToXInY(allSchemas, schemaX, _, checked + stripped, maybeRefs :+ stripped))
+          .toSet
+          .flatten
+      }
+    case _: OpenapiSchemaSimpleType | _: OpenapiSchemaEnum | _: OpenapiSchemaConstantString => Set.empty
+    case OpenapiSchemaArray(items, _) => getReferencesToXInY(allSchemas, schemaX, items, checked, maybeRefs)
+    case OpenapiSchemaNot(items)      => getReferencesToXInY(allSchemas, schemaX, items, checked, maybeRefs)
+    case OpenapiSchemaMap(items, _)   => getReferencesToXInY(allSchemas, schemaX, items, checked, maybeRefs)
+    case OpenapiSchemaOneOf(items, _) => items.flatMap(getReferencesToXInY(allSchemas, schemaX, _, checked, maybeRefs)).toSet
+    case OpenapiSchemaAllOf(items)    => items.flatMap(getReferencesToXInY(allSchemas, schemaX, _, checked, maybeRefs)).toSet
+    case OpenapiSchemaAnyOf(items)    => items.flatMap(getReferencesToXInY(allSchemas, schemaX, _, checked, maybeRefs)).toSet
+    case OpenapiSchemaObject(kvs, _, _) =>
+      kvs.values.flatMap(v => getReferencesToXInY(allSchemas, schemaX, v.`type`, checked, maybeRefs)).toSet
+  }
+
+  private def schemaForObject(name: String, schema: OpenapiSchemaObject): String = {
+    val subs = schema.properties.collect {
+      case (k, OpenapiSchemaField(`type`: OpenapiSchemaObject, _)) => schemaForObject(s"$name${k.capitalize}", `type`)
+      case (k, OpenapiSchemaField(OpenapiSchemaArray(`type`: OpenapiSchemaObject, _), _)) =>
+        schemaForObject(s"$name${k.capitalize}Item", `type`)
+      case (k, OpenapiSchemaField(OpenapiSchemaMap(`type`: OpenapiSchemaObject, _), _)) =>
+        schemaForObject(s"$name${k.capitalize}Item", `type`)
+    } match {
+      case Nil => ""
+      case s   => s.mkString("", "\n", "\n")
+    }
+    s"${subs}implicit lazy val ${BasicGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
+  }
+  private def schemaForMap(name: String, schema: OpenapiSchemaMap): String = {
+    val subs = schema.items match {
+      case `type`: OpenapiSchemaObject => Some(schemaForObject(s"${name}ObjectsItem", `type`))
+      case _                           => None
+    }
+    subs.fold("")("\n" + _)
+  }
+  private def genADTSchema(name: String, schema: OpenapiSchemaOneOf, fullModelPath: Option[String]): String = {
+    val schemaImpl = schema match {
+      case OpenapiSchemaOneOf(_, None) => "sttp.tapir.Schema.derived"
+      case OpenapiSchemaOneOf(_, Some(Discriminator(propertyName, maybeMapping))) =>
+        val mapping =
+          maybeMapping.map(_.map { case (propName, fullRef) => propName -> fullRef.stripPrefix("#/components/schemas/") }).getOrElse {
+            schema.types.map {
+              case ref: OpenapiSchemaRef => ref.stripped -> ref.stripped
+              case other =>
+                throw new IllegalArgumentException(s"oneOf subtypes must be refs to explicit schema models, found $other for $name")
+            }.toMap
+          }
+        val fullModelPrefix = fullModelPath.map(_ + ".") getOrElse ""
+        val fields = mapping
+          .map { case (propValue, fullRef) =>
+            val fullClassName = fullModelPrefix + fullRef
+            s""""$propValue" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("$fullClassName"))"""
+          }
+          .mkString(",\n")
+        s"""{
+           |  val derived = implicitly[sttp.tapir.generic.Derived[sttp.tapir.Schema[$name]]].value
+           |  derived.schemaType match {
+           |    case s: sttp.tapir.SchemaType.SCoproduct[_] => derived.copy(schemaType = s.addDiscriminatorField(
+           |      sttp.tapir.FieldName("$propertyName"),
+           |      sttp.tapir.Schema.string,
+           |      Map(
+           |${indent(8)(fields)}
+           |      )
+           |    ))
+           |    case _ => throw new IllegalStateException("Derived schema for $name should be a coproduct")
+           |  }
+           |}""".stripMargin
+    }
+
+    s"implicit lazy val ${BasicGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = ${schemaImpl}"
+  }
+}

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
@@ -69,12 +69,18 @@ object SchemaGenerator {
       .flatMap(maybeAnySchema.toSeq ++ _)
       .toMap
 
+    // The algorithm here is to aviod mutually references between objects. It goes like this:
+    // 1) Find all 'rings' -- that is, sets of mutually-recursive object references that will need to be defined in the same object
+    // (e.g. the schemas for `case class A(maybeB: Option[B])` and `case class B(maybeA: Option[A])` would need to be defined together)
     val groupedByRing = constructRings(allSchemas)
+    // 2) Order the definitions, such that objects appear before any places they're referenced
     val orderedLayers = orderLayers(groupedByRing)
+    // 3) Group the definitions into at most `maxSchemasPerFile`, whilst avoiding splitting groups across files
     val foldedLayers = foldLayers(maxSchemasPerFile)(orderedLayers)
+    // Our output will now only need to imports the 'earlier' files into the 'later' files, and _not_ vice verse
     maybeAnySchema.map(_._2).toSeq ++ foldedLayers.map(ring => ring.map(openApiSchemasWithTapirSchemas apply _._1).mkString("\n"))
   }
-  // Group files into chunks
+  // Group files into chunks of size < maxLayerSize
   private def foldLayers(maxSchemasPerFile: Int)(layers: Seq[Seq[(String, OpenapiSchemaType)]]): Seq[Seq[(String, OpenapiSchemaType)]] = {
     val maxLayerSize = maxSchemasPerFile
     layers.foldLeft(Seq.empty[Seq[(String, OpenapiSchemaType)]]) { (acc, next) =>
@@ -106,10 +112,12 @@ object SchemaGenerator {
     val acquired = mutable.Set.empty[String]
     val res = mutable.ArrayBuffer.empty[Seq[(String, OpenapiSchemaType, Set[String])]]
     while (initialSet.nonEmpty) {
+      // Find all schema 'rings' that depend only on 'already aquired' schemas and/or other members of the same ring
       val nextLayers = initialSet.filter(g => g.forall(_._3.forall(c => acquired.contains(c) || g.map(_._1).contains(c))))
-
+      // remove these from the initial set, add to the 'acquired' set & res seq
       initialSet --= nextLayers
-      res ++= nextLayers
+      // sorting here for output stability
+      res ++= nextLayers.toSeq.sortBy(_.head._1)
       acquired ++= nextLayers.flatMap(_.map(_._1)).toSet
       if (initialSet.nonEmpty && nextLayers.isEmpty)
         throw new IllegalStateException("Cannot order layers until mutually-recursive references have been resolved.")
@@ -117,7 +125,7 @@ object SchemaGenerator {
 
     res.map(_.map { case (k, v, _) => k -> v })
   }
-  // finds all recursive and mutually-recursive references, grouping mutually-recursive schemas into a single 'layer' seq
+  // finds all mutually-recursive references, grouping mutually-recursive schemas into a single 'layer' seq
   private def constructRings(allSchemas: Map[String, OpenapiSchemaType]): Seq[Seq[(String, OpenapiSchemaType)]] = {
     val initialSet: mutable.Set[(String, OpenapiSchemaType)] = mutable.Set(allSchemas.toSeq: _*)
     val res = mutable.ArrayBuffer.empty[Seq[(String, OpenapiSchemaType)]]
@@ -127,45 +135,57 @@ object SchemaGenerator {
         val (nextName, nextSchema) = next
         nextRing += next
         initialSet -= next
+        // Find all simple reference loops for a single candidate
         val refs = getReferencesToXInY(allSchemas, nextName, nextSchema, Set.empty, Seq(nextName))
         val newRefs = refs.flatMap(r => initialSet.find(_._1 == r))
+        // New candidates may themselves have mutually-recursive references to other candidates that _don't_ have
+        // 'loop' references to initial candidate, so we need to recurse here - e.g for
+        // `case class A(maybeB: Option[B])`, `case class B(maybeA: Option[A], maybeC: Option[C])`, `case class C(maybeB: Option[B])`
+        // we have the loops A -> B -> A, and B -> C -> B, but the loop A -> B -> C -> B -> A would not be detected by `getReferencesToXInY`
+        // Fusing all simple loops should be a valid way of constructing the equivalence set.
         newRefs foreach recurse
       }
-      // need to check oneOfs first because the children don't know they have parents. Order lexicographically for stable output
-      val next = initialSet.filter(_._2.isInstanceOf[OpenapiSchemaOneOf]).toSeq.sortBy(_._1).headOption getOrElse initialSet.minBy(_._1)
+      // Select next candidate. Order lexicographically for stable output
+      val next = initialSet.minBy(_._1)
       recurse(next)
-      res += nextRing
+      res += nextRing.sortBy(_._1)
     }
     res.toSeq
   }
-  // finds recursive and mutually-recursive references to a single schema
+  // find all simple reference loops starting at a a single schema (e.g. A -> B -> C -> A)
   private def getReferencesToXInY(
       allSchemas: Map[String, OpenapiSchemaType],
-      schemaX: String,
-      schemaY: OpenapiSchemaType,
-      checked: Set[String],
-      maybeRefs: Seq[String]
-  ): Set[String] = schemaY match {
+      referrent: String, // The stripped ref of the schema we're looking for references to
+      referenceCandidate: OpenapiSchemaType, // candidate for mutually-recursive referrence
+      checked: Set[String], // refs we've already checked
+      maybeRefs: Seq[String] // chain of refs from referrent -> [...maybeRefs] -> referenceCandidate
+  ): Set[String] = referenceCandidate match {
     case ref: OpenapiSchemaRef =>
       val stripped = ref.stripped
-      if (stripped == schemaX) maybeRefs.toSet
+      // in this case, we have a chain of referrences from referrent -> [...maybeRefs] -> referrent, creating a mutually-recursive loop
+      if (stripped == referrent) maybeRefs.toSet
+      // if already checked, skip
       else if (checked contains stripped) Set.empty
+      // else add the ref to 'maybeRefs' chain and descend
       else {
         allSchemas
           .get(ref.stripped)
-          .map(getReferencesToXInY(allSchemas, schemaX, _, checked + stripped, maybeRefs :+ stripped))
+          .map(getReferencesToXInY(allSchemas, referrent, _, checked + stripped, maybeRefs :+ stripped))
           .toSet
           .flatten
       }
+    // these types cannot contain a referrence
     case _: OpenapiSchemaSimpleType | _: OpenapiSchemaEnum | _: OpenapiSchemaConstantString => Set.empty
-    case OpenapiSchemaArray(items, _) => getReferencesToXInY(allSchemas, schemaX, items, checked, maybeRefs)
-    case OpenapiSchemaNot(items)      => getReferencesToXInY(allSchemas, schemaX, items, checked, maybeRefs)
-    case OpenapiSchemaMap(items, _)   => getReferencesToXInY(allSchemas, schemaX, items, checked, maybeRefs)
-    case OpenapiSchemaOneOf(items, _) => items.flatMap(getReferencesToXInY(allSchemas, schemaX, _, checked, maybeRefs)).toSet
-    case OpenapiSchemaAllOf(items)    => items.flatMap(getReferencesToXInY(allSchemas, schemaX, _, checked, maybeRefs)).toSet
-    case OpenapiSchemaAnyOf(items)    => items.flatMap(getReferencesToXInY(allSchemas, schemaX, _, checked, maybeRefs)).toSet
+    // descend into the sole child type
+    case OpenapiSchemaArray(items, _) => getReferencesToXInY(allSchemas, referrent, items, checked, maybeRefs)
+    case OpenapiSchemaNot(items)      => getReferencesToXInY(allSchemas, referrent, items, checked, maybeRefs)
+    case OpenapiSchemaMap(items, _)   => getReferencesToXInY(allSchemas, referrent, items, checked, maybeRefs)
+    // descend into all child types
+    case OpenapiSchemaOneOf(items, _) => items.flatMap(getReferencesToXInY(allSchemas, referrent, _, checked, maybeRefs)).toSet
+    case OpenapiSchemaAllOf(items)    => items.flatMap(getReferencesToXInY(allSchemas, referrent, _, checked, maybeRefs)).toSet
+    case OpenapiSchemaAnyOf(items)    => items.flatMap(getReferencesToXInY(allSchemas, referrent, _, checked, maybeRefs)).toSet
     case OpenapiSchemaObject(kvs, _, _) =>
-      kvs.values.flatMap(v => getReferencesToXInY(allSchemas, schemaX, v.`type`, checked, maybeRefs)).toSet
+      kvs.values.flatMap(v => getReferencesToXInY(allSchemas, referrent, v.`type`, checked, maybeRefs)).toSet
   }
 
   private def schemaForObject(name: String, schema: OpenapiSchemaObject): String = {

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -240,7 +240,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       targetScala3 = false,
       useHeadTagForObjectNames = false,
       jsonSerdeLib = "circe",
-      validateNonDiscriminatedOneOfs = true
+      validateNonDiscriminatedOneOfs = true,
+      maxSchemasPerFile = 400
     )("TapirGeneratedEndpoints")
     generatedCode should include(
       """file: sttp.model.Part[java.io.File]"""
@@ -260,7 +261,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       targetScala3 = false,
       useHeadTagForObjectNames = false,
       jsonSerdeLib = "circe",
-      validateNonDiscriminatedOneOfs = true
+      validateNonDiscriminatedOneOfs = true,
+      maxSchemasPerFile = 400
     )("TapirGeneratedEndpoints")
     generatedCode shouldCompile ()
     val expectedAttrDecls = Seq(

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -12,6 +12,7 @@ trait OpenapiCodegenKeys {
   lazy val openapiJsonSerdeLib = settingKey[String]("The lib to use for json serdes. Supports 'circe' and 'jsoniter'.")
   lazy val openapiValidateNonDiscriminatedOneOfs =
     settingKey[Boolean]("Whether to fail if variants of a oneOf without a discriminator cannot be disambiguated..")
+  lazy val openapiMaxSchemasPerFile = settingKey[Int]("Maximum number of schemas to generate for a single file")
 
   lazy val generateTapirDefinitions = taskKey[Unit]("The task that generates tapir definitions based on the input swagger file.")
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -28,7 +28,8 @@ object OpenapiCodegenPlugin extends AutoPlugin {
     openapiObject := "TapirGeneratedEndpoints",
     openapiUseHeadTagForObjectName := false,
     openapiJsonSerdeLib := "circe",
-    openapiValidateNonDiscriminatedOneOfs := true
+    openapiValidateNonDiscriminatedOneOfs := true,
+    openapiMaxSchemasPerFile := 400
   )
 
   private def codegen = Def.task {
@@ -41,6 +42,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
       openapiUseHeadTagForObjectName,
       openapiJsonSerdeLib,
       openapiValidateNonDiscriminatedOneOfs,
+      openapiMaxSchemasPerFile,
       sourceManaged,
       streams,
       scalaVersion
@@ -52,6 +54,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
           useHeadTagForObjectName: Boolean,
           jsonSerdeLib: String,
           validateNonDiscriminatedOneOfs: Boolean,
+          maxSchemasPerFile: Int,
           srcDir: File,
           taskStreams: TaskStreams,
           sv: String
@@ -63,6 +66,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
           useHeadTagForObjectName,
           jsonSerdeLib,
           validateNonDiscriminatedOneOfs,
+          maxSchemasPerFile,
           srcDir,
           taskStreams.cacheDirectory,
           sv.startsWith("3")

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -12,6 +12,7 @@ case class OpenapiCodegenTask(
     useHeadTagForObjectName: Boolean,
     jsonSerdeLib: String,
     validateNonDiscriminatedOneOfs: Boolean,
+    maxSchemasPerFile: Int,
     dir: File,
     cacheDir: File,
     targetScala3: Boolean
@@ -53,7 +54,8 @@ case class OpenapiCodegenTask(
           targetScala3,
           useHeadTagForObjectName,
           jsonSerdeLib,
-          validateNonDiscriminatedOneOfs
+          validateNonDiscriminatedOneOfs,
+          maxSchemasPerFile
         )
         .map { case (objectName, fileBody) =>
           val file = directory / s"$objectName.scala"

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -7,8 +7,9 @@ object TapirGeneratedEndpoints {
   import sttp.tapir.generic.auto._
   import sttp.tapir.json.circe._
   import io.circe.generic.semiauto._
-  
+
   import sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes._
+  import TapirGeneratedEndpointsSchemas._
 
   sealed trait ADTWithoutDiscriminator
   sealed trait ADTWithDiscriminator

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
@@ -1,0 +1,53 @@
+package sttp.tapir.generated
+
+object TapirGeneratedEndpointsJsonSerdes {
+  import sttp.tapir.generated.TapirGeneratedEndpoints._
+  import sttp.tapir.generic.auto._
+  implicit lazy val aDTWithDiscriminatorJsonEncoder: io.circe.Encoder[ADTWithDiscriminator] = io.circe.Encoder.instance {
+    case x: SubtypeWithD1 => io.circe.Encoder[SubtypeWithD1].apply(x).mapObject(_.add("type", io.circe.Json.fromString("SubA")))
+    case x: SubtypeWithD2 => io.circe.Encoder[SubtypeWithD2].apply(x).mapObject(_.add("type", io.circe.Json.fromString("SubB")))
+  }
+  implicit lazy val aDTWithDiscriminatorJsonDecoder: io.circe.Decoder[ADTWithDiscriminator] = io.circe.Decoder { (c: io.circe.HCursor) =>
+    for {
+      discriminator <- c.downField("type").as[String]
+      res <- discriminator match {
+        case "SubA" => c.as[SubtypeWithD1]
+        case "SubB" => c.as[SubtypeWithD2]
+      }
+    } yield res
+  }
+  implicit lazy val subtypeWithoutD1JsonDecoder: io.circe.Decoder[SubtypeWithoutD1] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithoutD1]
+  implicit lazy val subtypeWithoutD1JsonEncoder: io.circe.Encoder[SubtypeWithoutD1] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithoutD1]
+  implicit lazy val subtypeWithD1JsonDecoder: io.circe.Decoder[SubtypeWithD1] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithD1]
+  implicit lazy val subtypeWithD1JsonEncoder: io.circe.Encoder[SubtypeWithD1] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithD1]
+  implicit lazy val aDTWithDiscriminatorNoMappingJsonEncoder: io.circe.Encoder[ADTWithDiscriminatorNoMapping] = io.circe.Encoder.instance {
+    case x: SubtypeWithD1 => io.circe.Encoder[SubtypeWithD1].apply(x).mapObject(_.add("type", io.circe.Json.fromString("SubtypeWithD1")))
+    case x: SubtypeWithD2 => io.circe.Encoder[SubtypeWithD2].apply(x).mapObject(_.add("type", io.circe.Json.fromString("SubtypeWithD2")))
+  }
+  implicit lazy val aDTWithDiscriminatorNoMappingJsonDecoder: io.circe.Decoder[ADTWithDiscriminatorNoMapping] = io.circe.Decoder { (c: io.circe.HCursor) =>
+    for {
+      discriminator <- c.downField("type").as[String]
+      res <- discriminator match {
+        case "SubtypeWithD1" => c.as[SubtypeWithD1]
+        case "SubtypeWithD2" => c.as[SubtypeWithD2]
+      }
+    } yield res
+  }
+  implicit lazy val subtypeWithoutD3JsonDecoder: io.circe.Decoder[SubtypeWithoutD3] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithoutD3]
+  implicit lazy val subtypeWithoutD3JsonEncoder: io.circe.Encoder[SubtypeWithoutD3] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithoutD3]
+  implicit lazy val subtypeWithoutD2JsonDecoder: io.circe.Decoder[SubtypeWithoutD2] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithoutD2]
+  implicit lazy val subtypeWithoutD2JsonEncoder: io.circe.Encoder[SubtypeWithoutD2] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithoutD2]
+  implicit lazy val subtypeWithD2JsonDecoder: io.circe.Decoder[SubtypeWithD2] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithD2]
+  implicit lazy val subtypeWithD2JsonEncoder: io.circe.Encoder[SubtypeWithD2] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithD2]
+  implicit lazy val aDTWithoutDiscriminatorJsonEncoder: io.circe.Encoder[ADTWithoutDiscriminator] = io.circe.Encoder.instance {
+    case x: SubtypeWithoutD1 => io.circe.Encoder[SubtypeWithoutD1].apply(x)
+    case x: SubtypeWithoutD2 => io.circe.Encoder[SubtypeWithoutD2].apply(x)
+    case x: SubtypeWithoutD3 => io.circe.Encoder[SubtypeWithoutD3].apply(x)
+  }
+  implicit lazy val aDTWithoutDiscriminatorJsonDecoder: io.circe.Decoder[ADTWithoutDiscriminator] =
+    List[io.circe.Decoder[ADTWithoutDiscriminator]](
+      io.circe.Decoder[SubtypeWithoutD1].asInstanceOf[io.circe.Decoder[ADTWithoutDiscriminator]],
+      io.circe.Decoder[SubtypeWithoutD2].asInstanceOf[io.circe.Decoder[ADTWithoutDiscriminator]],
+      io.circe.Decoder[SubtypeWithoutD3].asInstanceOf[io.circe.Decoder[ADTWithoutDiscriminator]]
+    ).reduceLeft(_ or _)
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
@@ -3,11 +3,25 @@ package sttp.tapir.generated
 object TapirGeneratedEndpointsSchemas {
   import sttp.tapir.generated.TapirGeneratedEndpoints._
   import sttp.tapir.generic.auto._
-  implicit lazy val subtypeWithoutD2TapirSchema: sttp.tapir.Schema[SubtypeWithoutD2] = sttp.tapir.Schema.derived
-  implicit lazy val subtypeWithD2TapirSchema: sttp.tapir.Schema[SubtypeWithD2] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD1TapirSchema: sttp.tapir.Schema[SubtypeWithD1] = sttp.tapir.Schema.derived
+  implicit lazy val subtypeWithD2TapirSchema: sttp.tapir.Schema[SubtypeWithD2] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithoutD1TapirSchema: sttp.tapir.Schema[SubtypeWithoutD1] = sttp.tapir.Schema.derived
+  implicit lazy val subtypeWithoutD2TapirSchema: sttp.tapir.Schema[SubtypeWithoutD2] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithoutD3TapirSchema: sttp.tapir.Schema[SubtypeWithoutD3] = sttp.tapir.Schema.derived
+  implicit lazy val aDTWithDiscriminatorTapirSchema: sttp.tapir.Schema[ADTWithDiscriminator] = {
+    val derived = implicitly[sttp.tapir.generic.Derived[sttp.tapir.Schema[ADTWithDiscriminator]]].value
+    derived.schemaType match {
+      case s: sttp.tapir.SchemaType.SCoproduct[_] => derived.copy(schemaType = s.addDiscriminatorField(
+        sttp.tapir.FieldName("type"),
+        sttp.tapir.Schema.string,
+        Map(
+          "SubA" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithD1")),
+          "SubB" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithD2"))
+        )
+      ))
+      case _ => throw new IllegalStateException("Derived schema for ADTWithDiscriminator should be a coproduct")
+    }
+  }
   implicit lazy val aDTWithDiscriminatorNoMappingTapirSchema: sttp.tapir.Schema[ADTWithDiscriminatorNoMapping] = {
     val derived = implicitly[sttp.tapir.generic.Derived[sttp.tapir.Schema[ADTWithDiscriminatorNoMapping]]].value
     derived.schemaType match {
@@ -23,18 +37,4 @@ object TapirGeneratedEndpointsSchemas {
     }
   }
   implicit lazy val aDTWithoutDiscriminatorTapirSchema: sttp.tapir.Schema[ADTWithoutDiscriminator] = sttp.tapir.Schema.derived
-  implicit lazy val aDTWithDiscriminatorTapirSchema: sttp.tapir.Schema[ADTWithDiscriminator] = {
-    val derived = implicitly[sttp.tapir.generic.Derived[sttp.tapir.Schema[ADTWithDiscriminator]]].value
-    derived.schemaType match {
-      case s: sttp.tapir.SchemaType.SCoproduct[_] => derived.copy(schemaType = s.addDiscriminatorField(
-        sttp.tapir.FieldName("type"),
-        sttp.tapir.Schema.string,
-        Map(
-          "SubA" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithD1")),
-          "SubB" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithD2"))
-        )
-      ))
-      case _ => throw new IllegalStateException("Derived schema for ADTWithDiscriminator should be a coproduct")
-    }
-  }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
@@ -1,0 +1,40 @@
+package sttp.tapir.generated
+
+object TapirGeneratedEndpointsSchemas {
+  import sttp.tapir.generated.TapirGeneratedEndpoints._
+  import sttp.tapir.generic.auto._
+  implicit lazy val subtypeWithoutD2TapirSchema: sttp.tapir.Schema[SubtypeWithoutD2] = sttp.tapir.Schema.derived
+  implicit lazy val subtypeWithD2TapirSchema: sttp.tapir.Schema[SubtypeWithD2] = sttp.tapir.Schema.derived
+  implicit lazy val subtypeWithD1TapirSchema: sttp.tapir.Schema[SubtypeWithD1] = sttp.tapir.Schema.derived
+  implicit lazy val subtypeWithoutD1TapirSchema: sttp.tapir.Schema[SubtypeWithoutD1] = sttp.tapir.Schema.derived
+  implicit lazy val subtypeWithoutD3TapirSchema: sttp.tapir.Schema[SubtypeWithoutD3] = sttp.tapir.Schema.derived
+  implicit lazy val aDTWithDiscriminatorNoMappingTapirSchema: sttp.tapir.Schema[ADTWithDiscriminatorNoMapping] = {
+    val derived = implicitly[sttp.tapir.generic.Derived[sttp.tapir.Schema[ADTWithDiscriminatorNoMapping]]].value
+    derived.schemaType match {
+      case s: sttp.tapir.SchemaType.SCoproduct[_] => derived.copy(schemaType = s.addDiscriminatorField(
+        sttp.tapir.FieldName("type"),
+        sttp.tapir.Schema.string,
+        Map(
+          "SubtypeWithD1" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithD1")),
+          "SubtypeWithD2" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithD2"))
+        )
+      ))
+      case _ => throw new IllegalStateException("Derived schema for ADTWithDiscriminatorNoMapping should be a coproduct")
+    }
+  }
+  implicit lazy val aDTWithoutDiscriminatorTapirSchema: sttp.tapir.Schema[ADTWithoutDiscriminator] = sttp.tapir.Schema.derived
+  implicit lazy val aDTWithDiscriminatorTapirSchema: sttp.tapir.Schema[ADTWithDiscriminator] = {
+    val derived = implicitly[sttp.tapir.generic.Derived[sttp.tapir.Schema[ADTWithDiscriminator]]].value
+    derived.schemaType match {
+      case s: sttp.tapir.SchemaType.SCoproduct[_] => derived.copy(schemaType = s.addDiscriminatorField(
+        sttp.tapir.FieldName("type"),
+        sttp.tapir.Schema.string,
+        Map(
+          "SubA" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithD1")),
+          "SubB" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithD2"))
+        )
+      ))
+      case _ => throw new IllegalStateException("Derived schema for ADTWithDiscriminator should be a coproduct")
+    }
+  }
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -10,6 +10,7 @@ object TapirGeneratedEndpoints {
   import com.github.plokhotnyuk.jsoniter_scala.core._
 
   import sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes._
+  import TapirGeneratedEndpointsSchemas._
 
   sealed trait ADTWithoutDiscriminator
   sealed trait ADTWithDiscriminator

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -9,6 +9,7 @@ object TapirGeneratedEndpoints {
   import io.circe.generic.semiauto._
 
   import sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes._
+  import TapirGeneratedEndpointsSchemas._
 
   sealed trait ADTWithoutDiscriminator
   sealed trait ADTWithDiscriminator


### PR DESCRIPTION
This would address two issues with the code currently being generated:

1) When using the codegen, until now I've had to add in a sourceGenerator hack to replace `import sttp.tapir.generic.auto._` with a `implicit def schemaForAny[T]: sttp.tapir.Schema[T] = sttp.tapir.Schema.any[T]` stub, since I was hitting javac class size limits (also, compilation was taking a while to fail - I guess because the leaf schemas were being regenerated for everything that needed it? I don't really know enough about how the scala compiler handles memoization of implicit resolution to be sure of that though...). ANYWAY:

2) This also means that the schemas for ADTs should be more* correct (automatic derivation didn't know about discriminators or lack thereof).

This pr will create explicit schemas for every class model, and emit them to `TapirGeneratedEndpointsSchemas` (or `TapirGeneratedEndpointsSchemas1`, `TapirGeneratedEndpointsSchemas2` etc if split over multiple files). The maximum number of schemas per file is configurable via the new option `openapiMaxSchemasPerFile`. Experimentally, a value of 400 worked fine for me, so that's the default.


Generating the correct schemas for objects and maps made me aware of the fact that I'd mucked up circe json serdes for object schemas with fields that were, themselves, inlined object or map declarations; so this pr also fixes that.

\* The 'more' qualifier is here because I don't know how to mark an array field as required in the generated JSON schema, so round-tripping the swagger example I've touched fails to retain semantics. I tried adding `@sttp.tapir.Schema.annotations.customise((_: sttp.tapir.Schema[_]).copy(isOptional = false))` to Seq fields but that didn't change the output...