### PR TITLE
[FIX] `errorOutVariantsPrepend` should try to match passed variants before falling back to the default one

### DIFF
--- a/core/src/main/scala/sttp/tapir/Endpoint.scala
+++ b/core/src/main/scala/sttp/tapir/Endpoint.scala
@@ -222,7 +222,7 @@ trait EndpointErrorOutputVariantsOps[A, I, E, O, -R] {
 
   /** Same as [[errorOutVariantPrepend]], but allows appending multiple variants in one go. */
   def errorOutVariantsPrepend[E2 >: E](first: OneOfVariant[_ <: E2], other: OneOfVariant[_ <: E2]*): EndpointType[A, I, E2, O, R] =
-    withErrorOutputVariant(oneOf[E2](oneOfDefaultVariant(errorOutput), first +: other: _*), identity)
+    withErrorOutputVariant(oneOf[E2](first, other :+ oneOfDefaultVariant(errorOutput): _*), identity)
 
   /** Same as [[errorOutVariant]], but allows appending multiple variants in one go. */
   def errorOutVariants[E2 >: E](first: OneOfVariant[_ <: E2], other: OneOfVariant[_ <: E2]*)(implicit


### PR DESCRIPTION
The errorOutVariantsPrepend method should match over the prepended error variants before falling back to the default variant passed to .errorOut or other, previously defined prepend variants.

This fixes https://github.com/softwaremill/tapir/issues/3592