### PR TITLE
Generate `anyOf` schema for `oneOfVariant`s with the same status code and content-type

### DIFF
--- a/docs/openapi-docs/src/test/resources/oneOf/expected_the_same_status_codes_and_content_types.yml
+++ b/docs/openapi-docs/src/test/resources/oneOf/expected_the_same_status_codes_and_content_types.yml
@@ -1,0 +1,53 @@
+openapi: 3.1.0
+info:
+  title: Fruits
+  version: '1.0'
+paths:
+  /:
+    get:
+      operationId: getRoot
+      responses:
+        '200':
+          description: not found
+          content:
+            application/json:
+              schema:
+                anyOf:
+                - $ref: '#/components/schemas/NotFound'
+                - $ref: '#/components/schemas/Unauthorized'
+        '204':
+          description: unknown
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Unknown'
+components:
+  schemas:
+    NotFound:
+      title: NotFound
+      type: object
+      required:
+      - what
+      properties:
+        what:
+          type: string
+    Unauthorized:
+      title: Unauthorized
+      type: object
+      required:
+      - realm
+      properties:
+        realm:
+          type: string
+    Unknown:
+      title: Unknown
+      type: object
+      required:
+      - code
+      - msg
+      properties:
+        code:
+          type: integer
+          format: int32
+        msg:
+          type: string

--- a/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlOneOfTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlOneOfTest.scala
@@ -59,7 +59,24 @@ class VerifyYamlOneOfTest extends AnyFunSuite with Matchers {
     actualYamlNoIndent shouldBe expectedYaml
   }
 
-  test("should support multiple the same status codes") {
+  test("should support multiple the same status codes and same content types") {
+    val expectedYaml = load("oneOf/expected_the_same_status_codes_and_content_types.yml")
+
+    val e = endpoint.out(
+      sttp.tapir.oneOf(
+        oneOfVariant(StatusCode.Ok, jsonBody[NotFound].description("not found")),
+        oneOfVariant(StatusCode.Ok, jsonBody[Unauthorized]),
+        oneOfVariant(StatusCode.NoContent, jsonBody[Unknown].description("unknown"))
+      )
+    )
+
+    val actualYaml = OpenAPIDocsInterpreter().toOpenAPI(e, Info("Fruits", "1.0")).toYaml
+    val actualYamlNoIndent = noIndentation(actualYaml)
+
+    actualYamlNoIndent shouldBe expectedYaml
+  }
+
+  test("should support multiple the same status codes and different content types") {
     val expectedYaml = load("oneOf/expected_the_same_status_codes.yml")
 
     implicit val unauthorizedTextPlainCodec: Codec[String, Unauthorized, CodecFormat.TextPlain] =


### PR DESCRIPTION
Fixes #3660 

Chose to use `anyOf` (not `oneOf`) because there's no discriminator and we cannot guarantee that only one model will match.