### PR TITLE
Optimize byte array operations in Http4sRequestBody

### DIFF
--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestBody.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestBody.scala
@@ -40,7 +40,7 @@ private[http4s] class Http4sRequestBody[F[_]: Async](
 
     bodyType match {
       case RawBodyType.StringBody(defaultCharset) =>
-        body.through(decodeWithCharset(charset.map(_.nioCharset).getOrElse(defaultCharset))).compile.foldMonoid.map(RawValue(_))
+        body.through(decodeWithCharset(charset.map(_.nioCharset).getOrElse(defaultCharset))).compile.string.map(RawValue(_))
       case RawBodyType.ByteArrayBody  => asByteArray.map(RawValue(_))
       case RawBodyType.ByteBufferBody => asChunk.map(c => RawValue(c.toByteBuffer))
       case RawBodyType.InputStreamBody =>

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestBody.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestBody.scala
@@ -5,17 +5,13 @@ import cats.syntax.all._
 import fs2.Chunk
 import fs2.io.file.Files
 import org.http4s.headers.{`Content-Disposition`, `Content-Type`}
-import org.http4s.{Charset, EntityDecoder, Request, multipart}
+import org.http4s.{Charset, EntityDecoder, Headers, Media, Request, multipart}
 import sttp.capabilities.fs2.Fs2Streams
 import sttp.model.{Header, Part}
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.interpreter.{RawValue, RequestBody}
 import sttp.tapir.{FileRange, InputStreamRange, RawBodyType, RawPart}
 
-import java.io.ByteArrayInputStream
-import org.http4s.Media
-import org.http4s.Headers
-import java.nio.charset.StandardCharsets
 
 private[http4s] class Http4sRequestBody[F[_]: Async](
     serverOptions: Http4sServerOptions[F]


### PR DESCRIPTION
This update optimizes how `Stream[F, Byte]` is handled.

- For `StringBody`, instead of combining all chunks and copying the entire resulting byte array, I propose `body.through(decodeWithCharset(...).compile.string`, which decodes incoming byte chunks into smaller Strings, and then collects them efficiently into one final `String` using fs2's `.string`.
- More importantly, for `InputStreamBody` and `InputStreamBodyRange`, I propose `fs2.io.toInputStreamBody(body)` to produce a lazily evaluated `InputStream` instead of fetching all bytes and returning them wrapped  in a `ByteArrayInputStream`.

P.S. Similar optimization to `StringBody` can be adapted to `netty-cats`