### PR TITLE
chore: Upgrade zio-http to version 3.0.0-RC7

### DIFF
--- a/doc/server/ziohttp.md
+++ b/doc/server/ziohttp.md
@@ -45,7 +45,7 @@ example:
 import sttp.tapir.PublicEndpoint
 import sttp.tapir.ztapir._
 import sttp.tapir.server.ziohttp.ZioHttpInterpreter
-import zio.http.{HttpApp, Request, Response}
+import zio.http.{Request, Response, Routes}
 import zio._
 
 def countCharacters(s: String): ZIO[Any, Nothing, Int] =
@@ -54,7 +54,7 @@ def countCharacters(s: String): ZIO[Any, Nothing, Int] =
 val countCharactersEndpoint: PublicEndpoint[String, Unit, Int, Any] =
   endpoint.in(stringBody).out(plainBody[Int])
   
-val countCharactersHttp: HttpApp[Any] =
+val countCharactersHttp: Routes[Any, Response] =
   ZioHttpInterpreter().toHttp(countCharactersEndpoint.zServerLogic(countCharacters))
 ```
 

--- a/examples/src/main/scala/sttp/tapir/examples/HelloWorldZioHttpServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/HelloWorldZioHttpServer.scala
@@ -6,7 +6,7 @@ import sttp.tapir.json.zio.*
 import sttp.tapir.server.ziohttp.ZioHttpInterpreter
 import sttp.tapir.ztapir.*
 import zio.*
-import zio.http.{HttpApp, Server}
+import zio.http.{Response => ZioHttpResponse, Routes, Server}
 import zio.json.{DeriveJsonDecoder, DeriveJsonEncoder, JsonDecoder, JsonEncoder}
 
 object HelloWorldZioHttpServer extends ZIOAppDefault {
@@ -31,7 +31,7 @@ object HelloWorldZioHttpServer extends ZIOAppDefault {
       .out(jsonBody[AddResult])
 
   // converting the endpoint descriptions to the Http type
-  val app: HttpApp[Any] =
+  val app: Routes[Any, ZioHttpResponse] =
     ZioHttpInterpreter().toHttp(helloWorld.zServerLogic(name => ZIO.succeed(s"Hello, $name!"))) ++
       ZioHttpInterpreter().toHttp(add.zServerLogic { case (x, y) => ZIO.succeed(AddResult(x, y, x + y)) })
 

--- a/examples/src/main/scala/sttp/tapir/examples/ZioExampleZioHttpServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/ZioExampleZioHttpServer.scala
@@ -7,7 +7,7 @@ import sttp.tapir.json.circe.*
 import sttp.tapir.server.ziohttp.ZioHttpInterpreter
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
 import sttp.tapir.ztapir.*
-import zio.http.{HttpApp, Server}
+import zio.http.{Response => ZioHttpResponse, Routes, Server}
 import zio.{ExitCode, Task, URIO, ZIO, ZIOAppDefault, ZLayer}
 
 object ZioExampleZioHttpServer extends ZIOAppDefault {
@@ -17,7 +17,7 @@ object ZioExampleZioHttpServer extends ZIOAppDefault {
   val petEndpoint: PublicEndpoint[Int, String, Pet, Any] =
     endpoint.get.in("pet" / path[Int]("petId")).errorOut(stringBody).out(jsonBody[Pet])
 
-  val petRoutes: HttpApp[Any] =
+  val petRoutes: Routes[Any, ZioHttpResponse] =
     ZioHttpInterpreter().toHttp(
       petEndpoint.zServerLogic(petId =>
         if (petId == 35) ZIO.succeed(Pet("Tapirus terrestris", "https://en.wikipedia.org/wiki/Tapir"))
@@ -38,7 +38,7 @@ object ZioExampleZioHttpServer extends ZIOAppDefault {
   val swaggerEndpoints: List[ZServerEndpoint[Any, Any]] = SwaggerInterpreter().fromEndpoints[Task](List(petEndpoint), "Our pets", "1.0")
 
   // Starting the server
-  val routes: HttpApp[Any] = ZioHttpInterpreter().toHttp(List(petServerEndpoint) ++ swaggerEndpoints)
+  val routes: Routes[Any, ZioHttpResponse] = ZioHttpInterpreter().toHttp(List(petServerEndpoint) ++ swaggerEndpoints)
 
   override def run: URIO[Any, ExitCode] =
     Server

--- a/examples/src/main/scala/sttp/tapir/examples/observability/ZioMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/ZioMetricsExample.scala
@@ -5,8 +5,7 @@ import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
 import sttp.tapir.server.metrics.zio.ZioMetrics
 import sttp.tapir.server.ziohttp.{ZioHttpInterpreter, ZioHttpServerOptions}
 import sttp.tapir.ztapir.ZServerEndpoint
-import zio.http.HttpApp
-import zio.http.Server
+import zio.http.{Response => ZioHttpResponse, Routes, Server}
 import zio.{Task, ZIO, _}
 
 /** Based on https://adopt-tapir.softwaremill.com zio version. */
@@ -31,7 +30,7 @@ object ZioMetricsExample extends ZIOAppDefault {
   override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] = {
     val serverOptions: ZioHttpServerOptions[Any] =
       ZioHttpServerOptions.customiseInterceptors.metricsInterceptor(metricsInterceptor).options
-    val app: HttpApp[Any] = ZioHttpInterpreter(serverOptions).toHttp(all)
+    val app: Routes[Any, ZioHttpResponse] = ZioHttpInterpreter(serverOptions).toHttp(all)
 
     val port = sys.env.get("http.port").map(_.toInt).getOrElse(8080)
 

--- a/examples/src/main/scala/sttp/tapir/examples/openapi/RedocZioHttpServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/openapi/RedocZioHttpServer.scala
@@ -6,8 +6,7 @@ import sttp.tapir.json.circe.*
 import sttp.tapir.redoc.bundle.RedocInterpreter
 import sttp.tapir.server.ziohttp.ZioHttpInterpreter
 import sttp.tapir.ztapir.*
-import zio.http.HttpApp
-import zio.http.Server
+import zio.http.{Response => ZioHttpResponse, Routes, Server}
 import zio.Console.{printLine, readLine}
 import zio.{Task, ZIO, ZIOAppDefault, ZLayer}
 
@@ -20,9 +19,9 @@ object RedocZioHttpServer extends ZIOAppDefault {
       else ZIO.fail("Unknown pet id")
     }
 
-  val petRoutes: HttpApp[Any] = ZioHttpInterpreter().toHttp(petEndpoint)
+  val petRoutes: Routes[Any, ZioHttpResponse] = ZioHttpInterpreter().toHttp(petEndpoint)
 
-  val redocRoutes: HttpApp[Any] =
+  val redocRoutes: Routes[Any, ZioHttpResponse] =
     ZioHttpInterpreter().toHttp(RedocInterpreter().fromServerEndpoints[Task](List(petEndpoint), "Our pets", "1.0"))
 
   val app = (petRoutes ++ redocRoutes)

--- a/examples/src/main/scala/sttp/tapir/examples/streaming/StreamingZioHttpServer.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/streaming/StreamingZioHttpServer.scala
@@ -5,8 +5,7 @@ import sttp.model.HeaderNames
 import sttp.tapir.{CodecFormat, PublicEndpoint}
 import sttp.tapir.ztapir.*
 import sttp.tapir.server.ziohttp.ZioHttpInterpreter
-import zio.http.HttpApp
-import zio.http.Server
+import zio.http.{Response => ZioHttpResponse, Routes, Server}
 import zio.{ExitCode, Schedule, URIO, ZIO, ZIOAppDefault, ZLayer}
 import zio.stream.*
 
@@ -36,7 +35,7 @@ object StreamingZioHttpServer extends ZIOAppDefault {
     ZIO.succeed((size, stream))
   }
 
-  val routes: HttpApp[Any] = ZioHttpInterpreter().toHttp(streamingServerEndpoint)
+  val routes: Routes[Any, ZioHttpResponse] = ZioHttpInterpreter().toHttp(streamingServerEndpoint)
 
   // Test using: curl http://localhost:8080/receive
   override def run: URIO[Any, ExitCode] =

--- a/examples2/src/main/scala/sttp/tapir/examples2/security/ServerSecurityLogicZio.scala
+++ b/examples2/src/main/scala/sttp/tapir/examples2/security/ServerSecurityLogicZio.scala
@@ -5,7 +5,7 @@ import sttp.client3.asynchttpclient.zio.AsyncHttpClientZioBackend
 import sttp.model.HeaderNames
 import sttp.tapir.server.ziohttp.ZioHttpInterpreter
 import sttp.tapir.ztapir._
-import zio.http.{HttpApp, Server}
+import zio.http.{Response => ZioHttpResponse, Routes, Server}
 import zio.{Console, ExitCode, IO, Scope, Task, ZIO, ZIOAppDefault, ZLayer}
 
 object ServerSecurityLogicZio extends ZIOAppDefault {
@@ -55,7 +55,7 @@ object ServerSecurityLogicZio extends ZIOAppDefault {
   // ---
 
   // interpreting as an app
-  val routes: HttpApp[Any] = ZioHttpInterpreter().toHttp(secureHelloWorldWithLogic)
+  val routes: Routes[Any, ZioHttpResponse] = ZioHttpInterpreter().toHttp(secureHelloWorldWithLogic)
 
   override def run: ZIO[Scope, Throwable, ExitCode] = {
     def testWith(backend: SttpBackend[Task, Any], port: Int, path: String, salutation: String, token: String): Task[String] =

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -36,7 +36,7 @@ object Versions {
   val iron = "2.5.0"
   val enumeratum = "1.7.3"
   val zio = "2.1.1"
-  val zioHttp = "3.0.0-RC6"
+  val zioHttp = "3.0.0-RC7"
   val zioInteropCats = "23.0.0.8"
   val zioInteropReactiveStreams = "2.0.2"
   val zioJson = "0.6.2"

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
@@ -7,7 +7,7 @@ import sttp.client3._
 import sttp.model.StatusCode
 import sttp.tapir.server.tests.CreateServerTest
 import sttp.tapir.ztapir._
-import zio.http.{endpoint => _, _}
+import zio.http.{Response => ZioHttpResponse, endpoint => _, _}
 import zio.{Task, ZIO}
 
 class ZioHttpCompositionTest(
@@ -15,7 +15,7 @@ class ZioHttpCompositionTest(
       Task,
       Any,
       ZioHttpServerOptions[Any],
-      HttpApp[Any]
+      Routes[Any, ZioHttpResponse]
     ]
 ) {
   import createServerTest._
@@ -26,9 +26,9 @@ class ZioHttpCompositionTest(
         val ep1 = endpoint.get.in("p1").zServerLogic[Any](_ => ZIO.unit)
         val ep3 = endpoint.get.in("p3").zServerLogic[Any](_ => ZIO.fail(new RuntimeException("boom")))
 
-        val route1: HttpApp[Any] = ZioHttpInterpreter().toHttp(ep1)
-        val route2: HttpApp[Any] = Routes(Method.GET / "p2" -> handler(zio.http.Response.ok)).toHttpApp
-        val route3: HttpApp[Any] = ZioHttpInterpreter().toHttp(ep3)
+        val route1: Routes[Any, ZioHttpResponse] = ZioHttpInterpreter().toHttp(ep1)
+        val route2: Routes[Any, ZioHttpResponse] = Routes(Method.GET / "p2" -> handler(ZioHttpResponse.ok))
+        val route3: Routes[Any, ZioHttpResponse] = ZioHttpInterpreter().toHttp(ep3)
 
         NonEmptyList.of(route3, route1, route2)
       }

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
@@ -18,18 +18,18 @@ class ZioHttpTestServerInterpreter(
     channelFactory: ZLayer[Any, Nothing, ChannelFactory[ServerChannel]]
 )(implicit
     trace: Trace
-) extends TestServerInterpreter[Task, ZioStreams with WebSockets, ZioHttpServerOptions[Any], HttpApp[Any]] {
+) extends TestServerInterpreter[Task, ZioStreams with WebSockets, ZioHttpServerOptions[Any], Routes[Any, Response]] {
 
   override def route(
       es: List[ServerEndpoint[ZioStreams with WebSockets, Task]],
       interceptors: Interceptors
-  ): HttpApp[Any] = {
+  ): Routes[Any, Response] = {
     val serverOptions: ZioHttpServerOptions[Any] = interceptors(ZioHttpServerOptions.customiseInterceptors).options
     ZioHttpInterpreter(serverOptions).toHttp(es)
   }
 
   override def serverWithStop(
-      routes: NonEmptyList[HttpApp[Any]],
+      routes: NonEmptyList[Routes[Any, Response]],
       gracefulShutdownTimeout: Option[FiniteDuration]
   ): Resource[IO, (Port, KillSwitch)] = {
     implicit val r: Runtime[Any] = Runtime.default


### PR DESCRIPTION
Supersedes #3768 and fixes incompatibilities introduced by deprecating `HttpApp`.