### PR TITLE
Fixes for iron derivation for GreaterEqual, LessEqual, In

### DIFF
--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
@@ -156,12 +156,27 @@ trait TapirCodecIron extends DescriptionWitness with LowPriorityValidatorForPred
   ): ValidatorForPredicate[N, P] =
     validatorForAnd[N, id.Predicate].asInstanceOf[ValidatorForPredicate[N, P]]
 
-  inline given validatorForDescribedOr[N, P](using
+  inline given validatorForDescribedOr[N, P, Num](using
       id: IsDescription[P],
-      mirror: UnionTypeMirror[id.Predicate]
+      mirror: UnionTypeMirror[id.Predicate],
+      notGe: NotGiven[P =:= GreaterEqual[Num]],
+      notLe: NotGiven[P =:= LessEqual[Num]]
   ): ValidatorForPredicate[N, P] =
     validatorForOr[N, id.Predicate].asInstanceOf[ValidatorForPredicate[N, P]]
 
+  inline given validatorForDescribedOrGe[N: Numeric, P, Num <: N](using
+      id: IsDescription[P],
+      notGe: P =:= GreaterEqual[Num],
+      singleton: ValueOf[Num]
+  ): ValidatorForPredicate[N, P] =
+    validatorForGreaterEqual[N, Num].asInstanceOf[ValidatorForPredicate[N, P]]
+
+  inline given validatorForDescribedOrLe[N: Numeric, P, Num <: N](using
+      id: IsDescription[P],
+      notGe: P =:= LessEqual[Num],
+      singleton: ValueOf[Num]
+  ): ValidatorForPredicate[N, P] =
+    validatorForLessEqual[N, Num].asInstanceOf[ValidatorForPredicate[N, P]]
   inline given validatorForDescribedPrimitive[N, P](using
       id: IsDescription[P],
       notUnion: NotGiven[UnionTypeMirror[id.Predicate]],

--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/UnionTypeMirror.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/UnionTypeMirror.scala
@@ -6,11 +6,11 @@ import scala.quoted.*
 
 trait UnionTypeMirror[A] {
 
-  type ElementTypes <: Tuple
+  type ElementTypes <: NonEmptyTuple
 }
 
 // Building a class is more convenient to instantiate using macros
-class UnionTypeMirrorImpl[A, T <: Tuple] extends UnionTypeMirror[A] {
+class UnionTypeMirrorImpl[A, T <: NonEmptyTuple] extends UnionTypeMirror[A] {
 
   override type ElementTypes = T
 }

--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/UnionTypeMirror.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/UnionTypeMirror.scala
@@ -7,10 +7,12 @@ import scala.quoted.*
 trait UnionTypeMirror[A] {
 
   type ElementTypes <: NonEmptyTuple
+  // Number of elements in the union
+  def size: Int
 }
-
+ 
 // Building a class is more convenient to instantiate using macros
-class UnionTypeMirrorImpl[A, T <: NonEmptyTuple] extends UnionTypeMirror[A] {
+class UnionTypeMirrorImpl[A, T <: NonEmptyTuple](val size: Int) extends UnionTypeMirror[A] {
 
   override type ElementTypes = T
 }
@@ -31,15 +33,20 @@ object UnionTypeMirror {
     def concatTypes(left: TypeRepr, right: TypeRepr): TypeRepr =
       AppliedType(tplConcatType, List(left, right))
 
-    def rec(tpe: TypeRepr): TypeRepr =
+    def rec(tpe: TypeRepr): (Int, TypeRepr) =
       tpe.dealias match {
-        case OrType(left, right) => concatTypes(rec(left), rec(right))
-        case t                   => prependTypes(t, TypeRepr.of[EmptyTuple])
+        case OrType(left, right) =>
+          val (c1, rec1) = rec(left)
+          val (c2, rec2) = rec(right)
+          (c1 + c2, concatTypes(rec1, rec2))
+        case t => (1, prependTypes(t, TypeRepr.of[EmptyTuple]))
       }
-    val tupled =
+    val (size, tupled) =
       TypeRepr.of[A].dealias match {
-        case or: OrType => rec(or).asType.asInstanceOf[Type[Elems]]
-        case tpe        => report.errorAndAbort(s"${tpe.show} is not a union type")
+        case or: OrType =>
+          val (s, r) = rec(or)
+          (s, r.asType.asInstanceOf[Type[Elems]])
+        case tpe => report.errorAndAbort(s"${tpe.show} is not a union type")
       }
 
     type Elems
@@ -65,7 +72,7 @@ object UnionTypeMirror {
           TypeTree.of[Elems]
         )
       ),
-      Nil
+      List(Literal(IntConstant((size))))
     ).asExprOf[UnionTypeMirror[A]]
   }
 }

--- a/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
+++ b/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
@@ -196,6 +196,14 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
       case Validator.Mapped(Validator.All(List(Validator.Min(1, true), Validator.Max(3, true))), _) =>
     }
   }
+  "Generated validator for intersection of constraints" should "use tapir Validator.min(1, false) and Validator.max(3, false)" in {
+    type IntConstraint = GreaterEqual[1] & LessEqual[3]
+    type LimitedInt = Int :| IntConstraint
+
+    summon[Schema[LimitedInt]].validator should matchPattern {
+      case Validator.Mapped(Validator.All(List(Validator.Min(1, false), Validator.Max(3, false))), _) =>
+    }
+  }
 
   "Generated validator for union of constraints" should "use tapir Validator.min and Validator.max" in {
     type IntConstraint = Less[1] | Greater[3]
@@ -203,6 +211,22 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
 
     summon[Schema[LimitedInt]].validator should matchPattern {
       case Validator.Mapped(Validator.Any(List(Validator.Max(1, true), Validator.Min(3, true))), _) =>
+    }
+  }
+  "Generated validator for union of constraints" should "use tapir Validator.enumeration" in {
+    type IntConstraint = In[(
+        110354433,
+        110354454,
+        122483323
+      )]
+    type LimitedInt = Int :| IntConstraint
+
+    summon[Schema[LimitedInt]].validator should matchPattern {
+      case Validator.Mapped(Validator.Enumeration(List(
+      110354433,
+      110354454,
+      122483323
+      ), _, _), _) =>
     }
   }
 

--- a/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
+++ b/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
@@ -143,14 +143,7 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
 
     summon[Schema[LimitedInt]].validator should matchPattern {
       case Validator.Mapped(
-            Validator.All(
-              List(
-                Validator.Any(List(Validator.Min(1, true), Validator.Enumeration(List(1), _, _))),
-                Validator.Any(List(Validator.Max(3, true), Validator.Enumeration(List(3), _, _)))
-              )
-            ),
-            _
-          ) =>
+        Validator.All(List(Validator.Min(1, false), Validator.Max(3, false))), _) =>
     }
   }
 
@@ -160,14 +153,7 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
 
     summon[Schema[LimitedInt]].validator should matchPattern {
       case Validator.Mapped(
-            Validator.All(
-              List(
-                Validator.Min(1, true),
-                Validator.Any(List(Validator.Max(3, true), Validator.Enumeration(List(3), _, _)))
-              )
-            ),
-            _
-          ) =>
+        Validator.All(List(Validator.Min(1, true), Validator.Max(3, false))), _) =>
     }
   }
 
@@ -177,14 +163,7 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
 
     summon[Schema[LimitedInt]].validator should matchPattern {
       case Validator.Mapped(
-            Validator.All(
-              List(
-                Validator.Any(List(Validator.Min(1, true), Validator.Enumeration(List(1), _, _))),
-                Validator.Max(3, true)
-              )
-            ),
-            _
-          ) =>
+        Validator.All(List(Validator.Min(1, false), Validator.Max(3, true))), _) =>
     }
   }
 
@@ -236,6 +215,25 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
 
     summon[Schema[LimitedInt]].validator should matchPattern {
       case Validator.Mapped(Validator.Any(List(Validator.Max(1, true), Validator.Min(3, true))), _) =>
+    }
+  }
+  
+  "Generated validator for described union" should "work with strings" in {
+    type StrConstraint = (Match["[a-c]*"] | Match["[x-z]*"]) DescribedAs ("Some description")
+    type LimitedStr = String :| StrConstraint
+
+    val identifierCodec = implicitly[PlainCodec[LimitedStr]]
+    identifierCodec.decode("aac") shouldBe DecodeResult.Value("aac")
+    identifierCodec.decode("yzx") shouldBe DecodeResult.Value("yzx")
+    identifierCodec.decode("aax") shouldBe a[DecodeResult.InvalidValue]
+  }
+  
+  "Generated validator for described single constraint" should "use tapir Validator.max" in {
+    type IntConstraint = (Less[1]) DescribedAs ("Should be included in less than 1 or more than 3")
+    type LimitedInt = Int :| IntConstraint
+
+    summon[Schema[LimitedInt]].validator should matchPattern {
+      case Validator.Mapped(Validator.Max(1, true), _) =>
     }
   }
 

--- a/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
+++ b/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
@@ -142,8 +142,7 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
     type LimitedInt = Int :| IntConstraint
 
     summon[Schema[LimitedInt]].validator should matchPattern {
-      case Validator.Mapped(
-        Validator.All(List(Validator.Min(1, false), Validator.Max(3, false))), _) =>
+      case Validator.Mapped(Validator.All(List(Validator.Min(1, false), Validator.Max(3, false))), _) =>
     }
   }
 
@@ -152,8 +151,7 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
     type LimitedInt = Int :| IntConstraint
 
     summon[Schema[LimitedInt]].validator should matchPattern {
-      case Validator.Mapped(
-        Validator.All(List(Validator.Min(1, true), Validator.Max(3, false))), _) =>
+      case Validator.Mapped(Validator.All(List(Validator.Min(1, true), Validator.Max(3, false))), _) =>
     }
   }
 
@@ -162,8 +160,7 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
     type LimitedInt = Int :| IntConstraint
 
     summon[Schema[LimitedInt]].validator should matchPattern {
-      case Validator.Mapped(
-        Validator.All(List(Validator.Min(1, false), Validator.Max(3, true))), _) =>
+      case Validator.Mapped(Validator.All(List(Validator.Min(1, false), Validator.Max(3, true))), _) =>
     }
   }
 
@@ -193,19 +190,28 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
     }
   }
   "Generated validator for union of constraints" should "use tapir Validator.enumeration" in {
-    type IntConstraint = In[(
-        110354433,
-        110354454,
-        122483323
-      )]
+    type IntConstraint = In[
+      (
+          110354433,
+          110354454,
+          122483323
+      )
+    ]
     type LimitedInt = Int :| IntConstraint
 
     summon[Schema[LimitedInt]].validator should matchPattern {
-      case Validator.Mapped(Validator.Enumeration(List(
-      110354433,
-      110354454,
-      122483323
-      ), _, _), _) =>
+      case Validator.Mapped(
+            Validator.Enumeration(
+              List(
+                110354433,
+                110354454,
+                122483323
+              ),
+              _,
+              _
+            ),
+            _
+          ) =>
     }
   }
 

--- a/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
+++ b/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
@@ -189,6 +189,25 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
       case Validator.Mapped(Validator.Any(List(Validator.Max(1, true), Validator.Min(3, true))), _) =>
     }
   }
+
+  "Generated validator for union of constraints" should "use tapir Validator.min and strict equality (enumeration)" in {
+    type IntConstraint = StrictEqual[3] | Greater[5] 
+    type LimitedInt = Int :| IntConstraint
+
+    summon[Schema[LimitedInt]].validator should matchPattern {
+      case Validator.Mapped(Validator.Any(List(Validator.Enumeration(List(3), _, _), Validator.Min(5, true))), _) =>
+    }
+  }
+  
+  "Generated validator for union of constraints" should "put muiltiple StrictEquality into a single enum and follow with the rest of constrains" in {
+    type IntConstraint = StrictEqual[3] | StrictEqual[4] | StrictEqual[13] | GreaterEqual[23] 
+    type LimitedInt = Int :| IntConstraint
+
+    summon[Schema[LimitedInt]].validator should matchPattern {
+      case Validator.Mapped(Validator.Any(List(Validator.Enumeration(List(3, 4, 13), _, _), Validator.Min(23, false))), _) =>
+    }
+  }
+
   "Generated validator for union of constraints" should "use tapir Validator.enumeration" in {
     type IntConstraint = In[
       (


### PR DESCRIPTION
These fixes should address issues reported here: https://softwaremill.community/t/how-to-improve-open-api-documentation-for-iron-refined-types/396/9

1. `LessEqual` and `GreaterEqual` validators aren't resolved correctly if these predicates are combined with other predicates using `Or` or `And`. They would be handled by `validatorForDescribedOr`, so I added variants called `validatorForDescribedOrGe` and `validatorForDescribedOrLe` witch additional "witnesses" like `isGe: P =:= GreaterEqual[Num]` to redirect back to `validatorForGreaterEqual` and `validatorForLessEqual`.

2. Constraint `In[(1, 2, 3)]` was handled as a standard union type constraint, resulting in a list of validators, where each validator was a `Validator.enumeration(List(int))` with a single value in the list. I have added some tweaks to fix this:
- constrains like `In[(a, b, c, d)]` are now represented as a single `Validator.enumeration(List(a, b, c, d))`
- raw strict equals in unions are handled as well, so constraint like `StrictEquals[1] | StrictEquals[2]` will also produce a single enumeration
- Mixed unions of `StrictEquals` and other constrains are also supported, as long as `StrictEquals` are the first constrains in the union, for example: `StrictEquals[3] | StrictEquals[4] | GreaterEqual[23]` will give a `Validator.Enumeration(List(3, 4), _, _), Validator.Min(23, false))`