### PR TITLE
Add jsoniter-scala-bundle module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -175,6 +175,7 @@ lazy val rawAllAggregates = core.projectRefs ++
   circeJson.projectRefs ++
   files.projectRefs ++
   jsoniterScala.projectRefs ++
+  jsoniterScalaBundle.projectRefs ++
   prometheusMetrics.projectRefs ++
   opentelemetryMetrics.projectRefs ++
   datadogMetrics.projectRefs ++
@@ -897,6 +898,22 @@ lazy val jsoniterScala: ProjectMatrix = (projectMatrix in file("json/jsoniter"))
     settings = commonJsSettings
   )
   .dependsOn(core)
+
+lazy val jsoniterScalaBundle: ProjectMatrix = (projectMatrix in file("json/jsoniter-bundle"))
+  .settings(commonSettings)
+  .settings(
+    name := "tapir-jsoniter-scala-bundle",
+    libraryDependencies ++= Seq(
+      "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-macros" % "2.28.5",
+      scalaTest.value % Test
+    )
+  )
+  .jvmPlatform(scalaVersions = List(scala3))
+  .jsPlatform(
+    scalaVersions = List(scala3),
+    settings = commonJsSettings
+  )
+  .dependsOn(jsoniterScala)
 
 lazy val zioJson: ProjectMatrix = (projectMatrix in file("json/zio"))
   .settings(commonSettings)

--- a/doc/endpoint/json.md
+++ b/doc/endpoint/json.md
@@ -225,6 +225,33 @@ import sttp.tapir.json.jsoniter._
 
 Jsoniter Scala requires `JsonValueCodec` implicit value in scope for each type you want to serialize.
 
+## Jsoniter Scala for Scala 3
+
+If you are using Scala 3 and would like to use the `... derives` syntax for deriving codecs, some additional glue code
+is required in case of jsoniter. It's packaged in the `tapir-jsoniter-bundle` module:
+
+```scala
+"com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala-bundle" % "@VERSION@"
+```
+
+You can then use the module as follows:
+
+```scala
+import sttp.tapir.*
+import sttp.tapir.json.jsoniter.bundle.*
+
+case class Test(v1: String, v2: Int) derives ConfiguredJsonValueCodec
+
+endpoint.in(jsonBody[Test])
+```
+
+Configuration can be provided by an `inline given CodecMakerConfig` value, which needs to be visible in scope, and 
+defined/imported before the `... derives` usage. The bundle is an addition, not a replacement to the usual 
+jsoniter-scala functionality, hence e.g. `JsonValueCodec`s can also be derived using `JsonCodecMaker`.
+
+Note that adding the bundle as a dependency will cause the jsoniter's macros module to be included as a runtime 
+dependency, which is not required when deriving codecs using `JsonCodecMaker` directly.
+
 ## Json4s
 
 To use [json4s](https://github.com/json4s/json4s) add the following dependencies to your project:

--- a/doc/stability.md
+++ b/doc/stability.md
@@ -71,17 +71,18 @@ The modules are categorised using the following levels:
 
 ## JSON modules
 
-| Module     | Level        |
-|------------|--------------|
-| circe      | stabilising  |
-| json4s     | stabilising  |
-| jsoniter   | stabilising  |
-| play-json  | stabilising  |
-| spray-json | stabilising  |
-| tethys     | stabilising  |
-| upickle    | stabilising  |
-| pickler    | experimental |
-| zio-json   | experimental |
+| Module          | Level        |
+|-----------------|--------------|
+| circe           | stabilising  |
+| json4s          | stabilising  |
+| jsoniter        | stabilising  |
+| jsoniter-bundle | experimental |
+| play-json       | stabilising  |
+| spray-json      | stabilising  |
+| tethys          | stabilising  |
+| upickle         | stabilising  |
+| pickler         | experimental |
+| zio-json        | experimental |
 
 ## Testing modules
 

--- a/json/jsoniter-bundle/src/main/scala/sttp/tapir/json/jsoniter/bundle/ConfiguredJsonValueCodec.scala
+++ b/json/jsoniter-bundle/src/main/scala/sttp/tapir/json/jsoniter/bundle/ConfiguredJsonValueCodec.scala
@@ -1,0 +1,12 @@
+package sttp.tapir.json.jsoniter.bundle
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.macros.{CodecMakerConfig, JsonCodecMaker}
+
+trait ConfiguredJsonValueCodec[A] extends JsonValueCodec[A]
+
+// see https://github.com/plokhotnyuk/jsoniter-scala/issues/852#issuecomment-2017582987
+object ConfiguredJsonValueCodec:
+  inline def derived[A](using inline config: CodecMakerConfig = CodecMakerConfig): ConfiguredJsonValueCodec[A] = new:
+    private val impl = JsonCodecMaker.make[A](config)
+    export impl._

--- a/json/jsoniter-bundle/src/main/scala/sttp/tapir/json/jsoniter/bundle/package.scala
+++ b/json/jsoniter-bundle/src/main/scala/sttp/tapir/json/jsoniter/bundle/package.scala
@@ -1,0 +1,3 @@
+package sttp.tapir.json.jsoniter
+
+package object bundle extends TapirJsonJsoniter

--- a/json/jsoniter-bundle/src/test/scala/sttp/tapir/json/jsoniter/bundle/ConfiguredJsonValueCodecTest.scala
+++ b/json/jsoniter-bundle/src/test/scala/sttp/tapir/json/jsoniter/bundle/ConfiguredJsonValueCodecTest.scala
@@ -1,0 +1,18 @@
+package sttp.tapir.json.jsoniter.bundle
+
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import sttp.tapir.DecodeResult
+import sttp.tapir.generic.auto.*
+
+class ConfiguredJsonValueCodecTest extends AnyFlatSpecLike with Matchers:
+  case class Test(v1: String, v2: Int) derives ConfiguredJsonValueCodec
+
+  it should "encode and decode using tapir's codec" in {
+    val tapirCodec = jsonBody[Test].codec
+
+    val actual = tapirCodec.decode("""{"v1":"test","v2":42}""")
+    actual shouldBe DecodeResult.Value(Test("test", 42))
+
+    tapirCodec.encode(Test("test", 42)) shouldBe """{"v1":"test","v2":42}"""
+  }


### PR DESCRIPTION
This allows using jsoniter-scala in combination with Scala 3's `... derives`, using a single import.