### PR TITLE
Fix WebSocket frame concatenation for Netty

### DIFF
--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sWebSockets.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sWebSockets.scala
@@ -101,6 +101,8 @@ private[http4s] object Http4sWebSockets {
         case (None, f: WebSocketFrame.Pong)                                  => (None, Some(f))
         case (None, f: WebSocketFrame.Close)                                 => (None, Some(f))
         case (None, f: WebSocketFrame.Data[_]) if f.finalFragment            => (None, Some(f))
+        case (None, f: WebSocketFrame.Text)                                  => (Some(Right(f.payload)), None)
+        case (None, f: WebSocketFrame.Binary)                                => (Some(Left(f.payload)), None)
         case (Some(Left(acc)), f: WebSocketFrame.Binary) if f.finalFragment  => (None, Some(f.copy(payload = acc ++ f.payload)))
         case (Some(Left(acc)), f: WebSocketFrame.Binary) if !f.finalFragment => (Some(Left(acc ++ f.payload)), None)
         case (Some(Right(acc)), f: WebSocketFrame.Text) if f.finalFragment   => (None, Some(f.copy(payload = acc + f.payload)))

--- a/server/vertx-server/cats/src/test/scala/sttp/tapir/server/vertx/cats/CatsVertxServerTest.scala
+++ b/server/vertx-server/cats/src/test/scala/sttp/tapir/server/vertx/cats/CatsVertxServerTest.scala
@@ -43,7 +43,8 @@ class CatsVertxServerTest extends TestSuite {
           autoPing = false,
           failingPipe = false,
           handlePong = true,
-          expectCloseResponse = false
+          expectCloseResponse = false,
+          frameConcatenation = false
         ) {
           override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = in => in.map(f)
           override def emptyPipe[A, B]: streams.Pipe[A, B] = _ => Stream.empty

--- a/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/websocket.scala
+++ b/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/websocket.scala
@@ -15,6 +15,10 @@ object websocket {
         (None, Some(f))
       case (None, f: WebSocketFrame.Data[_]) if f.finalFragment =>
         (None, Some(f))
+      case (None, f: WebSocketFrame.Text) =>
+        (Some(Right(f.payload)), None)
+      case (None, f: WebSocketFrame.Binary) =>
+        (Some(Left(f.payload)), None)
       case (Some(Left(acc)), f: WebSocketFrame.Binary) if f.finalFragment =>
         (None, Some(f.copy(payload = acc ++ f.payload)))
       case (Some(Left(acc)), f: WebSocketFrame.Binary) if !f.finalFragment =>

--- a/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxServerTest.scala
+++ b/server/vertx-server/src/test/scala/sttp/tapir/server/vertx/VertxServerTest.scala
@@ -59,7 +59,8 @@ class VertxServerTest extends TestSuite {
           autoPing = false,
           failingPipe = false,
           handlePong = false,
-          expectCloseResponse = false
+          expectCloseResponse = false,
+          frameConcatenation = false
         ) {
           override def functionToPipe[A, B](f: A => B): VertxStreams.Pipe[A, B] = in => new ReadStreamMapping(in, f)
           override def emptyPipe[A, B]: VertxStreams.Pipe[A, B] = _ => new EmptyReadStream()

--- a/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/ZioVertxServerTest.scala
+++ b/server/vertx-server/zio/src/test/scala/sttp/tapir/server/vertx/zio/ZioVertxServerTest.scala
@@ -49,7 +49,8 @@ class ZioVertxServerTest extends TestSuite with OptionValues {
           autoPing = true,
           failingPipe = false,
           handlePong = false,
-          expectCloseResponse = false
+          expectCloseResponse = false,
+          frameConcatenation = false
         ) {
           override def functionToPipe[A, B](f: A => B): streams.Pipe[A, B] = in => in.map(f)
           override def emptyPipe[A, B]: streams.Pipe[A, B] = _ => ZStream.empty

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioWebSockets.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioWebSockets.scala
@@ -124,15 +124,13 @@ object ZioWebSockets {
           case (None, f: SttpWebSocketFrame.Pong)                                  => (None, Some(f))
           case (None, f: SttpWebSocketFrame.Close)                                 => (None, Some(f))
           case (None, f: SttpWebSocketFrame.Data[_]) if f.finalFragment            => (None, Some(f))
+          case (None, f: SttpWebSocketFrame.Text)                                  => (Some(Right(f.payload)), None)
+          case (None, f: SttpWebSocketFrame.Binary)                                => (Some(Left(f.payload)), None)
           case (Some(Left(acc)), f: SttpWebSocketFrame.Binary) if f.finalFragment  => (None, Some(f.copy(payload = acc ++ f.payload)))
           case (Some(Left(acc)), f: SttpWebSocketFrame.Binary) if !f.finalFragment => (Some(Left(acc ++ f.payload)), None)
           case (Some(Right(acc)), f: SttpWebSocketFrame.Text) if f.finalFragment =>
-            println(s"final fragment: $f")
-            println(s"acc: $acc")
             (None, Some(f.copy(payload = acc + f.payload)))
           case (Some(Right(acc)), f: SttpWebSocketFrame.Text) if !f.finalFragment =>
-            println(s"final fragment: $f")
-            println(s"acc: $acc")
             (Some(Right(acc + f.payload)), None)
 
           case (acc, f) => throw new IllegalStateException(s"Cannot accumulate web socket frames. Accumulator: $acc, frame: $f.")

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
@@ -271,7 +271,8 @@ class ZioHttpServerTest extends TestSuite {
             ZioStreams,
             autoPing = true,
             failingPipe = false,
-            handlePong = false
+            handlePong = false,
+            concatetatedFrames = false
           ) {
             override def functionToPipe[A, B](f: A => B): ZioStreams.Pipe[A, B] = in => in.map(f)
             override def emptyPipe[A, B]: ZioStreams.Pipe[A, B] = _ => ZStream.empty

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
@@ -272,7 +272,7 @@ class ZioHttpServerTest extends TestSuite {
             autoPing = true,
             failingPipe = false,
             handlePong = false,
-            concatetatedFrames = false
+            frameConcatenation = false
           ) {
             override def functionToPipe[A, B](f: A => B): ZioStreams.Pipe[A, B] = in => in.map(f)
             override def emptyPipe[A, B]: ZioStreams.Pipe[A, B] = _ => ZStream.empty


### PR DESCRIPTION
When handling incoming WebSocket frames, there was a missing case for a "non-final data frame and no data accumulated".
1. I added the case and moved frame concatenation to `WebSocketFrameConverters`, so it's shared between netty-sync and netty-cats
2. I also added cases where a binary frame comes after a text frame, this is specific to Netty (a `WebSocketContinuationFrame` is a binary frame that follows a text frame). 
3. I added test cases mentioned in 1. to other backends where they were missing: Vert.X, zio-http, http4s.

BTW it turns out http4s does frame concatenation by itself, regardless of our configuration.

After adding missing cases, there are issues with concatenation in zio-http and vert.x. The stream freezes after receiving first frame in the accumulation. This needs separate investigation.