### PR TITLE
Netty servers: handle requestTimeout properly, add idleTimeout

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2066,7 +2066,8 @@ lazy val examples: ProjectMatrix = (projectMatrix in file("examples"))
       scalaTest.value,
       logback
     ),
-    publishArtifact := false
+    publishArtifact := false,
+    Compile / run / fork := true
   )
   .jvmPlatform(scalaVersions = examplesScalaVersions)
   .dependsOn(

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServer.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServer.scala
@@ -78,7 +78,7 @@ case class NettyCatsServer[F[_]: Async](routes: Vector[Route[F]], options: Netty
     val channelFuture =
       NettyBootstrap(
         config,
-        new NettyServerHandler(route, unsafeRunAsync, channelGroup, isShuttingDown, config.serverHeader, config.isSsl),
+        new NettyServerHandler(route, unsafeRunAsync, channelGroup, isShuttingDown, config),
         eventLoopGroup,
         socketOverride
       )

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
@@ -30,9 +30,8 @@ import scala.concurrent.duration._
   *   contains tapir's server processing logic.
   *
   * @param requestTimeout
-  *   The maximum duration, to wait for a response before considering the request timed out.
-  * @throws ReadTimeoutException
-  *   when no data is read from Netty within the specified period of time for a request.
+  *   The maximum duration to wait for a response to be produced. If exceeded, the server will return a HTTP 503 response and close the
+  *   channel. This timeout is ignored in Web Sockets (after a handshake is established). Make sure it's lower than `idleTimeout`.
   *
   * @param connectionTimeout
   *   Specifies the maximum duration within which a connection between a client and a server must be established.
@@ -44,6 +43,10 @@ import scala.concurrent.duration._
   * @param gracefulShutdownTimeout
   *   If set, attempts to wait for a given time for all in-flight requests to complete, before proceeding with shutting down the server. If
   *   `None`, closes the channels and terminates the server without waiting.
+  *
+  * @param idleTimeout
+  *   Maximum inactivity time of a given connection. If nothing is sent or received within this timeout, the connection closes. Make sure
+  *   it's greater than `requestTimeout`, which should be the first one to be triggered if it's taking too long to produce a response.
   *
   * @param serverHeader
   *   If set, send this value in the 'Server' response header. If None, don't set the header.
@@ -64,6 +67,7 @@ case class NettyConfig(
     socketConfig: NettySocketConfig,
     initPipeline: NettyConfig => (ChannelPipeline, ChannelHandler) => Unit,
     gracefulShutdownTimeout: Option[FiniteDuration],
+    idleTimeout: Option[FiniteDuration],
     serverHeader: Option[String]
 ) {
   def host(h: String): NettyConfig = copy(host = h)
@@ -80,7 +84,8 @@ case class NettyConfig(
 
   def requestTimeout(r: FiniteDuration): NettyConfig = copy(requestTimeout = Some(r))
   def connectionTimeout(c: FiniteDuration): NettyConfig = copy(connectionTimeout = Some(c))
-  def lingerTimeout(l: FiniteDuration): NettyConfig = copy(requestTimeout = Some(l))
+  def lingerTimeout(l: FiniteDuration): NettyConfig = copy(lingerTimeout = Some(l))
+  def idleTimeout(r: FiniteDuration): NettyConfig = copy(idleTimeout = Some(r))
 
   def withSocketKeepAlive: NettyConfig = copy(socketKeepAlive = true)
   def withNoSocketKeepAlive: NettyConfig = copy(socketKeepAlive = false)
@@ -119,6 +124,7 @@ object NettyConfig {
     connectionTimeout = Some(10.seconds),
     lingerTimeout = None, // see #3576
     gracefulShutdownTimeout = Some(10.seconds),
+    idleTimeout = Some(60.seconds),
     maxConnections = None,
     addLoggingHandler = false,
     sslContext = None,

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyConfig.scala
@@ -31,7 +31,7 @@ import scala.concurrent.duration._
   *
   * @param requestTimeout
   *   The maximum duration to wait for a response to be produced. If exceeded, the server will return a HTTP 503 response and close the
-  *   channel. This timeout is ignored in Web Sockets (after a handshake is established). Make sure it's lower than `idleTimeout`.
+  *   connection. This timeout is ignored in Web Sockets (after a handshake is established). Make sure it's lower than `idleTimeout`.
   *
   * @param connectionTimeout
   *   Specifies the maximum duration within which a connection between a client and a server must be established.

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServer.scala
@@ -71,7 +71,7 @@ case class NettyFutureServer(routes: Vector[FutureRoute], options: NettyFutureSe
     val channelFuture =
       NettyBootstrap(
         config,
-        new NettyServerHandler(route, unsafeRunAsync, channelGroup, isShuttingDown, config.serverHeader, config.isSsl),
+        new NettyServerHandler(route, unsafeRunAsync, channelGroup, isShuttingDown, config),
         eventLoopGroup,
         socketOverride
       )

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/UnhandledExceptionHandler.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/UnhandledExceptionHandler.scala
@@ -1,0 +1,16 @@
+package sttp.tapir.server.netty.internal
+
+import io.netty.channel.{ChannelHandlerContext, ChannelInboundHandlerAdapter}
+import io.netty.util.internal.logging.InternalLoggerFactory
+
+private[internal] class UnhandledExceptionHandler extends ChannelInboundHandlerAdapter {
+  private lazy val logger = InternalLoggerFactory.getInstance(getClass)
+
+  override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable): Unit = {
+    cause match {
+      case ex =>
+        logger.warn("Unhandled exception", ex)
+    }
+    val _ = ctx.close()
+  }
+}

--- a/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/NettySyncServer.scala
+++ b/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/NettySyncServer.scala
@@ -27,15 +27,15 @@ import scala.util.control.NonFatal
   * options.
   */
 private[sync] case class NettySyncServerEndpointListOverridenOptions(
-                                                                      ses: List[ServerEndpoint[OxStreams & WebSockets, Identity]],
-                                                                      overridenOptions: NettySyncServerOptions
+    ses: List[ServerEndpoint[OxStreams & WebSockets, Identity]],
+    overridenOptions: NettySyncServerOptions
 )
 
 case class NettySyncServer(
-                            endpoints: List[ServerEndpoint[OxStreams & WebSockets, Identity]],
-                            endpointsWithOptions: List[NettySyncServerEndpointListOverridenOptions],
-                            options: NettySyncServerOptions,
-                            config: NettyConfig
+    endpoints: List[ServerEndpoint[OxStreams & WebSockets, Identity]],
+    endpointsWithOptions: List[NettySyncServerEndpointListOverridenOptions],
+    options: NettySyncServerOptions,
+    config: NettyConfig
 ):
   private val executor = Executors.newVirtualThreadPerTaskExecutor()
 
@@ -134,8 +134,7 @@ case class NettySyncServer(
         unsafeRunF,
         channelGroup,
         isShuttingDown,
-        config.serverHeader,
-        config.isSsl
+        config
       ),
       eventLoopGroup,
       socketOverride

--- a/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/NettyZioServer.scala
+++ b/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/NettyZioServer.scala
@@ -91,8 +91,7 @@ case class NettyZioServer[R](routes: Vector[RIO[R, Route[RIO[R, *]]]], options: 
           unsafeRunAsync(runtime),
           channelGroup,
           isShuttingDown,
-          config.serverHeader,
-          config.isSsl
+          config
         ),
         eventLoopGroup,
         socketOverride


### PR DESCRIPTION
Fixes https://github.com/softwaremill/tapir/issues/3795

This PR replaces usage of `ReadTimeoutHandler` with `IdleStateHandler`.
The `ReadStateHandler` was configured using `NettyConfig.requestTimeout` value, but it wasn't serving the purpose of failing when there is no response within given timeout. This handler throws an exception when there is no data _read_ , which means no request from the client.

We will be using `IdleStateHandler` to deal with timeouts correctly:
1. One such handler is created for each request, with timeout set to `nettyConfig.requestTimeout`. If it expires, the channel is closed, a HTTP 503 response is returned, and in-flight requests in the channel are canceled. An error is logged.
2. if backend manages to produce a response, the handler is removed.
3. Thus, in case of pieplining, there will be multiple IdleStateHandler instances running, one for each running request processing.
4. Additionally, we introduce `NettyConfig.idleTimeout`. Similarly to idle-timeout in akka-http, it defines a time of no reads nor writes, after which the channel will be closed silently (only with a debug log). This is a "normal situation" that may happen after a long-running keep-alive connection expires (typically from a web browser), like in #3795, which initiated this work.
5. The value of `idleTimeout` is set by default to 60s, while `requestTimeout` is 20s. 