### PR TITLE
Pickler: add transientNone for optional fields

### DIFF
--- a/doc/endpoint/pickler.md
+++ b/doc/endpoint/pickler.md
@@ -235,7 +235,9 @@ you can proceed with `Pickler.derived[T]`.
 
 ## Divergences from default µPickle behavior
 
-* Tapir pickler serialises None values as `null`, instead of wrapping the value in an array
+* Tapir pickler serialises fields of type `Option[T]` as direct value `T` or skips serialisation if field value is `None`. 
+  This default behavior can be changed by setting `.withTransientNone(false)` in `PicklerConfiguration`, which would result in serialising `None` as `null`.
+  This differs from uPickle, where optional values are wrapped in arrays.
 * Value classes (case classes extending AnyVal) will be serialised as simple values
 * Discriminator field value is a short class name, instead of full package with class name
 

--- a/json/pickler/src/main/scala/sttp/tapir/json/pickler/PicklerConfiguration.scala
+++ b/json/pickler/src/main/scala/sttp/tapir/json/pickler/PicklerConfiguration.scala
@@ -3,7 +3,13 @@ package sttp.tapir.json.pickler
 import sttp.tapir.generic.Configuration
 import upickle.core.Annotator
 
-final case class PicklerConfiguration(genericDerivationConfig: Configuration) {
+/** Configuration parameters for Pickler.
+  * @param genericDerivationConfig
+  *   basic configuration for schema and codec derivation
+  * @param transientNone
+  *   skip serialization of Option fields if their value is None. If false, None will be serialized as null.
+  */
+final case class PicklerConfiguration(genericDerivationConfig: Configuration, transientNone: Boolean = true) {
   export genericDerivationConfig.{toEncodedName, toDiscriminatorValue}
 
   def discriminator: String = genericDerivationConfig.discriminator.getOrElse(Annotator.defaultTagKey)
@@ -31,6 +37,7 @@ final case class PicklerConfiguration(genericDerivationConfig: Configuration) {
   def withFullKebabCaseDiscriminatorValues: PicklerConfiguration = PicklerConfiguration(
     genericDerivationConfig.withFullKebabCaseDiscriminatorValues
   )
+  def withTransientNone(transientNone: Boolean): PicklerConfiguration = copy(transientNone = transientNone)
 }
 
 object PicklerConfiguration {

--- a/json/pickler/src/main/scala/sttp/tapir/json/pickler/Writers.scala
+++ b/json/pickler/src/main/scala/sttp/tapir/json/pickler/Writers.scala
@@ -4,7 +4,6 @@ import _root_.upickle.core.Annotator.Checker
 import _root_.upickle.core.{ObjVisitor, Visitor, _}
 import _root_.upickle.implicits.{WritersVersionSpecific, macros => upickleMacros}
 import sttp.tapir.Schema
-import sttp.tapir.Schema.SName
 import sttp.tapir.SchemaType.SProduct
 import sttp.tapir.generic.Configuration
 import sttp.tapir.internal.EnumerationMacros.*
@@ -47,7 +46,8 @@ private[pickler] trait Writers extends WritersVersionSpecific with UpickleHelper
             v,
             ctx,
             childWriters,
-            childDefaults
+            childDefaults,
+            config.transientNone
           )
           ctx.visitEnd(-1)
         }
@@ -61,7 +61,8 @@ private[pickler] trait Writers extends WritersVersionSpecific with UpickleHelper
           v,
           ctx,
           childWriters,
-          childDefaults
+          childDefaults,
+          config.transientNone                  
         )
     }
 

--- a/json/pickler/src/test/scala/sttp/tapir/json/pickler/Fixtures.scala
+++ b/json/pickler/src/test/scala/sttp/tapir/json/pickler/Fixtures.scala
@@ -44,7 +44,7 @@ object Fixtures:
       fieldC: InnerCaseClass
   )
   case class InnerCaseClass(fieldInner: String, @default(4) fieldInnerInt: Int)
-  case class FlatClassWithOption(fieldA: String, fieldB: Option[Int])
+  case class FlatClassWithOption(fieldA: String, fieldB: Option[Int], fieldC: Boolean)
   case class NestedClassWithOption(innerField: Option[FlatClassWithOption])
 
   case class FlatClassWithList(fieldA: String, fieldB: List[Int])


### PR DESCRIPTION
This PR enhances Pickler JSON codec with 2 features:

1. When deserializing, missing fields for `Option` fields are now treated as `None` instead of causing errors.
2. When serializing a `None`, a `transientNone` flag from `PicklerConfiguration` decides how to handle it:
  a) skip the field entirely (when transientNone == true, default)
  b) serialize value as `null` (when transientNone == false)
The flag name and behavior are inspired by jsoniter-scala. This changes the current behavior, which was b). Skipping by default seems like a more convenient default though.