### PR TITLE
Iron: add validator for Pure constraint

### DIFF
--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
@@ -66,6 +66,12 @@ trait TapirCodecIron extends DescriptionWitness with LowPriorityValidatorForPred
   inline given PrimitiveValidatorForPredicate[String, Not[Empty]] =
     ValidatorForPredicate.fromPrimitiveValidator[String, Not[Empty]](Validator.minLength(1))
 
+  inline given validatorForPure[T]: ValidatorForPredicate[T, Pure] =
+    new ValidatorForPredicate[T, Pure] {
+      override val validator: Validator[T] = Validator.pass
+      override def makeErrors(value: T, errorMessage: String): List[ValidationError[_]] = Nil
+    }
+
   inline given validatorForMatchesRegexpString[S <: String](using witness: ValueOf[S]): PrimitiveValidatorForPredicate[String, Match[S]] =
     ValidatorForPredicate.fromPrimitiveValidator(Validator.pattern[String](witness.value))
 

--- a/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
+++ b/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
@@ -266,4 +266,9 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
     summon[Schema[RefinedInt]]
     summon[Codec[String, RefinedInt, TextPlain]]
 
+  "Instances for newtypes" should "be correctly derived" in:
+    type NewtypeInt = Int :| Pure
+    summon[Schema[NewtypeInt]]
+    summon[Codec[String, NewtypeInt, TextPlain]]
+
 }


### PR DESCRIPTION
This PR adds validator for `Pure` constraint, which allows to automatically derive `Schema` and `Codec` instances for pure newtypes, eg `type NewtypeInt = Int :| Pure`
