### PR TITLE
Fix handling of WS Close frame in Netty backends

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -25,7 +25,7 @@ object Versions {
   val json4s = "4.0.7"
   val metrics4Scala = "4.2.9"
   val nettyReactiveStreams = "3.0.2"
-  val ox = "0.1.0"
+  val ox = "0.2.1"
   val reactiveStreams = "1.0.4"
   val sprayJson = "1.3.6"
   val scalaCheck = "1.18.0"

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/internal/WebSocketPipeProcessor.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/internal/WebSocketPipeProcessor.scala
@@ -104,8 +104,7 @@ class WebSocketPipeProcessor[F[_]: Async, REQ, RESP](
     } else s
 
   private def optionallyPassThroughCloseFrame(doPassThrough: Boolean)(s: Stream[F, WebSocketFrame]): Stream[F, WebSocketFrame] =
-    s.takeWhile(
-      _ match {
+    s.takeWhile({
         case _: WebSocketFrame.Close => false
         case _                       => true
       },

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/internal/WebSocketPipeProcessor.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/internal/WebSocketPipeProcessor.scala
@@ -45,7 +45,7 @@ class WebSocketPipeProcessor[F[_]: Async, REQ, RESP](
       sttpFrame
     }
     val stream: Stream[F, NettyWebSocketFrame] =
-      optionallyConcatenateFrames(sttpFrames, o.concatenateFragmentedFrames)
+      optionallyConcatenateFrames(o.concatenateFragmentedFrames)(optionallyPassThroughCloseFrame(o.decodeCloseRequests)(sttpFrames))
         .map(f =>
           o.requests.decode(f) match {
             case x: DecodeResult.Value[REQ]    => x.v
@@ -98,10 +98,19 @@ class WebSocketPipeProcessor[F[_]: Async, REQ, RESP](
 
   }
 
-  private def optionallyConcatenateFrames(s: Stream[F, WebSocketFrame], doConcatenate: Boolean): Stream[F, WebSocketFrame] =
+  private def optionallyConcatenateFrames(doConcatenate: Boolean)(s: Stream[F, WebSocketFrame]): Stream[F, WebSocketFrame] =
     if (doConcatenate) {
       s.mapAccumulate(None: Accumulator)(accumulateFrameState).collect { case (_, Some(f)) => f }
     } else s
+
+  private def optionallyPassThroughCloseFrame(doPassThrough: Boolean)(s: Stream[F, WebSocketFrame]): Stream[F, WebSocketFrame] =
+    s.takeWhile(
+      _ match {
+        case _: WebSocketFrame.Close => false
+        case _                       => true
+      },
+      takeFailure = doPassThrough
+    )
 }
 
 /** A special wrapper used to override internal logic of fs2, which calls cancel() silently when internal stream failures happen, causing

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyServerHandler.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyServerHandler.scala
@@ -20,7 +20,7 @@ import sttp.tapir.server.netty.NettyResponseContent.{
   ReactivePublisherNettyResponseContent,
   ReactiveWebSocketProcessorNettyResponseContent
 }
-import sttp.tapir.server.netty.internal.ws.{NettyControlFrameHandler, WebSocketAutoPingHandler}
+import sttp.tapir.server.netty.internal.ws.{WebSocketAutoPingHandler, WebSocketPingPongFrameHandler}
 import sttp.tapir.server.netty.{NettyConfig, NettyResponse, NettyServerRequest, Route}
 
 import java.util.concurrent.TimeUnit
@@ -281,10 +281,9 @@ class NettyServerHandler[F[_]](
       .addAfter(
         ServerCodecHandlerName,
         WebSocketControlFrameHandlerName,
-        new NettyControlFrameHandler(
+        new WebSocketPingPongFrameHandler(
           ignorePong = r.ignorePong,
-          autoPongOnPing = r.autoPongOnPing,
-          decodeCloseRequests = r.decodeCloseRequests
+          autoPongOnPing = r.autoPongOnPing
         )
       )
     r.autoPing.foreach { case (interval, pingMsg) =>

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/ws/WebSocketPingPongFrameHandler.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/ws/WebSocketPingPongFrameHandler.scala
@@ -1,13 +1,12 @@
 package sttp.tapir.server.netty.internal.ws
 
 import io.netty.channel.{ChannelHandlerContext, ChannelInboundHandlerAdapter}
-import io.netty.handler.codec.http.websocketx.{CloseWebSocketFrame, PingWebSocketFrame, PongWebSocketFrame}
+import io.netty.handler.codec.http.websocketx.{PingWebSocketFrame, PongWebSocketFrame}
 import sttp.tapir.server.netty.internal._
 
-/** Handles Ping, Pong, and Close frames for WebSockets.
+/** Handles incoming Ping and Pong frames for WebSockets.
   */
-class NettyControlFrameHandler(ignorePong: Boolean, autoPongOnPing: Boolean, decodeCloseRequests: Boolean)
-    extends ChannelInboundHandlerAdapter {
+class WebSocketPingPongFrameHandler(ignorePong: Boolean, autoPongOnPing: Boolean) extends ChannelInboundHandlerAdapter {
 
   override def channelRead(ctx: ChannelHandlerContext, msg: Any): Unit = {
     msg match {
@@ -22,16 +21,6 @@ class NettyControlFrameHandler(ignorePong: Boolean, autoPongOnPing: Boolean, dec
           val _ = ctx.fireChannelRead(pong)
         } else {
           val _ = pong.content().release()
-        }
-      case close: CloseWebSocketFrame =>
-        if (decodeCloseRequests) {
-          // Passing the Close frame for further processing
-          val _ = ctx.fireChannelRead(close)
-        } else {
-          // Responding with Close immediately
-          val _ = ctx
-            .writeAndFlush(close)
-            .close()
         }
       case other =>
         val _ = ctx.fireChannelRead(other)

--- a/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/internal/reactivestreams/OxProcessor.scala
+++ b/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/internal/reactivestreams/OxProcessor.scala
@@ -69,7 +69,6 @@ private[sync] class OxProcessor[A, B](
         requestsSubscription.request(1)
         e
       })
-      
       val channelSubscription = new ChannelSubscription(wrappedSubscriber, outgoingResponses)
       subscriber.onSubscribe(channelSubscription)
       channelSubscription.runBlocking() // run the main loop which reads from the channel if there's demand
@@ -104,4 +103,3 @@ private[sync] class OxProcessor[A, B](
             s"$requestsSubscription violated the Reactive Streams rule 3.15 by throwing an exception from cancel.",
             t
           )
-

--- a/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/internal/ws/OxSourceWebSocketProcessor.scala
+++ b/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/internal/ws/OxSourceWebSocketProcessor.scala
@@ -70,8 +70,7 @@ private[sync] object OxSourceWebSocketProcessor:
     else s
 
   private def optionallyPassThroughCloseFrame(doPassThrough: Boolean)(s: Source[WebSocketFrame])(using Ox): Source[WebSocketFrame] =
-    s.takeWhile(
-      _ match {
+    s.takeWhile({
         case _: WebSocketFrame.Close => false
         case _                       => true
       },

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerWebSocketTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerWebSocketTests.scala
@@ -186,6 +186,35 @@ abstract class ServerWebSocketTests[F[_], S <: Streams[S], OPTIONS, ROUTE](
         )
     },
     testServer(
+      endpoint.out(
+        webSocketBody[Option[String], CodecFormat.TextPlain, String, CodecFormat.TextPlain](streams)
+          .decodeCloseRequests(true)
+      ),
+      "decode close requests"
+    )((_: Unit) =>
+      pureResult(
+        functionToPipe((s: Option[String]) => s"echo: ${s.getOrElse("close")}")
+          .asRight[Unit]
+      )
+    ) { (backend, baseUri) =>
+      basicRequest
+        .response(asWebSocket { (ws: WebSocket[IO]) =>
+          for {
+            _ <- ws.sendText("test1")
+            _ <- ws.close()
+            m1 <- ws.receiveText()
+            m2 <- ws.receiveText()
+            m3 <- ws.eitherClose(ws.receiveText())
+            closeAsStr = m3.fold(_.statusCode.toString, identity)
+          } yield List(m1, m2, closeAsStr)
+        })
+        .get(baseUri.scheme("ws"))
+        .send(backend)
+        .map(
+          _.body shouldBe Right(List("echo: test1", "echo: close", "1000"))
+        )
+    },
+    testServer(
       endpoint.out(webSocketBody[String, CodecFormat.TextPlain, String, CodecFormat.TextPlain](streams)),
       "empty client stream"
     )((_: Unit) => pureResult(emptyPipe.asRight[Unit])) { (backend, baseUri) =>
@@ -315,52 +344,55 @@ abstract class ServerWebSocketTests[F[_], S <: Streams[S], OPTIONS, ROUTE](
       )
     else List.empty
 
-  val frameConcatenationTests = if (frameConcatenation) List(
-    testServer(
-      endpoint.out(
-        webSocketBody[String, CodecFormat.TextPlain, String, CodecFormat.TextPlain](streams)
-          .autoPing(None)
-          .autoPongOnPing(false)
-          .concatenateFragmentedFrames(true)
-      ),
-      "concatenate fragmented text frames"
-    )((_: Unit) => pureResult(stringEcho.asRight[Unit])) { (backend, baseUri) =>
-      basicRequest
-        .response(asWebSocket { (ws: WebSocket[IO]) =>
-          for {
-            _ <- ws.send(WebSocketFrame.Text("f1", finalFragment = false, None))
-            _ <- ws.sendText("f2")
-            r <- ws.receiveText()
-            _ <- ws.close()
-          } yield r
-        })
-        .get(baseUri.scheme("ws"))
-        .send(backend)
-        .map { _.body shouldBe (Right("echo: f1f2")) }
-    },
-    testServer(
-      endpoint.out(
-        webSocketBody[Array[Byte], CodecFormat.OctetStream, String, CodecFormat.TextPlain](streams)
-          .autoPing(None)
-          .autoPongOnPing(false)
-          .concatenateFragmentedFrames(true)
-      ),
-      "concatenate fragmented binary frames"
-    )((_: Unit) => pureResult(functionToPipe((bs: Array[Byte]) => s"echo: ${new String(bs)}").asRight[Unit])) { (backend, baseUri) =>
-      basicRequest
-        .response(asWebSocket { (ws: WebSocket[IO]) =>
-          for {
-            _ <- ws.send(WebSocketFrame.Binary("frame1-bytes;".getBytes(), finalFragment = false, None))
-            _ <- ws.sendBinary("frame2-bytes".getBytes())
-            r <- ws.receiveText()
-            _ <- ws.close()
-          } yield r
-        })
-        .get(baseUri.scheme("ws"))
-        .send(backend)
-        .map { _.body shouldBe (Right("echo: frame1-bytes;frame2-bytes")) }
-    }
-  ) else Nil
+  val frameConcatenationTests =
+    if (frameConcatenation)
+      List(
+        testServer(
+          endpoint.out(
+            webSocketBody[String, CodecFormat.TextPlain, String, CodecFormat.TextPlain](streams)
+              .autoPing(None)
+              .autoPongOnPing(false)
+              .concatenateFragmentedFrames(true)
+          ),
+          "concatenate fragmented text frames"
+        )((_: Unit) => pureResult(stringEcho.asRight[Unit])) { (backend, baseUri) =>
+          basicRequest
+            .response(asWebSocket { (ws: WebSocket[IO]) =>
+              for {
+                _ <- ws.send(WebSocketFrame.Text("f1", finalFragment = false, None))
+                _ <- ws.sendText("f2")
+                r <- ws.receiveText()
+                _ <- ws.close()
+              } yield r
+            })
+            .get(baseUri.scheme("ws"))
+            .send(backend)
+            .map { _.body shouldBe (Right("echo: f1f2")) }
+        },
+        testServer(
+          endpoint.out(
+            webSocketBody[Array[Byte], CodecFormat.OctetStream, String, CodecFormat.TextPlain](streams)
+              .autoPing(None)
+              .autoPongOnPing(false)
+              .concatenateFragmentedFrames(true)
+          ),
+          "concatenate fragmented binary frames"
+        )((_: Unit) => pureResult(functionToPipe((bs: Array[Byte]) => s"echo: ${new String(bs)}").asRight[Unit])) { (backend, baseUri) =>
+          basicRequest
+            .response(asWebSocket { (ws: WebSocket[IO]) =>
+              for {
+                _ <- ws.send(WebSocketFrame.Binary("frame1-bytes;".getBytes(), finalFragment = false, None))
+                _ <- ws.sendBinary("frame2-bytes".getBytes())
+                r <- ws.receiveText()
+                _ <- ws.close()
+              } yield r
+            })
+            .get(baseUri.scheme("ws"))
+            .send(backend)
+            .map { _.body shouldBe (Right("echo: frame1-bytes;frame2-bytes")) }
+        }
+      )
+    else Nil
 
   val handlePongTests =
     if (handlePong)


### PR DESCRIPTION
Fixes https://github.com/softwaremill/tapir/issues/3776

With this fix, netty-cats and netty-sync backends should handle `Close` frame sequentially, after all previously received frames are processed.

- [x] depends on https://github.com/softwaremill/ox/pull/151