### PR TITLE
Add Endpoint serverLogicSuccessPure and serverLogicErrorPure

### DIFF
--- a/docs/swagger-ui/src/main/scala/sttp/tapir/swagger/SwaggerUI.scala
+++ b/docs/swagger-ui/src/main/scala/sttp/tapir/swagger/SwaggerUI.scala
@@ -53,7 +53,7 @@ object SwaggerUI {
         // #2396: although application/yaml is not official, that's what swagger ui sends in the accept header
         override def mediaType: MediaType = MediaType("application", "yaml")
       })))
-      .serverLogicPure[F](_ => Right(yaml))
+      .serverLogicSuccessPure[F](_ => yaml)
 
     // swagger-ui webjar comes with the petstore pre-configured; this cannot be changed at runtime
     // (see https://github.com/softwaremill/tapir/issues/1695), hence replacing the address in the served document
@@ -69,7 +69,7 @@ object SwaggerUI {
 
     val textJavascriptUtf8: EndpointIO.Body[String, String] = stringBodyUtf8AnyFormat(Codec.string.format(CodecFormat.TextJavascript()))
     val swaggerInitializerJsEndpoint =
-      baseEndpoint.in("swagger-initializer.js").out(textJavascriptUtf8).serverLogicPure[F](_ => Right(swaggerInitializerJsWithOptions))
+      baseEndpoint.in("swagger-initializer.js").out(textJavascriptUtf8).serverLogicSuccessPure[F](_ => swaggerInitializerJsWithOptions)
 
     val resourcesEndpoint = staticResourcesGetServerEndpoint[F](prefixInput)(
       SwaggerUI.getClass.getClassLoader,
@@ -84,10 +84,10 @@ object SwaggerUI {
         .in(queryParams)
         .in(lastSegmentInput)
         .out(redirectOutput)
-        .serverLogicPure[F] { case (params, lastSegment) =>
+        .serverLogicSuccessPure[F] { case (params, lastSegment) =>
           val queryString = if (params.toSeq.nonEmpty) s"?${params.toString}" else ""
           val path = if (options.useRelativePaths) lastSegment.map(str => s"$str/").getOrElse("") else ""
-          Right(s"${concat(fullPathPrefix, path + queryString)}")
+          s"${concat(fullPathPrefix, path + queryString)}"
         }
 
       List(yamlEndpoint, redirectToSlashEndpoint, swaggerInitializerJsEndpoint, resourcesEndpoint)

--- a/server/core/src/test/scala/sttp/tapir/server/interpreter/FilterServerEndpointsTest.scala
+++ b/server/core/src/test/scala/sttp/tapir/server/interpreter/FilterServerEndpointsTest.scala
@@ -137,7 +137,7 @@ class FilterServerEndpointsTest extends AnyFlatSpec with Matchers {
   }
 
   implicit class NoLogic[I, E](e: PublicEndpoint[I, E, Unit, Any]) {
-    def noLogic: ServerEndpoint[Any, Future] = e.serverLogicPure[Future](_ => Right(()))
+    def noLogic: ServerEndpoint[Any, Future] = e.serverLogicSuccessPure[Future](_ => ())
   }
 
   def requestWithPath(path: String): ServerRequest = new ServerRequest {


### PR DESCRIPTION
This PR adds two methods to `Endpoint` to avoid boilerplates 

- `serverLogicSuccessPure` - For cases where the result is always a pure success ( healthcheck, stream*, etc... )
- `serverLogicErrorPure` - For cases where the result is always a pure failure 


\* stream = when you build a streamed API the logic is `F[Either[E, Stream[...]]]` since the errors and the side effects will be handled by the stream you often have to write `.serverLogicSuccess(i => myStream(i).pure[F])`. with `serverLogicSuccessPure` you can avoid that small boiler plate when needed.

I also wonder if it would be useful to add something like `serverStreamLogic` which is equals to `serverLogicSuccessPure` but have the constraints that the output is a stream ( Idk if this is feasible ). The advantages in this case are just the readability and the clarity of the code 