### PR TITLE
Improve PlayServerInterpreter.toRoutes

### DIFF
--- a/perf-tests/README.md
+++ b/perf-tests/README.md
@@ -31,7 +31,7 @@ sbt -Dtapir.perf.user-count=100 -Dtapir.perf.duration-seconds=60
 ```
 or within an already running interactive sbt session:
 ```
-set ThisBuild/javaOptions += ""-Dtapir.perf.user-count=100"
+set ThisBuild/javaOptions += "-Dtapir.perf.user-count=100"
 ```
 If not set, default values will be used (see `sttp.tapir.perf.CommonSimulations`).
 

--- a/perf-tests/src/test/scala/sttp/tapir/perf/Simulations.scala
+++ b/perf-tests/src/test/scala/sttp/tapir/perf/Simulations.scala
@@ -76,7 +76,7 @@ object CommonSimulations {
     )
       .exec(handleLatencyHistogram(histogram, warmup))
 
-    scenario(s"Repeatedly invoke POST with short string body")
+    scenario(s"${namePrefix(warmup)} Repeatedly invoke POST with short string body")
       .during(duration(warmup))(execHttpPost)
       .inject(atOnceUsers(userCount))
       .protocols(httpProtocol)
@@ -92,7 +92,7 @@ object CommonSimulations {
     )
       .exec(handleLatencyHistogram(histogram, warmup))
 
-    scenario(s"Repeatedly invoke POST with short byte array body")
+    scenario(s"${namePrefix(warmup)} Repeatedly invoke POST with short byte array body")
       .during(duration(warmup))(execHttpPost)
       .inject(atOnceUsers(userCount))
       .protocols(httpProtocol)
@@ -108,7 +108,7 @@ object CommonSimulations {
     )
       .exec(handleLatencyHistogram(histogram, warmup))
 
-    scenario(s"Repeatedly invoke POST with large byte array")
+    scenario(s"${namePrefix(warmup)} Repeatedly invoke POST with large byte array")
       .during(duration(warmup))(execHttpPost)
       .inject(atOnceUsers(userCount))
       .protocols(httpProtocol)
@@ -124,7 +124,7 @@ object CommonSimulations {
     )
       .exec(handleLatencyHistogram(histogram, warmup))
 
-    scenario(s"Repeatedly invoke POST with large byte array, interpreted to a String")
+    scenario(s"${namePrefix(warmup)} Repeatedly invoke POST with large byte array, interpreted to a String")
       .during(duration(warmup))(execHttpPost)
       .inject(atOnceUsers(userCount))
       .protocols(httpProtocol)

--- a/server/play29-server/src/main/scala/sttp/tapir/server/play/PlayServerInterpreter.scala
+++ b/server/play29-server/src/main/scala/sttp/tapir/server/play/PlayServerInterpreter.scala
@@ -43,6 +43,16 @@ trait PlayServerInterpreter {
     val filterServerEndpoints = FilterServerEndpoints(serverEndpoints)
     val singleEndpoint = serverEndpoints.size == 1
 
+    implicit val bodyListener: BodyListener[Future, PlayResponseBody] = new PlayBodyListener
+
+    val interpreter = new ServerInterpreter(
+      filterServerEndpoints,
+      new PlayRequestBody(playServerOptions),
+      new PlayToResponseBody,
+      playServerOptions.interceptors,
+      playServerOptions.deleteFile
+    )
+
     new PartialFunction[RequestHeader, Handler] {
       override def isDefinedAt(request: RequestHeader): Boolean = {
         val filtered = filterServerEndpoints(PlayServerRequest(request, request))
@@ -76,15 +86,7 @@ trait PlayServerInterpreter {
           header: RequestHeader,
           request: Request[AkkaStreams.BinaryStream]
       ): Future[Either[Result, Flow[Message, Message, Any]]] = {
-        implicit val bodyListener: BodyListener[Future, PlayResponseBody] = new PlayBodyListener
         val serverRequest = PlayServerRequest(header, request)
-        val interpreter = new ServerInterpreter(
-          filterServerEndpoints,
-          new PlayRequestBody(playServerOptions),
-          new PlayToResponseBody,
-          playServerOptions.interceptors,
-          playServerOptions.deleteFile
-        )
 
         interpreter(serverRequest)
           .map {


### PR DESCRIPTION
Related issue: https://github.com/softwaremill/tapir/issues/3549

This PR makes the following changes:
- in `PlayServerInterpreter.toRoutes`, avoid instantiating a `ServerInterpreter` for each request.
- Fix scenario names in `Simulations.scala`, to avoid a runtime error related to duplicate names.

-------------

I ran some of the gatling tests a couple times (as explained in the perf-tests [README](https://github.com/softwaremill/tapir/blob/master/perf-tests/README.md)), and this change seems to increase throughput.

I started a server using 
```
perfTests/runMain sttp.tapir.perf.apis.ServerRunner play.Tapir
```

Then I ran the tests using
```
perfTests/Gatling/testOnly sttp.tapir.perf.SimpleGetSimulation
perfTests/Gatling/testOnly sttp.tapir.perf.PostLongBytesSimulation
```

### SimpleGetSimulation
1) Without the changes of this PR

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                    1174121 (OK=1174121 KO=0     )
> min response time                                      0 (OK=0      KO=-     )
> max response time                                    427 (OK=427    KO=-     )
> mean response time                                     1 (OK=1      KO=-     )
> std deviation                                          5 (OK=5      KO=-     )
> response time 50th percentile                          1 (OK=1      KO=-     )
> response time 75th percentile                          1 (OK=1      KO=-     )
> response time 95th percentile                          2 (OK=2      KO=-     )
> response time 99th percentile                          5 (OK=5      KO=-     )
> mean requests/sec                                27955.26 (OK=27955.26 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                       1174121 (   100%)
> 800 ms <= t < 1200 ms                                  0 (     0%)
> t >= 1200 ms                                           0 (     0%)
> failed                                                 0 (     0%)
================================================================================

================================================================================
---- Global Information --------------------------------------------------------
> request count                                    1238179 (OK=1238179 KO=0     )
> min response time                                      0 (OK=0      KO=-     )
> max response time                                    386 (OK=386    KO=-     )
> mean response time                                     1 (OK=1      KO=-     )
> std deviation                                          5 (OK=5      KO=-     )
> response time 50th percentile                          1 (OK=1      KO=-     )
> response time 75th percentile                          1 (OK=1      KO=-     )
> response time 95th percentile                          2 (OK=2      KO=-     )
> response time 99th percentile                          5 (OK=5      KO=-     )
> mean requests/sec                                29480.45 (OK=29480.45 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                       1238179 (   100%)
> 800 ms <= t < 1200 ms                                  0 (     0%)
> t >= 1200 ms                                           0 (     0%)
> failed                                                 0 (     0%)
================================================================================

================================================================================
---- Global Information --------------------------------------------------------
> request count                                    1259757 (OK=1259757 KO=0     )
> min response time                                      0 (OK=0      KO=-     )
> max response time                                    449 (OK=449    KO=-     )
> mean response time                                     1 (OK=1      KO=-     )
> std deviation                                          5 (OK=5      KO=-     )
> response time 50th percentile                          1 (OK=1      KO=-     )
> response time 75th percentile                          1 (OK=1      KO=-     )
> response time 95th percentile                          2 (OK=2      KO=-     )
> response time 99th percentile                          4 (OK=4      KO=-     )
> mean requests/sec                                29994.21 (OK=29994.21 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                       1259757 (   100%)
> 800 ms <= t < 1200 ms                                  0 (     0%)
> t >= 1200 ms                                           0 (     0%)
> failed                                                 0 (     0%)
================================================================================
```

2) With the changes of this PR

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                    1210686 (OK=1210686 KO=0     )
> min response time                                      0 (OK=0      KO=-     )
> max response time                                    514 (OK=514    KO=-     )
> mean response time                                     1 (OK=1      KO=-     )
> std deviation                                          5 (OK=5      KO=-     )
> response time 50th percentile                          1 (OK=1      KO=-     )
> response time 75th percentile                          1 (OK=1      KO=-     )
> response time 95th percentile                          2 (OK=2      KO=-     )
> response time 99th percentile                          5 (OK=5      KO=-     )
> mean requests/sec                                28825.86 (OK=28825.86 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                       1210686 (   100%)
> 800 ms <= t < 1200 ms                                  0 (     0%)
> t >= 1200 ms                                           0 (     0%)
> failed                                                 0 (     0%)
================================================================================

================================================================================
---- Global Information --------------------------------------------------------
> request count                                    1287812 (OK=1287812 KO=0     )
> min response time                                      0 (OK=0      KO=-     )
> max response time                                    427 (OK=427    KO=-     )
> mean response time                                     1 (OK=1      KO=-     )
> std deviation                                          5 (OK=5      KO=-     )
> response time 50th percentile                          1 (OK=1      KO=-     )
> response time 75th percentile                          1 (OK=1      KO=-     )
> response time 95th percentile                          2 (OK=2      KO=-     )
> response time 99th percentile                          4 (OK=4      KO=-     )
> mean requests/sec                                30662.19 (OK=30662.19 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                       1287812 (   100%)
> 800 ms <= t < 1200 ms                                  0 (     0%)
> t >= 1200 ms                                           0 (     0%)
> failed                                                 0 (     0%)
================================================================================

================================================================================
---- Global Information --------------------------------------------------------
> request count                                    1314742 (OK=1314742 KO=0     )
> min response time                                      0 (OK=0      KO=-     )
> max response time                                    382 (OK=382    KO=-     )
> mean response time                                     1 (OK=1      KO=-     )
> std deviation                                          6 (OK=6      KO=-     )
> response time 50th percentile                          1 (OK=1      KO=-     )
> response time 75th percentile                          1 (OK=1      KO=-     )
> response time 95th percentile                          2 (OK=2      KO=-     )
> response time 99th percentile                          4 (OK=4      KO=-     )
> mean requests/sec                                31303.38 (OK=31303.38 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                       1314742 (   100%)
> 800 ms <= t < 1200 ms                                  0 (     0%)
> t >= 1200 ms                                           0 (     0%)
> failed                                                 0 (     0%)
================================================================================

```



### PostLongBytesSimulation
1) Without the changes of this PR

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      17099 (OK=17099  KO=0     )
> min response time                                      7 (OK=7      KO=-     )
> max response time                                   1227 (OK=1227   KO=-     )
> mean response time                                    70 (OK=70     KO=-     )
> std deviation                                         77 (OK=77     KO=-     )
> response time 50th percentile                         49 (OK=49     KO=-     )
> response time 75th percentile                         84 (OK=84     KO=-     )
> response time 95th percentile                        158 (OK=158    KO=-     )
> response time 99th percentile                        388 (OK=388    KO=-     )
> mean requests/sec                                 407.12 (OK=407.12 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                         17072 ( 99.84%)
> 800 ms <= t < 1200 ms                                 21 (  0.12%)
> t >= 1200 ms                                           6 (  0.04%)
> failed                                                 0 (     0%)
================================================================================


================================================================================
---- Global Information --------------------------------------------------------
> request count                                      21473 (OK=21473  KO=0     )
> min response time                                      2 (OK=2      KO=-     )
> max response time                                    836 (OK=836    KO=-     )
> mean response time                                    55 (OK=55     KO=-     )
> std deviation                                         62 (OK=62     KO=-     )
> response time 50th percentile                         33 (OK=33     KO=-     )
> response time 75th percentile                         70 (OK=70     KO=-     )
> response time 95th percentile                        143 (OK=143    KO=-     )
> response time 99th percentile                        367 (OK=367    KO=-     )
> mean requests/sec                                 511.26 (OK=511.26 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                         21470 ( 99.99%)
> 800 ms <= t < 1200 ms                                  3 (  0.01%)
> t >= 1200 ms                                           0 (     0%)
> failed                                                 0 (     0%)
================================================================================

```

2) With the changes of this PR

```
================================================================================
---- Global Information --------------------------------------------------------
> request count                                      32840 (OK=32840  KO=0     )
> min response time                                      3 (OK=3      KO=-     )
> max response time                                    477 (OK=477    KO=-     )
> mean response time                                    36 (OK=36     KO=-     )
> std deviation                                         37 (OK=37     KO=-     )
> response time 50th percentile                         24 (OK=24     KO=-     )
> response time 75th percentile                         35 (OK=35     KO=-     )
> response time 95th percentile                        124 (OK=125    KO=-     )
> response time 99th percentile                        168 (OK=168    KO=-     )
> mean requests/sec                                  781.9 (OK=781.9  KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                         32840 (   100%)
> 800 ms <= t < 1200 ms                                  0 (     0%)
> t >= 1200 ms                                           0 (     0%)
> failed                                                 0 (     0%)
================================================================================



================================================================================
---- Global Information --------------------------------------------------------
> request count                                      35517 (OK=35517  KO=0     )
> min response time                                      3 (OK=3      KO=-     )
> max response time                                    856 (OK=856    KO=-     )
> mean response time                                    33 (OK=33     KO=-     )
> std deviation                                         36 (OK=36     KO=-     )
> response time 50th percentile                         22 (OK=22     KO=-     )
> response time 75th percentile                         31 (OK=31     KO=-     )
> response time 95th percentile                        121 (OK=121    KO=-     )
> response time 99th percentile                        161 (OK=161    KO=-     )
> mean requests/sec                                 845.64 (OK=845.64 KO=-     )
---- Response Time Distribution ------------------------------------------------
> t < 800 ms                                         35515 ( 99.99%)
> 800 ms <= t < 1200 ms                                  2 (  0.01%)
> t >= 1200 ms                                           0 (     0%)
> failed                                                 0 (     0%)
================================================================================
```