### PR TITLE
Refined: Treat fields with NonEmpty or MinSize(>0) as required

### DIFF
--- a/integrations/refined/src/test/scala-2/sttp/tapir/codec/refined/TapirCodecRefinedTestScala2.scala
+++ b/integrations/refined/src/test/scala-2/sttp/tapir/codec/refined/TapirCodecRefinedTestScala2.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.codec.refined
 
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.boolean.Or
+import eu.timepit.refined.boolean._
 import eu.timepit.refined.collection.{MaxSize, MinSize, NonEmpty}
 import eu.timepit.refined.numeric.{Greater, GreaterEqual, Interval, Less, LessEqual}
 import eu.timepit.refined.string.MatchesRegex
@@ -157,6 +157,17 @@ class TapirCodecRefinedTestScala2 extends AnyFlatSpec with Matchers with TapirCo
     implicitly[Schema[LimitedInt]].validator should matchPattern {
       case Validator.Mapped(Validator.Any(List(Validator.Min(3, true), Validator.Max(-3, true))), _) =>
     }
+  }
+
+  "Generated schema for NonEmpty and MinSize" should "not be optional" in {
+    assert(implicitly[Schema[List[Int]]].isOptional)
+    assert(!implicitly[Schema[List[Int] Refined NonEmpty]].isOptional)
+    assert(!implicitly[Schema[Set[Int] Refined NonEmpty]].isOptional)
+    assert(!implicitly[Schema[List[Int] Refined MinSize[W.`3`.T]]].isOptional)
+    assert(!implicitly[Schema[List[Int] Refined (MinSize[W.`3`.T] And MaxSize[W.`6`.T])]].isOptional)
+    assert(implicitly[Schema[List[Int] Refined MinSize[W.`0`.T]]].isOptional)
+    assert(implicitly[Schema[List[Int] Refined MaxSize[W.`5`.T]]].isOptional)
+    assert(implicitly[Schema[Option[List[Int] Refined NonEmpty]]].isOptional)
   }
 
   "TapirCodecRefined" should "compile using implicit schema for refined types" in {

--- a/integrations/refined/src/test/scala-3/sttp/tapir/codec/refined/TapirCodecRefinedTestScala3.scala
+++ b/integrations/refined/src/test/scala-3/sttp/tapir/codec/refined/TapirCodecRefinedTestScala3.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.codec.refined
 
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.boolean.Or
+import eu.timepit.refined.boolean.*
 import eu.timepit.refined.collection.{MaxSize, MinSize, NonEmpty}
 import eu.timepit.refined.numeric.{Greater, GreaterEqual, Interval, Less, LessEqual}
 import eu.timepit.refined.string.MatchesRegex
@@ -160,6 +160,17 @@ class TapirCodecRefinedTestScala3 extends AnyFlatSpec with Matchers with TapirCo
     implicitly[Schema[LimitedInt]].validator should matchPattern {
       case Validator.Mapped(Validator.Any(List(Validator.Min(3, true), Validator.Max(-3, true))), _) =>
     }
+  }
+  
+  "Generated schema for NonEmpty and MinSize" should "not be optional" in {    
+    assert(implicitly[Schema[List[Int]]].isOptional)
+    assert(!implicitly[Schema[List[Int] Refined NonEmpty]].isOptional)
+    assert(!implicitly[Schema[Set[Int] Refined NonEmpty]].isOptional)
+    assert(!implicitly[Schema[List[Int] Refined MinSize[3]]].isOptional)
+    assert(!implicitly[Schema[List[Int] Refined (MinSize[3] And MaxSize[6])]].isOptional)
+    assert(implicitly[Schema[List[Int] Refined MinSize[0]]].isOptional)
+    assert(implicitly[Schema[List[Int] Refined MaxSize[5]]].isOptional)
+    assert(implicitly[Schema[Option[List[Int] Refined NonEmpty]]].isOptional)
   }
 
   "TapirCodecRefined" should "compile using implicit schema for refined types" in {

--- a/integrations/refined/src/test/scala-3/sttp/tapir/codec/refined/TapirCodecRefinedTestScala3.scala
+++ b/integrations/refined/src/test/scala-3/sttp/tapir/codec/refined/TapirCodecRefinedTestScala3.scala
@@ -3,8 +3,8 @@ package sttp.tapir.codec.refined
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.boolean.Or
 import eu.timepit.refined.collection.{MaxSize, MinSize, NonEmpty}
-import eu.timepit.refined.numeric.{Greater, GreaterEqual, Interval, Less, LessEqual, Negative, NonNegative, NonPositive, Positive}
-import eu.timepit.refined.string.{IPv4, MatchesRegex}
+import eu.timepit.refined.numeric.{Greater, GreaterEqual, Interval, Less, LessEqual}
+import eu.timepit.refined.string.MatchesRegex
 import eu.timepit.refined.types.string.NonEmptyString
 import eu.timepit.refined.refineV
 import org.scalatest.flatspec.AnyFlatSpec

--- a/integrations/refined/src/test/scala/sttp/tapir/codec/refined/TapirCodecRefinedTest.scala
+++ b/integrations/refined/src/test/scala/sttp/tapir/codec/refined/TapirCodecRefinedTest.scala
@@ -1,6 +1,8 @@
 package sttp.tapir.codec.refined
 
 import eu.timepit.refined.api.Refined
+import eu.timepit.refined.boolean._
+import eu.timepit.refined.collection._
 import eu.timepit.refined.numeric.{Negative, NonNegative, NonPositive, Positive}
 import eu.timepit.refined.string.IPv4
 import eu.timepit.refined.types.string.NonEmptyString
@@ -59,6 +61,17 @@ class TapirCodecRefinedTest extends AnyFlatSpec with Matchers with TapirCodecRef
     implicitly[Schema[LimitedInt]].validator should matchPattern { case Validator.Mapped(Validator.Max(0, true), _) => }
   }
 
+  "Generated schema for NonEmpty and MinSize" should "not be optional" in {    
+    assert(implicitly[Schema[List[Int]]].isOptional)
+    assert(!implicitly[Schema[List[Int] Refined NonEmpty]].isOptional)
+    assert(!implicitly[Schema[Set[Int] Refined NonEmpty]].isOptional)
+    assert(!implicitly[Schema[List[Int] Refined MinSize[3]]].isOptional)
+    assert(!implicitly[Schema[List[Int] Refined (MinSize[3] And MaxSize[6])]].isOptional)
+    assert(implicitly[Schema[List[Int] Refined MinSize[0]]].isOptional)
+    assert(implicitly[Schema[List[Int] Refined MaxSize[5]]].isOptional)
+    assert(implicitly[Schema[Option[List[Int] Refined NonEmpty]]].isOptional)
+  }
+  
   "Using refined" should "compile when using tapir endpoints" in {
     // this used to cause a:
     // [error] java.lang.StackOverflowError

--- a/integrations/refined/src/test/scala/sttp/tapir/codec/refined/TapirCodecRefinedTest.scala
+++ b/integrations/refined/src/test/scala/sttp/tapir/codec/refined/TapirCodecRefinedTest.scala
@@ -1,8 +1,6 @@
 package sttp.tapir.codec.refined
 
 import eu.timepit.refined.api.Refined
-import eu.timepit.refined.boolean._
-import eu.timepit.refined.collection._
 import eu.timepit.refined.numeric.{Negative, NonNegative, NonPositive, Positive}
 import eu.timepit.refined.string.IPv4
 import eu.timepit.refined.types.string.NonEmptyString
@@ -61,17 +59,6 @@ class TapirCodecRefinedTest extends AnyFlatSpec with Matchers with TapirCodecRef
     implicitly[Schema[LimitedInt]].validator should matchPattern { case Validator.Mapped(Validator.Max(0, true), _) => }
   }
 
-  "Generated schema for NonEmpty and MinSize" should "not be optional" in {    
-    assert(implicitly[Schema[List[Int]]].isOptional)
-    assert(!implicitly[Schema[List[Int] Refined NonEmpty]].isOptional)
-    assert(!implicitly[Schema[Set[Int] Refined NonEmpty]].isOptional)
-    assert(!implicitly[Schema[List[Int] Refined MinSize[3]]].isOptional)
-    assert(!implicitly[Schema[List[Int] Refined (MinSize[3] And MaxSize[6])]].isOptional)
-    assert(implicitly[Schema[List[Int] Refined MinSize[0]]].isOptional)
-    assert(implicitly[Schema[List[Int] Refined MaxSize[5]]].isOptional)
-    assert(implicitly[Schema[Option[List[Int] Refined NonEmpty]]].isOptional)
-  }
-  
   "Using refined" should "compile when using tapir endpoints" in {
     // this used to cause a:
     // [error] java.lang.StackOverflowError


### PR DESCRIPTION
Fixes https://github.com/softwaremill/tapir/issues/3828

- Schemas for types with refined constrains `MinSize`, `MaxSize` and `NonEmpty` will now get proper non-custom validators, translated to `minItems` and `maxItems` properties in specs.
- Schemas for types validated with `MinSize` will now be marked as required (`optional = false`)

Example fields:
```scala
    nicknames: List[String Refined (MinSize[3] And MaxSize[6])] Refined NonEmpty,
    nicknames2: List[String Refined MinSize[4]] Refined (MaxSize[7] And MinSize[2]),
    nicknames3: List[String] Refined MaxSize[50]
```
Docs:
![image](https://github.com/softwaremill/tapir/assets/1413553/5034ec10-5109-495b-871b-c190cad716a7)
