### PR TITLE
Play: Optimize usages of `route`

### DIFF
--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerWithContextTest.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayServerWithContextTest.scala
@@ -27,7 +27,7 @@ class PlayServerWithContextTest(backend: SttpBackend[IO, Fs2Streams[IO] with Web
       val components = new DefaultPekkoHttpServerComponents {
         override lazy val serverConfig: ServerConfig = ServerConfig(port = Some(0), address = "127.0.0.1", mode = Mode.Test)
         override lazy val actorSystem: ActorSystem = ActorSystem("tapir", defaultExecutionContext = Some(_actorSystem.dispatcher))
-        override def router: Router = Router.from(PlayServerInterpreter().toRoutes(e)).withPrefix("/test")
+        override lazy val router: Router = Router.from(PlayServerInterpreter().toRoutes(e)).withPrefix("/test")
       }
       val s = components.server
       val r = Future.successful(()).flatMap { _ =>
@@ -49,7 +49,7 @@ class PlayServerWithContextTest(backend: SttpBackend[IO, Fs2Streams[IO] with Web
       val components = new DefaultPekkoHttpServerComponents {
         override lazy val serverConfig: ServerConfig = ServerConfig(port = Some(0), address = "127.0.0.1", mode = Mode.Test)
         override lazy val actorSystem: ActorSystem = ActorSystem("tapir", defaultExecutionContext = Some(_actorSystem.dispatcher))
-        override def router: Router = Router.from(PlayServerInterpreter().toRoutes(e)).withPrefix("/test")
+        override lazy val router: Router = Router.from(PlayServerInterpreter().toRoutes(e)).withPrefix("/test")
       }
       val s = components.server
       val r = basicRequest

--- a/server/play-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
+++ b/server/play-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
@@ -48,7 +48,7 @@ class PlayTestServerInterpreter(implicit actorSystem: ActorSystem)
         initialServerConfig.copy(configuration = customConf.withFallback(initialServerConfig.configuration))
       override lazy val actorSystem: ActorSystem =
         ActorSystem("tapir", defaultExecutionContext = Some(PlayTestServerInterpreter.this.actorSystem.dispatcher))
-      override def router: Router =
+      override lazy val router: Router =
         Router.from(
           routes.reduce((a: Routes, b: Routes) => {
             val handler: PartialFunction[RequestHeader, Handler] = { case request =>

--- a/server/play29-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
+++ b/server/play29-server/src/test/scala/sttp/tapir/server/play/PlayServerTest.scala
@@ -1,7 +1,6 @@
 package sttp.tapir.server.play
 
 import akka.actor.ActorSystem
-import enumeratum._
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
@@ -17,8 +16,6 @@ import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
 
 import scala.concurrent.Future
-import sttp.tapir.codec.enumeratum.TapirCodecEnumeratum
-import sttp.tapir.server.interceptor.decodefailure.DefaultDecodeFailureHandler
 
 class PlayServerTest extends TestSuite {
 

--- a/server/play29-server/src/test/scala/sttp/tapir/server/play/PlayServerWithContextTest.scala
+++ b/server/play29-server/src/test/scala/sttp/tapir/server/play/PlayServerWithContextTest.scala
@@ -27,7 +27,7 @@ class PlayServerWithContextTest(backend: SttpBackend[IO, Fs2Streams[IO] with Web
       val components = new DefaultAkkaHttpServerComponents {
         override lazy val serverConfig: ServerConfig = ServerConfig(port = Some(0), address = "127.0.0.1", mode = Mode.Test)
         override lazy val actorSystem: ActorSystem = ActorSystem("tapir", defaultExecutionContext = Some(_actorSystem.dispatcher))
-        override def router: Router = Router.from(PlayServerInterpreter().toRoutes(e)).withPrefix("/test")
+        override lazy val router: Router = Router.from(PlayServerInterpreter().toRoutes(e)).withPrefix("/test")
       }
       val s = components.server
       val r = Future.successful(()).flatMap { _ =>
@@ -49,7 +49,7 @@ class PlayServerWithContextTest(backend: SttpBackend[IO, Fs2Streams[IO] with Web
       val components = new DefaultAkkaHttpServerComponents {
         override lazy val serverConfig: ServerConfig = ServerConfig(port = Some(0), address = "127.0.0.1", mode = Mode.Test)
         override lazy val actorSystem: ActorSystem = ActorSystem("tapir", defaultExecutionContext = Some(_actorSystem.dispatcher))
-        override def router: Router = Router.from(PlayServerInterpreter().toRoutes(e)).withPrefix("/test")
+        override lazy val router: Router = Router.from(PlayServerInterpreter().toRoutes(e)).withPrefix("/test")
       }
       val s = components.server
       val r = basicRequest

--- a/server/play29-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
+++ b/server/play29-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
@@ -31,8 +31,6 @@ class PlayTestServerInterpreter(implicit actorSystem: ActorSystem)
     PlayServerInterpreter(serverOptions).toRoutes(es)
   }
 
-  import play.core.server.AkkaHttpServer
-
   override def serverWithStop(
       routes: NonEmptyList[Routes],
       gracefulShutdownTimeout: Option[FiniteDuration]
@@ -48,7 +46,7 @@ class PlayTestServerInterpreter(implicit actorSystem: ActorSystem)
         initialServerConfig.copy(configuration = customConf.withFallback(initialServerConfig.configuration))
       override lazy val actorSystem: ActorSystem =
         ActorSystem("tapir", defaultExecutionContext = Some(PlayTestServerInterpreter.this.actorSystem.dispatcher))
-      override def router: Router =
+      override lazy val router: Router =
         Router.from(
           routes.reduce((a: Routes, b: Routes) => {
             val handler: PartialFunction[RequestHeader, Handler] = { case request =>


### PR DESCRIPTION
Closes https://github.com/softwaremill/tapir/issues/3549

Turns out Play calls `DefaultPekkoHttpServerComponents.route` on each request, so we shouldn't rebuild routing in that method. Instead, it should return a pre-calculated value.
This isn't a fix to Tapir per se, but to all usages of the Play server we have in standard tests and performance tests.
Performance tests used to show terrible latency/throughput and Tapir code occupying over 90% of all frames registered by the profiler.
After this fix, the latency is dramatically better (see the blue line):
![image](https://github.com/softwaremill/tapir/assets/1413553/7bdc5de9-9beb-4106-9831-10b7ac5644ef)

Throughput also reaches great values: ~160k reqs/sec vs 5k before the fix. Tapir code occupies no more than 9% of all profiler frames. There may be still some possible optimizations in the late 0.999s of latency to reach values closer to the vanilla server under very heavy load, but at this point I don't see them as necessary.