### PR TITLE
codgegen: Optional query parameters

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -182,8 +182,7 @@ class EndpointGenerator {
         param.schema match {
           case st: OpenapiSchemaSimpleType =>
             val (t, _) = mapSchemaSimpleTypeToType(st)
-            val required = (param.in != "query") || param.required.getOrElse(true)
-            val req = if (required) t else s"Option[$t]"
+            val req = if (param.required.getOrElse(true)) t else s"Option[$t]"
             val desc = param.description.map(d => JavaEscape.escapeString(d)).fold("")(d => s""".description("$d")""")
             s""".in(${param.in}[$req]("${param.name}")$desc)"""
           case x => bail(s"Can't create non-simple params to input - found $x")

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -182,8 +182,10 @@ class EndpointGenerator {
         param.schema match {
           case st: OpenapiSchemaSimpleType =>
             val (t, _) = mapSchemaSimpleTypeToType(st)
+            val required = (param.in != "query") || param.param.required.getOrElse(true)
+            val req = if (required) t else s"Option[$t]"
             val desc = param.description.map(d => JavaEscape.escapeString(d)).fold("")(d => s""".description("$d")""")
-            s""".in(${param.in}[$t]("${param.name}")$desc)"""
+            s""".in(${param.in}[$req]("${param.name}")$desc)"""
           case x => bail(s"Can't create non-simple params to input - found $x")
         }
       }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -182,7 +182,7 @@ class EndpointGenerator {
         param.schema match {
           case st: OpenapiSchemaSimpleType =>
             val (t, _) = mapSchemaSimpleTypeToType(st)
-            val required = (param.in != "query") || param.param.required.getOrElse(true)
+            val required = (param.in != "query") || param.required.getOrElse(true)
             val req = if (required) t else s"Option[$t]"
             val desc = param.description.map(d => JavaEscape.escapeString(d)).fold("")(d => s""".description("$d")""")
             s""".in(${param.in}[$req]("${param.name}")$desc)"""

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -41,7 +41,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               methodType = "get",
               parameters = Seq(
                 Resolved(OpenapiParameter("asd-id", "path", Some(true), None, OpenapiSchemaString(false))),
-                Resolved(OpenapiParameter("fgh-id", "query", Some(false), None, OpenapiSchemaString(false)))),
+                Resolved(OpenapiParameter("fgh-id", "query", Some(false), None, OpenapiSchemaString(false))),
                 Resolved(OpenapiParameter("jkl-id", "header", Some(false), None, OpenapiSchemaString(false)))),
               responses = Seq(
                 OpenapiResponse(

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -39,7 +39,9 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           Seq(
             OpenapiPathMethod(
               methodType = "get",
-              parameters = Seq(Resolved(OpenapiParameter("asd-id", "path", Some(true), None, OpenapiSchemaString(false)))),
+              parameters = Seq(
+                Resolved(OpenapiParameter("asd-id", "path", Some(true), None, OpenapiSchemaString(false))),
+                Resolved(OpenapiParameter("fgh-id", "query", Some(false), None, OpenapiSchemaString(false)))),
               responses = Seq(
                 OpenapiResponse(
                   "200",
@@ -60,6 +62,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
     val generatedCode = BasicGenerator.imports(JsonSerdeLib.Circe) ++
       new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false).endpointDecls(None)
     generatedCode should include("val getTestAsdId =")
+    generatedCode should include(""".in(query[Option[String]]("fgh-id"))""")
     generatedCode shouldCompile ()
   }
 

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -42,6 +42,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               parameters = Seq(
                 Resolved(OpenapiParameter("asd-id", "path", Some(true), None, OpenapiSchemaString(false))),
                 Resolved(OpenapiParameter("fgh-id", "query", Some(false), None, OpenapiSchemaString(false)))),
+                Resolved(OpenapiParameter("jkl-id", "header", Some(false), None, OpenapiSchemaString(false)))),
               responses = Seq(
                 OpenapiResponse(
                   "200",
@@ -63,6 +64,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       new EndpointGenerator().endpointDefs(doc, useHeadTagForObjectNames = false).endpointDecls(None)
     generatedCode should include("val getTestAsdId =")
     generatedCode should include(""".in(query[Option[String]]("fgh-id"))""")
+    generatedCode should include(""".in(header[Option[String]]("jkl-id"))""")
     generatedCode shouldCompile ()
   }
 


### PR DESCRIPTION
Small change to openapi codegen to make non-required query parameters to generate as `Option[_]` types.