### PR TITLE
Fixes in iron: union, intersection, Not[Empty] and other cases

### DIFF
--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/IntersectionTypeMirror.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/IntersectionTypeMirror.scala
@@ -33,7 +33,12 @@ object IntersectionTypeMirror {
     def rec(tpe: TypeRepr): TypeRepr = {
       tpe.dealias match
         case AndType(left, right) => concatTypes(rec(left), rec(right))
-        case t                    => prependTypes(tpe, TypeRepr.of[EmptyTuple])
+        case t                    =>
+          // Intentionally using `tpe` instead of `t`. Dealiased representation `t` "loses" information 
+          // about the original type from the intersection. For example, an Iron predicate `MinLength[N]` 
+          // would be dealiased to `DescribedAs[Length[GreaterEqual[N]], _]`. 
+          // Then, a given `ValidatorForPredicate[T, MinLength[N]]` would not be used in implicit resolution.
+          prependTypes(tpe, TypeRepr.of[EmptyTuple])
     }
     val tupled =
       TypeRepr.of[A].dealias match {

--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/IntersectionTypeMirror.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/IntersectionTypeMirror.scala
@@ -33,7 +33,7 @@ object IntersectionTypeMirror {
     def rec(tpe: TypeRepr): TypeRepr = {
       tpe.dealias match
         case AndType(left, right) => concatTypes(rec(left), rec(right))
-        case t                    => prependTypes(t, TypeRepr.of[EmptyTuple])
+        case t                    => prependTypes(tpe, TypeRepr.of[EmptyTuple])
     }
     val tupled =
       TypeRepr.of[A].dealias match {

--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
@@ -84,16 +84,16 @@ trait TapirCodecIron extends DescriptionWitness with LowPriorityValidatorForPred
   inline given validatorForMatchesRegexpString[S <: String](using witness: ValueOf[S]): PrimitiveValidatorForPredicate[String, Match[S]] =
     ValidatorForPredicate.fromPrimitiveValidator(Validator.pattern[String](witness.value))
 
-  inline given validatorForMaxSizeOnString[T <: String, NM <: Int](using
+  inline given validatorForMaxLengthOnString[T <: String, NM <: Int](using
       witness: ValueOf[NM]
   ): PrimitiveValidatorForPredicate[T, MaxLength[NM]] =
     ValidatorForPredicate.fromPrimitiveValidator(Validator.maxLength[T](witness.value))
-
-  inline given validatorForMinSizeOnString[T <: String, NM <: Int](using
+ 
+  inline given validatorForMinLengthOnString[T <: String, NM <: Int](using
       witness: ValueOf[NM]
   ): PrimitiveValidatorForPredicate[T, MinLength[NM]] =
     ValidatorForPredicate.fromPrimitiveValidator(Validator.minLength[T](witness.value))
-
+  
   inline given validatorForMinLengthOnIterable[X, C[X] <: Iterable[X], NM <: Int](using
       witness: ValueOf[NM]
   ): PrimitiveValidatorForPredicate[C[X], MinLength[NM]] =
@@ -133,8 +133,8 @@ trait TapirCodecIron extends DescriptionWitness with LowPriorityValidatorForPred
       case _: EmptyTuple => Nil
       case _: (head *: tail) =>
         val headValidator: ValidatorForPredicate[N, ?] = summonFrom {
-          case pv: PrimitiveValidatorForPredicate[N, head] => pv
-          case _                                           => summonInline[ValidatorForPredicate[N, head]]
+          case pv: PrimitiveValidatorForPredicate[N, `head`] => pv
+          case _                                             => summonInline[ValidatorForPredicate[N, head]]
         }
         headValidator.asInstanceOf[ValidatorForPredicate[N, Any]] :: summonValidators[N, tail]
   }
@@ -234,14 +234,14 @@ trait TapirCodecIron extends DescriptionWitness with LowPriorityValidatorForPred
       singleton: ValueOf[Num]
   ): ValidatorForPredicate[N, P] =
     validatorForLessEqual[N, Num].asInstanceOf[ValidatorForPredicate[N, P]]
+
   inline given validatorForDescribedPrimitive[N, P](using
       id: IsDescription[P],
       notUnion: NotGiven[UnionTypeMirror[id.Predicate]],
       notIntersection: NotGiven[IntersectionTypeMirror[id.Predicate]],
-      inline validator: ValidatorForPredicate[N, id.Predicate]
-  ): ValidatorForPredicate[N, P] =
-    validator.asInstanceOf[ValidatorForPredicate[N, P]]
-
+      inline validator: PrimitiveValidatorForPredicate[N, id.Predicate]
+  ): PrimitiveValidatorForPredicate[N, P] =
+    validator.asInstanceOf[PrimitiveValidatorForPredicate[N, P]]
 }
 
 private[iron] trait ValidatorForPredicate[Value, Predicate] {

--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
@@ -88,12 +88,12 @@ trait TapirCodecIron extends DescriptionWitness with LowPriorityValidatorForPred
       witness: ValueOf[NM]
   ): PrimitiveValidatorForPredicate[T, MaxLength[NM]] =
     ValidatorForPredicate.fromPrimitiveValidator(Validator.maxLength[T](witness.value))
- 
+
   inline given validatorForMinLengthOnString[T <: String, NM <: Int](using
       witness: ValueOf[NM]
   ): PrimitiveValidatorForPredicate[T, MinLength[NM]] =
     ValidatorForPredicate.fromPrimitiveValidator(Validator.minLength[T](witness.value))
-  
+
   inline given validatorForMinLengthOnIterable[X, C[X] <: Iterable[X], NM <: Int](using
       witness: ValueOf[NM]
   ): PrimitiveValidatorForPredicate[C[X], MinLength[NM]] =

--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/UnionTypeMirror.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/UnionTypeMirror.scala
@@ -39,7 +39,7 @@ object UnionTypeMirror {
           val (c1, rec1) = rec(left)
           val (c2, rec2) = rec(right)
           (c1 + c2, concatTypes(rec1, rec2))
-        case t => (1, prependTypes(t, TypeRepr.of[EmptyTuple]))
+        case t => (1, prependTypes(tpe, TypeRepr.of[EmptyTuple]))
       }
     val (size, tupled) =
       TypeRepr.of[A].dealias match {

--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/UnionTypeMirror.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/UnionTypeMirror.scala
@@ -39,7 +39,12 @@ object UnionTypeMirror {
           val (c1, rec1) = rec(left)
           val (c2, rec2) = rec(right)
           (c1 + c2, concatTypes(rec1, rec2))
-        case t => (1, prependTypes(tpe, TypeRepr.of[EmptyTuple]))
+        case t => 
+          // Intentionally using `tpe` instead of `t`. Dealiased representation `t` "loses" information 
+          // about the original type from the union. For example, an Iron predicate `MinLength[N]` 
+          // would be dealiased to `DescribedAs[Length[GreaterEqual[N]], _]`. 
+          // Then, a given `ValidatorForPredicate[T, MinLength[N]]` would not be used in implicit resolution.
+          (1, prependTypes(tpe, TypeRepr.of[EmptyTuple]))
       }
     val (size, tupled) =
       TypeRepr.of[A].dealias match {

--- a/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
+++ b/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala
@@ -79,13 +79,12 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
   "Generated schema for described Int with extra constrains" should "apply given constrains" in {
     val schema = implicitly[Schema[Int :| (Positive DescribedAs "Age should be positive")]]
 
-    schema.validator should matchPattern {
-      case Validator.Mapped(Validator.Min(0, true), _) =>
+    schema.validator should matchPattern { case Validator.Mapped(Validator.Min(0, true), _) =>
     }
   }
-  
+
   "Generated schema for described String with extra constrains" should "apply given constrains" in {
-    type Constraint      = (Not[Empty] & Alphanumeric) DescribedAs "name should not be empty and only made of alphanumeric characters"
+    type Constraint = (Not[Empty] & Alphanumeric) DescribedAs "name should not be empty and only made of alphanumeric characters"
     type VariableString = String :| Constraint
     val schema = implicitly[Schema[VariableString]]
 
@@ -99,13 +98,12 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
     codec.decode("954") shouldBe a[DecodeResult.Value[_]]
     codec.decode("spaces not allowed") shouldBe a[DecodeResult.InvalidValue]
   }
-  
+
   "Generated schema for non empty string" should "use a MinLength validator" in {
     type VariableString = String :| Not[Empty]
     val schema = implicitly[Schema[VariableString]]
 
-    schema.validator should matchPattern {
-      case Validator.Mapped(Validator.MinLength(1, false), _) =>
+    schema.validator should matchPattern { case Validator.Mapped(Validator.MinLength(1, false), _) =>
     }
   }
 
@@ -117,7 +115,6 @@ class TapirCodecIronTestScala3 extends AnyFlatSpec with Matchers {
       case Validator.Mapped(Validator.All(List(Validator.MinLength(33, false), Validator.MaxLength(83, false))), _) =>
     }
   }
-  
 
   "Generated codec for Less" should "use tapir Validator.max" in {
     type IntConstraint = Less[3]


### PR DESCRIPTION
Fixes https://github.com/softwaremill/tapir/issues/3830

This PR fixes some bugs in iron integration:
* union and intersection mirrors were using dealiased types, causing predicates like `MinLength` become `DescribedAs[Length[GreaterEqual[0]]], _]`. This made our validator resolution fail.
* union and intersection primitive elements had an issue in `summonFrom`, resulting in wrong validators being resolved

These fixes should cover cases of problematic schema resolution for types with constrains like `DescribedAs`, `String :| Not[Empty]`, unions, intersections, and possibly some other cases.