### PR TITLE
codegen: add openapiAdditionalPackages arg to sbt plugin

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -43,6 +43,7 @@ openapiUseHeadTagForObjectName        false                                If tr
 openapiJsonSerdeLib                   circe                                The json serde library to use.
 openapiValidateNonDiscriminatedOneOfs true                                 Whether to fail if variants of a oneOf without a discriminator cannot be disambiguated.
 openapiMaxSchemasPerFile              400                                  Maximum number of schemas to generate in a single file (tweak if hitting javac class size limits).
+openapiAdditionalPackages             Nil                                  Additional packageName/swaggerFile pairs for generating from multiple schemas 
 ===================================== ==================================== ==================================================================================================
 ```
 

--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -89,6 +89,16 @@ If `openapiUseHeadTagForObjectName = true`, then the  `GET /foo` and `GET /bar` 
 `Baz.scala` file, containing a single `object Baz` with those endpoint definitions; the `PUT /foo` endpoint, by dint of
 having no tags, would be output to the `TapirGeneratedEndpoints` file, along with any schema and parameter definitions.
 
+Files can be generated from multiple openapi schemas if `openapiAdditionalPackages` is configured; for example
+```sbt
+openapiAdditionalPackages := List(
+      "sttp.tapir.generated.v1" -> baseDirectory.value / "src" / "main" / "resources" / "openapi_v1.yml")
+```
+would generate files in the package `sttp.tapir.generated.v1` based on the `openapi_v1.yml` schema at the provided
+location. This would be in addition to files generated in `openapiPackage` from the specs configured by
+`openapiSwaggerFile`
+
+
 ### Json Support
 
 ```{eval-rst}

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -42,7 +42,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               parameters = Seq(
                 Resolved(OpenapiParameter("asd-id", "path", Some(true), None, OpenapiSchemaString(false))),
                 Resolved(OpenapiParameter("fgh-id", "query", Some(false), None, OpenapiSchemaString(false))),
-                Resolved(OpenapiParameter("jkl-id", "header", Some(false), None, OpenapiSchemaString(false)))),
+                Resolved(OpenapiParameter("jkl-id", "header", Some(false), None, OpenapiSchemaString(false)))
+              ),
               responses = Seq(
                 OpenapiResponse(
                   "200",

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -13,6 +13,7 @@ trait OpenapiCodegenKeys {
   lazy val openapiValidateNonDiscriminatedOneOfs =
     settingKey[Boolean]("Whether to fail if variants of a oneOf without a discriminator cannot be disambiguated..")
   lazy val openapiMaxSchemasPerFile = settingKey[Int]("Maximum number of schemas to generate for a single file")
+  lazy val openapiAdditionalPackages = taskKey[List[(String, File)]]("Addition package -> spec mappings to generate.")
 
   lazy val generateTapirDefinitions = taskKey[Unit]("The task that generates tapir definitions based on the input swagger file.")
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -15,11 +15,13 @@ case class OpenapiCodegenTask(
     maxSchemasPerFile: Int,
     dir: File,
     cacheDir: File,
-    targetScala3: Boolean
+    targetScala3: Boolean,
+    overrideDirectoryName: Option[String]
 ) {
 
-  val tempDirectory = cacheDir / "sbt-openapi-codegen"
-  val outDirectory = dir / "sbt-openapi-codegen"
+  private val directoryName: String = overrideDirectoryName.getOrElse("sbt-openapi-codegen")
+  val tempDirectory = cacheDir / directoryName
+  val outDirectory = dir / directoryName
 
   // 1. make the files under cache/sbt-tapircodegen.
   // 2. compare their SHA1 against cache/sbtbuildinfo-inputs


### PR DESCRIPTION
This will permit generating multiple packages based on multiple schemas (e.g. for generating versioned apis)