### PR TITLE
codegen: Support enums in paths

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -172,10 +172,6 @@ object BasicGenerator {
       |      case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
       |    }(_.map(_.values.map(support.encode).mkString(",")))
       |}
-      |implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
-      |  sttp.tapir.Codec.list[String, String, sttp.tapir.CodecFormat.TextPlain]
-      |    .mapDecode(values => DecodeResult.sequence(values.map(support.decode)).map(s => ExplodedValues(s.toList)))(_.values.map(support.encode))
-      |}
       |implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
       |  support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)
       |}

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EnumGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EnumGenerator.scala
@@ -23,8 +23,8 @@ object EnumGenerator {
       val maybeCompanion =
         if (queryParamRefs contains name) {
           def helperImpls =
-            s"""  given enumCodecSupport${name.capitalize}: QueryParamSupport[$name] =
-               |    queryCodecSupport[$name]""".stripMargin
+            s"""  given enumCodecSupport${name.capitalize}: ExtraParamSupport[$name] =
+               |    extraCodecSupport[$name]""".stripMargin
           s"""
              |object $name {
              |$helperImpls
@@ -52,8 +52,8 @@ object EnumGenerator {
       val maybeQueryCodecDefn =
         if (queryParamRefs contains name) {
           s"""
-               |  implicit val enumCodecSupport${name.capitalize}: QueryParamSupport[$name] =
-               |    queryCodecSupport[$name]("${name}", ${name})""".stripMargin
+               |  implicit val enumCodecSupport${name.capitalize}: ExtraParamSupport[$name] =
+               |    extraCodecSupport[$name]("${name}", ${name})""".stripMargin
         } else ""
       s"""
          |sealed trait $name extends enumeratum.EnumEntry

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -294,7 +294,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       .classDefs(doc, true, jsonParamRefs = Set("Test"))
       .map(concatted)
     val resWithQueryParamCodec = gen
-      .classDefs(doc, true, queryParamRefs = Set("Test"), jsonParamRefs = Set("Test"))
+      .classDefs(doc, true, queryOrPathParamRefs = Set("Test"), jsonParamRefs = Set("Test"))
       .map(concatted)
     // can't just check whether these compile, because our tests only run on scala 2.12 - so instead just eyeball it...
     res shouldBe Some("""enum Test derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec {
@@ -304,7 +304,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       |  Map.from(
       |    for e <- enumextensions.EnumMirror[E].values yield e.name.toUpperCase -> e
       |  )
-      |case class EnumQueryParamSupport[T: enumextensions.EnumMirror](eMap: Map[String, T]) extends QueryParamSupport[T] {
+      |case class EnumExtraParamSupport[T: enumextensions.EnumMirror](eMap: Map[String, T]) extends ExtraParamSupport[T] {
       |  // Case-insensitive mapping
       |  def decode(s: String): sttp.tapir.DecodeResult[T] =
       |    scala.util
@@ -321,11 +321,11 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       |      )
       |  def encode(t: T): String = t.name
       |}
-      |def queryCodecSupport[T: enumextensions.EnumMirror]: QueryParamSupport[T] =
-      |  EnumQueryParamSupport(enumMap[T](using enumextensions.EnumMirror[T]))
+      |def extraCodecSupport[T: enumextensions.EnumMirror]: ExtraParamSupport[T] =
+      |  EnumExtraParamSupport(enumMap[T](using enumextensions.EnumMirror[T]))
       |object Test {
-      |  given enumCodecSupportTest: QueryParamSupport[Test] =
-      |    queryCodecSupport[Test]
+      |  given enumCodecSupportTest: ExtraParamSupport[Test] =
+      |    extraCodecSupport[Test]
       |}
       |enum Test derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec, enumextensions.EnumMirror {
       |  case enum1, enum2

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -526,10 +526,25 @@ object TestHelpers {
       |          $ref: '#/components/schemas/Test'
       |    post:
       |      responses: {}
+      |  /pathTest/{test2}:
+      |    parameters:
+      |      - name: test2
+      |        in: path
+      |        required: true
+      |        schema:
+      |          $ref: '#/components/schemas/Test2'
+      |    post:
+      |      responses: {}
       |
       |components:
       |  schemas:
       |    Test:
+      |      title: Test
+      |      type: string
+      |      enum:
+      |        - paperback
+      |        - hardback
+      |    Test2:
       |      title: Test
       |      type: string
       |      enum:
@@ -555,7 +570,24 @@ object TestHelpers {
           )
         ),
         parameters = Seq(
-          Resolved(OpenapiParameter("test", "query", None, None, OpenapiSchemaRef("#/components/schemas/Test")))
+          Resolved(OpenapiParameter("test", "query", Some(false), None, OpenapiSchemaRef("#/components/schemas/Test")))
+        )
+      ),
+      OpenapiPath(
+        "/pathTest/{test2}",
+        Seq(
+          OpenapiPathMethod(
+            methodType = "post",
+            parameters = Seq(),
+            responses = Seq(),
+            requestBody = None,
+            summary = None,
+            tags = None,
+            operationId = None
+          )
+        ),
+        parameters = Seq(
+          Resolved(OpenapiParameter("test2", "path", Some(true), None, OpenapiSchemaRef("#/components/schemas/Test2")))
         )
       )
     ),
@@ -563,6 +595,11 @@ object TestHelpers {
       OpenapiComponent(
         Map(
           "Test" -> OpenapiSchemaEnum(
+            "string",
+            Seq(OpenapiSchemaConstantString("paperback"), OpenapiSchemaConstantString("hardback")),
+            false
+          ),
+          "Test2" -> OpenapiSchemaEnum(
             "string",
             Seq(OpenapiSchemaConstantString("paperback"), OpenapiSchemaConstantString("hardback")),
             false

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
@@ -166,6 +166,12 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers {
     res shouldBe Right(
       OpenapiSchemaEnum("string", Seq(OpenapiSchemaConstantString("paperback"), OpenapiSchemaConstantString("hardback")), false)
     )
+    parser
+      .parse(TestHelpers.enumQueryParamYaml)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[OpenapiDocument]) shouldBe Right(
+      TestHelpers.enumQueryParamDocs
+    )
   }
 
   it should "parse endpoint with defaults" in {

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
@@ -19,6 +19,9 @@ object TapirGeneratedEndpoints {
     def decode(s: String): sttp.tapir.DecodeResult[T]
     def encode(t: T): String
   }
+  implicit def makePathCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[String, T, sttp.tapir.CodecFormat.TextPlain] = {
+    sttp.tapir.Codec.string.mapDecode(support.decode)(support.encode)
+  }
   implicit def makeQueryCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(support.decode)(support.encode)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
@@ -41,10 +41,6 @@ object TapirGeneratedEndpoints {
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
       }(_.map(_.values.map(support.encode).mkString(",")))
   }
-  implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
-    sttp.tapir.Codec.list[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.map(support.decode)).map(s => ExplodedValues(s.toList)))(_.values.map(support.encode))
-  }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)
   }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
@@ -15,15 +15,15 @@ object TapirGeneratedEndpoints {
 
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
-  trait QueryParamSupport[T] {
+  trait ExtraParamSupport[T] {
     def decode(s: String): sttp.tapir.DecodeResult[T]
     def encode(t: T): String
   }
-  implicit def makeQueryCodecFromSupport[T](implicit support: QueryParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
+  implicit def makeQueryCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(support.decode)(support.encode)
   }
-  implicit def makeQueryOptCodecFromSupport[T](implicit support: QueryParamSupport[T]): sttp.tapir.Codec[List[String], Option[T], sttp.tapir.CodecFormat.TextPlain] = {
+  implicit def makeQueryOptCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], Option[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(maybeV => DecodeResult.sequence(maybeV.toSeq.map(support.decode)).map(_.headOption))(_.map(support.encode))
   }
@@ -38,7 +38,7 @@ object TapirGeneratedEndpoints {
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
       }(_.map(_.values.map(support.encode).mkString(",")))
   }
-  implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: QueryParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
+  implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.list[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(values => DecodeResult.sequence(values.map(support.decode)).map(s => ExplodedValues(s.toList)))(_.values.map(support.encode))
   }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -18,6 +18,9 @@ object TapirGeneratedEndpoints {
     def decode(s: String): sttp.tapir.DecodeResult[T]
     def encode(t: T): String
   }
+  implicit def makePathCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[String, T, sttp.tapir.CodecFormat.TextPlain] = {
+    sttp.tapir.Codec.string.mapDecode(support.decode)(support.encode)
+  }
   implicit def makeQueryCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(support.decode)(support.encode)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -40,10 +40,6 @@ object TapirGeneratedEndpoints {
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
       }(_.map(_.values.map(support.encode).mkString(",")))
   }
-  implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
-    sttp.tapir.Codec.list[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.map(support.decode)).map(s => ExplodedValues(s.toList)))(_.values.map(support.encode))
-  }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)
   }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -14,15 +14,15 @@ object TapirGeneratedEndpoints {
 
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
-  trait QueryParamSupport[T] {
+  trait ExtraParamSupport[T] {
     def decode(s: String): sttp.tapir.DecodeResult[T]
     def encode(t: T): String
   }
-  implicit def makeQueryCodecFromSupport[T](implicit support: QueryParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
+  implicit def makeQueryCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(support.decode)(support.encode)
   }
-  implicit def makeQueryOptCodecFromSupport[T](implicit support: QueryParamSupport[T]): sttp.tapir.Codec[List[String], Option[T], sttp.tapir.CodecFormat.TextPlain] = {
+  implicit def makeQueryOptCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], Option[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(maybeV => DecodeResult.sequence(maybeV.toSeq.map(support.decode)).map(_.headOption))(_.map(support.encode))
   }
@@ -37,7 +37,7 @@ object TapirGeneratedEndpoints {
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
       }(_.map(_.values.map(support.encode).mkString(",")))
   }
-  implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: QueryParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
+  implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.list[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(values => DecodeResult.sequence(values.map(support.decode)).map(s => ExplodedValues(s.toList)))(_.values.map(support.encode))
   }
@@ -46,7 +46,7 @@ object TapirGeneratedEndpoints {
   }
 
 
-  case class EnumQueryParamSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]) extends QueryParamSupport[T] {
+  case class EnumExtraParamSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]) extends ExtraParamSupport[T] {
     // Case-insensitive mapping
     def decode(s: String): sttp.tapir.DecodeResult[T] =
       scala.util.Try(T.upperCaseNameValuesToMap(s.toUpperCase))
@@ -62,8 +62,8 @@ object TapirGeneratedEndpoints {
         )
     def encode(t: T): String = t.entryName
   }
-  def queryCodecSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): QueryParamSupport[T] =
-    EnumQueryParamSupport(enumName, T)
+  def extraCodecSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): ExtraParamSupport[T] =
+    EnumExtraParamSupport(enumName, T)
   sealed trait ADTWithoutDiscriminator
   sealed trait ADTWithDiscriminator
   sealed trait ADTWithDiscriminatorNoMapping
@@ -145,8 +145,8 @@ object TapirGeneratedEndpoints {
     case object bar1 extends PostInlineEnumTestQueryEnum
     case object bar2 extends PostInlineEnumTestQueryEnum
     case object bar3 extends PostInlineEnumTestQueryEnum
-    implicit val enumCodecSupportPostInlineEnumTestQueryEnum: QueryParamSupport[PostInlineEnumTestQueryEnum] =
-      queryCodecSupport[PostInlineEnumTestQueryEnum]("PostInlineEnumTestQueryEnum", PostInlineEnumTestQueryEnum)
+    implicit val enumCodecSupportPostInlineEnumTestQueryEnum: ExtraParamSupport[PostInlineEnumTestQueryEnum] =
+      extraCodecSupport[PostInlineEnumTestQueryEnum]("PostInlineEnumTestQueryEnum", PostInlineEnumTestQueryEnum)
   }
 
   sealed trait PostInlineEnumTestQueryOptEnum extends enumeratum.EnumEntry
@@ -155,8 +155,8 @@ object TapirGeneratedEndpoints {
     case object bar1 extends PostInlineEnumTestQueryOptEnum
     case object bar2 extends PostInlineEnumTestQueryOptEnum
     case object bar3 extends PostInlineEnumTestQueryOptEnum
-    implicit val enumCodecSupportPostInlineEnumTestQueryOptEnum: QueryParamSupport[PostInlineEnumTestQueryOptEnum] =
-      queryCodecSupport[PostInlineEnumTestQueryOptEnum]("PostInlineEnumTestQueryOptEnum", PostInlineEnumTestQueryOptEnum)
+    implicit val enumCodecSupportPostInlineEnumTestQueryOptEnum: ExtraParamSupport[PostInlineEnumTestQueryOptEnum] =
+      extraCodecSupport[PostInlineEnumTestQueryOptEnum]("PostInlineEnumTestQueryOptEnum", PostInlineEnumTestQueryOptEnum)
   }
 
   sealed trait PostInlineEnumTestQuerySeqEnum extends enumeratum.EnumEntry
@@ -165,8 +165,8 @@ object TapirGeneratedEndpoints {
     case object baz1 extends PostInlineEnumTestQuerySeqEnum
     case object baz2 extends PostInlineEnumTestQuerySeqEnum
     case object baz3 extends PostInlineEnumTestQuerySeqEnum
-    implicit val enumCodecSupportPostInlineEnumTestQuerySeqEnum: QueryParamSupport[PostInlineEnumTestQuerySeqEnum] =
-      queryCodecSupport[PostInlineEnumTestQuerySeqEnum]("PostInlineEnumTestQuerySeqEnum", PostInlineEnumTestQuerySeqEnum)
+    implicit val enumCodecSupportPostInlineEnumTestQuerySeqEnum: ExtraParamSupport[PostInlineEnumTestQuerySeqEnum] =
+      extraCodecSupport[PostInlineEnumTestQuerySeqEnum]("PostInlineEnumTestQuerySeqEnum", PostInlineEnumTestQuerySeqEnum)
   }
 
   sealed trait PostInlineEnumTestQueryOptSeqEnum extends enumeratum.EnumEntry
@@ -175,8 +175,8 @@ object TapirGeneratedEndpoints {
     case object baz1 extends PostInlineEnumTestQueryOptSeqEnum
     case object baz2 extends PostInlineEnumTestQueryOptSeqEnum
     case object baz3 extends PostInlineEnumTestQueryOptSeqEnum
-    implicit val enumCodecSupportPostInlineEnumTestQueryOptSeqEnum: QueryParamSupport[PostInlineEnumTestQueryOptSeqEnum] =
-      queryCodecSupport[PostInlineEnumTestQueryOptSeqEnum]("PostInlineEnumTestQueryOptSeqEnum", PostInlineEnumTestQueryOptSeqEnum)
+    implicit val enumCodecSupportPostInlineEnumTestQueryOptSeqEnum: ExtraParamSupport[PostInlineEnumTestQueryOptSeqEnum] =
+      extraCodecSupport[PostInlineEnumTestQueryOptSeqEnum]("PostInlineEnumTestQueryOptSeqEnum", PostInlineEnumTestQueryOptSeqEnum)
   }
 
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -19,6 +19,9 @@ object TapirGeneratedEndpoints {
     def decode(s: String): sttp.tapir.DecodeResult[T]
     def encode(t: T): String
   }
+  implicit def makePathCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[String, T, sttp.tapir.CodecFormat.TextPlain] = {
+    sttp.tapir.Codec.string.mapDecode(support.decode)(support.encode)
+  }
   implicit def makeQueryCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(support.decode)(support.encode)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -41,10 +41,6 @@ object TapirGeneratedEndpoints {
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
       }(_.map(_.values.map(support.encode).mkString(",")))
   }
-  implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
-    sttp.tapir.Codec.list[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.map(support.decode)).map(s => ExplodedValues(s.toList)))(_.values.map(support.encode))
-  }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)
   }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -15,15 +15,15 @@ object TapirGeneratedEndpoints {
 
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
-  trait QueryParamSupport[T] {
+  trait ExtraParamSupport[T] {
     def decode(s: String): sttp.tapir.DecodeResult[T]
     def encode(t: T): String
   }
-  implicit def makeQueryCodecFromSupport[T](implicit support: QueryParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
+  implicit def makeQueryCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(support.decode)(support.encode)
   }
-  implicit def makeQueryOptCodecFromSupport[T](implicit support: QueryParamSupport[T]): sttp.tapir.Codec[List[String], Option[T], sttp.tapir.CodecFormat.TextPlain] = {
+  implicit def makeQueryOptCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], Option[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(maybeV => DecodeResult.sequence(maybeV.toSeq.map(support.decode)).map(_.headOption))(_.map(support.encode))
   }
@@ -38,7 +38,7 @@ object TapirGeneratedEndpoints {
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
       }(_.map(_.values.map(support.encode).mkString(",")))
   }
-  implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: QueryParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
+  implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.list[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(values => DecodeResult.sequence(values.map(support.decode)).map(s => ExplodedValues(s.toList)))(_.values.map(support.encode))
   }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -18,6 +18,9 @@ object TapirGeneratedEndpoints {
     def decode(s: String): sttp.tapir.DecodeResult[T]
     def encode(t: T): String
   }
+  implicit def makePathCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[String, T, sttp.tapir.CodecFormat.TextPlain] = {
+    sttp.tapir.Codec.string.mapDecode(support.decode)(support.encode)
+  }
   implicit def makeQueryCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(support.decode)(support.encode)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -40,10 +40,6 @@ object TapirGeneratedEndpoints {
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
       }(_.map(_.values.map(support.encode).mkString(",")))
   }
-  implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
-    sttp.tapir.Codec.list[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.map(support.decode)).map(s => ExplodedValues(s.toList)))(_.values.map(support.encode))
-  }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)
   }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -14,15 +14,15 @@ object TapirGeneratedEndpoints {
 
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
-  trait QueryParamSupport[T] {
+  trait ExtraParamSupport[T] {
     def decode(s: String): sttp.tapir.DecodeResult[T]
     def encode(t: T): String
   }
-  implicit def makeQueryCodecFromSupport[T](implicit support: QueryParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
+  implicit def makeQueryCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(support.decode)(support.encode)
   }
-  implicit def makeQueryOptCodecFromSupport[T](implicit support: QueryParamSupport[T]): sttp.tapir.Codec[List[String], Option[T], sttp.tapir.CodecFormat.TextPlain] = {
+  implicit def makeQueryOptCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], Option[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(maybeV => DecodeResult.sequence(maybeV.toSeq.map(support.decode)).map(_.headOption))(_.map(support.encode))
   }
@@ -37,7 +37,7 @@ object TapirGeneratedEndpoints {
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
       }(_.map(_.values.map(support.encode).mkString(",")))
   }
-  implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: QueryParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
+  implicit def makeExplodedQuerySeqCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.list[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode(values => DecodeResult.sequence(values.map(support.decode)).map(s => ExplodedValues(s.toList)))(_.values.map(support.encode))
   }
@@ -50,7 +50,7 @@ object TapirGeneratedEndpoints {
     Map.from(
       for e <- enumextensions.EnumMirror[E].values yield e.name.toUpperCase -> e
     )
-  case class EnumQueryParamSupport[T: enumextensions.EnumMirror](eMap: Map[String, T]) extends QueryParamSupport[T] {
+  case class EnumExtraParamSupport[T: enumextensions.EnumMirror](eMap: Map[String, T]) extends ExtraParamSupport[T] {
     // Case-insensitive mapping
     def decode(s: String): sttp.tapir.DecodeResult[T] =
       scala.util
@@ -67,8 +67,8 @@ object TapirGeneratedEndpoints {
         )
     def encode(t: T): String = t.name
   }
-  def queryCodecSupport[T: enumextensions.EnumMirror]: QueryParamSupport[T] =
-    EnumQueryParamSupport(enumMap[T](using enumextensions.EnumMirror[T]))
+  def extraCodecSupport[T: enumextensions.EnumMirror]: ExtraParamSupport[T] =
+    EnumExtraParamSupport(enumMap[T](using enumextensions.EnumMirror[T]))
   sealed trait ADTWithoutDiscriminator
   sealed trait ADTWithDiscriminator
   sealed trait ADTWithDiscriminatorNoMapping
@@ -137,32 +137,32 @@ object TapirGeneratedEndpoints {
       .out(statusCode(sttp.model.StatusCode(204)).description("No Content"))
 
   object PostInlineEnumTestQueryEnum {
-    given enumCodecSupportPostInlineEnumTestQueryEnum: QueryParamSupport[PostInlineEnumTestQueryEnum] =
-      queryCodecSupport[PostInlineEnumTestQueryEnum]
+    given enumCodecSupportPostInlineEnumTestQueryEnum: ExtraParamSupport[PostInlineEnumTestQueryEnum] =
+      extraCodecSupport[PostInlineEnumTestQueryEnum]
   }
   enum PostInlineEnumTestQueryEnum derives enumextensions.EnumMirror {
     case bar1, bar2, bar3
   }
 
   object PostInlineEnumTestQueryOptEnum {
-    given enumCodecSupportPostInlineEnumTestQueryOptEnum: QueryParamSupport[PostInlineEnumTestQueryOptEnum] =
-      queryCodecSupport[PostInlineEnumTestQueryOptEnum]
+    given enumCodecSupportPostInlineEnumTestQueryOptEnum: ExtraParamSupport[PostInlineEnumTestQueryOptEnum] =
+      extraCodecSupport[PostInlineEnumTestQueryOptEnum]
   }
   enum PostInlineEnumTestQueryOptEnum derives enumextensions.EnumMirror {
     case bar1, bar2, bar3
   }
 
   object PostInlineEnumTestQuerySeqEnum {
-    given enumCodecSupportPostInlineEnumTestQuerySeqEnum: QueryParamSupport[PostInlineEnumTestQuerySeqEnum] =
-      queryCodecSupport[PostInlineEnumTestQuerySeqEnum]
+    given enumCodecSupportPostInlineEnumTestQuerySeqEnum: ExtraParamSupport[PostInlineEnumTestQuerySeqEnum] =
+      extraCodecSupport[PostInlineEnumTestQuerySeqEnum]
   }
   enum PostInlineEnumTestQuerySeqEnum derives enumextensions.EnumMirror {
     case baz1, baz2, baz3
   }
 
   object PostInlineEnumTestQueryOptSeqEnum {
-    given enumCodecSupportPostInlineEnumTestQueryOptSeqEnum: QueryParamSupport[PostInlineEnumTestQueryOptSeqEnum] =
-      queryCodecSupport[PostInlineEnumTestQueryOptSeqEnum]
+    given enumCodecSupportPostInlineEnumTestQueryOptSeqEnum: ExtraParamSupport[PostInlineEnumTestQueryOptSeqEnum] =
+      extraCodecSupport[PostInlineEnumTestQueryOptSeqEnum]
   }
   enum PostInlineEnumTestQueryOptSeqEnum derives enumextensions.EnumMirror {
     case baz1, baz2, baz3


### PR DESCRIPTION
Support enums in path params. Most of the diff here is just renaming variables and types to reflect that they no longer pertain only to _query_ params, but also to path params; nearly all of the implementation is supported just by reusing those existing mechanisms