### PR TITLE
Fix releasing resources in TestServerInterpreter

### DIFF
--- a/server/tests/src/main/scala/sttp/tapir/server/tests/TestServerInterpreter.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/TestServerInterpreter.scala
@@ -21,5 +21,5 @@ trait TestServerInterpreter[F[_], +R, OPTIONS, ROUTE] {
   def serverWithStop(routes: NonEmptyList[ROUTE], gracefulShutdownTimeout: Option[FiniteDuration] = None): Resource[IO, (Port, KillSwitch)]
 
   def server(routes: NonEmptyList[ROUTE]): Resource[IO, Port] =
-    serverWithStop(routes, gracefulShutdownTimeout = None).map(_._1)
+    serverWithStop(routes, gracefulShutdownTimeout = None).flatMap { case (port, killSwitch) => Resource.pure(port).onFinalize(killSwitch) }
 }


### PR DESCRIPTION
The `server` resource uses `serverWithStop` and ignores its `release` effect. As a result, non-erroneous closing of this resource doesn't release anything, so we need to call the hook manually.