### PR TITLE
Fix shutdowns in test servers

### DIFF
--- a/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpTestServerInterpreter.scala
+++ b/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpTestServerInterpreter.scala
@@ -23,22 +23,14 @@ class AkkaHttpTestServerInterpreter(implicit actorSystem: ActorSystem)
     AkkaHttpServerInterpreter(serverOptions).toRoute(es)
   }
 
-  override def serverWithStop(
+  override def server(
       routes: NonEmptyList[Route],
       gracefulShutdownTimeout: Option[FiniteDuration]
-  ): Resource[IO, (Port, KillSwitch)] = {
+  ): Resource[IO, Port] = {
     val bind = IO.fromFuture(IO(Http().newServerAt("localhost", 0).bind(concat(routes.toList: _*))))
 
     Resource
-      .make(
-        bind.map(b =>
-          (
-            b.localAddress.getPort,
-            IO.fromFuture(IO(b.terminate(gracefulShutdownTimeout.getOrElse(50.millis)))).void
-          )
-        )
-      ) { case (_, release) =>
-        release
-      }
+      .make(bind)(server => IO.fromFuture(IO(server.terminate(gracefulShutdownTimeout.getOrElse(50.millis)))).void)
+      .map(_.localAddress.getPort)
   }
 }

--- a/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sTestServerInterpreter.scala
+++ b/server/http4s-server/zio/src/test/scala/sttp/tapir/server/http4s/ztapir/ZHttp4sTestServerInterpreter.scala
@@ -2,6 +2,7 @@ package sttp.tapir.server.http4s.ztapir
 
 import cats.data.NonEmptyList
 import cats.effect.{IO, Resource}
+import cats._
 import cats.syntax.all._
 import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.server.websocket.WebSocketBuilder2
@@ -15,7 +16,6 @@ import sttp.tapir.tests._
 import sttp.tapir.ztapir.ZServerEndpoint
 import zio.{Runtime, Task, Unsafe}
 import zio.interop.catz._
-import zio.interop.catz.implicits._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
@@ -34,28 +34,22 @@ class ZHttp4sTestServerInterpreter extends TestServerInterpreter[Task, ZioStream
     ZHttp4sServerInterpreter(serverOptions).fromWebSocket(es).toRoutes
   }
 
-  override def serverWithStop(
+  override def server(
       routes: NonEmptyList[Routes],
       gracefulShutdownTimeout: Option[FiniteDuration]
-  ): Resource[IO, (Port, KillSwitch)] = {
+  ): Resource[IO, Port] = {
     val service: WebSocketBuilder2[Task] => HttpApp[Task] =
       wsb => routes.map(_.apply(wsb)).reduceK.orNotFound
 
-    val serverResource = BlazeServerBuilder[Task]
+    BlazeServerBuilder[Task]
       .withExecutionContext(ExecutionContext.global)
       .bindHttp(0, "localhost")
       .withHttpWebSocketApp(service)
       .resource
       .map(_.address.getPort)
-
-    // Converting a zio.RIO-resource to an cats.IO-resource
-    val runtime = implicitly[zio.Runtime[Any]]
-    Resource
-      .eval(IO.fromFuture(IO(Unsafe.unsafe(implicit u => Runtime.default.unsafe.runToFuture(serverResource.allocated)))))
-      .flatMap { case (port, release) => // Blaze has no graceful shutdown support https://github.com/http4s/blaze/issues/676
-        Resource.make(IO.pure((port, IO.fromFuture(IO(Unsafe.unsafe(implicit u => Runtime.default.unsafe.runToFuture(release))))))) {
-          case (_, release) => release
-        }
-      }
+      .mapK(new ~>[Task, IO] { 
+        // Converting a ZIO effect to an Cats Effect IO effect
+        def apply[B](fa: Task[B]): IO[B] = IO.fromFuture(Unsafe.unsafe(implicit u => IO(Runtime.default.unsafe.runToFuture(fa))))
+      })
   }
 }

--- a/server/play29-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
+++ b/server/play29-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
@@ -31,10 +31,10 @@ class PlayTestServerInterpreter(implicit actorSystem: ActorSystem)
     PlayServerInterpreter(serverOptions).toRoutes(es)
   }
 
-  override def serverWithStop(
+  override def serverWith(
       routes: NonEmptyList[Routes],
       gracefulShutdownTimeout: Option[FiniteDuration]
-  ): Resource[IO, (Port, KillSwitch)] = {
+  ): Resource[IO, Port] = {
     val components = new DefaultAkkaHttpServerComponents {
       val initialServerConfig = ServerConfig(port = Some(0), address = "127.0.0.1", mode = Mode.Test)
 
@@ -57,9 +57,9 @@ class PlayTestServerInterpreter(implicit actorSystem: ActorSystem)
           })
         )
     }
-    val bind = IO {
+    val bind = IO.blocking {
       components.server
     }
-    Resource.make(bind.map(s => (s.mainAddress.getPort, IO(s.stop())))) { case (_, release) => release }
+    Resource.make(bind)(s => IO.blocking(s.stop())).map(s => (s.mainAddress.getPort))
   }
 }

--- a/server/play29-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
+++ b/server/play29-server/src/test/scala/sttp/tapir/server/play/PlayTestServerInterpreter.scala
@@ -31,7 +31,7 @@ class PlayTestServerInterpreter(implicit actorSystem: ActorSystem)
     PlayServerInterpreter(serverOptions).toRoutes(es)
   }
 
-  override def serverWith(
+  override def server(
       routes: NonEmptyList[Routes],
       gracefulShutdownTimeout: Option[FiniteDuration]
   ): Resource[IO, Port] = {

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/CreateServerTest.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/CreateServerTest.scala
@@ -13,7 +13,6 @@ import sttp.tapir._
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.interceptor.CustomiseInterceptors
 import sttp.tapir.tests._
-import org.scalactic.anyvals.FiniteDouble
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.FiniteDuration
@@ -53,7 +52,7 @@ trait CreateServerTest[F[_], +R, OPTIONS, ROUTE] {
     */
   def testServerWithStop(name: String, rs: => NonEmptyList[ROUTE], gracefulShutdownTimeout: Option[FiniteDuration])(
       runTest: KillSwitch => (SttpBackend[IO, Fs2Streams[IO] with WebSockets], Uri) => IO[Assertion]
-  ): Test = testServer(name, rs)(runTest(IO.unit))
+  ): Test
 }
 
 class DefaultCreateServerTest[F[_], +R, OPTIONS, ROUTE](

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/TestServerInterpreter.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/TestServerInterpreter.scala
@@ -18,8 +18,11 @@ trait TestServerInterpreter[F[_], +R, OPTIONS, ROUTE] {
 
   def route(es: List[ServerEndpoint[R, F]], interceptors: Interceptors = identity): ROUTE
 
-  def serverWithStop(routes: NonEmptyList[ROUTE], gracefulShutdownTimeout: Option[FiniteDuration] = None): Resource[IO, (Port, KillSwitch)]
+  def serverWithStop(
+      routes: NonEmptyList[ROUTE],
+      gracefulShutdownTimeout: Option[FiniteDuration] = None
+  ): Resource[IO, (Port, KillSwitch)] =
+    Resource.eval(server(routes, gracefulShutdownTimeout).allocated)
 
-  def server(routes: NonEmptyList[ROUTE]): Resource[IO, Port] =
-    serverWithStop(routes, gracefulShutdownTimeout = None).map(_._1)
+  def server(routes: NonEmptyList[ROUTE], gracefulShutdownTimeout: Option[FiniteDuration] = None): Resource[IO, Port]
 }

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/TestServerInterpreter.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/TestServerInterpreter.scala
@@ -21,5 +21,5 @@ trait TestServerInterpreter[F[_], +R, OPTIONS, ROUTE] {
   def serverWithStop(routes: NonEmptyList[ROUTE], gracefulShutdownTimeout: Option[FiniteDuration] = None): Resource[IO, (Port, KillSwitch)]
 
   def server(routes: NonEmptyList[ROUTE]): Resource[IO, Port] =
-    serverWithStop(routes, gracefulShutdownTimeout = None).flatMap { case (port, killSwitch) => Resource.pure(port).onFinalize(killSwitch) }
+    serverWithStop(routes, gracefulShutdownTimeout = None).map(_._1)
 }

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpTestServerInterpreter.scala
@@ -52,4 +52,8 @@ class ZioHttpTestServerInterpreter(
 
     Resource.make(Resource.scoped[IO, Any, Port](effect).allocated) { case (_, release) => release }
   }
+
+  // Needs to manually call killSwitch, because serverWithStop uses `allocated`
+  override def server(routes: NonEmptyList[Routes[Any, Response]]): Resource[IO, Port] =    
+    serverWithStop(routes, gracefulShutdownTimeout = None).flatMap { case (port, killSwitch) => Resource.pure(port).onFinalize(killSwitch) }
 }

--- a/serverless/aws/lambda-cats-effect-tests/src/test/scala/sttp/tapir/serverless/aws/lambda/tests/AwsLambdaCreateServerStubTest.scala
+++ b/serverless/aws/lambda-cats-effect-tests/src/test/scala/sttp/tapir/serverless/aws/lambda/tests/AwsLambdaCreateServerStubTest.scala
@@ -33,6 +33,10 @@ class AwsLambdaCreateServerStubTest extends CreateServerTest[IO, Any, AwsServerO
     Test(name)(runTest(stubBackend(route), uri"http://localhost:3001").unsafeToFuture())
   }
 
+  def testServerWithStop(name: String, rs: => NonEmptyList[Route[IO]], gracefulShutdownTimeout: Option[FiniteDuration])(
+      runTest: KillSwitch => (SttpBackend[IO, Fs2Streams[IO] with WebSockets], Uri) => IO[Assertion]
+  ): Test = throw new UnsupportedOperationException
+
   override def testServerLogic(e: ServerEndpoint[Any, IO], testNameSuffix: String, interceptors: Interceptors = identity)(
       runTest: (SttpBackend[IO, Fs2Streams[IO] with WebSockets], Uri) => IO[Assertion]
   ): Test = {

--- a/serverless/aws/lambda-cats-effect-tests/src/test/scala/sttp/tapir/serverless/aws/lambda/tests/AwsLambdaStubHttpTest.scala
+++ b/serverless/aws/lambda-cats-effect-tests/src/test/scala/sttp/tapir/serverless/aws/lambda/tests/AwsLambdaStubHttpTest.scala
@@ -29,9 +29,10 @@ object AwsLambdaStubHttpTest {
       AwsCatsEffectServerInterpreter(serverOptions).toRoute(es)
     }
 
-    override def serverWithStop(
+    override def server(
         routes: NonEmptyList[Route[IO]],
         gracefulShutdownTimeout: Option[FiniteDuration]
-    ): Resource[IO, (Port, KillSwitch)] = ???
+    ): Resource[IO, Port] = throw new UnsupportedOperationException
+
   }
 }

--- a/serverless/aws/lambda-zio-tests/src/test/scala/sttp/tapir/serverless/aws/ziolambda/tests/AwsLambdaCreateServerStubTest.scala
+++ b/serverless/aws/lambda-zio-tests/src/test/scala/sttp/tapir/serverless/aws/ziolambda/tests/AwsLambdaCreateServerStubTest.scala
@@ -40,6 +40,10 @@ class AwsLambdaCreateServerStubTest extends CreateServerTest[Task, Any, AwsServe
     Test(name)(runTest(stubBackend(transformMonad(route)), uri"http://localhost:3002").unsafeToFuture())
   }
 
+  def testServerWithStop(name: String, rs: => NonEmptyList[Route[Task]], gracefulShutdownTimeout: Option[FiniteDuration])(
+      runTest: KillSwitch => (SttpBackend[IO, Fs2Streams[IO] with WebSockets], Uri) => IO[Assertion]
+  ): Test = throw new UnsupportedOperationException
+
   override def testServerLogic(e: ServerEndpoint[Any, Task], testNameSuffix: String, interceptors: Interceptors = identity)(
       runTest: (SttpBackend[IO, Fs2Streams[IO] with WebSockets], Uri) => IO[Assertion]
   ): Test = {

--- a/serverless/aws/lambda-zio-tests/src/test/scala/sttp/tapir/serverless/aws/ziolambda/tests/AwsLambdaStubHttpTest.scala
+++ b/serverless/aws/lambda-zio-tests/src/test/scala/sttp/tapir/serverless/aws/ziolambda/tests/AwsLambdaStubHttpTest.scala
@@ -35,9 +35,10 @@ object AwsLambdaStubHttpTest {
       AwsZioServerInterpreter(serverOptions).toRoute(es)
     }
 
-    override def serverWithStop(
+    override def server(
         routes: NonEmptyList[Route[Task]],
         gracefulShutdownTimeout: Option[FiniteDuration]
-    ): Resource[IO, (Port, KillSwitch)] = ???
+    ): Resource[IO, Port] = throw new UnsupportedOperationException
+
   }
 }


### PR DESCRIPTION
Instead of defining `serverWithStop` and deriving `server` on top of it, each backend's test interpreter will now do the opposite: define `server`, which returns a `Resource[IO, Port]`, then use this in base `serverWithStop`.