### PR TITLE
 Async api example rendering bugfix

### DIFF
--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/ExampleConverter.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/ExampleConverter.scala
@@ -1,20 +1,20 @@
 package sttp.tapir.docs.asyncapi
 
 import sttp.apispec._
+import sttp.apispec.asyncapi.MessageExample
 import sttp.tapir.{Codec, EndpointIO}
 import sttp.ws.WebSocketFrame
 
 private[asyncapi] object ExampleConverter {
-  def convertExamples[T](c: Codec[WebSocketFrame, T, _], examples: List[EndpointIO.Example[T]]): List[ExampleValue] = {
+  def convertExamples[T](c: Codec[WebSocketFrame, T, _], examples: List[EndpointIO.Example[T]]): List[MessageExample] = {
     examples
       .flatMap { example =>
-        val exampleValue = c.encode(example.value) match {
-          case WebSocketFrame.Text(payload, _, _) => Some(payload)
-          case WebSocketFrame.Binary(_, _, _)     => None
-          case _: WebSocketFrame.Control          => None
+        c.encode(example.value) match {
+          case WebSocketFrame.Text(payload, _, _) =>
+            Some(MessageExample(headers = None, Some(ExampleSingleValue(payload)), example.name, example.summary))
+          case WebSocketFrame.Binary(_, _, _) => None
+          case _: WebSocketFrame.Control => None
         }
-
-        exampleValue.map(ExampleSingleValue)
       }
   }
 }

--- a/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/MessagesForEndpoints.scala
+++ b/docs/asyncapi-docs/src/main/scala/sttp/tapir/docs/asyncapi/MessagesForEndpoints.scala
@@ -39,7 +39,6 @@ private[asyncapi] class MessagesForEndpoints(tschemaToASchema: TSchemaToASchema,
   )
 
   private def message[T](ci: CodecWithInfo[T]): Message = {
-    val convertedExamples = ExampleConverter.convertExamples(ci.codec, ci.info.examples)
     SingleMessage(
       None,
       Some(Right(tschemaToASchema(ci.codec))),
@@ -53,7 +52,7 @@ private[asyncapi] class MessagesForEndpoints(tschemaToASchema: TSchemaToASchema,
       Nil,
       None,
       Nil,
-      convertedExamples.map(example => Map("payload" -> (example :: Nil))),
+      ExampleConverter.convertExamples(ci.codec, ci.info.examples),
       Nil
     )
   }

--- a/docs/asyncapi-docs/src/test/resources/expected_json_example_name_summary.yml
+++ b/docs/asyncapi-docs/src/test/resources/expected_json_example_name_summary.yml
@@ -33,11 +33,10 @@ components:
       examples:
         - payload:
             f: apple
+          name: Apple
+          summary: Sample representation of apple
     integer:
       payload:
         type: integer
         format: int32
       contentType: application/json
-      examples:
-        - payload: 10
-        - payload: 42

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -11,7 +11,7 @@ object Versions {
   val sttp = "3.9.7"
   val sttpModel = "1.7.11"
   val sttpShared = "1.3.19"
-  val sttpApispec = "0.10.0"
+  val sttpApispec = "0.11.0"
   val akkaHttp = "10.2.10"
   val akkaStreams = "2.6.20"
   val pekkoHttp = "1.0.1"


### PR DESCRIPTION
Updated sttpApispec to 0.11.
Fixes example rendering issue (softwaremill/sttp-apispec#174, #3901).

Note tapir lacks convenient api to define async example name and summary (see TODO in the VerifyAsyncAPIYamlTest).
