### PR TITLE
Move `validatorForDescribed*` to LowPriority trait to prevent ambigious implicits under Scala 3.6+

### DIFF
--- a/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
+++ b/integrations/iron/src/main/scala/sttp/iron/codec/iron/TapirCodecIron.scala
@@ -207,6 +207,35 @@ trait TapirCodecIron extends DescriptionWitness with LowPriorityValidatorForPred
 
       }
 
+}
+
+private[iron] trait ValidatorForPredicate[Value, Predicate] {
+  def validator: Validator[Value]
+  def makeErrors(value: Value, errorMessage: String): List[ValidationError[_]]
+  lazy val containsMinSizePositive: Boolean = validator.asPrimitiveValidators.exists {
+    case Validator.MinSize(a) => a > 0
+    case _                    => false
+  }
+}
+
+private[iron] trait PrimitiveValidatorForPredicate[Value, Predicate] extends ValidatorForPredicate[Value, Predicate] {
+  def validator: Validator.Primitive[Value]
+  def makeErrors(value: Value, errorMessage: String): List[ValidationError[_]]
+}
+
+private[iron] object ValidatorForPredicate {
+  def fromPrimitiveValidator[Value, Predicate](
+      primitiveValidator: Validator.Primitive[Value]
+  ): PrimitiveValidatorForPredicate[Value, Predicate] =
+    new PrimitiveValidatorForPredicate[Value, Predicate] {
+      override def validator: Validator.Primitive[Value] = primitiveValidator
+      override def makeErrors(value: Value, errorMessage: String): List[ValidationError[_]] =
+        List(ValidationError[Value](primitiveValidator, value))
+    }
+}
+
+private[iron] trait LowPriorityValidatorForPredicate extends LowPriorityValidatorForPredicate2 {
+
   inline given validatorForDescribedAnd[N, P](using
       id: IsDescription[P],
       mirror: IntersectionTypeMirror[id.Predicate]
@@ -244,32 +273,7 @@ trait TapirCodecIron extends DescriptionWitness with LowPriorityValidatorForPred
     validator.asInstanceOf[PrimitiveValidatorForPredicate[N, P]]
 }
 
-private[iron] trait ValidatorForPredicate[Value, Predicate] {
-  def validator: Validator[Value]
-  def makeErrors(value: Value, errorMessage: String): List[ValidationError[_]]
-  lazy val containsMinSizePositive: Boolean = validator.asPrimitiveValidators.exists {
-    case Validator.MinSize(a) => a > 0
-    case _                    => false
-  }
-}
-
-private[iron] trait PrimitiveValidatorForPredicate[Value, Predicate] extends ValidatorForPredicate[Value, Predicate] {
-  def validator: Validator.Primitive[Value]
-  def makeErrors(value: Value, errorMessage: String): List[ValidationError[_]]
-}
-
-private[iron] object ValidatorForPredicate {
-  def fromPrimitiveValidator[Value, Predicate](
-      primitiveValidator: Validator.Primitive[Value]
-  ): PrimitiveValidatorForPredicate[Value, Predicate] =
-    new PrimitiveValidatorForPredicate[Value, Predicate] {
-      override def validator: Validator.Primitive[Value] = primitiveValidator
-      override def makeErrors(value: Value, errorMessage: String): List[ValidationError[_]] =
-        List(ValidationError[Value](primitiveValidator, value))
-    }
-}
-
-private[iron] trait LowPriorityValidatorForPredicate {
+private[iron] trait LowPriorityValidatorForPredicate2 {
 
   inline given [Value, Predicate](using
       inline constraint: Constraint[Value, Predicate],


### PR DESCRIPTION
This change adds 1 more intermediate `LowPriorityValidatorForPredicate` trait which now contains `validatorForDescribed*` methods. Change is motivated by [failures in Scala 3 Open Community Build ](https://github.com/VirtusLab/community-build3/actions/runs/9915156118/job/27395918787) under changes to implicit resolution in Scala 3.6. 

Example of snippet that fails to compile
```scala
    type IntConstraint = LessEqual[3]
    type LimitedInt = Int :| IntConstraint
    val limitedIntCodec = summon[PlainCodec[LimitedInt]]
```

Under 3.3 LTS compiler can construct `PlainCodec` in 2 different ways, but implicitly picks one of the alternatives. This behaviour has changed since 3.6 and the compiler warns about it since 3.5:
```scala
arn] -- Warning: /Users/wmazur/projects/community-build3/repo/integrations/iron/src/test/scala-3/sttp/iron/codec/iron/TapirCodecIronTestScala3.scala:93:56 
[warn] 93 |    val limitedIntCodec = summon[PlainCodec[LimitedInt]]
[warn]    |                                                        ^
[warn]    |Given search preference for sttp.tapir.codec.iron.ValidatorForPredicate[Int,
[warn]    |  io.github.iltotore.iron².constraint.any.DescribedAs[
[warn]    |    io.github.iltotore.iron².constraint.numeric.Less[(3 : Int)] |
[warn]    |      io.github.iltotore.iron².constraint.any.StrictEqual[(3 : Int)],
[warn]    |    ("Should be less than or equal to " : String) + (3 : Int)]
[warn]    |] between alternatives (sttp.tapir.codec.iron.validatorForDescribedOr :
[warn]    |  [N, P]
[warn]    |    (using id: sttp.tapir.codec.iron.IsDescription[P], mirror:
[warn]    |      sttp.tapir.typelevel.UnionTypeMirror[id.Predicate]):
[warn]    |      sttp.tapir.codec.iron.ValidatorForPredicate[N, P]
[warn]    |) and (sttp.tapir.codec.iron.validatorForLessEqual :
[warn]    |  [N, NM <: N]
[warn]    |    (implicit evidence$1: Numeric[N], witness: ValueOf[NM]):
[warn]    |      sttp.tapir.codec.iron.PrimitiveValidatorForPredicate[N,
[warn]    |        io.github.iltotore.iron².constraint.numeric.LessEqual[NM]]
[warn]    |) will change
[warn]    |Current choice           : the second alternative
[warn]    |New choice from Scala 3.6: none - it's ambiguous
```

Because of the change to implicits users of Tapir upgrading their Scala version to 3.6 or higher would not be able to compile their projects, unless their explicitly compile it using `-source:3.5` flag. 