### PR TITLE
Add contextSecurityIn for http4s endpoints

### DIFF
--- a/doc/server/http4s.md
+++ b/doc/server/http4s.md
@@ -117,8 +117,9 @@ val routes = Http4sServerInterpreter[IO]().toRoutes(sseEndpoint.serverLogicSucce
 ## Accessing http4s context
 
 If you'd like to access context provided by an http4s middleware, e.g. with authentication data, this can be done
-with a dedicated context-extracting input, `.contextIn`. Endpoints using such input need then to be interpreted to
-`org.http4s.ContextRoutes` (also known by its type alias `AuthedRoutes`) using the `.toContextRoutes` method.
+with a dedicated context-extracting input, `.contextIn` (or the analogous `.contextSecurityIn` for security inputs).
+Endpoints using such input need then to be interpreted to `org.http4s.ContextRoutes` (also known by its type alias
+`AuthedRoutes`) using the `.toContextRoutes` method.
 
 For example:
 

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerInterpreter.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerInterpreter.scala
@@ -22,7 +22,7 @@ import scala.reflect.ClassTag
 class Http4sInvalidWebSocketUse(val message: String) extends Exception
 
 /** A capability that is used by endpoints, when they need to access the http4s-provided context. Such a requirement can be added using the
-  * [[RichHttp4sEndpoint.contextIn]] method.
+  * [[RichHttp4sEndpoint.contextIn]] or [[RichHttp4sEndpoint.contextSecurityIn]] methods.
   */
 trait Context[T]
 

--- a/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerTest.scala
+++ b/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerTest.scala
@@ -11,7 +11,7 @@ import org.http4s.server.Router
 import org.http4s.server.ContextMiddleware
 import org.http4s.ContextRoutes
 import org.http4s.HttpRoutes
-import org.scalatest.OptionValues
+import org.scalatest.{Assertion, OptionValues}
 import org.scalatest.matchers.should.Matchers._
 import sttp.capabilities.WebSockets
 import sttp.capabilities.fs2.Fs2Streams
@@ -39,23 +39,25 @@ class Http4sServerTest[R >: Fs2Streams[IO] with WebSockets] extends TestSuite wi
     val sse1 = ServerSentEvent(randomUUID, randomUUID, randomUUID, Some(Random.nextInt(200)))
     val sse2 = ServerSentEvent(randomUUID, randomUUID, randomUUID, Some(Random.nextInt(200)))
 
+    def blazeServerAssertions[T](routes: HttpRoutes[IO], expectedContext: T): IO[Assertion] = BlazeServerBuilder[IO]
+      .withExecutionContext(ExecutionContext.global)
+      .bindHttp(0, "localhost")
+      .withHttpApp(Router("/api" -> routes).orNotFound)
+      .resource
+      .use { server =>
+        val port = server.address.getPort
+        basicRequest.get(uri"http://localhost:$port/api/test/router").send(backend).map(_.body shouldBe Right(expectedContext))
+      }
+
     def additionalTests(): List[Test] = List(
       Test("should work with a router and routes in a context") {
-        val e = endpoint.get.in("test" / "router").out(stringBody).serverLogic(_ => IO.pure("ok".asRight[Unit]))
+        val expectedContent: String = "ok"
+        val e = endpoint.get.in("test" / "router").out(stringBody).serverLogic(_ => IO.pure(expectedContent.asRight[Unit]))
         val routes = Http4sServerInterpreter[IO]().toRoutes(e)
 
-        BlazeServerBuilder[IO]
-          .withExecutionContext(ExecutionContext.global)
-          .bindHttp(0, "localhost")
-          .withHttpApp(Router("/api" -> routes).orNotFound)
-          .resource
-          .use { server =>
-            val port = server.address.getPort
-            basicRequest.get(uri"http://localhost:$port/api/test/router").send(backend).map(_.body shouldBe Right("ok"))
-          }
-          .unsafeRunSync()
+        blazeServerAssertions(routes, expectedContent).unsafeRunSync()
       },
-      Test("should work with a router and  context routes in a context") {
+      Test("should work with a router and context routes in a context") {
         val expectedContext: String = "Hello World!" // the context we expect http4s to provide to the endpoint
 
         val e: Endpoint[Unit, String, Unit, String, Context[String]] =
@@ -70,16 +72,21 @@ class Http4sServerTest[R >: Fs2Streams[IO] with WebSockets] extends TestSuite wi
         val middleware: ContextMiddleware[IO, String] =
           ContextMiddleware.const(expectedContext)
 
-        BlazeServerBuilder[IO]
-          .withExecutionContext(ExecutionContext.global)
-          .bindHttp(0, "localhost")
-          .withHttpApp(Router("/api" -> middleware(routesWithContext)).orNotFound)
-          .resource
-          .use { server =>
-            val port = server.address.getPort
-            basicRequest.get(uri"http://localhost:$port/api/test/router").send(backend).map(_.body shouldBe Right(expectedContext))
-          }
-          .unsafeRunSync()
+        blazeServerAssertions(middleware(routesWithContext), expectedContext).unsafeRunSync()
+      },
+      Test("should work with a router and context routes in a context using contextSecurityIn") {
+        val expectedContext: Int = 3
+
+        val e: Endpoint[Int, Unit, Unit, String, Context[Int]] =
+          endpoint.get.in("test" / "router").contextSecurityIn[Int]().out(stringBody)
+
+        val routesWithContext: ContextRoutes[Int, IO] =
+          Http4sServerInterpreter[IO]()
+            .toContextRoutes(e.serverSecurityLogicSuccess(IO.pure).serverLogicSuccess(x => _ => IO.pure(x.toString)))
+
+        val middleware: ContextMiddleware[IO, Int] = ContextMiddleware.const(expectedContext)
+
+        blazeServerAssertions(middleware(routesWithContext), expectedContext.toString).unsafeRunSync()
       },
       createServerTest.testServer(
         endpoint.out(


### PR DESCRIPTION
Hi!  I'd like to use the context of http4s `ContextRoutes` as part of security logic, though AFAICS currently threading through http4s context is supported only by `contextIn` which adds the context as a server logic input.  This PR adds a corresponding `securityContextIn` method for doing the same for security logic.

Thanks!