### PR TITLE
codegen: ensure schemas are distinct when splitting across ranges

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
@@ -148,7 +148,7 @@ object SchemaGenerator {
       // Select next candidate. Order lexicographically for stable output
       val next = initialSet.minBy(_._1)
       recurse(next)
-      res += nextRing.sortBy(_._1)
+      res += nextRing.distinct.sortBy(_._1)
     }
     res.toSeq
   }


### PR DESCRIPTION
There's an edge-case where this processing step otherwise produces duplicate schemas declarations for mutually-recursive objects