### PR TITLE
codegen: Fix issues with jsoniter in scala3

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -48,7 +48,6 @@ class ClassDefinitionGenerator {
       jsonSerdeLib,
       jsonParamRefs,
       allTransitiveJsonParamRefs,
-      fullModelPath,
       validateNonDiscriminatedOneOfs,
       adtInheritanceMap.mapValues(_.map(_._1)),
       targetScala3

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EnumGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EnumGenerator.scala
@@ -33,10 +33,12 @@ object EnumGenerator {
       val maybeCodecExtensions = jsonSerdeLib match {
         case _ if !jsonParamRefs.contains(name) && !queryParamRefs.contains(name) => ""
         case _ if !jsonParamRefs.contains(name)                                   => " derives enumextensions.EnumMirror"
-        case JsonSerdeLib.Circe if !queryParamRefs.contains(name) => " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec"
-        case JsonSerdeLib.Circe => " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec, enumextensions.EnumMirror"
-        case JsonSerdeLib.Jsoniter | JsonSerdeLib.Zio if !queryParamRefs.contains(name) => s" extends java.lang.Enum[$name]"
-        case JsonSerdeLib.Jsoniter | JsonSerdeLib.Zio => s" extends java.lang.Enum[$name] derives enumextensions.EnumMirror"
+        case JsonSerdeLib.Circe | JsonSerdeLib.Jsoniter if !queryParamRefs.contains(name) =>
+          " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec"
+        case JsonSerdeLib.Circe | JsonSerdeLib.Jsoniter =>
+          " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec, enumextensions.EnumMirror"
+        case JsonSerdeLib.Zio if !queryParamRefs.contains(name) => s" extends java.lang.Enum[$name]"
+        case JsonSerdeLib.Zio                                   => s" extends java.lang.Enum[$name] derives enumextensions.EnumMirror"
       }
       s"""$maybeCompanion
          |enum $name$maybeCodecExtensions {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EnumGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EnumGenerator.scala
@@ -33,10 +33,10 @@ object EnumGenerator {
       val maybeCodecExtensions = jsonSerdeLib match {
         case _ if !jsonParamRefs.contains(name) && !queryParamRefs.contains(name) => ""
         case _ if !jsonParamRefs.contains(name)                                   => " derives enumextensions.EnumMirror"
-        case JsonSerdeLib.Circe | JsonSerdeLib.Jsoniter if !queryParamRefs.contains(name) =>
-          " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec"
-        case JsonSerdeLib.Circe | JsonSerdeLib.Jsoniter =>
-          " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec, enumextensions.EnumMirror"
+        case JsonSerdeLib.Circe if !queryParamRefs.contains(name) => " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec"
+        case JsonSerdeLib.Circe => " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec, enumextensions.EnumMirror"
+        case JsonSerdeLib.Jsoniter if !queryParamRefs.contains(name) => ""
+        case JsonSerdeLib.Jsoniter => " derives enumextensions.EnumMirror"
         case JsonSerdeLib.Zio if !queryParamRefs.contains(name) => s" extends java.lang.Enum[$name]"
         case JsonSerdeLib.Zio                                   => s" extends java.lang.Enum[$name] derives enumextensions.EnumMirror"
       }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
@@ -323,11 +323,11 @@ object JsonSerdeGenerator {
         val body = if (schemaToJsonMapping.exists { case (className, jsonValue) => className != jsonValue }) {
           val discriminatorMap = indent(2)(
             schemaToJsonMapping
-              .map { case (k, v) => s"""case "$fullPathPrefix$k" => "$v"""" }
+              .map { case (k, v) => s"""case "$k" => "$v"""" }
               .mkString("\n", "\n", "\n")
           )
           val config =
-            s"""$jsoniterBaseConfig.withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("${discriminator.propertyName}")).withAdtLeafClassNameMapper{$discriminatorMap}"""
+            s"""$jsoniterBaseConfig.withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("${discriminator.propertyName}")).withAdtLeafClassNameMapper(x => com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.simpleClassName(x) match {$discriminatorMap})"""
           val serde =
             s"implicit lazy val ${uncapitalisedName}Codec: $jsoniterPkgCore.JsonValueCodec[$name] = $jsoniterPkgMacros.JsonCodecMaker.make($config)"
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
@@ -1,0 +1,101 @@
+package sttp.tapir.generated
+
+object TapirGeneratedEndpoints {
+
+  import sttp.tapir._
+  import sttp.tapir.model._
+  import sttp.tapir.generic.auto._
+  import sttp.tapir.json.jsoniter._
+  import com.github.plokhotnyuk.jsoniter_scala.macros._
+  import com.github.plokhotnyuk.jsoniter_scala.core._
+
+  import sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes._
+  import TapirGeneratedEndpointsSchemas._
+
+
+  case class CommaSeparatedValues[T](values: List[T])
+  case class ExplodedValues[T](values: List[T])
+  trait ExtraParamSupport[T] {
+    def decode(s: String): sttp.tapir.DecodeResult[T]
+    def encode(t: T): String
+  }
+  implicit def makePathCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[String, T, sttp.tapir.CodecFormat.TextPlain] = {
+    sttp.tapir.Codec.string.mapDecode(support.decode)(support.encode)
+  }
+  implicit def makeQueryCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain] = {
+    sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
+      .mapDecode(support.decode)(support.encode)
+  }
+  implicit def makeQueryOptCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[List[String], Option[T], sttp.tapir.CodecFormat.TextPlain] = {
+    sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
+      .mapDecode(maybeV => DecodeResult.sequence(maybeV.toSeq.map(support.decode)).map(_.headOption))(_.map(support.encode))
+  }
+  implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
+    sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+  }
+  implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
+    sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
+      .mapDecode{
+        case None => DecodeResult.Value(None)
+        case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
+      }(_.map(_.values.map(support.encode).mkString(",")))
+  }
+  implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
+    support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)
+  }
+
+
+  sealed trait ADTWithoutDiscriminator
+  sealed trait ADTWithDiscriminator
+  sealed trait ADTWithDiscriminatorNoMapping
+  case class SubtypeWithoutD1 (
+    s: String,
+    i: Option[Int] = None,
+    a: Seq[String],
+    absent: Option[String] = None
+  ) extends ADTWithoutDiscriminator
+  case class SubtypeWithD1 (
+    s: String,
+    i: Option[Int] = None,
+    d: Option[Double] = None
+  ) extends ADTWithDiscriminator with ADTWithDiscriminatorNoMapping
+  case class SubtypeWithoutD3 (
+    s: String,
+    i: Option[Int] = None,
+    e: Option[AnEnum] = None,
+    absent: Option[String] = None
+  ) extends ADTWithoutDiscriminator
+  case class SubtypeWithoutD2 (
+    a: Seq[String],
+    absent: Option[String] = None
+  ) extends ADTWithoutDiscriminator
+  case class SubtypeWithD2 (
+    s: String,
+    a: Option[Seq[String]] = None
+  ) extends ADTWithDiscriminator with ADTWithDiscriminatorNoMapping
+
+  enum AnEnum derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec {
+    case Foo, Bar, Baz
+  }
+
+
+
+  lazy val putAdtTest =
+    endpoint
+      .put
+      .in(("adt" / "test"))
+      .in(jsonBody[ADTWithoutDiscriminator])
+      .out(jsonBody[ADTWithoutDiscriminator].description("successful operation"))
+
+  lazy val postAdtTest =
+    endpoint
+      .post
+      .in(("adt" / "test"))
+      .in(jsonBody[ADTWithDiscriminatorNoMapping])
+      .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
+
+
+  lazy val generatedEndpoints = List(putAdtTest, postAdtTest)
+
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
@@ -75,7 +75,7 @@ object TapirGeneratedEndpoints {
     a: Option[Seq[String]] = None
   ) extends ADTWithDiscriminator with ADTWithDiscriminatorNoMapping
 
-  enum AnEnum derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec {
+  enum AnEnum {
     case Foo, Bar, Baz
   }
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/build.sbt
@@ -1,0 +1,39 @@
+lazy val root = (project in file("."))
+  .enablePlugins(OpenapiCodegenPlugin)
+  .settings(
+    scalaVersion := "3.3.3",
+    version := "0.1",
+    openapiJsonSerdeLib := "jsoniter"
+  )
+
+libraryDependencies ++= Seq(
+  "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % "1.10.0",
+  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.10.0",
+  "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.8.0",
+  "com.beachape" %% "enumeratum" % "1.7.4",
+  "org.latestbit" %% "circe-tagged-adt-codec" % "0.11.0",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.30.7",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.30.7" % "compile-internal",
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test,
+  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.10.0" % Test
+)
+
+import sttp.tapir.sbt.OpenapiCodegenPlugin.autoImport.{openapiJsonSerdeLib, openapiUseHeadTagForObjectName}
+
+import scala.io.Source
+
+TaskKey[Unit]("check") := {
+  val generatedCode =
+    Source.fromFile("target/scala-3.3.3/src_managed/main/sbt-openapi-codegen/TapirGeneratedEndpoints.scala").getLines.mkString("\n")
+  val expected = Source.fromFile("Expected.scala.txt").getLines.mkString("\n")
+  val generatedTrimmed =
+    generatedCode.linesIterator.zipWithIndex.filterNot(_._1.forall(_.isWhitespace)).map { case (a, i) => a.trim -> i }.toSeq
+  val expectedTrimmed = expected.linesIterator.filterNot(_.forall(_.isWhitespace)).map(_.trim).toSeq
+  if (generatedTrimmed.size != expectedTrimmed.size)
+    sys.error(s"expected ${expectedTrimmed.size} non-empty lines, found ${generatedTrimmed.size}")
+  generatedTrimmed.zip(expectedTrimmed).foreach { case ((a, i), b) =>
+    if (a != b) sys.error(s"Generated code did not match (expected '$b' on line $i, found '$a')")
+  }
+  println("Skipping swagger roundtrip for petstore")
+  ()
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/build.sbt
@@ -11,7 +11,6 @@ libraryDependencies ++= Seq(
   "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.10.0",
   "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.8.0",
   "com.beachape" %% "enumeratum" % "1.7.4",
-  "org.latestbit" %% "circe-tagged-adt-codec" % "0.11.0",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.30.7",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.30.7" % "compile-internal",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/project/build.properties
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.10.1

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/project/plugins.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/project/plugins.sbt
@@ -1,0 +1,11 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|
+                                  |
+                                  |The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.
+                                  |
+                                  |""".stripMargin)
+  else addSbtPlugin("com.softwaremill.sttp.tapir" % "sbt-openapi-codegen" % pluginVersion)
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/src/main/scala/Main.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/src/main/scala/Main.scala
@@ -1,0 +1,12 @@
+object Main extends App {
+  import sttp.apispec.openapi.circe.yaml._
+  import sttp.tapir.generated._
+  import sttp.tapir.docs.openapi._
+
+  val docs = OpenAPIDocsInterpreter().toOpenAPI(TapirGeneratedEndpoints.generatedEndpoints, "My Bookshop", "1.0")
+
+  import java.nio.file.{Paths, Files}
+  import java.nio.charset.StandardCharsets
+
+  Files.write(Paths.get("target/swagger.yaml"), docs.toYaml.getBytes(StandardCharsets.UTF_8))
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/src/test/scala/JsonRoundtrip.scala
@@ -1,0 +1,151 @@
+import com.github.plokhotnyuk.jsoniter_scala.core.writeToString
+import io.circe.parser.parse
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.client3.UriContext
+import sttp.client3.testing.SttpBackendStub
+import sttp.tapir.generated.{TapirGeneratedEndpoints, TapirGeneratedEndpointsJsonSerdes}
+import sttp.tapir.generated.TapirGeneratedEndpoints.*
+import sttp.tapir.generated.TapirGeneratedEndpointsSchemas.*
+import TapirGeneratedEndpointsJsonSerdes._
+import sttp.tapir.server.stub.TapirStubInterpreter
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class JsonRoundtrip extends AnyFreeSpec with Matchers {
+  "println!" in {
+    println(">> A: " +SubtypeWithD1("a", None, None).getClass.getName)
+    println(">> B: " +classOf[SubtypeWithD1])
+  }
+  "oneOf without discriminator can be round-tripped by generated serdes" in {
+    val route = TapirGeneratedEndpoints.putAdtTest.serverLogic[Future]({
+      case foo: SubtypeWithoutD1 =>
+        Future successful Right[Unit, ADTWithoutDiscriminator](SubtypeWithoutD1(foo.s + "+SubtypeWithoutD1", foo.i, foo.a))
+      case foo: SubtypeWithoutD2 => Future successful Right[Unit, ADTWithoutDiscriminator](SubtypeWithoutD2(foo.a :+ "+SubtypeWithoutD2"))
+      case foo: SubtypeWithoutD3 =>
+        Future successful Right[Unit, ADTWithoutDiscriminator](SubtypeWithoutD3(foo.s + "+SubtypeWithoutD3", foo.i, foo.e))
+    })
+
+    val stub = TapirStubInterpreter(SttpBackendStub.asynchronousFuture)
+      .whenServerEndpoint(route)
+      .thenRunLogic()
+      .backend()
+
+    def normalise(json: String): String = parse(json).toTry.get.noSpacesSortKeys
+    locally {
+      val reqBody = SubtypeWithoutD1("a string", Some(123), Seq("string 1", "string 2"))
+      val reqJsonBody = writeToString(reqBody)
+      val respBody = SubtypeWithoutD1("a string+SubtypeWithoutD1", Some(123), Seq("string 1", "string 2"))
+      val respJsonBody = writeToString(respBody)
+      reqJsonBody shouldEqual """{"s":"a string","i":123,"a":["string 1","string 2"]}"""
+      respJsonBody shouldEqual """{"s":"a string+SubtypeWithoutD1","i":123,"a":["string 1","string 2"]}"""
+      Await.result(
+        sttp.client3.basicRequest
+          .put(uri"http://test.com/adt/test")
+          .body(reqJsonBody)
+          .send(stub)
+          .map { resp =>
+            resp.code.code === 200
+            resp.body shouldEqual Right(respJsonBody)
+          },
+        1.second
+      )
+    }
+
+    locally {
+      val reqBody = SubtypeWithoutD2(Seq("string 1", "string 2"))
+      val reqJsonBody = writeToString(reqBody)
+      val respBody = SubtypeWithoutD2(Seq("string 1", "string 2", "+SubtypeWithoutD2"))
+      val respJsonBody = writeToString(respBody)
+      reqJsonBody shouldEqual """{"a":["string 1","string 2"]}"""
+      respJsonBody shouldEqual """{"a":["string 1","string 2","+SubtypeWithoutD2"]}"""
+      Await.result(
+        sttp.client3.basicRequest
+          .put(uri"http://test.com/adt/test")
+          .body(reqJsonBody)
+          .send(stub)
+          .map { resp =>
+            resp.body shouldEqual Right(respJsonBody)
+            resp.code.code === 200
+          },
+        1.second
+      )
+    }
+
+    locally {
+      val reqBody = SubtypeWithoutD3("a string", Some(123), Some(AnEnum.Foo))
+      val reqJsonBody = writeToString(reqBody)
+      val respBody = SubtypeWithoutD3("a string+SubtypeWithoutD3", Some(123), Some(AnEnum.Foo))
+      val respJsonBody = writeToString(respBody)
+      reqJsonBody shouldEqual """{"s":"a string","i":123,"e":"Foo"}"""
+      respJsonBody shouldEqual """{"s":"a string+SubtypeWithoutD3","i":123,"e":"Foo"}"""
+      Await.result(
+        sttp.client3.basicRequest
+          .put(uri"http://test.com/adt/test")
+          .body(reqJsonBody)
+          .send(stub)
+          .map { resp =>
+            resp.body shouldEqual Right(respJsonBody)
+            resp.code.code === 200
+          },
+        1.second
+      )
+    }
+  }
+  "oneOf with discriminator can be round-tripped by generated serdes" in {
+    val route = TapirGeneratedEndpoints.postAdtTest.serverLogic[Future]({
+      case foo: SubtypeWithD1 => Future successful Right[Unit, ADTWithDiscriminator](SubtypeWithD1(foo.s + "+SubtypeWithD1", foo.i, foo.d))
+      case foo: SubtypeWithD2 => Future successful Right[Unit, ADTWithDiscriminator](SubtypeWithD2(foo.s + "+SubtypeWithD2", foo.a))
+    })
+
+    val stub = TapirStubInterpreter(SttpBackendStub.asynchronousFuture)
+      .whenServerEndpoint(route)
+      .thenRunLogic()
+      .backend()
+
+    def normalise(json: String): String = parse(json).toTry.get.noSpacesSortKeys
+
+    locally {
+      val reqBody: ADTWithDiscriminatorNoMapping = SubtypeWithD1("a string", Some(123), Some(23.4))
+      val reqJsonBody = writeToString(reqBody)
+      val respBody: ADTWithDiscriminator = SubtypeWithD1("a string+SubtypeWithD1", Some(123), Some(23.4))
+      val respJsonBody = writeToString(respBody)
+      reqJsonBody shouldEqual """{"type":"SubtypeWithD1","s":"a string","i":123,"d":23.4}"""
+      respJsonBody shouldEqual """{"type":"SubA","s":"a string+SubtypeWithD1","i":123,"d":23.4}"""
+      Await.result(
+        sttp.client3.basicRequest
+          .post(uri"http://test.com/adt/test")
+          .body(reqJsonBody)
+          .send(stub)
+          .map { resp =>
+            resp.code.code === 200
+            resp.body shouldEqual Right(respJsonBody)
+          },
+        1.second
+      )
+    }
+
+    locally {
+      val reqBody: ADTWithDiscriminatorNoMapping = SubtypeWithD2("a string", Some(Seq("string 1", "string 2")))
+      val reqJsonBody = writeToString(reqBody)
+      val respBody: ADTWithDiscriminator = SubtypeWithD2("a string+SubtypeWithD2", Some(Seq("string 1", "string 2")))
+      val respJsonBody = writeToString(respBody)
+      reqJsonBody shouldEqual """{"type":"SubtypeWithD2","s":"a string","a":["string 1","string 2"]}"""
+      respJsonBody shouldEqual """{"type":"SubB","s":"a string+SubtypeWithD2","a":["string 1","string 2"]}"""
+      Await.result(
+        sttp.client3.basicRequest
+          .post(uri"http://test.com/adt/test")
+          .body(reqJsonBody)
+          .send(stub)
+          .map { resp =>
+            resp.code.code === 200
+            resp.body shouldEqual Right(respJsonBody)
+          },
+        1.second
+      )
+    }
+
+  }
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/src/test/scala/JsonRoundtrip.scala
@@ -15,10 +15,6 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class JsonRoundtrip extends AnyFreeSpec with Matchers {
-  "println!" in {
-    println(">> A: " +SubtypeWithD1("a", None, None).getClass.getName)
-    println(">> B: " +classOf[SubtypeWithD1])
-  }
   "oneOf without discriminator can be round-tripped by generated serdes" in {
     val route = TapirGeneratedEndpoints.putAdtTest.serverLogic[Future]({
       case foo: SubtypeWithoutD1 =>

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/swagger.yaml
@@ -1,0 +1,138 @@
+openapi: 3.0.3
+servers:
+  - url: /v3
+info:
+  description: File for testing json roundtripping of oneOf defns in scala 2.x with jsoniter-scala
+  version: 1.0.20-SNAPSHOT
+  title: OneOf Json test for jsoniter-scala
+tags: []
+paths:
+  '/adt/test':
+    post:
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ADTWithDiscriminator'
+      requestBody:
+        required: true
+        description: Update an existent user in the store
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ADTWithDiscriminatorNoMapping'
+    put:
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ADTWithoutDiscriminator'
+      requestBody:
+        required: true
+        description: Update an existent user in the store
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ADTWithoutDiscriminator'
+
+components:
+  schemas:
+    ADTWithDiscriminator:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/SubtypeWithD1'
+        - $ref: '#/components/schemas/SubtypeWithD2'
+      discriminator:
+        propertyName: type
+        mapping:
+          'SubA': '#/components/schemas/SubtypeWithD1'
+          'SubB': '#/components/schemas/SubtypeWithD2'
+    # This has the same members as ADTWithDiscriminator, to test that we can extend multiple sealed traits in our ADT mappings
+    ADTWithDiscriminatorNoMapping:
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/SubtypeWithD1'
+        - $ref: '#/components/schemas/SubtypeWithD2'
+      discriminator:
+        propertyName: type
+    SubtypeWithD1:
+      type: object
+      required:
+        - s
+      properties:
+        s:
+          type: string
+        i:
+          type: integer
+        d:
+          type: number
+          format: double
+    SubtypeWithD2:
+      type: object
+      required:
+        - s
+      properties:
+        s:
+          type: string
+        a:
+          type: array
+          items:
+            type: string
+    ADTWithoutDiscriminator:
+      type: object
+      oneOf:
+        ## A 'SubtypeWithoutD1' with only 'a' and 'd' fields set could be decoded as either a SubtypeWithoutD2 or SubtypeWithoutD3,
+        ## and so must be defined first here, or else we'd fail validation
+        - $ref: '#/components/schemas/SubtypeWithoutD1'
+        - $ref: '#/components/schemas/SubtypeWithoutD2'
+        - $ref: '#/components/schemas/SubtypeWithoutD3'
+    SubtypeWithoutD1:
+      type: object
+      required:
+        - s
+        - a
+      properties:
+        s:
+          type: string
+        i:
+          type: integer
+        a:
+          type: array
+          items:
+            type: string
+        absent:
+          type: string
+    SubtypeWithoutD2:
+      type: object
+      required:
+        - a
+      properties:
+        a:
+          type: array
+          items:
+            type: string
+        absent:
+          type: string
+    SubtypeWithoutD3:
+      type: object
+      required:
+        - s
+      properties:
+        s:
+          type: string
+        i:
+          type: integer
+        e:
+          $ref: '#/components/schemas/AnEnum'
+        absent:
+          type: string
+    AnEnum:
+      type: string
+      enum:
+        - Foo
+        - Bar
+        - Baz

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/test
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/test
@@ -1,0 +1,6 @@
+> clean
+> generateTapirDefinitions
+> run
+> test
+> check
+


### PR DESCRIPTION
Fixes a couple of issues with jsoniter in scala 3:
- Enum serde generation now works
- Custom discriminator mappings now work

I'm not sure what magic makes `JsonCodecMaker.simpleClassName` work when trying to construct the full path name fails, but since the parent traits for all oneOf definitions are sealed, and our class heirarchy is completely flat, there's no potential for ambiguity just using the simple class name.

With this change, we no longer do anything with the full package path in the serde generations, so I was able to remove that parameter entirely from the class, which is nice.