### PR TITLE
codegen: add streaming support for application/octet-stream contents

### DIFF
--- a/generated-doc/out/generator/sbt-openapi-codegen.md
+++ b/generated-doc/out/generator/sbt-openapi-codegen.md
@@ -44,6 +44,7 @@ openapiJsonSerdeLib                   circe                                The j
 openapiValidateNonDiscriminatedOneOfs true                                 Whether to fail if variants of a oneOf without a discriminator cannot be disambiguated.
 openapiMaxSchemasPerFile              400                                  Maximum number of schemas to generate in a single file (tweak if hitting javac class size limits).
 openapiAdditionalPackages             Nil                                  Additional packageName/swaggerFile pairs for generating from multiple schemas 
+openapiStreamingImplementation        fs2                                  Backend capability to assume for streaming content. Supports akka, fs2, pekko and zio.  
 ===================================== ==================================== ==================================================================================================
 ```
 

--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -62,6 +62,9 @@ object GenScala {
   private val jsonLibOpt: Opts[Option[String]] =
     Opts.option[String]("jsonLib", "Json library to use for serdes", "j").orNone
 
+  private val streamingImplementationOpt: Opts[Option[String]] =
+    Opts.option[String]("streamingImplementation", "Capability to use for binary streams", "s").orNone
+
   private val destDirOpt: Opts[File] =
     Opts
       .option[String]("destdir", "Destination directory", "d")
@@ -84,7 +87,8 @@ object GenScala {
       headTagForNamesOpt,
       jsonLibOpt,
       validateNonDiscriminatedOneOfsOpt,
-      maxSchemasPerFileOpt
+      maxSchemasPerFileOpt,
+      streamingImplementationOpt
     )
       .mapN {
         case (
@@ -96,7 +100,8 @@ object GenScala {
               headTagForNames,
               jsonLib,
               validateNonDiscriminatedOneOfs,
-              maxSchemasPerFile
+              maxSchemasPerFile,
+              streamingImplementation
             ) =>
           val objectName = maybeObjectName.getOrElse(DefaultObjectName)
 
@@ -109,6 +114,7 @@ object GenScala {
                 targetScala3,
                 headTagForNames,
                 jsonLib.getOrElse("circe"),
+                streamingImplementation.getOrElse("fs2"),
                 validateNonDiscriminatedOneOfs,
                 maxSchemasPerFile.getOrElse(400)
               )

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -396,7 +396,7 @@ class EndpointGenerator {
                 val (t, _) = mapSchemaSimpleTypeToType(st)
                 s"Map[String, $t]"
               case x => bail(s"Can't create this param as output (found $x)")
-                }
+            }
             s"streamBody($capability)(Schema.binary[$outT], CodecFormat.OctetStream())"
         }
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -382,7 +382,7 @@ class EndpointGenerator {
               case StreamingImplementation.Pekko => "sttp.capabilities.pekko.PekkoStreams"
               case StreamingImplementation.Zio   => "sttp.capabilities.zio.ZioStreams"
             }
-            s"streamTextBody($capability)(CodecFormat.TextPlain())"
+            s"streamTextBody($capability)(CodecFormat.OctetStream())"
           case x => bail(s"$contentType only supports binary schema. Found $x")
         }
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -383,6 +383,7 @@ class EndpointGenerator {
               case StreamingImplementation.Zio   => "sttp.capabilities.zio.ZioStreams"
             }
             s"streamTextBody($capability)(CodecFormat.TextPlain())"
+          case x => bail(s"$contentType only supports binary schema. Found $x")
         }
 
       case x => bail(s"Not all content types supported! Found $x")

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
@@ -17,7 +17,8 @@ class BasicGeneratorSpec extends CompileCheckTestBase {
       useHeadTagForObjectNames = useHeadTagForObjectNames,
       jsonSerdeLib = jsonSerdeLib,
       validateNonDiscriminatedOneOfs = true,
-      maxSchemasPerFile = 400
+      maxSchemasPerFile = 400,
+      streamingImplementation = "fs2"
     )
   }
   def gen(

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -391,7 +391,13 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       case Left(value) => throw new Exception(value)
       case Right(doc) =>
         new EndpointGenerator()
-          .endpointDefs(doc, useHeadTagForObjectNames = false, targetScala3 = false, jsonSerdeLib = JsonSerdeLib.Circe)
+          .endpointDefs(
+            doc,
+            useHeadTagForObjectNames = false,
+            targetScala3 = false,
+            jsonSerdeLib = JsonSerdeLib.Circe,
+            streamingImplementation = StreamingImplementation.FS2
+          )
           .endpointDecls(None)
     }
 

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -63,7 +63,13 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
     )
     val generatedCode = BasicGenerator.imports(JsonSerdeLib.Circe) ++
       new EndpointGenerator()
-        .endpointDefs(doc, useHeadTagForObjectNames = false, targetScala3 = false, jsonSerdeLib = JsonSerdeLib.Circe)
+        .endpointDefs(
+          doc,
+          useHeadTagForObjectNames = false,
+          targetScala3 = false,
+          jsonSerdeLib = JsonSerdeLib.Circe,
+          streamingImplementation = StreamingImplementation.FS2
+        )
         .endpointDecls(None)
     generatedCode should include("val getTestAsdId =")
     generatedCode should include(""".in(query[Option[String]]("fgh-id"))""")
@@ -142,7 +148,13 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
     )
     BasicGenerator.imports(JsonSerdeLib.Circe) ++
       new EndpointGenerator()
-        .endpointDefs(doc, useHeadTagForObjectNames = false, targetScala3 = false, jsonSerdeLib = JsonSerdeLib.Circe)
+        .endpointDefs(
+          doc,
+          useHeadTagForObjectNames = false,
+          targetScala3 = false,
+          jsonSerdeLib = JsonSerdeLib.Circe,
+          streamingImplementation = StreamingImplementation.FS2
+        )
         .endpointDecls(None) shouldCompile ()
   }
 
@@ -188,7 +200,13 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
     )
     val generatedCode = BasicGenerator.imports(JsonSerdeLib.Circe) ++
       new EndpointGenerator()
-        .endpointDefs(doc, useHeadTagForObjectNames = false, targetScala3 = false, jsonSerdeLib = JsonSerdeLib.Circe)
+        .endpointDefs(
+          doc,
+          useHeadTagForObjectNames = false,
+          targetScala3 = false,
+          jsonSerdeLib = JsonSerdeLib.Circe,
+          streamingImplementation = StreamingImplementation.FS2
+        )
         .endpointDecls(None)
     generatedCode should include(
       """.out(stringBody.description("Processing").and(statusCode(sttp.model.StatusCode(202))))"""
@@ -253,7 +271,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       useHeadTagForObjectNames = false,
       jsonSerdeLib = "circe",
       validateNonDiscriminatedOneOfs = true,
-      maxSchemasPerFile = 400
+      maxSchemasPerFile = 400,
+      streamingImplementation = "fs2"
     )("TapirGeneratedEndpoints")
     generatedCode should include(
       """file: sttp.model.Part[java.io.File]"""
@@ -274,7 +293,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       useHeadTagForObjectNames = false,
       jsonSerdeLib = "circe",
       validateNonDiscriminatedOneOfs = true,
-      maxSchemasPerFile = 400
+      maxSchemasPerFile = 400,
+      streamingImplementation = "fs2"
     )("TapirGeneratedEndpoints")
     generatedCode shouldCompile ()
     val expectedAttrDecls = Seq(

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -2,6 +2,18 @@ package sttp.tapir.sbt
 
 import sbt._
 
+case class OpenApiConfiguration(
+    swaggerFile: File,
+    packageName: String,
+    objectName: String,
+    useHeadTagForObjectName: Boolean,
+    jsonSerdeLib: String,
+    streamingImplementation: String,
+    validateNonDiscriminatedOneOfs: Boolean,
+    maxSchemasPerFile: Int,
+    additionalPackages: List[(String, File)]
+)
+
 trait OpenapiCodegenKeys {
   lazy val openapiSwaggerFile = settingKey[File]("The swagger file with the api definitions.")
   lazy val openapiPackage = settingKey[String]("The name for the generated package.")
@@ -13,7 +25,10 @@ trait OpenapiCodegenKeys {
   lazy val openapiValidateNonDiscriminatedOneOfs =
     settingKey[Boolean]("Whether to fail if variants of a oneOf without a discriminator cannot be disambiguated..")
   lazy val openapiMaxSchemasPerFile = settingKey[Int]("Maximum number of schemas to generate for a single file")
-  lazy val openapiAdditionalPackages = taskKey[List[(String, File)]]("Addition package -> spec mappings to generate.")
+  lazy val openapiAdditionalPackages = settingKey[List[(String, File)]]("Addition package -> spec mappings to generate.")
+  lazy val openapiStreamingImplementation = settingKey[String]("Implementation for streamTextBody. Supports: akka, fs2, pekko, zio.")
+  lazy val openapiOpenApiConfiguration =
+    settingKey[OpenApiConfiguration]("Aggregation of other settings. Manually set value will be disregarded.")
 
   lazy val generateTapirDefinitions = taskKey[Unit]("The task that generates tapir definitions based on the input swagger file.")
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -66,8 +66,8 @@ object OpenapiCodegenPlugin extends AutoPlugin {
         ) =>
           def genTask(swaggerFile: File, packageName: String, directoryName: Option[String] = None) =
             OpenapiCodegenTask(
-              c.swaggerFile,
-              c.packageName,
+              swaggerFile,
+              packageName,
               c.objectName,
               c.useHeadTagForObjectName,
               c.jsonSerdeLib,

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -47,8 +47,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
     standardParamSetting
   )
 
-  private def codegen = Def.sequential(
-    Def.task { standardParamSetting },
+  private def codegen =
     Def.task {
       val log = sLog.value
       log.info("Zipping file...")
@@ -85,5 +84,4 @@ object OpenapiCodegenPlugin extends AutoPlugin {
             .reduceLeft((l, r) => l.flatMap(_l => r.map(_l ++ _)))
       }) map (Seq(_))).value
     }
-  )
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -18,7 +18,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
   def openapiCodegenScopedSettings(conf: Configuration): Seq[Setting[_]] = inConfig(conf)(
     Seq(
       generateTapirDefinitions := codegen.value,
-      sourceGenerators += (codegen.taskValue).map(_.flatMap(_.map(_.toPath.toFile)))
+      sourceGenerators += (codegen.taskValue).map(_.map(_.toPath.toFile))
     )
   )
 
@@ -51,12 +51,12 @@ object OpenapiCodegenPlugin extends AutoPlugin {
     Def.task {
       val log = sLog.value
       log.info("Zipping file...")
-      (((
+      (
         openapiOpenApiConfiguration,
         sourceManaged,
         streams,
         scalaVersion
-      ) flatMap {
+      ).flatMap {
         (
             c: OpenApiConfiguration,
             srcDir: File,
@@ -82,6 +82,6 @@ object OpenapiCodegenPlugin extends AutoPlugin {
             genTask(defns, pkg, Some(pkg.replace('.', '/'))).file
           })
             .reduceLeft((l, r) => l.flatMap(_l => r.map(_l ++ _)))
-      }) map (Seq(_))).value
+      }.value
     }
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -11,6 +11,7 @@ case class OpenapiCodegenTask(
     objectName: String,
     useHeadTagForObjectName: Boolean,
     jsonSerdeLib: String,
+    streamingImplementation: String,
     validateNonDiscriminatedOneOfs: Boolean,
     maxSchemasPerFile: Int,
     dir: File,
@@ -56,6 +57,7 @@ case class OpenapiCodegenTask(
           targetScala3,
           useHeadTagForObjectName,
           jsonSerdeLib,
+          streamingImplementation,
           validateNonDiscriminatedOneOfs,
           maxSchemasPerFile
         )

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -123,13 +123,13 @@ object TapirGeneratedEndpoints {
     endpoint
       .get
       .in(("binary" / "test"))
-      .out(streamTextBody(sttp.capabilities.pekko.PekkoStreams)(CodecFormat.OctetStream()).description("Response CSV body"))
+      .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Array[Byte]], CodecFormat.OctetStream()).description("Response CSV body"))
 
   lazy val postBinaryTest =
     endpoint
       .post
       .in(("binary" / "test"))
-      .in(streamTextBody(sttp.capabilities.pekko.PekkoStreams)(CodecFormat.OctetStream()))
+      .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Array[Byte]], CodecFormat.OctetStream()))
       .out(jsonBody[String].description("successful operation"))
 
   lazy val putAdtTest =

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -117,6 +117,21 @@ object TapirGeneratedEndpoints {
     case object Baz extends AnEnum
   }
 
+
+
+  lazy val getBinaryTest =
+    endpoint
+      .get
+      .in(("binary" / "test"))
+      .out(streamTextBody(sttp.capabilities.pekko.PekkoStreams)(CodecFormat.TextPlain()).description("Response CSV body"))
+
+  lazy val postBinaryTest =
+    endpoint
+      .post
+      .in(("binary" / "test"))
+      .in(streamTextBody(sttp.capabilities.pekko.PekkoStreams)(CodecFormat.TextPlain()))
+      .out(jsonBody[String].description("successful operation"))
+
   lazy val putAdtTest =
     endpoint
       .put
@@ -183,6 +198,6 @@ object TapirGeneratedEndpoints {
   }
 
 
-  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, postInlineEnumTest)
+  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putAdtTest, postAdtTest, postInlineEnumTest)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -123,13 +123,13 @@ object TapirGeneratedEndpoints {
     endpoint
       .get
       .in(("binary" / "test"))
-      .out(streamTextBody(sttp.capabilities.pekko.PekkoStreams)(CodecFormat.TextPlain()).description("Response CSV body"))
+      .out(streamTextBody(sttp.capabilities.pekko.PekkoStreams)(CodecFormat.OctetStream()).description("Response CSV body"))
 
   lazy val postBinaryTest =
     endpoint
       .post
       .in(("binary" / "test"))
-      .in(streamTextBody(sttp.capabilities.pekko.PekkoStreams)(CodecFormat.TextPlain()))
+      .in(streamTextBody(sttp.capabilities.pekko.PekkoStreams)(CodecFormat.OctetStream()))
       .out(jsonBody[String].description("successful operation"))
 
   lazy val putAdtTest =

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/build.sbt
@@ -2,12 +2,14 @@ lazy val root = (project in file("."))
   .enablePlugins(OpenapiCodegenPlugin)
   .settings(
     scalaVersion := "2.13.14",
-    version := "0.1"
+    version := "0.1",
+    openapiStreamingImplementation := "pekko"
   )
 
 libraryDependencies ++= Seq(
   "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % "1.10.0",
   "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.10.0",
+  "com.softwaremill.sttp.tapir" %% "tapir-pekko-http-server" % "1.10.0",
   "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.8.0",
   "io.circe" %% "circe-generic" % "0.14.9",
   "com.beachape" %% "enumeratum" % "1.7.4",

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/BinaryEndpoints.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/BinaryEndpoints.scala
@@ -1,0 +1,81 @@
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.capabilities.pekko.PekkoStreams
+import sttp.client3.testing.SttpBackendStub
+import sttp.client3.{Response, UriContext, asStringAlways}
+import sttp.monad.FutureMonad
+import sttp.tapir.generated.TapirGeneratedEndpoints
+import sttp.tapir.server.stub.TapirStubInterpreter
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
+import scala.util.Random
+
+class BinaryEndpoints extends AnyFreeSpec with Matchers {
+  private implicit val system: ActorSystem = ActorSystem()
+  private implicit val materializer: Materializer = Materializer.matFromSystem(system)
+  "binary endpoints work" in {
+    val respQueue = mutable.Queue.empty[String]
+    def iterator: Iterator[ByteString] = new Iterator[ByteString] {
+      private var linesToGo: Int = 100
+      def hasNext: Boolean = linesToGo > 0
+      def next(): ByteString = {
+        val nxt = Random.alphanumeric.take(40).mkString
+        linesToGo -= 1
+        ByteString.fromString(nxt, "utf-8")
+      }
+    }
+    val route1 =
+      TapirGeneratedEndpoints.postBinaryTest.serverLogicSuccess[Future]({ source: Source[ByteString, Any] =>
+        source
+          .map(bs => respQueue.append(bs.utf8String.reverse))
+          .run()
+          .map(_ => "ok")
+      })
+    val route2 =
+      TapirGeneratedEndpoints.getBinaryTest.serverLogicSuccess[Future]({ _ =>
+        Future.successful(org.apache.pekko.stream.scaladsl.Source[ByteString]({
+          respQueue.map(ByteString.fromString).toSeq
+        }))
+      })
+
+    val stub1 = TapirStubInterpreter(SttpBackendStub[Future, PekkoStreams](new FutureMonad()))
+      .whenServerEndpoint(route1)
+      .thenRunLogic()
+      .backend()
+    val stub2 = TapirStubInterpreter(SttpBackendStub[Future, PekkoStreams](new FutureMonad()))
+      .whenServerEndpoint(route2)
+      .thenRunLogic()
+      .backend()
+
+    def genSomeLines: Source[ByteString, Any] = Source.fromIterator(() => iterator)
+
+    def doPost = sttp.client3.basicRequest
+      .post(uri"http://test.com/binary/test")
+      .response(asStringAlways)
+      .streamBody(PekkoStreams)(genSomeLines)
+      .send(stub1)
+      .map { resp =>
+        resp.code.code === 200
+        resp.body === Right("ok")
+      }
+
+    def doGet: Future[Response[Source[ByteString, Any]]] = sttp.client3.basicRequest
+      .get(uri"http://test.com/binary/test")
+      .response(sttp.client3.asStreamUnsafe(PekkoStreams).map { case Right(s) => s })
+      .send[Future, PekkoStreams](stub2)
+
+    Await.result(doPost, 5.seconds)
+    respQueue.size shouldEqual 100
+    val orig = respQueue.toSeq
+    val b = Await.result(doGet.flatMap(_.body.runFold(Seq.empty[String])((l, a) => l :+ a.utf8String)), 5.seconds)
+    b.size shouldEqual 100
+    b shouldEqual orig
+  }
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -7,6 +7,34 @@ info:
   title: OneOf Json test for scala 2
 tags: [ ]
 paths:
+  '/binary/test':
+    get:
+      responses:
+        "200":
+          description: "Response CSV body"
+          content:
+            application/octet-stream:
+              schema:
+                description: "csv file"
+                type: string
+                format: binary
+    post:
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: string
+      requestBody:
+        required: true
+        description: Upload a csv
+        content:
+          application/octet-stream:
+            schema:
+              description: "csv file"
+              type: string
+              format: binary
   '/adt/test':
     post:
       responses:


### PR DESCRIPTION
Adding support for `application/octet-stream` content types, via `streamBody`/`streamTextBody`. Since the correct output code to produce depends upon the server provider, this also adds the flag `openapiStreamingImplementation`. 

There are more interpreters that this could support, but I figured that the 4 I've added are probably the most common and it should be easy to add support for others down the line.

I'd originally intended to support only Array[Byte] schemas, but I don't think that restriction is actually necessary; given that the implementing service will need to provide the serdes to/from the bytestream independently of the endpoint generation, and the Schema generation already seems to work pretty well, I figure it's probably fine just to use `Schema.binary[$theFormat]` and support the same range of types as the json endpoints.

This pr also refactors the SBT plugin a bit, since we'd reached the limit of the number of params that could be sustained by the old code.