### PR TITLE
Add multipart body support for ZIO-HTTP integration

### DIFF
--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpRequestBody.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpRequestBody.scala
@@ -1,16 +1,22 @@
 package sttp.tapir.server.ziohttp
 
-import sttp.capabilities
+import sttp.{capabilities, model}
 import sttp.capabilities.zio.ZioStreams
+import sttp.model.Part
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.interpreter.{RawValue, RequestBody}
-import sttp.tapir.{FileRange, InputStreamRange, RawBodyType}
-import zio.http.Request
+import sttp.tapir.{FileRange, InputStreamRange, RawBodyType, RawPart}
+import zio.http.FormField.StreamingBinary
+import zio.http.{FormField, Request}
 import zio.stream.{Stream, ZSink, ZStream}
 import zio.{RIO, Task, ZIO}
 
 import java.io.ByteArrayInputStream
 import java.nio.ByteBuffer
+import java.nio.file.Files
+import scala.collection.immutable
+import sttp.tapir.RawBodyType.FileBody
+import zio.http.multipart.mixed.MultipartMixed
 
 class ZioHttpRequestBody[R](serverOptions: ZioHttpServerOptions[R]) extends RequestBody[RIO[R, *], ZioStreams] {
   override val streams: capabilities.Streams[ZioStreams] = ZioStreams
@@ -30,9 +36,12 @@ class ZioHttpRequestBody[R](serverOptions: ZioHttpServerOptions[R]) extends Requ
       case RawBodyType.FileBody =>
         for {
           file <- serverOptions.createFile(serverRequest)
-          _ <- (toStream(serverRequest, maxBytes).asInstanceOf[ZStream[Any, Throwable, Byte]]).run(ZSink.fromFile(file)).map(_ => ())
+          _ <- (toStream(serverRequest, maxBytes)
+            .asInstanceOf[ZStream[Any, Throwable, Byte]])
+            .run(ZSink.fromFile(file))
+            .map(_ => ())
         } yield RawValue(FileRange(file), Seq(FileRange(file)))
-      case RawBodyType.MultipartBody(_, _) => ZIO.fail(new UnsupportedOperationException("Multipart is not supported"))
+      case RawBodyType.MultipartBody(partTypes, _) => toRawMultipart(serverRequest, partTypes)
     }
   }
 
@@ -45,4 +54,47 @@ class ZioHttpRequestBody[R](serverOptions: ZioHttpServerOptions[R]) extends Requ
     zioHttpRequest(serverRequest).body.asStream
 
   private def zioHttpRequest(serverRequest: ServerRequest) = serverRequest.underlying.asInstanceOf[Request]
+
+  private def decodeFilePart(part: MultipartMixed.Part, filename: Option[String]): Task[model.Part[FileRange]] =
+    for {
+      file <- ZIO.attemptBlocking(Files.createTempFile("upload-", ".tmp"))
+      sink = ZSink.fromFile(file.toFile)
+      _ <- part.bytes.run(sink)
+    } yield model.Part(name = "file", body = FileRange(file.toFile), fileName = filename)
+
+  private def decodeTextPart(part: MultipartMixed.Part, fieldName: String): Task[model.Part[String]] =
+    part.toBody.asString.map(body => model.Part(name = fieldName, body = body))
+
+  private def toRawMultipart(
+                              serverRequest: ServerRequest,
+                              partTypes: Map[String, RawBodyType[_]]
+                            ): Task[RawValue[Seq[Part[Any]]]] = // Task[RawValue[Seq[Part[String | FileRange]]]]
+  {
+    def isFile(formField: FormField): Boolean = partTypes.getOrElse(
+      formField.name,
+      throw new IllegalArgumentException(s"Can't find the part type with name ${formField.name}")
+    ) match {
+      case FileBody => true
+      case _        => false
+    }
+
+    ZStream
+      // we use `asMultipartMixed` because it gives access to the raw data...
+      .fromZIO(zioHttpRequest(serverRequest).body.asMultipartMixed)
+      .flatMap(_.parts)
+      .zip(
+        // ...and we use `asMultipartFormStream` for the form field name and the filename only because
+        // the file content appears to be decoded wrongly by `asMultipartFormStream`
+        ZStream.fromZIO(zioHttpRequest(serverRequest).body.asMultipartFormStream).flatMap(_.fields)
+      )
+      .flatMap {
+        case (part, metadata) if isFile(metadata) =>
+          ZStream.fromZIO(decodeFilePart(part, filename = metadata.filename))
+        case (part, metadata) =>
+          ZStream.fromZIO(decodeTextPart(part, fieldName = metadata.name))
+      }
+      .runCollect
+      .map(RawValue(_))
+  }
+
 }


### PR DESCRIPTION
This is an attempt to support the multipart request body. I tested it to work in our corporate setup, with a derived multipart codec for a case class which included a file part.

Here is a list of excuses for how clumsy this code looks:
- I had to tread really carefully to provide the object of the correct class to resulting `Part[_]` to avoid `ClassCastException`s down the stream,
- There wasn't one good way I could come up with to collect the needed information about each of the body parts. In particular, I used `MultipartBody.partTypes` to figure out the part type (file vs text), `asMultipartFormStream` for parts metadata like field name and filename, 
- And I used `asMultipartMixed` for the actual file payload because `asMultipartFormStream` gave me this content with line-breaks corrupted.