### PR TITLE
Make inlined schema derivation null safe

### DIFF
--- a/core/src/main/scala-3/sttp/tapir/generic/auto/SchemaMagnoliaDerivation.scala
+++ b/core/src/main/scala-3/sttp/tapir/generic/auto/SchemaMagnoliaDerivation.scala
@@ -119,14 +119,14 @@ trait SchemaMagnoliaDerivation {
         */
       private def withCache[T](typeName: TypeInfo, annotations: Seq[Any])(f: => Schema[T]): Schema[T] = {
         val cacheKey = typeName.full
-        val inProgressOrNull = deriveCache.get()
+        val inProgressOrNull: mutable.Set[String] | Null = deriveCache.get()
         val newCache = inProgressOrNull == null
-
-        val inProgress = if (inProgressOrNull == null) {
+        
+        val inProgress = if (newCache) {
           val newInProgress = mutable.Set[String]()
           deriveCache.set(newInProgress)
           newInProgress
-        } else inProgressOrNull
+        } else inProgressOrNull.nn
 
         if (inProgress.contains(cacheKey)) {
           Schema[T](SRef(typeNameToSchemaName(typeName, annotations)))

--- a/core/src/main/scala-3/sttp/tapir/generic/auto/SchemaMagnoliaDerivation.scala
+++ b/core/src/main/scala-3/sttp/tapir/generic/auto/SchemaMagnoliaDerivation.scala
@@ -121,7 +121,7 @@ trait SchemaMagnoliaDerivation {
         val cacheKey = typeName.full
         val inProgressOrNull: mutable.Set[String] | Null = deriveCache.get()
         val newCache = inProgressOrNull == null
-        
+
         val inProgress = if (newCache) {
           val newInProgress = mutable.Set[String]()
           deriveCache.set(newInProgress)


### PR DESCRIPTION
https://github.com/softwaremill/tapir/pull/3970 does not actually resolve https://github.com/softwaremill/tapir/issues/3967 but this change does.

Scala 3's explicit nulls requires that `inProgress` be of type `mutable.Set[String]` (note the absence of ` | Null`) otherwise this causes client code to fail compilation.

By adding `.nn` after the null check we safely discard the ` | Null` half of the type, which allows `inProgress` to be the required non-null type.