### PR TITLE
codegen: limited support for oneOfVariant in responses

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
@@ -54,7 +54,10 @@ object SchemaGenerator {
             false
           ) -> "implicit lazy val anyTapirSchema: sttp.tapir.Schema[io.circe.Json] = sttp.tapir.Schema.any[io.circe.Json]"
         )
-      else throw new NotImplementedError("any not implemented for json libs other than circe")
+      else
+        throw new NotImplementedError(
+          s"any not implemented for json libs other than circe (problematic models: ${schemasWithAny.map(_._1)})"
+        )
     val openApiSchemasWithTapirSchemas = doc.components
       .map(_.schemas.map {
         case (name, _: OpenapiSchemaEnum) =>

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -100,6 +100,12 @@ object TestHelpers {
       |                type: array
       |                items:
       |                  $ref: '#/components/schemas/Book'
+      |        '401':
+      |          description: 'unauthorized'
+      |          content:
+      |            text/plain:
+      |              schema:
+      |                type: string
       |        default:
       |          description: ''
       |          content:
@@ -165,6 +171,7 @@ object TestHelpers {
                 "",
                 Seq(OpenapiResponseContent("application/json", OpenapiSchemaArray(OpenapiSchemaRef("#/components/schemas/Book"), false)))
               ),
+              OpenapiResponse("401", "unauthorized", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false)))),
               OpenapiResponse("default", "", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false))))
             ),
             requestBody = None,


### PR DESCRIPTION
Adding a bit of support for oneOfVariants. Where the previous code would've generated
```scala
.errorOut(jsonBody[MessageResponse].description("Bad Request").and(statusCode(sttp.model.StatusCode(400))))
.errorOut(jsonBody[MessageResponse].description("Forbidden").and(statusCode(sttp.model.StatusCode(403))))
.errorOut(jsonBody[MessageResponse].description("Not Found").and(statusCode(sttp.model.StatusCode(404))))
.errorOut(jsonBody[MessageResponse].description("Unauthorized").and(statusCode(sttp.model.StatusCode(401))))
```
we would now generate
```scala
.errorOut(oneOf(oneOfVariant(sttp.model.StatusCode(400), jsonBody[MessageResponse].description("Bad Request")), oneOfVariant(sttp.model.StatusCode(404), jsonBody[MessageResponse].description("Not Found")), oneOfVariant(sttp.model.StatusCode(403), jsonBody[MessageResponse].description("Forbidden")), oneOfVariant(sttp.model.StatusCode(401), jsonBody[MessageResponse].description("Unauthorized"))))
```
given
```yaml
      responses:
        '400':
          description: Bad Request
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/MessageResponse'
        '401':
          description: Unauthorized
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/MessageResponse'
        '403':
          description: Forbidden
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/MessageResponse'
        '404':
          description: Not Found
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/MessageResponse'
```