### PR TITLE
Enable Scala 3 build for Play 2.9 Server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1419,7 +1419,7 @@ lazy val play29Server: ProjectMatrix = (projectMatrix in file("server/play29-ser
       "org.scala-lang.modules" %% "scala-collection-compat" % Versions.scalaCollectionCompat
     )
   )
-  .jvmPlatform(scalaVersions = List(scala2_13))
+  .jvmPlatform(scalaVersions = scala2_13And3Versions)
   .dependsOn(serverCore, serverTests % Test)
 
 lazy val jdkhttpServer: ProjectMatrix = (projectMatrix in file("server/jdkhttp-server"))

--- a/build.sbt
+++ b/build.sbt
@@ -1407,17 +1407,35 @@ lazy val playServer: ProjectMatrix = (projectMatrix in file("server/play-server"
   .jvmPlatform(scalaVersions = scala2_13And3Versions)
   .dependsOn(serverCore, serverTests % Test)
 
+// Play 2.9 Server
+lazy val play29Scala2Deps = Map(
+  "com.typesafe.akka"            -> ("2.6.21", Seq("akka-actor", "akka-actor-typed", "akka-slf4j", "akka-serialization-jackson", "akka-stream")),
+  "com.typesafe"                 -> ("0.6.1", Seq("ssl-config-core")),
+  "com.fasterxml.jackson.module" -> ("2.14.3", Seq("jackson-module-scala"))
+)
+
 lazy val play29Server: ProjectMatrix = (projectMatrix in file("server/play29-server"))
   .settings(commonJvmSettings)
   .settings(
     name := "tapir-play29-server",
+    excludeDependencies ++=
+      (if (scalaBinaryVersion.value == "3") {
+        play29Scala2Deps.flatMap(e => e._2._2.map(_ + "_3").map(ExclusionRule(e._1, _))).toSeq
+      } else {
+        Seq.empty
+      }),
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-server" % Versions.play29Server,
       "com.typesafe.play" %% "play" % Versions.play29Server,
       "com.typesafe.play" %% "play-akka-http-server" % Versions.play29Server,
       "com.softwaremill.sttp.shared" %% "akka" % Versions.sttpShared,
       "org.scala-lang.modules" %% "scala-collection-compat" % Versions.scalaCollectionCompat
-    )
+    ) ++
+      (if (scalaBinaryVersion.value == "3") {
+        play29Scala2Deps.flatMap(e => e._2._2.map(e._1 %% _ % e._2._1).map(_.cross(CrossVersion.for3Use2_13))).toSeq
+      } else {
+        Seq.empty
+      }),
   )
   .jvmPlatform(scalaVersions = scala2_13And3Versions)
   .dependsOn(serverCore, serverTests % Test)

--- a/server/play29-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
+++ b/server/play29-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
@@ -98,7 +98,8 @@ private[play] class PlayRequestBody(serverOptions: PlayServerOptions)(implicit
       mat: Materializer,
       ec: ExecutionContext
   ): Future[RawValue[Seq[RawPart]]] = {
-    val bodyParser = maxBytes.map(parsers.multipartFormData(filePartHandler, _)).getOrElse(parsers.multipartFormData(filePartHandler))
+    val bodyParser =
+      maxBytes.map(parsers.multipartFormData(filePartHandler, _, false)).getOrElse(parsers.multipartFormData(filePartHandler))
     bodyParser.apply(request).run(body()).flatMap {
       case Left(r) =>
         Future.failed(new PlayBodyParserException(r))


### PR DESCRIPTION
Back when we added the Play 2.9 module (#3313), the tests for Scala 3 failed and so it was removed.
Now, however, we'd like to move to Scala 3 and so this PR re-enables the Scala 3 build, fixing the dependency issues.

It seems like Scala 3 artifacts for Akka are pulled in, but akka-http-core was never published for Scala 3 and so these different binary versions clash.
Following the [official guide](https://www.playframework.com/documentation/2.9.x/ScalaAkka#Important-note-on-using-Akka-HTTP-10.5.0-or-newer-with-Scala-3), I excluded all the relevant native Scala 3 dependencies and replaced them with `for3Use2_13` ones.