### PR TITLE
use ByteString unsafe methods where it is ok

### DIFF
--- a/server/akka-grpc-server/src/main/scala/sttp/tapir/server/akkagrpc/AkkaGrpcRequestBody.scala
+++ b/server/akka-grpc-server/src/main/scala/sttp/tapir/server/akkagrpc/AkkaGrpcRequestBody.scala
@@ -39,10 +39,10 @@ private[akkagrpc] class AkkaGrpcRequestBody(serverOptions: AkkaHttpServerOptions
 
   private def toExpectedBodyType[R](byteString: ByteString, bodyType: RawBodyType[R]): RawValue[R] = {
     bodyType match {
-      case RawBodyType.ByteArrayBody        => RawValue(byteString.toArray)
+      case RawBodyType.ByteArrayBody        => RawValue(byteString.toArrayUnsafe())
       case RawBodyType.ByteBufferBody       => RawValue(byteString.asByteBuffer)
-      case RawBodyType.InputStreamBody      => RawValue(new ByteArrayInputStream(byteString.toArray))
-      case RawBodyType.InputStreamRangeBody => RawValue(InputStreamRange(() => new ByteArrayInputStream(byteString.toArray)))
+      case RawBodyType.InputStreamBody      => RawValue(new ByteArrayInputStream(byteString.toArrayUnsafe()))
+      case RawBodyType.InputStreamRangeBody => RawValue(InputStreamRange(() => new ByteArrayInputStream(byteString.toArrayUnsafe())))
       case RawBodyType.FileBody             => ???
       case m: RawBodyType.MultipartBody     => ???
       case _                                => ???

--- a/server/akka-grpc-server/src/main/scala/sttp/tapir/server/akkagrpc/AkkaGrpcToResponseBody.scala
+++ b/server/akka-grpc-server/src/main/scala/sttp/tapir/server/akkagrpc/AkkaGrpcToResponseBody.scala
@@ -46,7 +46,7 @@ private[akkagrpc] class AkkaGrpcToResponseBody(implicit m: Materializer, ec: Exe
   ): ResponseEntity = {
     bodyType match {
       case RawBodyType.StringBody(charset)  => ???
-      case RawBodyType.ByteArrayBody        => HttpEntity(ct, encodeDataToFrameBytes(ByteString(r)))
+      case RawBodyType.ByteArrayBody        => HttpEntity(ct, encodeDataToFrameBytes(ByteString.fromArrayUnsafe(r)))
       case RawBodyType.ByteBufferBody       => HttpEntity(ct, encodeDataToFrameBytes(ByteString(r)))
       case RawBodyType.InputStreamBody      => ???
       case RawBodyType.InputStreamRangeBody => ???

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaWebSockets.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaWebSockets.scala
@@ -40,13 +40,13 @@ private[akkahttp] object AkkaWebSockets {
       case msg: TextMessage =>
         msg.textStream.runFold("")(_ + _).map(t => WebSocketFrame.text(t))
       case msg: BinaryMessage =>
-        msg.dataStream.runFold(ByteString.empty)(_ ++ _).map(b => WebSocketFrame.binary(b.toArray))
+        msg.dataStream.runFold(ByteString.empty)(_ ++ _).map(b => WebSocketFrame.binary(b.toArrayUnsafe()))
     }
 
   private def frameToMessage(w: WebSocketFrame): Option[Message] = {
     w match {
       case WebSocketFrame.Text(p, _, _)   => Some(TextMessage(p))
-      case WebSocketFrame.Binary(p, _, _) => Some(BinaryMessage(ByteString(p)))
+      case WebSocketFrame.Binary(p, _, _) => Some(BinaryMessage(ByteString.fromArrayUnsafe(p)))
       case WebSocketFrame.Ping(_)         => None
       case WebSocketFrame.Pong(_)         => None
       case WebSocketFrame.Close(_, _)     => throw WebSocketClosed(None)

--- a/server/pekko-grpc-server/src/main/scala/sttp/tapir/server/pekkogrpc/PekkoGrpcRequestBody.scala
+++ b/server/pekko-grpc-server/src/main/scala/sttp/tapir/server/pekkogrpc/PekkoGrpcRequestBody.scala
@@ -11,7 +11,6 @@ import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.pekkohttp.PekkoHttpServerOptions
 import sttp.tapir.server.interpreter.{RawValue, RequestBody}
 
-import java.io.ByteArrayInputStream
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
@@ -39,10 +38,10 @@ private[pekkogrpc] class PekkoGrpcRequestBody(serverOptions: PekkoHttpServerOpti
 
   private def toExpectedBodyType[R](byteString: ByteString, bodyType: RawBodyType[R]): RawValue[R] = {
     bodyType match {
-      case RawBodyType.ByteArrayBody        => RawValue(byteString.toArray)
+      case RawBodyType.ByteArrayBody        => RawValue(byteString.toArrayUnsafe())
       case RawBodyType.ByteBufferBody       => RawValue(byteString.asByteBuffer)
-      case RawBodyType.InputStreamBody      => RawValue(new ByteArrayInputStream(byteString.toArray))
-      case RawBodyType.InputStreamRangeBody => RawValue(InputStreamRange(() => new ByteArrayInputStream(byteString.toArray)))
+      case RawBodyType.InputStreamBody      => RawValue(byteString.asInputStream)
+      case RawBodyType.InputStreamRangeBody => RawValue(InputStreamRange(() => byteString.asInputStream))
       case RawBodyType.FileBody             => ???
       case m: RawBodyType.MultipartBody     => ???
       case _                                => ???

--- a/server/pekko-grpc-server/src/main/scala/sttp/tapir/server/pekkogrpc/PekkoGrpcToResponseBody.scala
+++ b/server/pekko-grpc-server/src/main/scala/sttp/tapir/server/pekkogrpc/PekkoGrpcToResponseBody.scala
@@ -46,7 +46,7 @@ private[pekkogrpc] class PekkoGrpcToResponseBody(implicit m: Materializer, ec: E
   ): ResponseEntity = {
     bodyType match {
       case RawBodyType.StringBody(charset)  => ???
-      case RawBodyType.ByteArrayBody        => HttpEntity(ct, encodeDataToFrameBytes(ByteString(r)))
+      case RawBodyType.ByteArrayBody        => HttpEntity(ct, encodeDataToFrameBytes(ByteString.fromArrayUnsafe(r)))
       case RawBodyType.ByteBufferBody       => HttpEntity(ct, encodeDataToFrameBytes(ByteString(r)))
       case RawBodyType.InputStreamBody      => ???
       case RawBodyType.InputStreamRangeBody => ???

--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoWebSockets.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoWebSockets.scala
@@ -40,13 +40,13 @@ private[pekkohttp] object PekkoWebSockets {
       case msg: TextMessage =>
         msg.textStream.runFold("")(_ + _).map(t => WebSocketFrame.text(t))
       case msg: BinaryMessage =>
-        msg.dataStream.runFold(ByteString.empty)(_ ++ _).map(b => WebSocketFrame.binary(b.toArray))
+        msg.dataStream.runFold(ByteString.empty)(_ ++ _).map(b => WebSocketFrame.binary(b.toArrayUnsafe()))
     }
 
   private def frameToMessage(w: WebSocketFrame): Option[Message] = {
     w match {
       case WebSocketFrame.Text(p, _, _)   => Some(TextMessage(p))
-      case WebSocketFrame.Binary(p, _, _) => Some(BinaryMessage(ByteString(p)))
+      case WebSocketFrame.Binary(p, _, _) => Some(BinaryMessage(ByteString.fromArrayUnsafe(p)))
       case WebSocketFrame.Ping(_)         => None
       case WebSocketFrame.Pong(_)         => None
       case WebSocketFrame.Close(_, _)     => throw WebSocketClosed(None)

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
@@ -63,11 +63,11 @@ private[play] class PlayRequestBody(serverOptions: PlayServerOptions)(implicit
     bodyType match {
       case RawBodyType.StringBody(defaultCharset) =>
         bodyAsByteString().map(b => RawValue(b.decodeString(charset.getOrElse(defaultCharset))))
-      case RawBodyType.ByteArrayBody   => bodyAsByteString().map(b => RawValue(b.toArray))
+      case RawBodyType.ByteArrayBody   => bodyAsByteString().map(b => RawValue(b.toArrayUnsafe()))
       case RawBodyType.ByteBufferBody  => bodyAsByteString().map(b => RawValue(b.toByteBuffer))
-      case RawBodyType.InputStreamBody => bodyAsByteString().map(b => RawValue(new ByteArrayInputStream(b.toArray)))
+      case RawBodyType.InputStreamBody => bodyAsByteString().map(b => RawValue(b.asInputStream()))
       case RawBodyType.InputStreamRangeBody =>
-        bodyAsByteString().map(b => RawValue(new InputStreamRange(() => new ByteArrayInputStream(b.toArray))))
+        bodyAsByteString().map(b => RawValue(new InputStreamRange(() => b.asInputStream())))
       case RawBodyType.FileBody =>
         bodyAsFile match {
           case Some(file) =>

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
@@ -12,7 +12,7 @@ import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.interpreter.{RawValue, RequestBody}
 import sttp.tapir.{FileRange, InputStreamRange, RawBodyType, RawPart}
 
-import java.io.File
+import java.io.{ByteArrayInputStream, File}
 import java.nio.charset.Charset
 import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.compat._
@@ -65,9 +65,9 @@ private[play] class PlayRequestBody(serverOptions: PlayServerOptions)(implicit
         bodyAsByteString().map(b => RawValue(b.decodeString(charset.getOrElse(defaultCharset))))
       case RawBodyType.ByteArrayBody   => bodyAsByteString().map(b => RawValue(b.toArrayUnsafe()))
       case RawBodyType.ByteBufferBody  => bodyAsByteString().map(b => RawValue(b.toByteBuffer))
-      case RawBodyType.InputStreamBody => bodyAsByteString().map(b => RawValue(b.asInputStream))
+      case RawBodyType.InputStreamBody => bodyAsByteString().map(b => RawValue(new ByteArrayInputStream(b.toArrayUnsafe())))
       case RawBodyType.InputStreamRangeBody =>
-        bodyAsByteString().map(b => RawValue(new InputStreamRange(() => b.asInputStream)))
+        bodyAsByteString().map(b => RawValue(new InputStreamRange(() => new ByteArrayInputStream(b.toArrayUnsafe()))))
       case RawBodyType.FileBody =>
         bodyAsFile match {
           case Some(file) =>

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
@@ -12,7 +12,7 @@ import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.interpreter.{RawValue, RequestBody}
 import sttp.tapir.{FileRange, InputStreamRange, RawBodyType, RawPart}
 
-import java.io.{ByteArrayInputStream, File}
+import java.io.File
 import java.nio.charset.Charset
 import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.compat._

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
@@ -65,9 +65,9 @@ private[play] class PlayRequestBody(serverOptions: PlayServerOptions)(implicit
         bodyAsByteString().map(b => RawValue(b.decodeString(charset.getOrElse(defaultCharset))))
       case RawBodyType.ByteArrayBody   => bodyAsByteString().map(b => RawValue(b.toArrayUnsafe()))
       case RawBodyType.ByteBufferBody  => bodyAsByteString().map(b => RawValue(b.toByteBuffer))
-      case RawBodyType.InputStreamBody => bodyAsByteString().map(b => RawValue(b.asInputStream()))
+      case RawBodyType.InputStreamBody => bodyAsByteString().map(b => RawValue(b.asInputStream))
       case RawBodyType.InputStreamRangeBody =>
-        bodyAsByteString().map(b => RawValue(new InputStreamRange(() => b.asInputStream())))
+        bodyAsByteString().map(b => RawValue(new InputStreamRange(() => b.asInputStream)))
       case RawBodyType.FileBody =>
         bodyAsFile match {
           case Some(file) =>

--- a/server/play29-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
+++ b/server/play29-server/src/main/scala/sttp/tapir/server/play/PlayRequestBody.scala
@@ -63,11 +63,11 @@ private[play] class PlayRequestBody(serverOptions: PlayServerOptions)(implicit
     bodyType match {
       case RawBodyType.StringBody(defaultCharset) =>
         bodyAsByteString().map(b => RawValue(b.decodeString(charset.getOrElse(defaultCharset))))
-      case RawBodyType.ByteArrayBody   => bodyAsByteString().map(b => RawValue(b.toArray))
+      case RawBodyType.ByteArrayBody   => bodyAsByteString().map(b => RawValue(b.toArrayUnsafe()))
       case RawBodyType.ByteBufferBody  => bodyAsByteString().map(b => RawValue(b.toByteBuffer))
-      case RawBodyType.InputStreamBody => bodyAsByteString().map(b => RawValue(new ByteArrayInputStream(b.toArray)))
+      case RawBodyType.InputStreamBody => bodyAsByteString().map(b => RawValue(new ByteArrayInputStream(b.toArrayUnsafe())))
       case RawBodyType.InputStreamRangeBody =>
-        bodyAsByteString().map(b => RawValue(new InputStreamRange(() => new ByteArrayInputStream(b.toArray))))
+        bodyAsByteString().map(b => RawValue(new InputStreamRange(() => new ByteArrayInputStream(b.toArrayUnsafe()))))
       case RawBodyType.FileBody =>
         bodyAsFile match {
           case Some(file) =>


### PR DESCRIPTION
Pekko/Akka ByteString supports unsafe methods to create ByteStrings without cloning arrays or output the underlying array data (again without cloning). This is ok if no the other code that works with the arrays isn't modifying the array data.

Pekko 1.1 also has a ByteString.asInputStream method which is more efficient than getting an array and wrapping as ByteArrayInputStream. 