### PR TITLE
Better handling of Empty entity in Akka an Pekko BodyListener.

### DIFF
--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaBodyListener.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaBodyListener.scala
@@ -14,7 +14,7 @@ class AkkaBodyListener(implicit ec: ExecutionContext) extends BodyListener[Futur
   override def onComplete(body: AkkaResponseBody)(cb: Try[Unit] => Future[Unit]): Future[AkkaResponseBody] = {
     body match {
       case ws @ Left(_) => cb(Success(())).map(_ => ws)
-      case Right(e @ HttpEntity.Empty) =>
+      case Right(e) if e.isKnownEmpty =>
         Future.successful(Right(e)).andThen { case _ => cb(Success(())) }
       case Right(e: UniversalEntity) =>
         Future.successful(

--- a/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerTest.scala
+++ b/server/akka-http-server/src/test/scala/sttp/tapir/server/akkahttp/AkkaHttpServerTest.scala
@@ -14,15 +14,19 @@ import sttp.capabilities.akka.AkkaStreams
 import sttp.client3._
 import sttp.client3.akkahttp.AkkaHttpBackend
 import sttp.model.sse.ServerSentEvent
+import sttp.model.Header
+import sttp.model.MediaType
 import sttp.monad.FutureMonad
 import sttp.monad.syntax._
 import sttp.tapir._
 import sttp.tapir.server.interceptor._
 import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
+import sttp.tapir.server.metrics.{EndpointMetric, Metric}
 import sttp.tapir.server.tests._
 import sttp.tapir.tests.{Test, TestSuite}
 
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.Future
 import scala.util.Random
 
@@ -150,6 +154,58 @@ class AkkaHttpServerTest extends TestSuite with EitherValues {
             r.header("Content-Length") shouldBe Some("0")
             r.header("Transfer-Encoding") shouldBe None
           }
+        },
+        Test("execute metrics interceptors for empty body and json content type") {
+          val e = endpoint.post.in(stringBody)
+            .out(stringBody)
+            .out(header(Header.contentType(MediaType.ApplicationJson)))
+            .serverLogicSuccess[Future](body => Future.successful(body))
+
+          class DummyMetric {
+            val onRequestCnt = new AtomicInteger(0)
+            val onEndpointRequestCnt = new AtomicInteger(0)
+            val onResponseHeadersCnt = new AtomicInteger(0)
+            val onResponseBodyCnt = new AtomicInteger(0)
+          }
+          val metric = new DummyMetric()
+          val customMetrics: Metric[Future, DummyMetric] =
+            Metric(
+              metric = metric,
+              onRequest = (_, metric, me) =>
+                me.eval {
+                  metric.onRequestCnt.incrementAndGet()
+                  EndpointMetric(
+                    onEndpointRequest = Some((_) =>
+                      me.eval(metric.onEndpointRequestCnt.incrementAndGet()),
+                    ),
+                    onResponseHeaders = Some((_, _) =>
+                      me.eval(metric.onResponseHeadersCnt.incrementAndGet()),
+                    ),
+                    onResponseBody = Some((_, _) =>
+                      me.eval(metric.onResponseBodyCnt.incrementAndGet()),
+                    ),
+                    onException = None,
+                  )
+                },
+            )
+          val route = AkkaHttpServerInterpreter(
+            AkkaHttpServerOptions.customiseInterceptors
+              .metricsInterceptor(new MetricsRequestInterceptor[Future](List(customMetrics), Seq.empty))
+              .options
+          ).toRoute(e)
+
+          interpreter
+            .server(NonEmptyList.of(route))
+            .use { port =>
+              basicRequest.post(uri"http://localhost:$port").body("").send(backend).map { response =>
+                response.body shouldBe Right("")
+                metric.onRequestCnt.get() shouldBe 1
+                metric.onEndpointRequestCnt.get() shouldBe 1
+                metric.onResponseHeadersCnt.get() shouldBe 1
+                metric.onResponseBodyCnt.get() shouldBe 1
+              }
+            }
+            .unsafeToFuture()
         }
       )
       def drainAkka(stream: AkkaStreams.BinaryStream): Future[Unit] =

--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoBodyListener.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoBodyListener.scala
@@ -14,7 +14,7 @@ class PekkoBodyListener(implicit ec: ExecutionContext) extends BodyListener[Futu
   override def onComplete(body: PekkoResponseBody)(cb: Try[Unit] => Future[Unit]): Future[PekkoResponseBody] = {
     body match {
       case ws @ Left(_) => cb(Success(())).map(_ => ws)
-      case Right(e @ HttpEntity.Empty) =>
+      case Right(e) if e.isKnownEmpty =>
         Future.successful(Right(e)).andThen { case _ => cb(Success(())) }
       case Right(e: UniversalEntity) =>
         Future.successful(


### PR DESCRIPTION
Current implementation will throw IllegalArgumentException from HttpEntity.Default if `contentLenght` is 0 but `contentType` doesn't match `NoContentType`.
For example following entity breaks bodyListener: `Right(HttpEntity.Strict(application/json,0 bytes total))` 
Such entity could be created when one use Circe to generate body from simple Scala types like `None`

<img width="859" alt="Screenshot 2024-11-07 at 17 15 57" src="https://github.com/user-attachments/assets/23da79b9-102a-4f29-930e-2f39374b6e22">

Original bug: https://github.com/softwaremill/tapir/issues/4138