### PR TITLE
codegen: Permit autogenerating types aliases for endpoints

### DIFF
--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -68,6 +68,9 @@ object GenScala {
   private val endpointCapabilitesOpt: Opts[Option[String]] =
     Opts.option[String]("endpointCapabilites", "Capability to use for endpoints", "c").orNone
 
+  private val generateEndpointTypesOpt: Opts[Boolean] =
+    Opts.flag("generateEndpointTypes", "Whether to emit explicit type aliases for endpoint declarations", "e").orFalse
+
   private val destDirOpt: Opts[File] =
     Opts
       .option[String]("destdir", "Destination directory", "d")
@@ -92,7 +95,8 @@ object GenScala {
       validateNonDiscriminatedOneOfsOpt,
       maxSchemasPerFileOpt,
       streamingImplementationOpt,
-      endpointCapabilitesOpt
+      endpointCapabilitesOpt,
+      generateEndpointTypesOpt
     )
       .mapN {
         case (
@@ -106,7 +110,8 @@ object GenScala {
               validateNonDiscriminatedOneOfs,
               maxSchemasPerFile,
               streamingImplementation,
-              endpointCapabilites
+              endpointCapabilites,
+              generateEndpointTypes
             ) =>
           val objectName = maybeObjectName.getOrElse(DefaultObjectName)
 
@@ -122,7 +127,8 @@ object GenScala {
                 streamingImplementation.getOrElse("fs2"),
                 endpointCapabilites.getOrElse("nothing"),
                 validateNonDiscriminatedOneOfs,
-                maxSchemasPerFile.getOrElse(400)
+                maxSchemasPerFile.getOrElse(400),
+                generateEndpointTypes
               )
             )
             destFiles <- contents.toVector.traverse { case (fileName, content) => writeGeneratedFile(destDir, fileName, content) }

--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -65,6 +65,9 @@ object GenScala {
   private val streamingImplementationOpt: Opts[Option[String]] =
     Opts.option[String]("streamingImplementation", "Capability to use for binary streams", "s").orNone
 
+  private val endpointCapabilitesOpt: Opts[Option[String]] =
+    Opts.option[String]("endpointCapabilites", "Capability to use for endpoints", "c").orNone
+
   private val destDirOpt: Opts[File] =
     Opts
       .option[String]("destdir", "Destination directory", "d")
@@ -88,7 +91,8 @@ object GenScala {
       jsonLibOpt,
       validateNonDiscriminatedOneOfsOpt,
       maxSchemasPerFileOpt,
-      streamingImplementationOpt
+      streamingImplementationOpt,
+      endpointCapabilitesOpt
     )
       .mapN {
         case (
@@ -101,7 +105,8 @@ object GenScala {
               jsonLib,
               validateNonDiscriminatedOneOfs,
               maxSchemasPerFile,
-              streamingImplementation
+              streamingImplementation,
+              endpointCapabilites
             ) =>
           val objectName = maybeObjectName.getOrElse(DefaultObjectName)
 
@@ -115,6 +120,7 @@ object GenScala {
                 headTagForNames,
                 jsonLib.getOrElse("circe"),
                 streamingImplementation.getOrElse("fs2"),
+                endpointCapabilites.getOrElse("nothing"),
                 validateNonDiscriminatedOneOfs,
                 maxSchemasPerFile.getOrElse(400)
               )

--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -65,9 +65,6 @@ object GenScala {
   private val streamingImplementationOpt: Opts[Option[String]] =
     Opts.option[String]("streamingImplementation", "Capability to use for binary streams", "s").orNone
 
-  private val endpointCapabilitesOpt: Opts[Option[String]] =
-    Opts.option[String]("endpointCapabilites", "Capability to use for endpoints", "c").orNone
-
   private val generateEndpointTypesOpt: Opts[Boolean] =
     Opts.flag("generateEndpointTypes", "Whether to emit explicit type aliases for endpoint declarations", "e").orFalse
 
@@ -95,7 +92,6 @@ object GenScala {
       validateNonDiscriminatedOneOfsOpt,
       maxSchemasPerFileOpt,
       streamingImplementationOpt,
-      endpointCapabilitesOpt,
       generateEndpointTypesOpt
     )
       .mapN {
@@ -110,7 +106,6 @@ object GenScala {
               validateNonDiscriminatedOneOfs,
               maxSchemasPerFile,
               streamingImplementation,
-              endpointCapabilites,
               generateEndpointTypes
             ) =>
           val objectName = maybeObjectName.getOrElse(DefaultObjectName)
@@ -125,7 +120,6 @@ object GenScala {
                 headTagForNames,
                 jsonLib.getOrElse("circe"),
                 streamingImplementation.getOrElse("fs2"),
-                endpointCapabilites.getOrElse("nothing"),
                 validateNonDiscriminatedOneOfs,
                 maxSchemasPerFile.getOrElse(400),
                 generateEndpointTypes

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -45,7 +45,8 @@ object BasicGenerator {
       streamingImplementation: String,
       endpointCapabilites: String,
       validateNonDiscriminatedOneOfs: Boolean,
-      maxSchemasPerFile: Int
+      maxSchemasPerFile: Int,
+      generateEndpointTypes: Boolean
   ): Map[String, String] = {
     val normalisedJsonLib = jsonSerdeLib.toLowerCase match {
       case "circe"    => JsonSerdeLib.Circe
@@ -82,7 +83,15 @@ object BasicGenerator {
     }
 
     val EndpointDefs(endpointsByTag, queryOrPathParamRefs, jsonParamRefs, enumsDefinedOnEndpointParams) =
-      endpointGenerator.endpointDefs(doc, useHeadTagForObjectNames, targetScala3, normalisedJsonLib, normalisedStreamingImplementation, normalisedEndpointCapabilites)
+      endpointGenerator.endpointDefs(
+        doc,
+        useHeadTagForObjectNames,
+        targetScala3,
+        normalisedJsonLib,
+        normalisedStreamingImplementation,
+        normalisedEndpointCapabilites,
+        generateEndpointTypes
+      )
     val GeneratedClassDefinitions(classDefns, jsonSerdes, schemas) =
       classGenerator
         .classDefs(

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -43,7 +43,6 @@ object BasicGenerator {
       useHeadTagForObjectNames: Boolean,
       jsonSerdeLib: String,
       streamingImplementation: String,
-      endpointCapabilites: String,
       validateNonDiscriminatedOneOfs: Boolean,
       maxSchemasPerFile: Int,
       generateEndpointTypes: Boolean
@@ -69,18 +68,6 @@ object BasicGenerator {
         )
         StreamingImplementation.FS2
     }
-    val normalisedEndpointCapabilites = endpointCapabilites.toLowerCase match {
-      case "akka"    => EndpointCapabilites.Akka
-      case "fs2"     => EndpointCapabilites.FS2
-      case "nothing" => EndpointCapabilites.Nothing
-      case "pekko"   => EndpointCapabilites.Pekko
-      case "zio"     => EndpointCapabilites.Zio
-      case _ =>
-        System.err.println(
-          s"!!! Unrecognised value $endpointCapabilites for endpoint capabilities -- should be one of akka, fs2, nothing, pekko or zio. Defaulting to nothing !!!"
-        )
-        EndpointCapabilites.Nothing
-    }
 
     val EndpointDefs(endpointsByTag, queryOrPathParamRefs, jsonParamRefs, enumsDefinedOnEndpointParams) =
       endpointGenerator.endpointDefs(
@@ -89,7 +76,6 @@ object BasicGenerator {
         targetScala3,
         normalisedJsonLib,
         normalisedStreamingImplementation,
-        normalisedEndpointCapabilites,
         generateEndpointTypes
       )
     val GeneratedClassDefinitions(classDefns, jsonSerdes, schemas) =

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -25,6 +25,10 @@ object StreamingImplementation extends Enumeration {
   val Akka, FS2, Pekko, Zio = Value
   type StreamingImplementation = Value
 }
+object EndpointCapabilites extends Enumeration {
+  val Akka, FS2, Nothing, Pekko, Zio = Value
+  type EndpointCapabilites = Value
+}
 
 object BasicGenerator {
 
@@ -39,6 +43,7 @@ object BasicGenerator {
       useHeadTagForObjectNames: Boolean,
       jsonSerdeLib: String,
       streamingImplementation: String,
+      endpointCapabilites: String,
       validateNonDiscriminatedOneOfs: Boolean,
       maxSchemasPerFile: Int
   ): Map[String, String] = {
@@ -63,9 +68,21 @@ object BasicGenerator {
         )
         StreamingImplementation.FS2
     }
+    val normalisedEndpointCapabilites = endpointCapabilites.toLowerCase match {
+      case "akka"    => EndpointCapabilites.Akka
+      case "fs2"     => EndpointCapabilites.FS2
+      case "nothing" => EndpointCapabilites.Nothing
+      case "pekko"   => EndpointCapabilites.Pekko
+      case "zio"     => EndpointCapabilites.Zio
+      case _ =>
+        System.err.println(
+          s"!!! Unrecognised value $endpointCapabilites for endpoint capabilities -- should be one of akka, fs2, nothing, pekko or zio. Defaulting to nothing !!!"
+        )
+        EndpointCapabilites.Nothing
+    }
 
     val EndpointDefs(endpointsByTag, queryOrPathParamRefs, jsonParamRefs, enumsDefinedOnEndpointParams) =
-      endpointGenerator.endpointDefs(doc, useHeadTagForObjectNames, targetScala3, normalisedJsonLib, normalisedStreamingImplementation)
+      endpointGenerator.endpointDefs(doc, useHeadTagForObjectNames, targetScala3, normalisedJsonLib, normalisedStreamingImplementation, normalisedEndpointCapabilites)
     val GeneratedClassDefinitions(classDefns, jsonSerdes, schemas) =
       classGenerator
         .classDefs(

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -442,9 +442,10 @@ class EndpointGenerator {
           if (allElemTypes.size == 1) allElemTypes.head
           else
             allElemTypes.map { s => parentMap.getOrElse(s, Nil).toSet }.reduce(_ intersect _) match {
-              case s if s.isEmpty & targetScala3 => types.mkString(" | ")
-              case s if s.isEmpty                => "Any"
-              case s                             => s.mkString(" with ")
+              case s if s.isEmpty && targetScala3 => types.mkString(" | ")
+              case s if s.isEmpty                 => "Any"
+              case s if targetScala3              => s.mkString(" & ")
+              case s                              => s.mkString(" with ")
             }
         Some(s"oneOf[$commmonType](${oneOfs.mkString(", ")})") -> Some(commmonType)
     }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
@@ -19,7 +19,6 @@ class BasicGeneratorSpec extends CompileCheckTestBase {
       validateNonDiscriminatedOneOfs = true,
       maxSchemasPerFile = 400,
       streamingImplementation = "fs2",
-      endpointCapabilites = "nothing",
       generateEndpointTypes = false
     )
   }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
@@ -18,7 +18,8 @@ class BasicGeneratorSpec extends CompileCheckTestBase {
       jsonSerdeLib = jsonSerdeLib,
       validateNonDiscriminatedOneOfs = true,
       maxSchemasPerFile = 400,
-      streamingImplementation = "fs2"
+      streamingImplementation = "fs2",
+      endpointCapabilites = "nothing"
     )
   }
   def gen(

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/BasicGeneratorSpec.scala
@@ -19,7 +19,8 @@ class BasicGeneratorSpec extends CompileCheckTestBase {
       validateNonDiscriminatedOneOfs = true,
       maxSchemasPerFile = 400,
       streamingImplementation = "fs2",
-      endpointCapabilites = "nothing"
+      endpointCapabilites = "nothing",
+      generateEndpointTypes = false
     )
   }
   def gen(

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -397,7 +397,6 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             targetScala3 = false,
             jsonSerdeLib = JsonSerdeLib.Circe,
             streamingImplementation = StreamingImplementation.FS2,
-            endpointCapabilites = EndpointCapabilites.Nothing,
             generateEndpointTypes = false
           )
           .endpointDecls(None)

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -397,7 +397,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             targetScala3 = false,
             jsonSerdeLib = JsonSerdeLib.Circe,
             streamingImplementation = StreamingImplementation.FS2,
-            endpointCapabilites = EndpointCapabilites.Nothing
+            endpointCapabilites = EndpointCapabilites.Nothing,
+            generateEndpointTypes = false
           )
           .endpointDecls(None)
     }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -396,7 +396,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             useHeadTagForObjectNames = false,
             targetScala3 = false,
             jsonSerdeLib = JsonSerdeLib.Circe,
-            streamingImplementation = StreamingImplementation.FS2
+            streamingImplementation = StreamingImplementation.FS2,
+            endpointCapabilites = EndpointCapabilites.Nothing
           )
           .endpointDecls(None)
     }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -69,7 +69,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           targetScala3 = false,
           jsonSerdeLib = JsonSerdeLib.Circe,
           streamingImplementation = StreamingImplementation.FS2,
-          endpointCapabilites = EndpointCapabilites.Nothing
+          endpointCapabilites = EndpointCapabilites.Nothing,
+          generateEndpointTypes = false
         )
         .endpointDecls(None)
     generatedCode should include("val getTestAsdId =")
@@ -155,7 +156,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           targetScala3 = false,
           jsonSerdeLib = JsonSerdeLib.Circe,
           streamingImplementation = StreamingImplementation.FS2,
-          endpointCapabilites = EndpointCapabilites.Nothing
+          endpointCapabilites = EndpointCapabilites.Nothing,
+          generateEndpointTypes = false
         )
         .endpointDecls(None) shouldCompile ()
   }
@@ -208,7 +210,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           targetScala3 = false,
           jsonSerdeLib = JsonSerdeLib.Circe,
           streamingImplementation = StreamingImplementation.FS2,
-          endpointCapabilites = EndpointCapabilites.Nothing
+          endpointCapabilites = EndpointCapabilites.Nothing,
+          generateEndpointTypes = false
         )
         .endpointDecls(None)
     generatedCode should include(
@@ -276,7 +279,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       validateNonDiscriminatedOneOfs = true,
       maxSchemasPerFile = 400,
       streamingImplementation = "fs2",
-      endpointCapabilites = "nothing"
+      endpointCapabilites = "nothing",
+      generateEndpointTypes = false
     )("TapirGeneratedEndpoints")
     generatedCode should include(
       """file: sttp.model.Part[java.io.File]"""
@@ -299,7 +303,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       validateNonDiscriminatedOneOfs = true,
       maxSchemasPerFile = 400,
       streamingImplementation = "fs2",
-      endpointCapabilites = "nothing"
+      endpointCapabilites = "nothing",
+      generateEndpointTypes = false
     )("TapirGeneratedEndpoints")
     generatedCode shouldCompile ()
     val expectedAttrDecls = Seq(

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -68,7 +68,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           useHeadTagForObjectNames = false,
           targetScala3 = false,
           jsonSerdeLib = JsonSerdeLib.Circe,
-          streamingImplementation = StreamingImplementation.FS2
+          streamingImplementation = StreamingImplementation.FS2,
+          endpointCapabilites = EndpointCapabilites.Nothing
         )
         .endpointDecls(None)
     generatedCode should include("val getTestAsdId =")
@@ -153,7 +154,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           useHeadTagForObjectNames = false,
           targetScala3 = false,
           jsonSerdeLib = JsonSerdeLib.Circe,
-          streamingImplementation = StreamingImplementation.FS2
+          streamingImplementation = StreamingImplementation.FS2,
+          endpointCapabilites = EndpointCapabilites.Nothing
         )
         .endpointDecls(None) shouldCompile ()
   }
@@ -205,7 +207,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           useHeadTagForObjectNames = false,
           targetScala3 = false,
           jsonSerdeLib = JsonSerdeLib.Circe,
-          streamingImplementation = StreamingImplementation.FS2
+          streamingImplementation = StreamingImplementation.FS2,
+          endpointCapabilites = EndpointCapabilites.Nothing
         )
         .endpointDecls(None)
     generatedCode should include(
@@ -272,7 +275,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       jsonSerdeLib = "circe",
       validateNonDiscriminatedOneOfs = true,
       maxSchemasPerFile = 400,
-      streamingImplementation = "fs2"
+      streamingImplementation = "fs2",
+      endpointCapabilites = "nothing"
     )("TapirGeneratedEndpoints")
     generatedCode should include(
       """file: sttp.model.Part[java.io.File]"""
@@ -294,7 +298,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       jsonSerdeLib = "circe",
       validateNonDiscriminatedOneOfs = true,
       maxSchemasPerFile = 400,
-      streamingImplementation = "fs2"
+      streamingImplementation = "fs2",
+      endpointCapabilites = "nothing"
     )("TapirGeneratedEndpoints")
     generatedCode shouldCompile ()
     val expectedAttrDecls = Seq(

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -69,7 +69,6 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           targetScala3 = false,
           jsonSerdeLib = JsonSerdeLib.Circe,
           streamingImplementation = StreamingImplementation.FS2,
-          endpointCapabilites = EndpointCapabilites.Nothing,
           generateEndpointTypes = false
         )
         .endpointDecls(None)
@@ -156,7 +155,6 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           targetScala3 = false,
           jsonSerdeLib = JsonSerdeLib.Circe,
           streamingImplementation = StreamingImplementation.FS2,
-          endpointCapabilites = EndpointCapabilites.Nothing,
           generateEndpointTypes = false
         )
         .endpointDecls(None) shouldCompile ()
@@ -210,7 +208,6 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           targetScala3 = false,
           jsonSerdeLib = JsonSerdeLib.Circe,
           streamingImplementation = StreamingImplementation.FS2,
-          endpointCapabilites = EndpointCapabilites.Nothing,
           generateEndpointTypes = false
         )
         .endpointDecls(None)
@@ -279,7 +276,6 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       validateNonDiscriminatedOneOfs = true,
       maxSchemasPerFile = 400,
       streamingImplementation = "fs2",
-      endpointCapabilites = "nothing",
       generateEndpointTypes = false
     )("TapirGeneratedEndpoints")
     generatedCode should include(
@@ -303,7 +299,6 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       validateNonDiscriminatedOneOfs = true,
       maxSchemasPerFile = 400,
       streamingImplementation = "fs2",
-      endpointCapabilites = "nothing",
       generateEndpointTypes = false
     )("TapirGeneratedEndpoints")
     generatedCode shouldCompile ()

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -12,6 +12,7 @@ case class OpenApiConfiguration(
     endpointCapabilites: String,
     validateNonDiscriminatedOneOfs: Boolean,
     maxSchemasPerFile: Int,
+    generateEndpointTypes: Boolean,
     additionalPackages: List[(String, File)]
 )
 
@@ -29,6 +30,7 @@ trait OpenapiCodegenKeys {
   lazy val openapiAdditionalPackages = settingKey[List[(String, File)]]("Addition package -> spec mappings to generate.")
   lazy val openapiStreamingImplementation = settingKey[String]("Implementation for streamTextBody. Supports: akka, fs2, pekko, zio.")
   lazy val openapiEndpointCapabilites = settingKey[String]("Implementation for streamTextBody. Supports: akka, fs2, nothing, pekko, zio.")
+  lazy val openapiGenerateEndpointTypes = settingKey[Boolean]("Whether to emit explicit types for endpoint denfs")
   lazy val openapiOpenApiConfiguration =
     settingKey[OpenApiConfiguration]("Aggregation of other settings. Manually set value will be disregarded.")
 

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -9,7 +9,6 @@ case class OpenApiConfiguration(
     useHeadTagForObjectName: Boolean,
     jsonSerdeLib: String,
     streamingImplementation: String,
-    endpointCapabilites: String,
     validateNonDiscriminatedOneOfs: Boolean,
     maxSchemasPerFile: Int,
     generateEndpointTypes: Boolean,
@@ -29,7 +28,6 @@ trait OpenapiCodegenKeys {
   lazy val openapiMaxSchemasPerFile = settingKey[Int]("Maximum number of schemas to generate for a single file")
   lazy val openapiAdditionalPackages = settingKey[List[(String, File)]]("Addition package -> spec mappings to generate.")
   lazy val openapiStreamingImplementation = settingKey[String]("Implementation for streamTextBody. Supports: akka, fs2, pekko, zio.")
-  lazy val openapiEndpointCapabilites = settingKey[String]("Implementation for streamTextBody. Supports: akka, fs2, nothing, pekko, zio.")
   lazy val openapiGenerateEndpointTypes = settingKey[Boolean]("Whether to emit explicit types for endpoint denfs")
   lazy val openapiOpenApiConfiguration =
     settingKey[OpenApiConfiguration]("Aggregation of other settings. Manually set value will be disregarded.")

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -9,6 +9,7 @@ case class OpenApiConfiguration(
     useHeadTagForObjectName: Boolean,
     jsonSerdeLib: String,
     streamingImplementation: String,
+    endpointCapabilites: String,
     validateNonDiscriminatedOneOfs: Boolean,
     maxSchemasPerFile: Int,
     additionalPackages: List[(String, File)]
@@ -27,6 +28,7 @@ trait OpenapiCodegenKeys {
   lazy val openapiMaxSchemasPerFile = settingKey[Int]("Maximum number of schemas to generate for a single file")
   lazy val openapiAdditionalPackages = settingKey[List[(String, File)]]("Addition package -> spec mappings to generate.")
   lazy val openapiStreamingImplementation = settingKey[String]("Implementation for streamTextBody. Supports: akka, fs2, pekko, zio.")
+  lazy val openapiEndpointCapabilites = settingKey[String]("Implementation for streamTextBody. Supports: akka, fs2, nothing, pekko, zio.")
   lazy val openapiOpenApiConfiguration =
     settingKey[OpenApiConfiguration]("Aggregation of other settings. Manually set value will be disregarded.")
 

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -30,6 +30,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
       openapiUseHeadTagForObjectName.value,
       openapiJsonSerdeLib.value,
       openapiStreamingImplementation.value,
+      openapiEndpointCapabilites.value,
       openapiValidateNonDiscriminatedOneOfs.value,
       openapiMaxSchemasPerFile.value,
       openapiAdditionalPackages.value
@@ -44,6 +45,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
     openapiMaxSchemasPerFile := 400,
     openapiAdditionalPackages := Nil,
     openapiStreamingImplementation := "fs2",
+    openapiEndpointCapabilites := "nothing",
     standardParamSetting
   )
 
@@ -71,6 +73,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
               c.useHeadTagForObjectName,
               c.jsonSerdeLib,
               c.streamingImplementation,
+              c.endpointCapabilites,
               c.validateNonDiscriminatedOneOfs,
               c.maxSchemasPerFile,
               srcDir,

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -33,6 +33,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
       openapiEndpointCapabilites.value,
       openapiValidateNonDiscriminatedOneOfs.value,
       openapiMaxSchemasPerFile.value,
+      openapiGenerateEndpointTypes.value,
       openapiAdditionalPackages.value
     )
   def openapiCodegenDefaultSettings: Seq[Setting[_]] = Seq(
@@ -46,6 +47,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
     openapiAdditionalPackages := Nil,
     openapiStreamingImplementation := "fs2",
     openapiEndpointCapabilites := "nothing",
+    openapiGenerateEndpointTypes := false,
     standardParamSetting
   )
 
@@ -76,6 +78,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
               c.endpointCapabilites,
               c.validateNonDiscriminatedOneOfs,
               c.maxSchemasPerFile,
+              c.generateEndpointTypes,
               srcDir,
               taskStreams.cacheDirectory,
               sv.startsWith("3"),

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -30,7 +30,6 @@ object OpenapiCodegenPlugin extends AutoPlugin {
       openapiUseHeadTagForObjectName.value,
       openapiJsonSerdeLib.value,
       openapiStreamingImplementation.value,
-      openapiEndpointCapabilites.value,
       openapiValidateNonDiscriminatedOneOfs.value,
       openapiMaxSchemasPerFile.value,
       openapiGenerateEndpointTypes.value,
@@ -46,7 +45,6 @@ object OpenapiCodegenPlugin extends AutoPlugin {
     openapiMaxSchemasPerFile := 400,
     openapiAdditionalPackages := Nil,
     openapiStreamingImplementation := "fs2",
-    openapiEndpointCapabilites := "nothing",
     openapiGenerateEndpointTypes := false,
     standardParamSetting
   )
@@ -75,7 +73,6 @@ object OpenapiCodegenPlugin extends AutoPlugin {
               c.useHeadTagForObjectName,
               c.jsonSerdeLib,
               c.streamingImplementation,
-              c.endpointCapabilites,
               c.validateNonDiscriminatedOneOfs,
               c.maxSchemasPerFile,
               c.generateEndpointTypes,

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -15,6 +15,7 @@ case class OpenapiCodegenTask(
     endpointCapabilites: String,
     validateNonDiscriminatedOneOfs: Boolean,
     maxSchemasPerFile: Int,
+    generateEndpointTypes: Boolean,
     dir: File,
     cacheDir: File,
     targetScala3: Boolean,
@@ -61,7 +62,8 @@ case class OpenapiCodegenTask(
           streamingImplementation,
           endpointCapabilites,
           validateNonDiscriminatedOneOfs,
-          maxSchemasPerFile
+          maxSchemasPerFile,
+          generateEndpointTypes
         )
         .map { case (objectName, fileBody) =>
           val file = directory / s"$objectName.scala"

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -12,6 +12,7 @@ case class OpenapiCodegenTask(
     useHeadTagForObjectName: Boolean,
     jsonSerdeLib: String,
     streamingImplementation: String,
+    endpointCapabilites: String,
     validateNonDiscriminatedOneOfs: Boolean,
     maxSchemasPerFile: Int,
     dir: File,
@@ -58,6 +59,7 @@ case class OpenapiCodegenTask(
           useHeadTagForObjectName,
           jsonSerdeLib,
           streamingImplementation,
+          endpointCapabilites,
           validateNonDiscriminatedOneOfs,
           maxSchemasPerFile
         )

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -12,7 +12,6 @@ case class OpenapiCodegenTask(
     useHeadTagForObjectName: Boolean,
     jsonSerdeLib: String,
     streamingImplementation: String,
-    endpointCapabilites: String,
     validateNonDiscriminatedOneOfs: Boolean,
     maxSchemasPerFile: Int,
     generateEndpointTypes: Boolean,
@@ -60,7 +59,6 @@ case class OpenapiCodegenTask(
           useHeadTagForObjectName,
           jsonSerdeLib,
           streamingImplementation,
-          endpointCapabilites,
           validateNonDiscriminatedOneOfs,
           maxSchemasPerFile,
           generateEndpointTypes

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -44,7 +44,6 @@ object TapirGeneratedEndpoints {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)
   }
 
-
   case class EnumExtraParamSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]) extends ExtraParamSupport[T] {
     // Case-insensitive mapping
     def decode(s: String): sttp.tapir.DecodeResult[T] =
@@ -63,9 +62,16 @@ object TapirGeneratedEndpoints {
   }
   def extraCodecSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): ExtraParamSupport[T] =
     EnumExtraParamSupport(enumName, T)
+  sealed trait Error
   sealed trait ADTWithoutDiscriminator
   sealed trait ADTWithDiscriminator
   sealed trait ADTWithDiscriminatorNoMapping
+  case class SimpleError (
+    message: String
+  ) extends Error
+  case class NotFoundError (
+    reason: String
+  ) extends Error
   case class SubtypeWithoutD1 (
     s: String,
     i: Option[Int] = None,
@@ -119,34 +125,39 @@ object TapirGeneratedEndpoints {
 
 
 
-  lazy val getBinaryTest =
+  type GetBinaryTestEndpoint = Endpoint[Unit, Unit, Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
+  lazy val getBinaryTest: GetBinaryTestEndpoint =
     endpoint
       .get
       .in(("binary" / "test"))
       .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Array[Byte]], CodecFormat.OctetStream()).description("Response CSV body"))
 
-  lazy val postBinaryTest =
+  type PostBinaryTestEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, Unit, String, sttp.capabilities.pekko.PekkoStreams]
+  lazy val postBinaryTest: PostBinaryTestEndpoint =
     endpoint
       .post
       .in(("binary" / "test"))
       .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Array[Byte]], CodecFormat.OctetStream()))
       .out(jsonBody[String].description("successful operation"))
 
-  lazy val putAdtTest =
+  type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
+  lazy val putAdtTest: PutAdtTestEndpoint =
     endpoint
       .put
       .in(("adt" / "test"))
       .in(jsonBody[ADTWithoutDiscriminator])
       .out(jsonBody[ADTWithoutDiscriminator].description("successful operation"))
 
-  lazy val postAdtTest =
+  type PostAdtTestEndpoint = Endpoint[Unit, ADTWithDiscriminatorNoMapping, Unit, ADTWithDiscriminator, Any]
+  lazy val postAdtTest: PostAdtTestEndpoint =
     endpoint
       .post
       .in(("adt" / "test"))
       .in(jsonBody[ADTWithDiscriminatorNoMapping])
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 
-  lazy val postInlineEnumTest =
+  type PostInlineEnumTestEndpoint = Endpoint[Unit, (PostInlineEnumTestQueryEnum, Option[PostInlineEnumTestQueryOptEnum], List[PostInlineEnumTestQuerySeqEnum], Option[List[PostInlineEnumTestQueryOptSeqEnum]], ObjectWithInlineEnum), Unit, Unit, Any]
+  lazy val postInlineEnumTest: PostInlineEnumTestEndpoint =
     endpoint
       .post
       .in(("inline" / "enum" / "test"))
@@ -197,7 +208,14 @@ object TapirGeneratedEndpoints {
       extraCodecSupport[PostInlineEnumTestQueryOptSeqEnum]("PostInlineEnumTestQueryOptSeqEnum", PostInlineEnumTestQueryOptSeqEnum)
   }
 
+  type GetOneofErrorTestEndpoint = Endpoint[Unit, Unit, Error, Unit, Any]
+  lazy val getOneofErrorTest: GetOneofErrorTestEndpoint =
+    endpoint
+      .get
+      .in(("oneof" / "error" / "test"))
+      .errorOut(oneOf[Error](oneOfVariant(sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")), oneOfVariant(sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
+      .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
 
-  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putAdtTest, postAdtTest, postInlineEnumTest)
+  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putAdtTest, postAdtTest, postInlineEnumTest, getOneofErrorTest)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
@@ -16,6 +16,10 @@ object TapirGeneratedEndpointsJsonSerdes {
       }
     } yield res
   }
+  implicit lazy val simpleErrorJsonDecoder: io.circe.Decoder[SimpleError] = io.circe.generic.semiauto.deriveDecoder[SimpleError]
+  implicit lazy val simpleErrorJsonEncoder: io.circe.Encoder[SimpleError] = io.circe.generic.semiauto.deriveEncoder[SimpleError]
+  implicit lazy val notFoundErrorJsonDecoder: io.circe.Decoder[NotFoundError] = io.circe.generic.semiauto.deriveDecoder[NotFoundError]
+  implicit lazy val notFoundErrorJsonEncoder: io.circe.Encoder[NotFoundError] = io.circe.generic.semiauto.deriveEncoder[NotFoundError]
   implicit lazy val subtypeWithoutD1JsonDecoder: io.circe.Decoder[SubtypeWithoutD1] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithoutD1]
   implicit lazy val subtypeWithoutD1JsonEncoder: io.circe.Encoder[SubtypeWithoutD1] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithoutD1]
   implicit lazy val subtypeWithD1JsonDecoder: io.circe.Decoder[SubtypeWithD1] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithD1]

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
@@ -4,8 +4,10 @@ object TapirGeneratedEndpointsSchemas {
   import sttp.tapir.generated.TapirGeneratedEndpoints._
   import sttp.tapir.generic.auto._
   implicit lazy val anEnumTapirSchema: sttp.tapir.Schema[AnEnum] = sttp.tapir.Schema.derived
+  implicit lazy val notFoundErrorTapirSchema: sttp.tapir.Schema[NotFoundError] = sttp.tapir.Schema.derived
   implicit lazy val objectWithInlineEnumInlineEnumTapirSchema: sttp.tapir.Schema[ObjectWithInlineEnumInlineEnum] = sttp.tapir.Schema.derived
   implicit lazy val objectWithInlineEnumTapirSchema: sttp.tapir.Schema[ObjectWithInlineEnum] = sttp.tapir.Schema.derived
+  implicit lazy val simpleErrorTapirSchema: sttp.tapir.Schema[SimpleError] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD1TapirSchema: sttp.tapir.Schema[SubtypeWithD1] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD2TapirSchema: sttp.tapir.Schema[SubtypeWithD2] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithoutD1TapirSchema: sttp.tapir.Schema[SubtypeWithoutD1] = sttp.tapir.Schema.derived
@@ -38,6 +40,7 @@ object TapirGeneratedEndpointsSchemas {
       case _ => throw new IllegalStateException("Derived schema for ADTWithDiscriminatorNoMapping should be a coproduct")
     }
   }
+  implicit lazy val errorTapirSchema: sttp.tapir.Schema[Error] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithoutD3TapirSchema: sttp.tapir.Schema[SubtypeWithoutD3] = sttp.tapir.Schema.derived
   implicit lazy val aDTWithoutDiscriminatorTapirSchema: sttp.tapir.Schema[ADTWithoutDiscriminator] = sttp.tapir.Schema.derived
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/build.sbt
@@ -4,7 +4,6 @@ lazy val root = (project in file("."))
     scalaVersion := "2.13.15",
     version := "0.1",
     openapiStreamingImplementation := "pekko",
-    openapiEndpointCapabilites := "pekko",
     openapiGenerateEndpointTypes := true
   )
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/build.sbt
@@ -3,7 +3,9 @@ lazy val root = (project in file("."))
   .settings(
     scalaVersion := "2.13.15",
     version := "0.1",
-    openapiStreamingImplementation := "pekko"
+    openapiStreamingImplementation := "pekko",
+    openapiEndpointCapabilites := "pekko",
+    openapiGenerateEndpointTypes := true
   )
 
 libraryDependencies ++= Seq(

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -127,6 +127,24 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ObjectWithInlineEnum'
+  '/oneof/error/test':
+    get:
+      responses:
+        "204":
+          description: "No response"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+        default:
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleError'
+
 
 components:
   schemas:
@@ -248,3 +266,25 @@ components:
             - foo2
             - foo3
             - foo4
+    Error:
+      title: Error
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/NotFoundError'
+        - $ref: '#/components/schemas/SimpleError'
+    NotFoundError:
+      title: NotFoundError
+      required:
+        - reason
+      type: object
+      properties:
+        reason:
+          type: string
+    SimpleError:
+      title: SimpleError
+      required:
+        - message
+      type: object
+      properties:
+        message:
+          type: string


### PR DESCRIPTION
Adds a new `openapiGenerateEndpointTypes` setting (default false).

If 'true', we will generate type aliases for generated endpoint declarations (see changes to openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt).

If 'false' the only behavioural change should be that the LUB type is specified explicitly when generating `.errorOut(oneOf[LUB](oneOfVariant...` stuff (this is actually a little nicer usually -- it means the type will be `TheParentType` rather than `TheParentType with Product with Serializable`)

I would find having pre-defined type aliases for all the endpoint types to be extremely useful; locally I have a sourceGenerator step that replaces the `lazy val generatedEndpoints = List(...)` declaration on generated files with an HList (which is easy to do) to help ensure exhaustivity on implementation; having the type aliases available would make the subsequent 'serverLogic' binding declarations _so much nicer_, and it's next to impossible to generate them outside of the tapir code generation itself.