### PR TITLE
Add correct handling of query parameters in SttpMockServerClient

### DIFF
--- a/server/sttp-mock-server/src/main/scala/sttp/tapir/server/mockserver/SttpMockServerClient.scala
+++ b/server/sttp-mock-server/src/main/scala/sttp/tapir/server/mockserver/SttpMockServerClient.scala
@@ -1,23 +1,24 @@
 package sttp.tapir.server.mockserver
 
 import io.circe.{JsonObject, Printer}
-import io.circe.syntax._
-import sttp.client3._
-import sttp.client3.testing._
-import sttp.model.Uri.UriContext
+import io.circe.syntax.*
+import sttp.client3.*
+import sttp.client3.testing.*
+import sttp.model.Uri.{QuerySegment, UriContext}
 import sttp.model.{ContentTypeRange, HasHeaders, Header, HeaderNames, Headers, MediaType, StatusCode, Uri}
 import sttp.tapir.internal.ParamsAsAny
 import sttp.tapir.{CodecFormat, DecodeResult, Endpoint, RawBodyType, WebSocketBodyOutput}
-import sttp.tapir.server.mockserver.impl.JsonCodecs._
-import cats.syntax.either._
+import sttp.tapir.server.mockserver.impl.JsonCodecs.*
+import cats.syntax.either.*
 
 import java.nio.charset.Charset
-import io.circe.parser._
+import io.circe.parser.*
 import sttp.tapir.capabilities.NoStreams
 import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.tapir.server.interpreter.{EncodeOutputs, OutputValues, ToResponseBody}
 
 import scala.collection.immutable.Seq
+import scala.collection.mutable
 
 class SttpMockServerClient[F[_]] private[mockserver] (baseUri: Uri, backend: SttpBackend[F, Any]) {
 
@@ -134,7 +135,8 @@ object SttpMockServerClient {
     val request = SttpClientInterpreter().toSecureRequest(endpoint, None).apply(securityInput).apply(input)
     ExpectationRequestDefinition(
       method = request.method,
-      path = request.uri,
+      path = request.uri.copy(querySegments = Seq()),
+      queryStringParameters = querySegmentsToMultiMapOpt(request.uri.querySegments),
       body = toExpectationBody(request),
       headers = headersToMultiMapOpt(request.headers)
     )
@@ -205,6 +207,16 @@ object SttpMockServerClient {
   private def headersToMultiMapOpt(headers: Seq[Header]): Option[Map[String, List[String]]] =
     if (headers.isEmpty) None
     else Some(headers.groupBy(_.name).map { case (name, values) => name -> values.map(_.value).toList })
+
+  private def querySegmentsToMultiMapOpt(querySegments: Seq[QuerySegment]): Option[Map[String, List[String]]] =
+    if (querySegments.isEmpty) None
+    else
+      Some(
+        querySegments
+          .collect { case kv: QuerySegment.KeyValue => kv }
+          .groupBy(x => x.k)
+          .map((key, values) => key -> values.map(_.v).toList)
+      )
 
   private val printer = Printer.noSpaces
 

--- a/server/sttp-mock-server/src/main/scala/sttp/tapir/server/mockserver/SttpMockServerClient.scala
+++ b/server/sttp-mock-server/src/main/scala/sttp/tapir/server/mockserver/SttpMockServerClient.scala
@@ -1,24 +1,23 @@
 package sttp.tapir.server.mockserver
 
 import io.circe.{JsonObject, Printer}
-import io.circe.syntax.*
-import sttp.client3.*
-import sttp.client3.testing.*
+import io.circe.syntax._
+import sttp.client3._
+import sttp.client3.testing._
 import sttp.model.Uri.{QuerySegment, UriContext}
 import sttp.model.{ContentTypeRange, HasHeaders, Header, HeaderNames, Headers, MediaType, StatusCode, Uri}
 import sttp.tapir.internal.ParamsAsAny
 import sttp.tapir.{CodecFormat, DecodeResult, Endpoint, RawBodyType, WebSocketBodyOutput}
-import sttp.tapir.server.mockserver.impl.JsonCodecs.*
-import cats.syntax.either.*
+import sttp.tapir.server.mockserver.impl.JsonCodecs._
+import cats.syntax.either._
 
 import java.nio.charset.Charset
-import io.circe.parser.*
+import io.circe.parser._
 import sttp.tapir.capabilities.NoStreams
 import sttp.tapir.client.sttp.SttpClientInterpreter
 import sttp.tapir.server.interpreter.{EncodeOutputs, OutputValues, ToResponseBody}
 
 import scala.collection.immutable.Seq
-import scala.collection.mutable
 
 class SttpMockServerClient[F[_]] private[mockserver] (baseUri: Uri, backend: SttpBackend[F, Any]) {
 

--- a/server/sttp-mock-server/src/main/scala/sttp/tapir/server/mockserver/SttpMockServerClient.scala
+++ b/server/sttp-mock-server/src/main/scala/sttp/tapir/server/mockserver/SttpMockServerClient.scala
@@ -214,7 +214,7 @@ object SttpMockServerClient {
         querySegments
           .collect { case kv: QuerySegment.KeyValue => kv }
           .groupBy(x => x.k)
-          .map((key, values) => key -> values.map(_.v).toList)
+          .map { case (key, values) => key -> values.map(_.v).toList }
       )
 
   private val printer = Printer.noSpaces

--- a/server/sttp-mock-server/src/main/scala/sttp/tapir/server/mockserver/model.scala
+++ b/server/sttp-mock-server/src/main/scala/sttp/tapir/server/mockserver/model.scala
@@ -27,6 +27,7 @@ case class Expectation(
 case class ExpectationRequestDefinition(
     method: Method,
     path: Uri,
+    queryStringParameters: Option[Map[String, List[String]]],
     body: Option[ExpectationBodyDefinition],
     headers: Option[Map[String, List[String]]]
 )


### PR DESCRIPTION
Mock Server expects the query parameters in a field called `queryStringParameters` instead of in the URL.
This PR follows the way headers are mapped to a MultiMapOpt to map query parameters to a `Map[String,List[String]]`

Closes #4219