### PR TITLE
Add server options to AWS Lambda handler

### DIFF
--- a/serverless/aws/cdk-tests/src/main/scala/sttp/tapir/serverless/aws/cdk/tests/CdkTestLambdaHandler.scala
+++ b/serverless/aws/cdk-tests/src/main/scala/sttp/tapir/serverless/aws/cdk/tests/CdkTestLambdaHandler.scala
@@ -11,7 +11,7 @@ import java.io.{InputStream, OutputStream}
 
 /** Used by [[AwsCdkAppTemplate]] for integration tests
   */
-object CdkTestLambdaHandler extends LambdaHandler[IO, AwsRequestV1] {
+object CdkTestLambdaHandler extends LambdaHandler[IO, AwsRequestV1](AwsCatsEffectServerOptions.default[IO]) {
   override protected def getAllEndpoints: List[ServerEndpoint[Any, IO]] = allEndpoints.toList
 
   override def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {

--- a/serverless/aws/cdk-tests/src/main/scala/sttp/tapir/serverless/aws/cdk/tests/CdkTestLambdaHandler.scala
+++ b/serverless/aws/cdk-tests/src/main/scala/sttp/tapir/serverless/aws/cdk/tests/CdkTestLambdaHandler.scala
@@ -11,7 +11,7 @@ import java.io.{InputStream, OutputStream}
 
 /** Used by [[AwsCdkAppTemplate]] for integration tests
   */
-object CdkTestLambdaHandler extends LambdaHandler[IO, AwsRequestV1](AwsCatsEffectServerOptions.default[IO]) {
+object CdkTestLambdaHandler extends LambdaHandler[IO, AwsRequestV1](AwsCatsEffectServerOptions.noEncoding[IO]) {
   override protected def getAllEndpoints: List[ServerEndpoint[Any, IO]] = allEndpoints.toList
 
   override def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {

--- a/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/IOLambdaHandlerV1Test.scala
+++ b/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/IOLambdaHandlerV1Test.scala
@@ -85,7 +85,7 @@ class IOLambdaHandlerV1Test extends AnyFunSuite with Matchers {
   test("lambda handler without encoding") {
     val output = new ByteArrayOutputStream()
 
-    val handler = new IOLambdaHandlerV1(AwsCatsEffectServerOptions.noEncoding[IO])
+    val handler = new IOLambdaHandlerV1()
     handler.handleRequest(new ByteArrayInputStream(input.getBytes), output, context)
 
     val expected = AwsResponse(

--- a/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/IOLambdaHandlerV1Test.scala
+++ b/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/IOLambdaHandlerV1Test.scala
@@ -1,13 +1,12 @@
 package sttp.tapir.serverless.aws.cdk
 
-import cats.effect.IO
 import com.amazonaws.services.lambda.runtime.api.client.api._
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import sttp.tapir.serverless.aws.cdk.test.IOLambdaHandlerV1
-import sttp.tapir.serverless.aws.lambda.{AwsCatsEffectServerOptions, AwsResponse}
+import sttp.tapir.serverless.aws.lambda.AwsResponse
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 
@@ -82,10 +81,10 @@ class IOLambdaHandlerV1Test extends AnyFunSuite with Matchers {
     new LambdaClientContext()
   )
 
-  test("lambda handler without encoding") {
+  test("lambda handler") {
     val output = new ByteArrayOutputStream()
 
-    val handler = new IOLambdaHandlerV1()
+    val handler = new IOLambdaHandlerV1
     handler.handleRequest(new ByteArrayInputStream(input.getBytes), output, context)
 
     val expected = AwsResponse(
@@ -93,22 +92,6 @@ class IOLambdaHandlerV1Test extends AnyFunSuite with Matchers {
       200,
       Map("Content-Length" -> "9", "Content-Type" -> "text/plain; charset=UTF-8"),
       "Hi! Julie"
-    )
-
-    decode[AwsResponse](output.toString()) shouldBe Right(expected)
-  }
-
-  test("lambda handler with default encoding") {
-    val output = new ByteArrayOutputStream()
-
-    val handler = new IOLambdaHandlerV1(AwsCatsEffectServerOptions.default[IO])
-    handler.handleRequest(new ByteArrayInputStream(input.getBytes), output, context)
-
-    val expected = AwsResponse(
-      isBase64Encoded = true,
-      200,
-      Map("Content-Length" -> "9", "Content-Type" -> "text/plain; charset=UTF-8"),
-      "SGkhIEp1bGll"
     )
 
     decode[AwsResponse](output.toString()) shouldBe Right(expected)

--- a/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/test/IOLambdaHandlerV1.scala
+++ b/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/test/IOLambdaHandlerV1.scala
@@ -3,13 +3,13 @@ package sttp.tapir.serverless.aws.cdk.test
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.amazonaws.services.lambda.runtime.Context
-import io.circe.generic.auto._
+import io.circe.generic.auto.*
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.serverless.aws.lambda.{AwsRequestV1, AwsServerOptions, LambdaHandler}
+import sttp.tapir.serverless.aws.lambda.{AwsCatsEffectServerOptions, AwsRequestV1, AwsServerOptions, LambdaHandler}
 
 import java.io.{InputStream, OutputStream}
 
-class IOLambdaHandlerV1(options: AwsServerOptions[IO]) extends LambdaHandler[IO, AwsRequestV1](options) {
+class IOLambdaHandlerV1(options: AwsServerOptions[IO] = AwsCatsEffectServerOptions.noEncoding[IO]) extends LambdaHandler[IO, AwsRequestV1](options) {
 
   override protected def getAllEndpoints: List[ServerEndpoint[Any, IO]] = TestEndpoints.all[IO].toList
 

--- a/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/test/IOLambdaHandlerV1.scala
+++ b/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/test/IOLambdaHandlerV1.scala
@@ -9,7 +9,7 @@ import sttp.tapir.serverless.aws.lambda.{AwsCatsEffectServerOptions, AwsRequestV
 
 import java.io.{InputStream, OutputStream}
 
-class IOLambdaHandlerV1(options: AwsServerOptions[IO] = AwsCatsEffectServerOptions.noEncoding[IO]) extends LambdaHandler[IO, AwsRequestV1](options) {
+class IOLambdaHandlerV1 extends LambdaHandler[IO, AwsRequestV1](AwsCatsEffectServerOptions.noEncoding[IO]) {
 
   override protected def getAllEndpoints: List[ServerEndpoint[Any, IO]] = TestEndpoints.all[IO].toList
 

--- a/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/test/IOLambdaHandlerV1.scala
+++ b/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/test/IOLambdaHandlerV1.scala
@@ -5,11 +5,11 @@ import cats.effect.unsafe.implicits.global
 import com.amazonaws.services.lambda.runtime.Context
 import io.circe.generic.auto._
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.serverless.aws.lambda.{AwsRequestV1, LambdaHandler}
+import sttp.tapir.serverless.aws.lambda.{AwsRequestV1, AwsServerOptions, LambdaHandler}
 
 import java.io.{InputStream, OutputStream}
 
-class IOLambdaHandlerV1 extends LambdaHandler[IO, AwsRequestV1] {
+class IOLambdaHandlerV1(options: AwsServerOptions[IO]) extends LambdaHandler[IO, AwsRequestV1](options) {
 
   override protected def getAllEndpoints: List[ServerEndpoint[Any, IO]] = TestEndpoints.all[IO].toList
 

--- a/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/test/IOLambdaHandlerV1.scala
+++ b/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/test/IOLambdaHandlerV1.scala
@@ -3,7 +3,7 @@ package sttp.tapir.serverless.aws.cdk.test
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.amazonaws.services.lambda.runtime.Context
-import io.circe.generic.auto.*
+import io.circe.generic.auto._
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.serverless.aws.lambda.{AwsCatsEffectServerOptions, AwsRequestV1, AwsServerOptions, LambdaHandler}
 

--- a/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/test/IOLambdaHandlerV1.scala
+++ b/serverless/aws/cdk/src/test/scala/sttp/tapir/serverless/aws/cdk/test/IOLambdaHandlerV1.scala
@@ -5,7 +5,7 @@ import cats.effect.unsafe.implicits.global
 import com.amazonaws.services.lambda.runtime.Context
 import io.circe.generic.auto._
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.serverless.aws.lambda.{AwsCatsEffectServerOptions, AwsRequestV1, AwsServerOptions, LambdaHandler}
+import sttp.tapir.serverless.aws.lambda.{AwsCatsEffectServerOptions, AwsRequestV1, LambdaHandler}
 
 import java.io.{InputStream, OutputStream}
 

--- a/serverless/aws/examples/src/main/scalajvm/sttp/tapir/serverless/aws/examples/LambdaApiExample.scala
+++ b/serverless/aws/examples/src/main/scalajvm/sttp/tapir/serverless/aws/examples/LambdaApiExample.scala
@@ -11,7 +11,7 @@ import sttp.tapir.serverless.aws.lambda._
 
 import java.io.{InputStream, OutputStream}
 
-object LambdaApiExample extends LambdaHandler[IO, AwsRequest] {
+object LambdaApiExample(options: AwsServerOptions[IO]) extends LambdaHandler[IO, AwsRequest](options) {
 
   val helloEndpoint: ServerEndpoint[Any, IO] = endpoint.get
     .in("api" / "hello")

--- a/serverless/aws/examples/src/main/scalajvm/sttp/tapir/serverless/aws/examples/LambdaApiExample.scala
+++ b/serverless/aws/examples/src/main/scalajvm/sttp/tapir/serverless/aws/examples/LambdaApiExample.scala
@@ -11,7 +11,7 @@ import sttp.tapir.serverless.aws.lambda._
 
 import java.io.{InputStream, OutputStream}
 
-object LambdaApiExample extends LambdaHandler[IO, AwsRequest](AwsCatsEffectServerOptions.default[IO]) {
+object LambdaApiExample extends LambdaHandler[IO, AwsRequest](AwsCatsEffectServerOptions.noEncoding[IO]) {
 
   val helloEndpoint: ServerEndpoint[Any, IO] = endpoint.get
     .in("api" / "hello")

--- a/serverless/aws/examples/src/main/scalajvm/sttp/tapir/serverless/aws/examples/LambdaApiExample.scala
+++ b/serverless/aws/examples/src/main/scalajvm/sttp/tapir/serverless/aws/examples/LambdaApiExample.scala
@@ -11,7 +11,7 @@ import sttp.tapir.serverless.aws.lambda._
 
 import java.io.{InputStream, OutputStream}
 
-object LambdaApiExample(options: AwsServerOptions[IO]) extends LambdaHandler[IO, AwsRequest](options) {
+object LambdaApiExample extends LambdaHandler[IO, AwsRequest](AwsCatsEffectServerOptions.default[IO]) {
 
   val helloEndpoint: ServerEndpoint[Any, IO] = endpoint.get
     .in("api" / "hello")

--- a/serverless/aws/examples/src/main/scalajvm/sttp/tapir/serverless/aws/examples/LambdaApiV1Example.scala
+++ b/serverless/aws/examples/src/main/scalajvm/sttp/tapir/serverless/aws/examples/LambdaApiV1Example.scala
@@ -11,7 +11,7 @@ import sttp.tapir.serverless.aws.lambda._
 
 import java.io.{InputStream, OutputStream}
 
-object LambdaApiV1Example extends LambdaHandler[IO, AwsRequestV1](AwsCatsEffectServerOptions.default[IO]) {
+object LambdaApiV1Example extends LambdaHandler[IO, AwsRequestV1](AwsCatsEffectServerOptions.noEncoding[IO]) {
 
   val helloEndpoint: ServerEndpoint[Any, IO] = endpoint.get
     .in("api" / "hello")

--- a/serverless/aws/examples/src/main/scalajvm/sttp/tapir/serverless/aws/examples/LambdaApiV1Example.scala
+++ b/serverless/aws/examples/src/main/scalajvm/sttp/tapir/serverless/aws/examples/LambdaApiV1Example.scala
@@ -11,7 +11,7 @@ import sttp.tapir.serverless.aws.lambda._
 
 import java.io.{InputStream, OutputStream}
 
-object LambdaApiV1Example extends LambdaHandler[IO, AwsRequestV1] {
+object LambdaApiV1Example(options: AwsServerOptions[IO]) extends LambdaHandler[IO, AwsRequestV1](options) {
 
   val helloEndpoint: ServerEndpoint[Any, IO] = endpoint.get
     .in("api" / "hello")

--- a/serverless/aws/examples/src/main/scalajvm/sttp/tapir/serverless/aws/examples/LambdaApiV1Example.scala
+++ b/serverless/aws/examples/src/main/scalajvm/sttp/tapir/serverless/aws/examples/LambdaApiV1Example.scala
@@ -11,7 +11,7 @@ import sttp.tapir.serverless.aws.lambda._
 
 import java.io.{InputStream, OutputStream}
 
-object LambdaApiV1Example(options: AwsServerOptions[IO]) extends LambdaHandler[IO, AwsRequestV1](options) {
+object LambdaApiV1Example extends LambdaHandler[IO, AwsRequestV1](AwsCatsEffectServerOptions.default[IO]) {
 
   val helloEndpoint: ServerEndpoint[Any, IO] = endpoint.get
     .in("api" / "hello")

--- a/serverless/aws/lambda-cats-effect-tests/src/main/scala/sttp/tapir/serverless/aws/lambda/tests/IOLambdaHandlerV2.scala
+++ b/serverless/aws/lambda-cats-effect-tests/src/main/scala/sttp/tapir/serverless/aws/lambda/tests/IOLambdaHandlerV2.scala
@@ -8,7 +8,7 @@ import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.serverless.aws.lambda.{AwsCatsEffectServerOptions, AwsRequest, AwsServerOptions, LambdaHandler}
 import java.io.{InputStream, OutputStream}
 
-class IOLambdaHandlerV2(options: AwsServerOptions[IO] = AwsCatsEffectServerOptions.noEncoding[IO]) extends LambdaHandler[IO, AwsRequest](options) {
+class IOLambdaHandlerV2 extends LambdaHandler[IO, AwsRequest](AwsCatsEffectServerOptions.noEncoding[IO]) {
 
   override protected def getAllEndpoints: List[ServerEndpoint[Any, IO]] = allEndpoints.toList
 

--- a/serverless/aws/lambda-cats-effect-tests/src/main/scala/sttp/tapir/serverless/aws/lambda/tests/IOLambdaHandlerV2.scala
+++ b/serverless/aws/lambda-cats-effect-tests/src/main/scala/sttp/tapir/serverless/aws/lambda/tests/IOLambdaHandlerV2.scala
@@ -5,7 +5,7 @@ import cats.effect.unsafe.implicits.global
 import com.amazonaws.services.lambda.runtime.Context
 import io.circe.generic.auto._
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.serverless.aws.lambda.{AwsRequest, LambdaHandler}
+import sttp.tapir.serverless.aws.lambda.{AwsRequest, AwsServerOptions, LambdaHandler}
 import java.io.{InputStream, OutputStream}
 
 class IOLambdaHandlerV2(options: AwsServerOptions[IO]) extends LambdaHandler[IO, AwsRequest](options) {

--- a/serverless/aws/lambda-cats-effect-tests/src/main/scala/sttp/tapir/serverless/aws/lambda/tests/IOLambdaHandlerV2.scala
+++ b/serverless/aws/lambda-cats-effect-tests/src/main/scala/sttp/tapir/serverless/aws/lambda/tests/IOLambdaHandlerV2.scala
@@ -5,10 +5,10 @@ import cats.effect.unsafe.implicits.global
 import com.amazonaws.services.lambda.runtime.Context
 import io.circe.generic.auto._
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.serverless.aws.lambda.{AwsRequest, AwsServerOptions, LambdaHandler}
+import sttp.tapir.serverless.aws.lambda.{AwsCatsEffectServerOptions, AwsRequest, AwsServerOptions, LambdaHandler}
 import java.io.{InputStream, OutputStream}
 
-class IOLambdaHandlerV2(options: AwsServerOptions[IO]) extends LambdaHandler[IO, AwsRequest](options) {
+class IOLambdaHandlerV2(options: AwsServerOptions[IO] = AwsCatsEffectServerOptions.noEncoding[IO]) extends LambdaHandler[IO, AwsRequest](options) {
 
   override protected def getAllEndpoints: List[ServerEndpoint[Any, IO]] = allEndpoints.toList
 

--- a/serverless/aws/lambda-cats-effect-tests/src/main/scala/sttp/tapir/serverless/aws/lambda/tests/IOLambdaHandlerV2.scala
+++ b/serverless/aws/lambda-cats-effect-tests/src/main/scala/sttp/tapir/serverless/aws/lambda/tests/IOLambdaHandlerV2.scala
@@ -8,7 +8,7 @@ import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.serverless.aws.lambda.{AwsRequest, LambdaHandler}
 import java.io.{InputStream, OutputStream}
 
-class IOLambdaHandlerV2 extends LambdaHandler[IO, AwsRequest] {
+class IOLambdaHandlerV2(options: AwsServerOptions[IO]) extends LambdaHandler[IO, AwsRequest](options) {
 
   override protected def getAllEndpoints: List[ServerEndpoint[Any, IO]] = allEndpoints.toList
 

--- a/serverless/aws/lambda-cats-effect/src/main/scala/sttp/tapir/serverless/aws/lambda/LambdaHandler.scala
+++ b/serverless/aws/lambda-cats-effect/src/main/scala/sttp/tapir/serverless/aws/lambda/LambdaHandler.scala
@@ -18,14 +18,15 @@ import java.nio.charset.StandardCharsets
   * @tparam R
   *   AWS API Gateway request type [[AwsRequestV1]] or [[AwsRequest]]. At the moment mapping is required as there is no support for
   *   generating API Gateway V2 definitions with AWS CDK v2.
+  * @param options
+  *   Server options of type AwsServerOptions.
   */
-abstract class LambdaHandler[F[_]: Sync, R: Decoder] extends RequestStreamHandler {
+abstract class LambdaHandler[F[_]: Sync, R: Decoder](options: AwsServerOptions[F]) extends RequestStreamHandler {
 
   protected def getAllEndpoints: List[ServerEndpoint[Any, F]]
 
   protected def process(input: InputStream, output: OutputStream): F[Unit] = {
-    val server: AwsCatsEffectServerInterpreter[F] =
-      AwsCatsEffectServerInterpreter(AwsCatsEffectServerOptions.noEncoding[F])
+    val server: AwsCatsEffectServerInterpreter[F] = AwsCatsEffectServerInterpreter(options)
 
     for {
       allBytes <- Sync[F].blocking(input.readAllBytes())

--- a/serverless/aws/lambda-zio/src/main/scala/sttp/tapir/serverless/aws/ziolambda/ZioLambdaHandler.scala
+++ b/serverless/aws/lambda-zio/src/main/scala/sttp/tapir/serverless/aws/ziolambda/ZioLambdaHandler.scala
@@ -16,7 +16,7 @@ import java.nio.charset.StandardCharsets
   *
   * @tparam Env
   *   The Environment type of the handler .
-  * @tparam options
+  * @param options
   *   Server options of type AwsServerOptions.
   */
 abstract class ZioLambdaHandler[Env: RIOMonadError](options: AwsServerOptions[RIO[Env, *]]) {


### PR DESCRIPTION
*Why I did it?*
LambdaHandler had the hardcoded AwsServerOptions, so delivering
the custom server options was impossible.

*How I did it:*
LambdaHandler started to accept options by analogous to ZioLambdaHandler

Closes #4064
