### PR TITLE
Collecting traces example using otel4s.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2078,6 +2078,8 @@ lazy val examples: ProjectMatrix = (projectMatrix in file("examples"))
       "io.opentelemetry" % "opentelemetry-sdk-metrics" % Versions.openTelemetry,
       "io.opentelemetry" % "opentelemetry-exporter-otlp" % Versions.openTelemetry,
       "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-macros" % Versions.jsoniter,
+      "org.typelevel" %% "otel4s-oteljava" % Versions.otel4s,
+      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % Versions.openTelemetry ,
       scalaTest.value,
       logback
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -2077,9 +2077,9 @@ lazy val examples: ProjectMatrix = (projectMatrix in file("examples"))
       "io.opentelemetry" % "opentelemetry-sdk" % Versions.openTelemetry,
       "io.opentelemetry" % "opentelemetry-sdk-metrics" % Versions.openTelemetry,
       "io.opentelemetry" % "opentelemetry-exporter-otlp" % Versions.openTelemetry,
+      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % Versions.openTelemetry ,
       "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-macros" % Versions.jsoniter,
       "org.typelevel" %% "otel4s-oteljava" % Versions.otel4s,
-      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % Versions.openTelemetry ,
       scalaTest.value,
       logback
     ),

--- a/examples/src/main/scala/sttp/tapir/examples/observability/Otel4sTracingExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/Otel4sTracingExample.scala
@@ -29,6 +29,7 @@ import scala.io.StdIn
   * {{{
   *   docker run --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 4317:4317 -p 4318:4318 jaegertracing/all-in-one:1.35
   * }}}
+  * Jaeger UI is available at http://localhost:16686. You can find the collected traces there.
   *
   * The example code requires the following dependencies:
   * {{{

--- a/examples/src/main/scala/sttp/tapir/examples/observability/Otel4sTracingExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/Otel4sTracingExample.scala
@@ -1,3 +1,13 @@
+// {cat=Observability; effects=cats-effect; server=Netty; json=circe}: Otel4s collecting traces
+
+//> using dep com.softwaremill.sttp.tapir::tapir-core:1.11.11
+//> using dep com.softwaremill.sttp.tapir::tapir-netty-server-cats:1.11.11
+//> using dep com.softwaremill.sttp.tapir::tapir-json-circe:1.11.11
+//> using dep com.softwaremill.sttp.tapir::tapir-opentelemetry-metrics:1.11.11
+//> using dep "org.typelevel::otel4s-oteljava:0.11.2" // <1>
+//> using dep "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.45.0" // <3>
+//> using dep org.slf4j:slf4j-api:2.0.16
+
 package sttp.tapir.examples.observability
 
 import cats.effect.std.{Console, Random}
@@ -117,16 +127,12 @@ object Otel4sTracingExample extends IOApp.Simple:
     // Please notice in your, production cases could be better to use env variable instead.
     // Under following link you may find more details about configuration https://typelevel.org/otel4s/sdk/configuration.html
     def customize(a: AutoConfigOtelSdkBuilder): AutoConfigOtelSdkBuilder = {
-      val customResource = Resource.getDefault
-        .merge(
-          Resource.create(
-            Attributes.of(io.opentelemetry.api.common.AttributeKey.stringKey("service.name"), "Otel4sTracingExample")
-          )
-        )
+      val customResource = Resource.getDefault.merge(
+        Resource.create(Attributes.of(io.opentelemetry.api.common.AttributeKey.stringKey("service.name"), "Otel4sTracingExample"))
+      )
       a.addResourceCustomizer((resource, config) => customResource)
       a
     }
 
-    OtelJava
-      .autoConfigured[IO](customize)
+    OtelJava.autoConfigured[IO](customize)
   }

--- a/examples/src/main/scala/sttp/tapir/examples/observability/Otel4sTracingExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/Otel4sTracingExample.scala
@@ -1,0 +1,131 @@
+package sttp.tapir.examples.observability
+
+import cats.effect.std.{Console, Random}
+import cats.effect.{Async, IO, IOApp}
+import io.circe.generic.auto.*
+import sttp.tapir.*
+import sttp.tapir.generic.auto.*
+import sttp.tapir.json.circe.jsonBody
+import sttp.tapir.server.netty.cats.NettyCatsServer
+import org.slf4j.{Logger, LoggerFactory}
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.trace.Tracer
+import cats.syntax.all.*
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder as AutoConfigOtelSdkBuilder
+import org.typelevel.otel4s.oteljava.OtelJava
+import io.opentelemetry.sdk.resources.Resource
+
+import scala.concurrent.duration.*
+import sttp.tapir.server.ServerEndpoint
+
+import scala.io.StdIn
+
+/** This example application demonstrates how to implement distributed tracing in a Scala application using the <a
+  * href="https://github.com/typelevel/otel4s"> otel4s library </a>. More info about oltel4s you may find <a
+  * href="https://typelevel.org/otel4s/">here</a>
+  *
+  * In order to collect and visualize traces, you can run Jaeger using Docker with the following command:
+  * {{{
+  *   docker run --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 4317:4317 -p 4318:4318 jaegertracing/all-in-one:1.35
+  * }}}
+  *
+  * The example code requires the following dependencies:
+  * {{{
+  *   val openTelemetryVersion = <OpenTelemetry version>
+  *   val otel4sVersion = <Otel4s version>
+  *
+  *   libraryDependencies ++= Seq(
+  *     "org.typelevel" %% "otel4s-oteljava" % otel4sVersion,
+  *      "io.opentelemetry" % "opentelemetry-sdk-extension-autoconfigure" % openTelemetryVersion,
+  *     "io.opentelemetry" % "opentelemetry-exporter-otlp" % openTelemetryVersion
+  *    )
+  * }}}
+  */
+
+class Service[F[_]: Async: Tracer: Console]:
+  def doWork(steps: Int): F[Unit] = doWorkInternal(steps)
+
+  private def doWorkInternal(steps: Int): F[Unit] = {
+    val step = Tracer[F]
+      .span("internal-work", Attribute("step", steps.toLong))
+      .surround {
+        for {
+          random <- Random.scalaUtilRandom
+          delay <- random.nextIntBounded(1000)
+          _ <- Async[F].sleep(delay.millis)
+          _ <- Console[F].println("Do work ...")
+        } yield ()
+      }
+
+    if (steps > 0) step *> doWorkInternal(steps - 1) else step
+  }
+
+class HttpApi[F[_]: Async: Tracer](service: Service[F]):
+  import HttpApi.*
+  private val doWork: PublicEndpoint[Work, Unit, Unit, Any] = endpoint.post.in("work").in(jsonBody[Work])
+
+  private val doWorkServerEndpoint: ServerEndpoint[Any, F] = doWork.serverLogicSuccess(work => {
+    Tracer[F].span("DoWorkRequest").use { span =>
+      span.addEvent("Do the work request received") *>
+        service.doWork(work.steps) *>
+        span.addEvent("Finished working.")
+    }
+  })
+
+  val all: List[ServerEndpoint[Any, F]] = List(doWorkServerEndpoint)
+
+  object HttpApi:
+    case class Work(steps: Int)
+
+object Otel4sTracingExample extends IOApp.Simple:
+  private val logger: Logger = LoggerFactory.getLogger(this.getClass.getName)
+  private val port = 9090
+  private val host = "localhost"
+
+  override def run: IO[Unit] = otel
+    .use { otel4s =>
+      otel4s.tracerProvider
+        .get("sttp.tapir.examples.observability")
+        .flatMap(implicit tracer => server(HttpApi[IO](Service[IO])))
+    }
+
+  private def server(httpApi: HttpApi[IO]): IO[Unit] =
+    NettyCatsServer
+      .io()
+      .use { server =>
+        for {
+          bind <- server
+            .port(port)
+            .host(host)
+            .addEndpoints(httpApi.all)
+            .start()
+          _ <- IO
+            .blocking {
+              logger.info(s"""Server started. Try it with: curl -X POST ${bind.hostName}:${bind.port}/work -d '{"steps": 10}'""")
+              logger.info("Press ENTER key to exit.")
+              StdIn.readLine()
+
+            }
+            .guarantee(bind.stop())
+        } yield ()
+      }
+
+  private def otel = {
+    // We implemented customization here to set service name.
+    // Please notice in your, production cases could be better to use env variable instead.
+    // Under following link you may find more details about configuration https://typelevel.org/otel4s/sdk/configuration.html
+    def customize(a: AutoConfigOtelSdkBuilder): AutoConfigOtelSdkBuilder = {
+      val customResource = Resource.getDefault
+        .merge(
+          Resource.create(
+            Attributes.of(io.opentelemetry.api.common.AttributeKey.stringKey("service.name"), "Otel4sTracingExample")
+          )
+        )
+      a.addResourceCustomizer((resource, config) => customResource)
+      a
+    }
+
+    OtelJava
+      .autoConfigured[IO](customize)
+  }

--- a/examples/src/main/scala/sttp/tapir/examples/observability/Otel4sTracingExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/Otel4sTracingExample.scala
@@ -49,10 +49,7 @@ object Otel4sTracingExample extends IOApp.Simple:
     .use { otel4s =>
       otel4s.tracerProvider
         .get("sttp.tapir.examples.observability")
-        .flatMap(t => {
-          given Tracer[IO] = t
-          server(HttpApi[IO](Service[IO]))
-        })
+        .flatMap { case given Tracer[IO] => server(HttpApi[IO](Service[IO])) }
     }
 
   private def server(httpApi: HttpApi[IO]): IO[Unit] =

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -67,4 +67,5 @@ object Versions {
   val logback = "1.5.15"
   val slf4j = "2.0.16"
   val jsoniter = "2.33.0"
+  val otel4s = "0.11.2"
 }


### PR DESCRIPTION
This example demonstrates how to implement distributed tracing in a Scala application using the 
[ otel4s library](https://github.com/typelevel/otel4s) . More info about oltel4s you may find [here](https://typelevel.org/otel4s/).

 In order to collect and visualize traces, you can run Jaeger using Docker with the following command:
`docker run --name jaeger -e COLLECTOR_OTLP_ENABLED=true -p 16686:16686 -p 4317:4317 -p 4318:4318 jaegertracing/all-in-one:1.35`

Jaeger UI is available at http://localhost:16686. You can find the collected traces there.
![Screenshot from 2025-01-02 15-27-11](https://github.com/user-attachments/assets/63696b82-f4cb-4371-b622-57a400e0ce38)
![Screenshot from 2025-01-02 15-27-20](https://github.com/user-attachments/assets/a3363248-096a-40a9-90d1-c48ede3c14ac)


