### PR TITLE
Fixed dependency graph

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -12,4 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: sbt/setup-sbt@v1
       - uses: scalacenter/sbt-dependency-submission@v2


### PR DESCRIPTION
*Why I did it?*
GitHub dropped sbt from ubuntu-latest

https://github.com/sbt/setup-sbt?tab=readme-ov-file#december-2024
