### PR TITLE
Adjusted dependabot's labels

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,3 +8,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    # Raise all pull requests with labels
+    labels:
+      - "dependency"
+      - "automerge"


### PR DESCRIPTION
*Why I did it?*
In order to mark its PRs with `automarge` and
`dependency` labels
https://bit.ly/3DNpUUt
