### PR TITLE
codegen: fix oneOf types without common parent for scala 3

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -442,7 +442,7 @@ class EndpointGenerator {
           if (allElemTypes.size == 1) allElemTypes.head
           else
             allElemTypes.map { s => parentMap.getOrElse(s, Nil).toSet }.reduce(_ intersect _) match {
-              case s if s.isEmpty && targetScala3 => types.mkString(" | ")
+              case s if s.isEmpty && targetScala3 => types.flatten.mkString(" | ")
               case s if s.isEmpty                 => "Any"
               case s if targetScala3              => s.mkString(" & ")
               case s                              => s.mkString(" with ")


### PR DESCRIPTION
Fixes return LUB type for return type when generating endpoints with response objects without a common parent in scala 3 (was generating `Some(Foo) | Some(Bar)` instead of `Foo | Bar` :facepalm:)