### PR TITLE
Http4sServerInterpreter fix compatibility with 1.0.0-M44

### DIFF
--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerInterpreter.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sServerInterpreter.scala
@@ -134,7 +134,7 @@ trait Http4sServerInterpreter[F[_]] {
           case Some(value) if response.contentLength.isEmpty => headers.put(`Content-Length`(value))
           case _                                             => headers
         }
-        Response(status = statusCode, headers = headers2, body = entity).pure[F]
+        Response(status = statusCode, headers = headers2).withEntity(entity).pure[F]
 
       case None => Response[F](status = statusCode, headers = headers).pure[F]
     }


### PR DESCRIPTION
This change maintains compatibility with http4s 0.23.30, and also adds compatibility with version 1.0.0-M44