### PR TITLE
Add support in Pekko interpreter for status codes >=600

### DIFF
--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoHttpServerInterpreter.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoHttpServerInterpreter.scala
@@ -74,7 +74,8 @@ trait PekkoHttpServerInterpreter {
   }
 
   private def serverResponseToPekko(response: ServerResponse[PekkoResponseBody], requestMethod: Method): Route = {
-    val statusCode = StatusCodes.getForKey(response.code.code).getOrElse(StatusCodes.custom(response.code.code, ""))
+    val statusCode = StatusCodes.getForKey(response.code.code)
+      .getOrElse(StatusCodes.custom(response.code.code, "", "", false, true))
     val pekkoHeaders = parseHeadersOrThrowWithoutContentHeaders(response)
 
     response.body match {

--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoHttpServerInterpreter.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoHttpServerInterpreter.scala
@@ -76,7 +76,7 @@ trait PekkoHttpServerInterpreter {
   private def serverResponseToPekko(response: ServerResponse[PekkoResponseBody], requestMethod: Method): Route = {
     val statusCode = StatusCodes
       .getForKey(response.code.code)
-      .getOrElse(StatusCodes.custom(response.code.code, "", "", false, true))
+      .getOrElse(StatusCodes.custom(response.code.code, "", "", 200 to 299 contains response.code.code, true))
     val pekkoHeaders = parseHeadersOrThrowWithoutContentHeaders(response)
 
     response.body match {

--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoHttpServerInterpreter.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoHttpServerInterpreter.scala
@@ -74,7 +74,8 @@ trait PekkoHttpServerInterpreter {
   }
 
   private def serverResponseToPekko(response: ServerResponse[PekkoResponseBody], requestMethod: Method): Route = {
-    val statusCode = StatusCodes.getForKey(response.code.code)
+    val statusCode = StatusCodes
+      .getForKey(response.code.code)
       .getOrElse(StatusCodes.custom(response.code.code, "", "", false, true))
     val pekkoHeaders = parseHeadersOrThrowWithoutContentHeaders(response)
 


### PR DESCRIPTION
Pekko [supports](https://pekko.apache.org/docs/pekko-http/current/common/http-model.html#registering-custom-status-codes) registering custom status codes with values >=600. Currently, if an endpoint returns such a status code, the Pekko interpreter will crash due to the call to the two argument version of `StatusCodes.custom`. This PR ~~adds possibility of registering Pekko custom status codes using `PekkoHttpServerOptions`~~ fixes that behavior by using the five parameter version of the method. 