### PR TITLE
Use a regex for Pattern validations

### DIFF
--- a/core/src/main/scala/sttp/tapir/Validator.scala
+++ b/core/src/main/scala/sttp/tapir/Validator.scala
@@ -168,8 +168,9 @@ object Validator extends ValidatorMacros {
       ValidationResult.validWhen(implicitly[Numeric[T]].lt(t, value) || (!exclusive && implicitly[Numeric[T]].equiv(t, value)))
   }
   case class Pattern[T <: String](value: String) extends Primitive[T] {
-    private lazy val regex: Regex = value.r
-    override def doValidate(t: T): ValidationResult = ValidationResult.validWhen(regex.matches(value))
+    // java.util.regex.Pattern is compatible with scalajs and scala native
+    private lazy val pattern: java.util.regex.Pattern = java.util.regex.Pattern.compile(value)
+    override def doValidate(t: T): ValidationResult = ValidationResult.validWhen(pattern.matcher(t).matches())
   }
 
   case class MinLength[T <: String](value: Int, countCodePoints: Boolean) extends Primitive[T] {


### PR DESCRIPTION
On the JVM it's general good practice to reuse regex Patterns, otherwise they need to be recompiled each time they are used

Introduce a `private lazy val regex: Regex = value.r` to the `Validator.Pattern` class as a quick performance win.

See this contrived example in scastie: https://scastie.scala-lang.org/bz96E0HCRn2r9AlkjkzaYw

Let me know if there are any drawbacks for this approach