### PR TITLE
codegen: Support top level nullables on json responses

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
@@ -154,7 +154,7 @@ object OpenapiSchemaType {
       tf <- typeField.as[String].map(Seq(_)).orElse(typeField.as[Seq[String]])
       (t: String, nullableByType: Boolean) = tf match {
         case Seq(t)                                       => t -> false
-        case seq if seq.size == 2 && seq.contains("null") => seq.find(_ != null).get -> true
+        case seq if seq.size == 2 && seq.contains("null") => seq.find(_ != "null").getOrElse("null") -> true
         case _ => DecodingFailure("Type lists are only supported for lists of length two where one type is 'null'", c.history)
       }
       nb <- c.downField("nullable").as[Option[Boolean]]

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
@@ -148,60 +148,69 @@ object OpenapiSchemaType {
     }
   }
 
+  def typeAndNullable(c: HCursor): Decoder.Result[(String, Boolean)] = {
+    val typeField = c.downField("type")
+    for {
+      tf <- typeField.as[String].map(Seq(_)).orElse(typeField.as[Seq[String]])
+      (t: String, nullableByType: Boolean) = tf match {
+        case Seq(t)                                       => t -> false
+        case seq if seq.size == 2 && seq.contains("null") => seq.find(_ != null).get -> true
+        case _ => DecodingFailure("Type lists are only supported for lists of length two where one type is 'null'", c.history)
+      }
+      nb <- c.downField("nullable").as[Option[Boolean]]
+    } yield (t, nullableByType || nb.contains(true))
+  }
+
   implicit val OpenapiSchemaBooleanDecoder: Decoder[OpenapiSchemaBoolean] = { (c: HCursor) =>
     for {
-      _ <- c.downField("type").as[String].ensure(DecodingFailure("Given type is not boolean!", c.history))(_ == "boolean")
-      nb <- c.downField("nullable").as[Option[Boolean]]
+      p <- typeAndNullable(c).ensure(DecodingFailure("Given type is not boolean!", c.history))(_._1 == "boolean")
     } yield {
-      OpenapiSchemaBoolean(nb.getOrElse(false))
+      OpenapiSchemaBoolean(p._2)
     }
   }
 
   implicit val OpenapiSchemaStringTypeDecoder: Decoder[OpenapiSchemaStringType] = { (c: HCursor) =>
     for {
-      _ <- c.downField("type").as[String].ensure(DecodingFailure("Given type is not string!", c.history))(_ == "string")
+      p <- typeAndNullable(c).ensure(DecodingFailure("Given type is not string!", c.history))(_._1 == "string")
       f <- c.downField("format").as[Option[String]]
-      nb <- c.downField("nullable").as[Option[Boolean]]
     } yield {
       f.fold[OpenapiSchemaStringType](
-        OpenapiSchemaString(nb.getOrElse(false))
+        OpenapiSchemaString(p._2)
       ) {
-        case "date"      => OpenapiSchemaDate(nb.getOrElse(false))
-        case "date-time" => OpenapiSchemaDateTime(nb.getOrElse(false))
-        case "byte"      => OpenapiSchemaByte(nb.getOrElse(false))
-        case "binary"    => OpenapiSchemaBinary(nb.getOrElse(false))
-        case "uuid"      => OpenapiSchemaUUID(nb.getOrElse(false))
-        case _           => OpenapiSchemaString(nb.getOrElse(false))
+        case "date"      => OpenapiSchemaDate(p._2)
+        case "date-time" => OpenapiSchemaDateTime(p._2)
+        case "byte"      => OpenapiSchemaByte(p._2)
+        case "binary"    => OpenapiSchemaBinary(p._2)
+        case "uuid"      => OpenapiSchemaUUID(p._2)
+        case _           => OpenapiSchemaString(p._2)
       }
     }
   }
 
   implicit val OpenapiSchemaNumericTypeDecoder: Decoder[OpenapiSchemaNumericType] = { (c: HCursor) =>
     for {
-      t <- c
-        .downField("type")
-        .as[String]
-        .ensure(DecodingFailure("Given type is not number/integer!", c.history))(v => v == "number" || v == "integer")
+      p <- typeAndNullable(c)
+        .ensure(DecodingFailure("Given type is not number/integer!", c.history))(v => v._1 == "number" || v._1 == "integer")
+      (t, nb) = p
       f <- c.downField("format").as[Option[String]]
-      nb <- c.downField("nullable").as[Option[Boolean]]
     } yield {
       if (t == "number") {
         f.fold[OpenapiSchemaNumericType](
-          OpenapiSchemaDouble(nb.getOrElse(false))
+          OpenapiSchemaDouble(nb)
         ) {
-          case "int64"  => OpenapiSchemaLong(nb.getOrElse(false))
-          case "int32"  => OpenapiSchemaInt(nb.getOrElse(false))
-          case "float"  => OpenapiSchemaFloat(nb.getOrElse(false))
-          case "double" => OpenapiSchemaDouble(nb.getOrElse(false))
-          case _        => OpenapiSchemaDouble(nb.getOrElse(false))
+          case "int64"  => OpenapiSchemaLong(nb)
+          case "int32"  => OpenapiSchemaInt(nb)
+          case "float"  => OpenapiSchemaFloat(nb)
+          case "double" => OpenapiSchemaDouble(nb)
+          case _        => OpenapiSchemaDouble(nb)
         }
       } else {
         f.fold[OpenapiSchemaNumericType](
-          OpenapiSchemaInt(nb.getOrElse(false))
+          OpenapiSchemaInt(nb)
         ) {
-          case "int64" => OpenapiSchemaLong(nb.getOrElse(false))
-          case "int32" => OpenapiSchemaInt(nb.getOrElse(false))
-          case _       => OpenapiSchemaInt(nb.getOrElse(false))
+          case "int64" => OpenapiSchemaLong(nb)
+          case "int32" => OpenapiSchemaInt(nb)
+          case _       => OpenapiSchemaInt(nb)
         }
       }
     }
@@ -268,11 +277,11 @@ object OpenapiSchemaType {
 
   implicit val OpenapiSchemaEnumDecoder: Decoder[OpenapiSchemaEnum] = { (c: HCursor) =>
     for {
-      tpe <- c.downField("type").as[String]
+      p <- typeAndNullable(c)
+      (tpe, nb) = p
       _ <- Either.cond(tpe == "string", (), DecodingFailure("only string enums are supported", c.history))
       items <- c.downField("enum").as[Seq[OpenapiSchemaConstantString]]
-      nb <- c.downField("nullable").as[Option[Boolean]]
-    } yield OpenapiSchemaEnum(tpe, items, nb.getOrElse(false))
+    } yield OpenapiSchemaEnum(tpe, items, nb)
   }
 
   implicit val SchemaTypeWithDefaultDecoder: Decoder[(OpenapiSchemaType, Option[Json])] = { (c: HCursor) =>
@@ -283,33 +292,33 @@ object OpenapiSchemaType {
   }
   implicit val OpenapiSchemaObjectDecoder: Decoder[OpenapiSchemaObject] = { (c: HCursor) =>
     for {
-      _ <- c.downField("type").as[String].ensure(DecodingFailure("Given type is not object!", c.history))(v => v == "object")
+      p <- typeAndNullable(c).ensure(DecodingFailure("Given type is not object!", c.history))(_._1 == "object")
       fieldsWithDefaults <- c.downField("properties").as[Option[Map[String, (OpenapiSchemaType, Option[Json])]]]
       r <- c.downField("required").as[Option[Seq[String]]]
-      nb <- c.downField("nullable").as[Option[Boolean]]
+      (_, nb) = p
       fields = fieldsWithDefaults.getOrElse(Map.empty).map { case (k, (f, d)) => k -> OpenapiSchemaField(f, d) }
     } yield {
-      OpenapiSchemaObject(fields, r.getOrElse(Seq.empty), nb.getOrElse(false))
+      OpenapiSchemaObject(fields, r.getOrElse(Seq.empty), nb)
     }
   }
 
   implicit val OpenapiSchemaMapDecoder: Decoder[OpenapiSchemaMap] = { (c: HCursor) =>
     for {
-      _ <- c.downField("type").as[String].ensure(DecodingFailure("Given type is not object!", c.history))(v => v == "object")
+      p <- typeAndNullable(c).ensure(DecodingFailure("Given type is not object!", c.history))(_._1 == "object")
       t <- c.downField("additionalProperties").as[OpenapiSchemaType]
-      nb <- c.downField("nullable").as[Option[Boolean]]
+      (_, nb) = p
     } yield {
-      OpenapiSchemaMap(t, nb.getOrElse(false))
+      OpenapiSchemaMap(t, nb)
     }
   }
 
   implicit val OpenapiSchemaArrayDecoder: Decoder[OpenapiSchemaArray] = { (c: HCursor) =>
     for {
-      _ <- c.downField("type").as[String].ensure(DecodingFailure("Given type is not array!", c.history))(v => v == "array" || v == "object")
+      p <- typeAndNullable(c).ensure(DecodingFailure("Given type is not array!", c.history))(v => v._1 == "array" || v._1 == "object")
       f <- c.downField("items").as[OpenapiSchemaType]
-      nb <- c.downField("nullable").as[Option[Boolean]]
+      (_, nb) = p
     } yield {
-      OpenapiSchemaArray(f, nb.getOrElse(false))
+      OpenapiSchemaArray(f, nb)
     }
   }
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -95,6 +95,11 @@ object TapirGeneratedEndpoints {
     e: Option[AnEnum] = None,
     absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
+
+  case class NullableThingy2 (
+    uuid: java.util.UUID
+  )
+
   case class ObjectWithInlineEnum (
     id: java.util.UUID,
     inlineEnum: ObjectWithInlineEnumInlineEnum
@@ -155,12 +160,12 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[Option[NotNullableThingy]])
       .out(jsonBody[NotNullableThingy].description("a non-optional response body"))
 
-  type PostOptionalTestEndpoint = Endpoint[Unit, Option[NullableThingy], Unit, Option[NullableThingy], Any]
+  type PostOptionalTestEndpoint = Endpoint[Unit, Option[NullableThingy2], Unit, Option[NullableThingy], Any]
   lazy val postOptionalTest: PostOptionalTestEndpoint =
     endpoint
       .post
       .in(("optional" / "test"))
-      .in(jsonBody[Option[NullableThingy]])
+      .in(jsonBody[Option[NullableThingy2]])
       .out(jsonBody[Option[NullableThingy]].description("an optional response body"))
 
   type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -1,3 +1,4 @@
+
 package sttp.tapir.generated
 
 object TapirGeneratedEndpoints {
@@ -66,6 +67,9 @@ object TapirGeneratedEndpoints {
   sealed trait ADTWithoutDiscriminator
   sealed trait ADTWithDiscriminator
   sealed trait ADTWithDiscriminatorNoMapping
+  case class NotNullableThingy (
+    uuid: java.util.UUID
+  )
   case class SimpleError (
     message: String
   ) extends Error
@@ -122,6 +126,9 @@ object TapirGeneratedEndpoints {
     case object Bar extends AnEnum
     case object Baz extends AnEnum
   }
+  case class NullableThingy (
+    uuid: java.util.UUID
+  )
 
 
 
@@ -140,6 +147,22 @@ object TapirGeneratedEndpoints {
       .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Array[Byte]], CodecFormat.OctetStream()))
       .out(jsonBody[String].description("successful operation"))
 
+  type PutOptionalTestEndpoint = Endpoint[Unit, Option[NotNullableThingy], Unit, NotNullableThingy, Any]
+  lazy val putOptionalTest: PutOptionalTestEndpoint =
+    endpoint
+      .put
+      .in(("optional" / "test"))
+      .in(jsonBody[Option[NotNullableThingy]])
+      .out(jsonBody[NotNullableThingy].description("a non-optional response body"))
+
+  type PostOptionalTestEndpoint = Endpoint[Unit, Option[NullableThingy], Unit, Option[NullableThingy], Any]
+  lazy val postOptionalTest: PostOptionalTestEndpoint =
+    endpoint
+      .post
+      .in(("optional" / "test"))
+      .in(jsonBody[Option[NullableThingy]])
+      .out(jsonBody[Option[NullableThingy]].description("an optional response body"))
+
   type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
   lazy val putAdtTest: PutAdtTestEndpoint =
     endpoint
@@ -155,6 +178,14 @@ object TapirGeneratedEndpoints {
       .in(("adt" / "test"))
       .in(jsonBody[ADTWithDiscriminatorNoMapping])
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
+
+  type GetOneofErrorTestEndpoint = Endpoint[Unit, Unit, Error, Unit, Any]
+  lazy val getOneofErrorTest: GetOneofErrorTestEndpoint =
+    endpoint
+      .get
+      .in(("oneof" / "error" / "test"))
+      .errorOut(oneOf[Error](oneOfVariant(sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")), oneOfVariant(sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
+      .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
 
   type PostInlineEnumTestEndpoint = Endpoint[Unit, (PostInlineEnumTestQueryEnum, Option[PostInlineEnumTestQueryOptEnum], List[PostInlineEnumTestQuerySeqEnum], Option[List[PostInlineEnumTestQueryOptSeqEnum]], ObjectWithInlineEnum), Unit, Unit, Any]
   lazy val postInlineEnumTest: PostInlineEnumTestEndpoint =
@@ -208,14 +239,6 @@ object TapirGeneratedEndpoints {
       extraCodecSupport[PostInlineEnumTestQueryOptSeqEnum]("PostInlineEnumTestQueryOptSeqEnum", PostInlineEnumTestQueryOptSeqEnum)
   }
 
-  type GetOneofErrorTestEndpoint = Endpoint[Unit, Unit, Error, Unit, Any]
-  lazy val getOneofErrorTest: GetOneofErrorTestEndpoint =
-    endpoint
-      .get
-      .in(("oneof" / "error" / "test"))
-      .errorOut(oneOf[Error](oneOfVariant(sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")), oneOfVariant(sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
-      .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
-
-  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putAdtTest, postAdtTest, postInlineEnumTest, getOneofErrorTest)
+  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, putAdtTest, postAdtTest, getOneofErrorTest, postInlineEnumTest)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
@@ -16,6 +16,8 @@ object TapirGeneratedEndpointsJsonSerdes {
       }
     } yield res
   }
+  implicit lazy val notNullableThingyJsonDecoder: io.circe.Decoder[NotNullableThingy] = io.circe.generic.semiauto.deriveDecoder[NotNullableThingy]
+  implicit lazy val notNullableThingyJsonEncoder: io.circe.Encoder[NotNullableThingy] = io.circe.generic.semiauto.deriveEncoder[NotNullableThingy]
   implicit lazy val simpleErrorJsonDecoder: io.circe.Decoder[SimpleError] = io.circe.generic.semiauto.deriveDecoder[SimpleError]
   implicit lazy val simpleErrorJsonEncoder: io.circe.Encoder[SimpleError] = io.circe.generic.semiauto.deriveEncoder[SimpleError]
   implicit lazy val notFoundErrorJsonDecoder: io.circe.Decoder[NotFoundError] = io.circe.generic.semiauto.deriveDecoder[NotFoundError]
@@ -56,4 +58,6 @@ object TapirGeneratedEndpointsJsonSerdes {
       io.circe.Decoder[SubtypeWithoutD2].asInstanceOf[io.circe.Decoder[ADTWithoutDiscriminator]],
       io.circe.Decoder[SubtypeWithoutD3].asInstanceOf[io.circe.Decoder[ADTWithoutDiscriminator]]
     ).reduceLeft(_ or _)
+  implicit lazy val nullableThingyJsonDecoder: io.circe.Decoder[NullableThingy] = io.circe.generic.semiauto.deriveDecoder[NullableThingy]
+  implicit lazy val nullableThingyJsonEncoder: io.circe.Encoder[NullableThingy] = io.circe.generic.semiauto.deriveEncoder[NullableThingy]
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
@@ -41,6 +41,8 @@ object TapirGeneratedEndpointsJsonSerdes {
   }
   implicit lazy val subtypeWithoutD3JsonDecoder: io.circe.Decoder[SubtypeWithoutD3] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithoutD3]
   implicit lazy val subtypeWithoutD3JsonEncoder: io.circe.Encoder[SubtypeWithoutD3] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithoutD3]
+  implicit lazy val nullableThingy2JsonDecoder: io.circe.Decoder[NullableThingy2] = io.circe.generic.semiauto.deriveDecoder[NullableThingy2]
+  implicit lazy val nullableThingy2JsonEncoder: io.circe.Encoder[NullableThingy2] = io.circe.generic.semiauto.deriveEncoder[NullableThingy2]
   implicit lazy val objectWithInlineEnumJsonDecoder: io.circe.Decoder[ObjectWithInlineEnum] = io.circe.generic.semiauto.deriveDecoder[ObjectWithInlineEnum]
   implicit lazy val objectWithInlineEnumJsonEncoder: io.circe.Encoder[ObjectWithInlineEnum] = io.circe.generic.semiauto.deriveEncoder[ObjectWithInlineEnum]
   implicit lazy val subtypeWithoutD2JsonDecoder: io.circe.Decoder[SubtypeWithoutD2] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithoutD2]

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
@@ -7,6 +7,7 @@ object TapirGeneratedEndpointsSchemas {
   implicit lazy val notFoundErrorTapirSchema: sttp.tapir.Schema[NotFoundError] = sttp.tapir.Schema.derived
   implicit lazy val notNullableThingyTapirSchema: sttp.tapir.Schema[NotNullableThingy] = sttp.tapir.Schema.derived
   implicit lazy val nullableThingyTapirSchema: sttp.tapir.Schema[NullableThingy] = sttp.tapir.Schema.derived
+  implicit lazy val nullableThingy2TapirSchema: sttp.tapir.Schema[NullableThingy2] = sttp.tapir.Schema.derived
   implicit lazy val objectWithInlineEnumInlineEnumTapirSchema: sttp.tapir.Schema[ObjectWithInlineEnumInlineEnum] = sttp.tapir.Schema.derived
   implicit lazy val objectWithInlineEnumTapirSchema: sttp.tapir.Schema[ObjectWithInlineEnum] = sttp.tapir.Schema.derived
   implicit lazy val simpleErrorTapirSchema: sttp.tapir.Schema[SimpleError] = sttp.tapir.Schema.derived

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
@@ -5,6 +5,8 @@ object TapirGeneratedEndpointsSchemas {
   import sttp.tapir.generic.auto._
   implicit lazy val anEnumTapirSchema: sttp.tapir.Schema[AnEnum] = sttp.tapir.Schema.derived
   implicit lazy val notFoundErrorTapirSchema: sttp.tapir.Schema[NotFoundError] = sttp.tapir.Schema.derived
+  implicit lazy val notNullableThingyTapirSchema: sttp.tapir.Schema[NotNullableThingy] = sttp.tapir.Schema.derived
+  implicit lazy val nullableThingyTapirSchema: sttp.tapir.Schema[NullableThingy] = sttp.tapir.Schema.derived
   implicit lazy val objectWithInlineEnumInlineEnumTapirSchema: sttp.tapir.Schema[ObjectWithInlineEnumInlineEnum] = sttp.tapir.Schema.derived
   implicit lazy val objectWithInlineEnumTapirSchema: sttp.tapir.Schema[ObjectWithInlineEnum] = sttp.tapir.Schema.derived
   implicit lazy val simpleErrorTapirSchema: sttp.tapir.Schema[SimpleError] = sttp.tapir.Schema.derived

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -35,6 +35,37 @@ paths:
               description: "csv file"
               type: string
               format: binary
+  '/optional/test':
+    post:
+      responses:
+        '200':
+          description: an optional response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NullableThingy'
+      requestBody:
+        required: true
+        description: an optional request body (nullable)
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NullableThingy'
+    put:
+      responses:
+        '200':
+          description: a non-optional response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotNullableThingy'
+      requestBody:
+        required: false
+        description: an optional request body (not required)
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotNullableThingy'
   '/adt/test':
     post:
       responses:
@@ -272,6 +303,25 @@ components:
       oneOf:
         - $ref: '#/components/schemas/NotFoundError'
         - $ref: '#/components/schemas/SimpleError'
+    NotNullableThingy:
+      title: NotNullableThingy
+      type: object
+      required:
+        - uuid
+      properties:
+        uuid:
+          type: string
+          format: uuid
+    NullableThingy:
+      title: NullableThingy
+      type: object
+      nullable: true
+      required:
+        - uuid
+      properties:
+        uuid:
+          type: string
+          format: uuid
     NotFoundError:
       title: NotFoundError
       required:

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -50,7 +50,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NullableThingy'
+              $ref: '#/components/schemas/NullableThingy2'
     put:
       responses:
         '200':
@@ -316,6 +316,17 @@ components:
       title: NullableThingy
       type: object
       nullable: true
+      required:
+        - uuid
+      properties:
+        uuid:
+          type: string
+          format: uuid
+    NullableThingy2:
+      title: NullableThingy2
+      type:
+        - object
+        - "null"
       required:
         - uuid
       properties:


### PR DESCRIPTION
Use case for this is being able to migrate an endpoint that returns an 'Option[Foo]'. It seemed to me that adding `nullable: true` is the most natural way to declare this in openapi 3.0; although I'm aware that this was removed in openapi 3.1, so I've _also_ added support for declaring nullability with multiple types (i.e. `type: ['null', 'object']`). I'm not sure what long-term plans really are for version support, but figured it'd be better to support the feature for both 3.0 and 3.1 specifications

Edit: this might not really be what I want actually. Might want to be able to declare optionality by specifying that one status code (e.g. 204) doesn't return a body, and derive it for a oneOf...