### PR TITLE
codegen: support deriving 'Option[T]' oneOf type …

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -433,7 +433,7 @@ class EndpointGenerator {
               s"""emptyOutput.description("${JavaEscape.escapeString(m.description)}"))(None)""" -> tpe
           else if (canBeEmptyResponse) {
             val (_, nonOptionalType) = bodyFmt(m)
-            val someType = nonOptionalType.map(": " + _).getOrElse("")
+            val someType = nonOptionalType.map(": " + _.replaceAll("^Option\\[(.+)]$", "$1")).getOrElse("")
             s"oneOfVariantValueMatcher(sttp.model.StatusCode(${code}), $decl){ case Some(_$someType) => true }" -> tpe
           } else s"oneOfVariant(sttp.model.StatusCode(${code}), $decl)" -> tpe
         }.unzip

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -470,7 +470,7 @@ class EndpointGenerator {
             }
             if (canBeEmptyResponse) s"Option[$baseType]" else baseType
           }
-        Some(s"oneOf[$commmonType](${oneOfs.mkString(", ")})") -> Some(commmonType)
+        Some(s"oneOf[$commmonType](${oneOfs.mkString("\n  ", ",\n  ", "")})") -> Some(commmonType)
     }
 
     val (outDecls, outTypes) = mappedGroup(outs)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -197,7 +197,7 @@ object TapirGeneratedEndpoints {
     endpoint
       .get
       .in(("oneof" / "option" / "test"))
-      .out(oneOf[Option[ObjectWithInlineEnum]](oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None), oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object")){ case Some(_) => true }))
+      .out(oneOf[Option[ObjectWithInlineEnum]](oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None), oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object")){ case Some(_: ObjectWithInlineEnum) => true }))
 
   type PostInlineEnumTestEndpoint = Endpoint[Unit, (PostInlineEnumTestQueryEnum, Option[PostInlineEnumTestQueryOptEnum], List[PostInlineEnumTestQuerySeqEnum], Option[List[PostInlineEnumTestQueryOptSeqEnum]], ObjectWithInlineEnum), Unit, Unit, Any]
   lazy val postInlineEnumTest: PostInlineEnumTestEndpoint =

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -192,6 +192,13 @@ object TapirGeneratedEndpoints {
       .errorOut(oneOf[Error](oneOfVariant(sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")), oneOfVariant(sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
       .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
 
+  type GetOneofOptionTestEndpoint = Endpoint[Unit, Unit, Unit, Option[ObjectWithInlineEnum], Any]
+  lazy val getOneofOptionTest: GetOneofOptionTestEndpoint =
+    endpoint
+      .get
+      .in(("oneof" / "option" / "test"))
+      .out(oneOf[Option[ObjectWithInlineEnum]](oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None), oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object")){ case Some(_) => true }))
+
   type PostInlineEnumTestEndpoint = Endpoint[Unit, (PostInlineEnumTestQueryEnum, Option[PostInlineEnumTestQueryOptEnum], List[PostInlineEnumTestQuerySeqEnum], Option[List[PostInlineEnumTestQueryOptSeqEnum]], ObjectWithInlineEnum), Unit, Unit, Any]
   lazy val postInlineEnumTest: PostInlineEnumTestEndpoint =
     endpoint
@@ -244,6 +251,6 @@ object TapirGeneratedEndpoints {
       extraCodecSupport[PostInlineEnumTestQueryOptSeqEnum]("PostInlineEnumTestQueryOptSeqEnum", PostInlineEnumTestQueryOptSeqEnum)
   }
 
-  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, putAdtTest, postAdtTest, getOneofErrorTest, postInlineEnumTest)
+  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, putAdtTest, postAdtTest, getOneofErrorTest, getOneofOptionTest, postInlineEnumTest)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -200,7 +200,9 @@ object TapirGeneratedEndpoints {
     endpoint
       .get
       .in(("oneof" / "error" / "test"))
-      .errorOut(oneOf[Error](oneOfVariant(sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")), oneOfVariant(sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
+      .errorOut(oneOf[Error](
+        oneOfVariant(sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")),
+        oneOfVariant(sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
       .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
 
   type GetOneofOptionTestEndpoint = Endpoint[Unit, Unit, Unit, Option[AnyObjectWithInlineEnum], Any]
@@ -208,7 +210,10 @@ object TapirGeneratedEndpoints {
     endpoint
       .get
       .in(("oneof" / "option" / "test"))
-      .out(oneOf[Option[AnyObjectWithInlineEnum]](oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None), oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object")){ case Some(_: ObjectWithInlineEnum) => true }, oneOfVariantValueMatcher(sttp.model.StatusCode(201), jsonBody[Option[ObjectWithInlineEnum2]].description("Another object")){ case Some(_: ObjectWithInlineEnum2) => true }))
+      .out(oneOf[Option[AnyObjectWithInlineEnum]](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None),
+        oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object")){ case Some(_: ObjectWithInlineEnum) => true },
+        oneOfVariantValueMatcher(sttp.model.StatusCode(201), jsonBody[Option[ObjectWithInlineEnum2]].description("Another object")){ case Some(_: ObjectWithInlineEnum2) => true }))
 
   type PostInlineEnumTestEndpoint = Endpoint[Unit, (PostInlineEnumTestQueryEnum, Option[PostInlineEnumTestQueryOptEnum], List[PostInlineEnumTestQuerySeqEnum], Option[List[PostInlineEnumTestQueryOptSeqEnum]], ObjectWithInlineEnum), Unit, Unit, Any]
   lazy val postInlineEnumTest: PostInlineEnumTestEndpoint =

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -63,13 +63,24 @@ object TapirGeneratedEndpoints {
   }
   def extraCodecSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): ExtraParamSupport[T] =
     EnumExtraParamSupport(enumName, T)
-  sealed trait Error
-  sealed trait ADTWithoutDiscriminator
   sealed trait ADTWithDiscriminator
+  sealed trait AnyObjectWithInlineEnum
+  sealed trait Error
   sealed trait ADTWithDiscriminatorNoMapping
+  sealed trait ADTWithoutDiscriminator
   case class NotNullableThingy (
     uuid: java.util.UUID
   )
+  case class ObjectWithInlineEnum2 (
+    inlineEnum: ObjectWithInlineEnum2InlineEnum
+  ) extends AnyObjectWithInlineEnum
+
+  sealed trait ObjectWithInlineEnum2InlineEnum extends enumeratum.EnumEntry
+  object ObjectWithInlineEnum2InlineEnum extends enumeratum.Enum[ObjectWithInlineEnum2InlineEnum] with enumeratum.CirceEnum[ObjectWithInlineEnum2InlineEnum] {
+    val values = findValues
+    case object bar1 extends ObjectWithInlineEnum2InlineEnum
+    case object bar2 extends ObjectWithInlineEnum2InlineEnum
+  }
   case class SimpleError (
     message: String
   ) extends Error
@@ -103,7 +114,7 @@ object TapirGeneratedEndpoints {
   case class ObjectWithInlineEnum (
     id: java.util.UUID,
     inlineEnum: ObjectWithInlineEnumInlineEnum
-  )
+  ) extends AnyObjectWithInlineEnum
 
   sealed trait ObjectWithInlineEnumInlineEnum extends enumeratum.EnumEntry
   object ObjectWithInlineEnumInlineEnum extends enumeratum.Enum[ObjectWithInlineEnumInlineEnum] with enumeratum.CirceEnum[ObjectWithInlineEnumInlineEnum] {
@@ -192,12 +203,12 @@ object TapirGeneratedEndpoints {
       .errorOut(oneOf[Error](oneOfVariant(sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")), oneOfVariant(sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
       .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
 
-  type GetOneofOptionTestEndpoint = Endpoint[Unit, Unit, Unit, Option[ObjectWithInlineEnum], Any]
+  type GetOneofOptionTestEndpoint = Endpoint[Unit, Unit, Unit, Option[AnyObjectWithInlineEnum], Any]
   lazy val getOneofOptionTest: GetOneofOptionTestEndpoint =
     endpoint
       .get
       .in(("oneof" / "option" / "test"))
-      .out(oneOf[Option[ObjectWithInlineEnum]](oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None), oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object")){ case Some(_: ObjectWithInlineEnum) => true }))
+      .out(oneOf[Option[AnyObjectWithInlineEnum]](oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None), oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object")){ case Some(_: ObjectWithInlineEnum) => true }, oneOfVariantValueMatcher(sttp.model.StatusCode(201), jsonBody[Option[ObjectWithInlineEnum2]].description("Another object")){ case Some(_: ObjectWithInlineEnum2) => true }))
 
   type PostInlineEnumTestEndpoint = Endpoint[Unit, (PostInlineEnumTestQueryEnum, Option[PostInlineEnumTestQueryOptEnum], List[PostInlineEnumTestQuerySeqEnum], Option[List[PostInlineEnumTestQueryOptSeqEnum]], ObjectWithInlineEnum), Unit, Unit, Any]
   lazy val postInlineEnumTest: PostInlineEnumTestEndpoint =

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
@@ -18,6 +18,8 @@ object TapirGeneratedEndpointsJsonSerdes {
   }
   implicit lazy val notNullableThingyJsonDecoder: io.circe.Decoder[NotNullableThingy] = io.circe.generic.semiauto.deriveDecoder[NotNullableThingy]
   implicit lazy val notNullableThingyJsonEncoder: io.circe.Encoder[NotNullableThingy] = io.circe.generic.semiauto.deriveEncoder[NotNullableThingy]
+  implicit lazy val objectWithInlineEnum2JsonDecoder: io.circe.Decoder[ObjectWithInlineEnum2] = io.circe.generic.semiauto.deriveDecoder[ObjectWithInlineEnum2]
+  implicit lazy val objectWithInlineEnum2JsonEncoder: io.circe.Encoder[ObjectWithInlineEnum2] = io.circe.generic.semiauto.deriveEncoder[ObjectWithInlineEnum2]
   implicit lazy val simpleErrorJsonDecoder: io.circe.Decoder[SimpleError] = io.circe.generic.semiauto.deriveDecoder[SimpleError]
   implicit lazy val simpleErrorJsonEncoder: io.circe.Encoder[SimpleError] = io.circe.generic.semiauto.deriveEncoder[SimpleError]
   implicit lazy val notFoundErrorJsonDecoder: io.circe.Decoder[NotFoundError] = io.circe.generic.semiauto.deriveDecoder[NotFoundError]

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
@@ -10,6 +10,8 @@ object TapirGeneratedEndpointsSchemas {
   implicit lazy val nullableThingy2TapirSchema: sttp.tapir.Schema[NullableThingy2] = sttp.tapir.Schema.derived
   implicit lazy val objectWithInlineEnumInlineEnumTapirSchema: sttp.tapir.Schema[ObjectWithInlineEnumInlineEnum] = sttp.tapir.Schema.derived
   implicit lazy val objectWithInlineEnumTapirSchema: sttp.tapir.Schema[ObjectWithInlineEnum] = sttp.tapir.Schema.derived
+  implicit lazy val objectWithInlineEnum2InlineEnumTapirSchema: sttp.tapir.Schema[ObjectWithInlineEnum2InlineEnum] = sttp.tapir.Schema.derived
+  implicit lazy val objectWithInlineEnum2TapirSchema: sttp.tapir.Schema[ObjectWithInlineEnum2] = sttp.tapir.Schema.derived
   implicit lazy val simpleErrorTapirSchema: sttp.tapir.Schema[SimpleError] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD1TapirSchema: sttp.tapir.Schema[SubtypeWithD1] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD2TapirSchema: sttp.tapir.Schema[SubtypeWithD2] = sttp.tapir.Schema.derived
@@ -43,6 +45,7 @@ object TapirGeneratedEndpointsSchemas {
       case _ => throw new IllegalStateException("Derived schema for ADTWithDiscriminatorNoMapping should be a coproduct")
     }
   }
+  implicit lazy val anyObjectWithInlineEnumTapirSchema: sttp.tapir.Schema[AnyObjectWithInlineEnum] = sttp.tapir.Schema.derived
   implicit lazy val errorTapirSchema: sttp.tapir.Schema[Error] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithoutD3TapirSchema: sttp.tapir.Schema[SubtypeWithoutD3] = sttp.tapir.Schema.derived
   implicit lazy val aDTWithoutDiscriminatorTapirSchema: sttp.tapir.Schema[ADTWithoutDiscriminator] = sttp.tapir.Schema.derived

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/build.sbt
@@ -8,15 +8,15 @@ lazy val root = (project in file("."))
   )
 
 libraryDependencies ++= Seq(
-  "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % "1.10.0",
-  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.10.0",
-  "com.softwaremill.sttp.tapir" %% "tapir-pekko-http-server" % "1.10.0",
-  "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.8.0",
+  "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % "1.11.15",
+  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.11.15",
+  "com.softwaremill.sttp.tapir" %% "tapir-pekko-http-server" % "1.11.15",
+  "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.11.7",
   "io.circe" %% "circe-generic" % "0.14.10",
   "com.beachape" %% "enumeratum" % "1.7.5",
   "com.beachape" %% "enumeratum-circe" % "1.7.5",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
-  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.10.0" % Test
+  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.11.15" % Test
 )
 
 import scala.io.Source

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/JsonRoundtrip.scala
@@ -43,7 +43,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
           .body(reqJsonBody)
           .send(stub)
           .map { resp =>
-            resp.code.code === 200
+            resp.code.code shouldEqual 200
             resp.body.map(normalise) shouldEqual Right(respJsonBody)
           },
         1.second
@@ -64,7 +64,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
           .send(stub)
           .map { resp =>
             resp.body.map(normalise) shouldEqual Right(respJsonBody)
-            resp.code.code === 200
+            resp.code.code shouldEqual 200
           },
         1.second
       )
@@ -84,7 +84,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
           .send(stub)
           .map { resp =>
             resp.body.map(normalise) shouldEqual Right(respJsonBody)
-            resp.code.code === 200
+            resp.code.code shouldEqual 200
           },
         1.second
       )
@@ -116,7 +116,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
           .body(reqJsonBody)
           .send(stub)
           .map { resp =>
-            resp.code.code === 200
+            resp.code.code shouldEqual 200
             resp.body.map(normalise) shouldEqual Right(respJsonBody)
           },
         1.second
@@ -136,7 +136,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
           .body(reqJsonBody)
           .send(stub)
           .map { resp =>
-            resp.code.code === 200
+            resp.code.code shouldEqual 200
             resp.body.map(normalise) shouldEqual Right(respJsonBody)
           },
         1.second
@@ -176,7 +176,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
           .body(reqJsonBody)
           .send(stub)
           .map { resp =>
-            resp.code.code === 200
+            resp.code.code shouldEqual 204
             resp.body shouldEqual Right("")
           },
         1.second
@@ -200,7 +200,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
           .body(reqJsonBody)
           .send(stub)
           .map { resp =>
-            resp.code.code === 200
+            resp.code.code shouldEqual 204
             resp.body shouldEqual Right("")
           },
         1.second
@@ -235,7 +235,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
         .get(uri"http://test.com/oneof/option/test")
         .send(stub)
         .map { resp =>
-          resp.code.code === 204
+          resp.code.code shouldEqual 204
           resp.body shouldEqual Right("")
         },
       1.second
@@ -246,7 +246,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
         .get(uri"http://test.com/oneof/option/test")
         .send(stub)
         .map { resp =>
-          resp.code.code === 200
+          resp.code.code shouldEqual 200
           resp.body shouldEqual Right(s"""{"id":"${someResponse1.id}","inlineEnum":"foo3"}""")
         },
       1.second
@@ -257,7 +257,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
         .get(uri"http://test.com/oneof/option/test")
         .send(stub)
         .map { resp =>
-          resp.code.code === 200
+          resp.code.code shouldEqual 201
           resp.body shouldEqual Right(s"""{"inlineEnum":"bar2"}""")
         },
       1.second

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -187,6 +187,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ObjectWithInlineEnum'
+        "201":
+          description: Another object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectWithInlineEnum2'
 
 
 components:
@@ -309,6 +315,23 @@ components:
             - foo2
             - foo3
             - foo4
+    ObjectWithInlineEnum2:
+      title: ObjectWithInlineEnum2
+      required:
+        - inlineEnum
+      type: object
+      properties:
+        inlineEnum:
+          type: string
+          enum:
+            - bar1
+            - bar2
+    AnyObjectWithInlineEnum:
+      title: AnyObjectWithInlineEnum
+#      type: object
+      oneOf:
+        - $ref: '#/components/schemas/ObjectWithInlineEnum'
+        - $ref: '#/components/schemas/ObjectWithInlineEnum2'
     Error:
       title: Error
       type: object

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -176,6 +176,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/SimpleError'
 
+  '/oneof/option/test':
+    get:
+      responses:
+        "204":
+          description: "No response"
+        "200":
+          description: An object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectWithInlineEnum'
+
 
 components:
   schemas:

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -328,7 +328,6 @@ components:
             - bar2
     AnyObjectWithInlineEnum:
       title: AnyObjectWithInlineEnum
-#      type: object
       oneOf:
         - $ref: '#/components/schemas/ObjectWithInlineEnum'
         - $ref: '#/components/schemas/ObjectWithInlineEnum2'

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -103,7 +103,9 @@ object TapirGeneratedEndpoints {
     endpoint
       .get
       .in(("oneof" / "option" / "test"))
-      .out(oneOf[Option[AnEnum]](oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None), oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[AnEnum]].description("An enum")){ case Some(_: AnEnum) => true }))
+      .out(oneOf[Option[AnEnum]](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None),
+        oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[AnEnum]].description("An enum")){ case Some(_: AnEnum) => true }))
 
   lazy val generatedEndpoints = List(putAdtTest, postAdtTest, getOneofOptionTest)
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -75,7 +75,6 @@ object TapirGeneratedEndpoints {
     a: Option[Seq[String]] = None
   ) extends ADTWithDiscriminator with ADTWithDiscriminatorNoMapping
 
-
   sealed trait AnEnum extends enumeratum.EnumEntry
   object AnEnum extends enumeratum.Enum[AnEnum] {
     val values = findValues
@@ -100,7 +99,12 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[ADTWithDiscriminatorNoMapping])
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 
+  lazy val getOneofOptionTest =
+    endpoint
+      .get
+      .in(("oneof" / "option" / "test"))
+      .out(oneOf[Option[AnEnum]](oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None), oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[AnEnum]].description("An enum")){ case Some(_: AnEnum) => true }))
 
-  lazy val generatedEndpoints = List(putAdtTest, postAdtTest)
+  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, getOneofOptionTest)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/build.sbt
@@ -7,14 +7,14 @@ lazy val root = (project in file("."))
   )
 
 libraryDependencies ++= Seq(
-  "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % "1.10.0",
-  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.10.0",
-  "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.8.0",
+  "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % "1.11.15",
+  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.11.15",
+  "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.11.7",
   "com.beachape" %% "enumeratum" % "1.7.5",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.33.2",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.33.2" % "compile-internal",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
-  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.10.0" % Test
+  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.11.15" % Test
 )
 
 import sttp.tapir.sbt.OpenapiCodegenPlugin.autoImport.{openapiJsonSerdeLib, openapiUseHeadTagForObjectName}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/JsonRoundtrip.scala
@@ -9,7 +9,6 @@ import TapirGeneratedEndpointsJsonSerdes._
 import sttp.tapir.generated.TapirGeneratedEndpoints._
 import sttp.tapir.server.stub.TapirStubInterpreter
 
-import java.util.UUID
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -43,7 +42,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
           .body(reqJsonBody)
           .send(stub)
           .map { resp =>
-            resp.code.code === 200
+            resp.code.code shouldEqual 200
             resp.body shouldEqual Right(respJsonBody)
           },
         1.second
@@ -64,7 +63,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
           .send(stub)
           .map { resp =>
             resp.body shouldEqual Right(respJsonBody)
-            resp.code.code === 200
+            resp.code.code shouldEqual 200
           },
         1.second
       )
@@ -84,7 +83,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
           .send(stub)
           .map { resp =>
             resp.body shouldEqual Right(respJsonBody)
-            resp.code.code === 200
+            resp.code.code shouldEqual 200
           },
         1.second
       )
@@ -116,7 +115,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
           .body(reqJsonBody)
           .send(stub)
           .map { resp =>
-            resp.code.code === 200
+            resp.code.code shouldEqual 200
             resp.body shouldEqual Right(respJsonBody)
           },
         1.second
@@ -136,7 +135,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
           .body(reqJsonBody)
           .send(stub)
           .map { resp =>
-            resp.code.code === 200
+            resp.code.code shouldEqual 200
             resp.body shouldEqual Right(respJsonBody)
           },
         1.second
@@ -159,7 +158,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
         .get(uri"http://test.com/oneof/option/test")
         .send(stub)
         .map { resp =>
-          resp.code.code === 204
+          resp.code.code shouldEqual 204
           resp.body shouldEqual Right("")
         },
       1.second
@@ -170,7 +169,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
         .get(uri"http://test.com/oneof/option/test")
         .send(stub)
         .map { resp =>
-          resp.code.code === 200
+          resp.code.code shouldEqual 200
           resp.body shouldEqual Right(s"\"Foo\"")
         },
       1.second

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
@@ -143,6 +143,7 @@ components:
           type: string
     AnEnum:
       type: string
+      nullable: true
       enum:
         - Foo
         - Bar

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
@@ -38,6 +38,17 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ADTWithoutDiscriminator'
+  '/oneof/option/test':
+    get:
+      responses:
+        "204":
+          description: "No response"
+        "200":
+          description: An enum
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AnEnum'
 
 components:
   schemas:

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -44,7 +44,6 @@ object TapirGeneratedEndpoints {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)
   }
 
-
   def enumMap[E: enumextensions.EnumMirror]: Map[String, E] =
     Map.from(
       for e <- enumextensions.EnumMirror[E].values yield e.name.toUpperCase -> e
@@ -68,9 +67,17 @@ object TapirGeneratedEndpoints {
   }
   def extraCodecSupport[T: enumextensions.EnumMirror]: ExtraParamSupport[T] =
     EnumExtraParamSupport(enumMap[T](using enumextensions.EnumMirror[T]))
+  sealed trait AnyObjectWithInlineEnum
   sealed trait ADTWithoutDiscriminator
   sealed trait ADTWithDiscriminator
   sealed trait ADTWithDiscriminatorNoMapping
+  case class ObjectWithInlineEnum2 (
+    inlineEnum: ObjectWithInlineEnum2InlineEnum
+  ) extends AnyObjectWithInlineEnum
+
+  enum ObjectWithInlineEnum2InlineEnum derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec {
+    case bar1, bar2
+  }
   case class SubtypeWithoutD1 (
     s: String,
     i: Option[Int] = None,
@@ -91,7 +98,7 @@ object TapirGeneratedEndpoints {
   case class ObjectWithInlineEnum (
     id: java.util.UUID,
     inlineEnum: ObjectWithInlineEnumInlineEnum
-  )
+  ) extends AnyObjectWithInlineEnum
 
   enum ObjectWithInlineEnumInlineEnum derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec {
     case foo1, foo2, foo3, foo4
@@ -167,7 +174,15 @@ object TapirGeneratedEndpoints {
     case baz1, baz2, baz3
   }
 
+  lazy val getOneofOptionTest =
+    endpoint
+      .get
+      .in(("oneof" / "option" / "test"))
+      .out(oneOf[Option[AnyObjectWithInlineEnum]](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None),
+        oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object")){ case Some(_: ObjectWithInlineEnum) => true },
+        oneOfVariantValueMatcher(sttp.model.StatusCode(201), jsonBody[Option[ObjectWithInlineEnum2]].description("Another object")){ case Some(_: ObjectWithInlineEnum2) => true }))
 
-  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, postInlineEnumTest)
+  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, postInlineEnumTest, getOneofOptionTest)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/build.sbt
@@ -6,14 +6,14 @@ lazy val root = (project in file("."))
   )
 
 libraryDependencies ++= Seq(
-  "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % "1.10.0",
-  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.10.0",
-  "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.8.0",
+  "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % "1.11.15",
+  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.11.15",
+  "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.11.7",
   "io.circe" %% "circe-generic" % "0.14.10",
   "org.latestbit" %% "circe-tagged-adt-codec" % "0.11.0",
   "io.github.bishabosha" %% "enum-extensions" % "0.1.1",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
-  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.10.0" % Test
+  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.11.15" % Test
 )
 
 import scala.io.Source

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/swagger.yaml
@@ -98,6 +98,23 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ObjectWithInlineEnum'
+  '/oneof/option/test':
+    get:
+      responses:
+        "204":
+          description: "No response"
+        "200":
+          description: An object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectWithInlineEnum'
+        "201":
+          description: Another object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectWithInlineEnum2'
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'
@@ -215,3 +232,19 @@ components:
             - foo2
             - foo3
             - foo4
+    ObjectWithInlineEnum2:
+      title: ObjectWithInlineEnum2
+      required:
+        - inlineEnum
+      type: object
+      properties:
+        inlineEnum:
+          type: string
+          enum:
+            - bar1
+            - bar2
+    AnyObjectWithInlineEnum:
+      title: AnyObjectWithInlineEnum
+      oneOf:
+        - $ref: '#/components/schemas/ObjectWithInlineEnum'
+        - $ref: '#/components/schemas/ObjectWithInlineEnum2'


### PR DESCRIPTION
…when one 'out' status code returns a T and the other returns nothing

Supports slightly different cases to https://github.com/softwaremill/tapir/pull/4351; specifically, the status code will permit distinguishing between Some/None variants, so there's no messing about with `nullable` or the null type. I don't think this would work to support multiple empty responses in the same status bucket (empty 204 and 404 obviously fine, but empty 202 and 204 would be indistinguishable to the server interpreter). Seems to work fine for 3 or more response types when one is empty and the others share a common 'oneOf' description, which is probably pretty niche but hey, why not.

Combining nullable schemas with status code variants is supported by treating the nullable variant as non-nullable when there's a status code mapped to the empty response. So the server response won't be empty for the status code mapped to the nullable object - only for the status code with no content.