### PR TITLE
codegen: add generic json support for jsoniter-scala

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -44,6 +44,8 @@ openapiJsonSerdeLib                   circe                                The j
 openapiValidateNonDiscriminatedOneOfs true                                 Whether to fail if variants of a oneOf without a discriminator cannot be disambiguated.
 openapiMaxSchemasPerFile              400                                  Maximum number of schemas to generate in a single file (tweak if hitting javac class size limits).
 openapiAdditionalPackages             Nil                                  Additional packageName/swaggerFile pairs for generating from multiple schemas 
+openapiStreamingImplementation        fs2                                  Implementation for streamTextBody. Supports: akka, fs2, pekko, zio
+openapiGenerateEndpointTypes          false                                Whether to emit explicit types for endpoint defns
 ===================================== ==================================== ==================================================================================================
 ```
 
@@ -108,7 +110,7 @@ location. This would be in addition to files generated in `openapiPackage` from 
 ===================== ================================================================== ===================================================================
 circe                 "io.circe" %% "circe-core"                                         "com.beachape" %% "enumeratum-circe" (scala 2 enum support).
                       "io.circe" %% "circe-generic"                                      "org.latestbit" %% "circe-tagged-adt-codec" (scala 3 enum support).
-jsoniter              "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"
+jsoniter              "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core"   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-circe" (free-form json support)
                       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros"
 ===================== ================================================================== ===================================================================
 ```

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
@@ -30,42 +30,28 @@ object SchemaGenerator {
       allSchemas: Map[String, OpenapiSchemaType],
       fullModelPath: String,
       jsonSerdeLib: JsonSerdeLib,
-      maxSchemasPerFile: Int
+      maxSchemasPerFile: Int,
+      schemasContainAny: Boolean
   ): Seq[String] = {
-    def schemaContainsAny(schema: OpenapiSchemaType): Boolean = schema match {
-      case _: OpenapiSchemaAny           => true
-      case OpenapiSchemaArray(items, _)  => schemaContainsAny(items)
-      case OpenapiSchemaMap(items, _)    => schemaContainsAny(items)
-      case OpenapiSchemaObject(fs, _, _) => fs.values.map(_.`type`).exists(schemaContainsAny)
-      case OpenapiSchemaOneOf(types, _)  => types.exists(schemaContainsAny)
-      case OpenapiSchemaAllOf(types)     => types.exists(schemaContainsAny)
-      case OpenapiSchemaAnyOf(types)     => types.exists(schemaContainsAny)
-      case OpenapiSchemaNot(item)        => schemaContainsAny(item)
-      case _: OpenapiSchemaSimpleType | _: OpenapiSchemaEnum | _: OpenapiSchemaConstantString | _: OpenapiSchemaRef => false
-    }
-    val schemasWithAny = allSchemas.filter { case (_, schema) =>
-      schemaContainsAny(schema)
-    }
-    val maybeAnySchema: Option[(OpenapiSchemaType, String)] =
-      if (schemasWithAny.isEmpty) None
-      else if (jsonSerdeLib == JsonSerdeLib.Circe)
+    val maybeAnySchema: Option[(String, String)] =
+      if (!schemasContainAny) None
+      else if (jsonSerdeLib == JsonSerdeLib.Circe || jsonSerdeLib == JsonSerdeLib.Jsoniter)
         Some(
-          OpenapiSchemaAny(
-            false
-          ) -> "implicit lazy val anyTapirSchema: sttp.tapir.Schema[io.circe.Json] = sttp.tapir.Schema.any[io.circe.Json]"
+          "anyTapirSchema" -> "implicit lazy val anyTapirSchema: sttp.tapir.Schema[io.circe.Json] = sttp.tapir.Schema.any[io.circe.Json]"
         )
-      else
-        throw new NotImplementedError(
-          s"any not implemented for json libs other than circe (problematic models: ${schemasWithAny.map(_._1)})"
-        )
+      else throw new NotImplementedError("any not implemented for json libs other than circe and jsoniter")
+    val maybeAnySchemaSchema = Seq(maybeAnySchema.map { case (_, _) => "anyTapirSchema" -> OpenapiSchemaAny(false) }.toSeq)
     val openApiSchemasWithTapirSchemas = doc.components
-      .map(_.schemas.map {
+      .map(_.schemas.flatMap {
         case (name, _: OpenapiSchemaEnum) =>
-          name -> s"implicit lazy val ${BasicGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
-        case (name, obj: OpenapiSchemaObject) => name -> schemaForObject(name, obj)
-        case (name, schema: OpenapiSchemaMap) => name -> schemaForMap(name, schema)
+          Some(
+            name -> s"implicit lazy val ${BasicGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
+          )
+        case (name, obj: OpenapiSchemaObject) => Some(name -> schemaForObject(name, obj))
+        case (name, schema: OpenapiSchemaMap) => Some(name -> schemaForMap(name, schema))
+        case (_, _: OpenapiSchemaAny)         => None
         case (name, schema: OpenapiSchemaOneOf) =>
-          name -> genADTSchema(name, schema, if (fullModelPath.isEmpty) None else Some(fullModelPath))
+          Some(name -> genADTSchema(name, schema, if (fullModelPath.isEmpty) None else Some(fullModelPath)))
         case (n, x) => throw new NotImplementedError(s"Only objects, enums, maps and oneOf supported! (for $n found ${x})")
       })
       .toSeq
@@ -79,9 +65,9 @@ object SchemaGenerator {
     // 2) Order the definitions, such that objects appear before any places they're referenced
     val orderedLayers = orderLayers(groupedByRing)
     // 3) Group the definitions into at most `maxSchemasPerFile`, whilst avoiding splitting groups across files
-    val foldedLayers = foldLayers(maxSchemasPerFile)(orderedLayers)
+    val foldedLayers = foldLayers(maxSchemasPerFile)(maybeAnySchemaSchema ++ orderedLayers)
     // Our output will now only need to imports the 'earlier' files into the 'later' files, and _not_ vice verse
-    maybeAnySchema.map(_._2).toSeq ++ foldedLayers.map(ring => ring.map(openApiSchemasWithTapirSchemas apply _._1).mkString("\n"))
+    foldedLayers.map(ring => ring.map(openApiSchemasWithTapirSchemas apply _._1).mkString("\n"))
   }
   // Group files into chunks of size < maxLayerSize
   private def foldLayers(maxSchemasPerFile: Int)(layers: Seq[Seq[(String, OpenapiSchemaType)]]): Seq[Seq[(String, OpenapiSchemaType)]] = {

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -28,7 +28,7 @@ trait OpenapiCodegenKeys {
   lazy val openapiMaxSchemasPerFile = settingKey[Int]("Maximum number of schemas to generate for a single file")
   lazy val openapiAdditionalPackages = settingKey[List[(String, File)]]("Addition package -> spec mappings to generate.")
   lazy val openapiStreamingImplementation = settingKey[String]("Implementation for streamTextBody. Supports: akka, fs2, pekko, zio.")
-  lazy val openapiGenerateEndpointTypes = settingKey[Boolean]("Whether to emit explicit types for endpoint denfs")
+  lazy val openapiGenerateEndpointTypes = settingKey[Boolean]("Whether to emit explicit types for endpoint defns")
   lazy val openapiOpenApiConfiguration =
     settingKey[OpenApiConfiguration]("Aggregation of other settings. Manually set value will be disregarded.")
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -107,6 +107,13 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None),
         oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[AnEnum]].description("An enum")){ case Some(_: AnEnum) => true }))
 
-  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, getOneofOptionTest)
+  lazy val postGenericJson =
+    endpoint
+      .post
+      .in(("generic" / "json"))
+      .in(jsonBody[Option[io.circe.Json]])
+      .out(jsonBody[io.circe.Json].description("anything back"))
+
+  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, getOneofOptionTest, postGenericJson)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/build.sbt
@@ -13,6 +13,7 @@ libraryDependencies ++= Seq(
   "com.beachape" %% "enumeratum" % "1.7.5",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.33.2",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.33.2" % "compile-internal",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-circe" % "2.33.2",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.11.16" % Test
 )

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
@@ -5,7 +5,7 @@ info:
   description: File for testing json roundtripping of oneOf defns in scala 2.x with jsoniter-scala
   version: 1.0.20-SNAPSHOT
   title: OneOf Json test for jsoniter-scala
-tags: []
+tags: [ ]
 paths:
   '/adt/test':
     post:
@@ -49,6 +49,19 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AnEnum'
+  '/generic/json':
+    post:
+      requestBody:
+        description: anything
+        content:
+          application/json:
+            schema: {}
+      responses:
+        "200":
+          description: anything back
+          content:
+            application/json:
+              schema: {}
 
 components:
   schemas:


### PR DESCRIPTION
Very basic 'works in some places' support for 'free-form' json in codegen with circe (which already worked a bit) and jsoniter-scala (which didn't work anywhere at all). Not trying to be exhaustive of all cases just yet... Doesn't handle more specific but still generic forms such as free-form object.

Also updated some documentation, which I'd overlooked in previous prs

Since jsoniter-scala doesn't have an intermediate JSON repr of its own, support for generic json will require the jsoniter-scala-circe dependency 