### PR TITLE
codegen: More content type support

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -69,7 +69,7 @@ object BasicGenerator {
         StreamingImplementation.FS2
     }
 
-    val EndpointDefs(endpointsByTag, queryOrPathParamRefs, jsonParamRefs, enumsDefinedOnEndpointParams) =
+    val EndpointDefs(endpointsByTag, queryOrPathParamRefs, jsonParamRefs, enumsDefinedOnEndpointParams, inlineDefns) =
       endpointGenerator.endpointDefs(
         doc,
         useHeadTagForObjectNames,
@@ -214,6 +214,7 @@ object BasicGenerator {
         |${indent(2)(queryParamSupport)}
         |
         |${indent(2)(classDefns)}
+        |${indent(2)(inlineDefns.mkString("\n"))}
         |
         |${indent(2)(maybeSpecificationExtensionKeys)}
         |

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -214,7 +214,7 @@ class ClassDefinitionGenerator {
   ): Seq[String] = {
     val valueSchemaName = valueSchema match {
       case simpleType: OpenapiSchemaSimpleType => BasicGenerator.mapSchemaSimpleTypeToType(simpleType)._1
-      case otherType => throw new NotImplementedError(s"Only simple value types and refs are implemented for named maps (found $otherType)")
+      case otherType => throw new NotImplementedError(s"Only simple value types and refs are implemented for named arrays (found $otherType)")
     }
     Seq(s"""type $name = List[$valueSchemaName]""")
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -574,10 +574,12 @@ class EndpointGenerator {
     val inlineClassName = endpointName.capitalize + position
     val properties = schemaRef.properties.map { case (k, v) =>
       val (st, nb) = mapSchemaSimpleTypeToType(v.`type`.asInstanceOf[OpenapiSchemaSimpleType], multipartForm = true)
+      val optional = !schemaRef.required.contains(k) || nb
+      val t = if (optional) s"Option[$st]" else st
       val default = v.default
-        .map(j => " = " + DefaultValueRenderer.render(Map.empty, v.`type`, schemaRef.required.contains(k) || nb, RenderConfig())(j))
-        .getOrElse("")
-      s"$k: $st$default"
+        .map(j => " = " + DefaultValueRenderer.render(Map.empty, v.`type`, optional, RenderConfig())(j))
+        .getOrElse(if (optional) " = None" else "")
+      s"$k: $t$default"
     }
     val inlineClassDefn =
       s"""case class $inlineClassName (

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -4,6 +4,7 @@ import cats.implicits.toTraverseOps
 import cats.syntax.either._
 import OpenapiSchemaType.OpenapiSchemaRef
 import io.circe.Json
+import sttp.tapir.codegen.BasicGenerator.strippedToCamelCase
 // https://swagger.io/specification/
 object OpenapiModels {
 
@@ -50,6 +51,7 @@ object OpenapiModels {
       operationId: Option[String] = None,
       specificationExtensions: Map[String, Json] = Map.empty
   ) {
+    def name(url: String) = strippedToCamelCase(operationId.getOrElse(methodType + url.capitalize))
     def resolvedParameters: Seq[OpenapiParameter] = parameters.collect { case Resolved(t) => t }
     def withResolvedParentParameters(
         pMap: Map[String, OpenapiParameter],

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -18,7 +18,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -35,7 +35,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -56,7 +56,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -73,7 +73,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -94,7 +94,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -115,7 +115,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -132,7 +132,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -155,7 +155,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -184,7 +184,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -213,7 +213,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc1 = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -225,7 +225,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc2 = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -245,7 +245,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc1 = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -257,7 +257,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc2 = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -276,7 +276,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -336,7 +336,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     val doc = OpenapiDocument(
       "",
       null,
-      null,
+      Nil,
       Some(
         OpenapiComponent(
           Map(
@@ -489,7 +489,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       .toTry
       .get
     val gen = new ClassDefinitionGenerator()
-    val res1 = Try(gen.classDefs(OpenapiDocument("", null, null, Some(doc)))).toEither
+    val res1 = Try(gen.classDefs(OpenapiDocument("", null, Nil, Some(doc)))).toEither
 
     res1.left.get.getMessage shouldEqual "Generating class for ReqWithDefaults: Cannot render a number as type sttp.tapir.codegen.openapi.models.OpenapiSchemaType$OpenapiSchemaString."
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
@@ -87,15 +87,15 @@ object TapirGeneratedEndpoints {
   type ListType = List[String]
   case class PutInlineSimpleObjectRequest (
     foo: String,
-    bar: java.util.UUID
+    bar: Option[java.util.UUID] = None
   )
   case class PutInlineSimpleObjectResponse (
     foo: String,
-    bar: java.util.UUID
+    bar: Option[java.util.UUID] = None
   )
   case class PostInlineSimpleObjectRequest (
     foo: String,
-    bar: java.util.UUID
+    bar: Option[java.util.UUID] = None
   )
 
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
@@ -45,10 +45,12 @@ object TapirGeneratedEndpoints {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)
   }
 
-
   sealed trait ADTWithoutDiscriminator
   sealed trait ADTWithDiscriminator
   sealed trait ADTWithDiscriminatorNoMapping
+  case class NotNullableThingy (
+    uuid: java.util.UUID
+  )
   case class SubtypeWithoutD1 (
     s: String,
     i: Option[Int] = None,
@@ -82,24 +84,77 @@ object TapirGeneratedEndpoints {
     case object Bar extends AnEnum
     case object Baz extends AnEnum
   }
+  type ListType = List[String]
+  case class PutInlineSimpleObjectRequest (
+    foo: String,
+    bar: java.util.UUID
+  )
+  case class PutInlineSimpleObjectResponse (
+    foo: String,
+    bar: java.util.UUID
+  )
+  case class PostInlineSimpleObjectRequest (
+    foo: String,
+    bar: java.util.UUID
+  )
 
 
 
-  lazy val putAdtTest =
+  type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
+  lazy val putAdtTest: PutAdtTestEndpoint =
     endpoint
       .put
       .in(("adt" / "test"))
       .in(jsonBody[ADTWithoutDiscriminator])
       .out(jsonBody[ADTWithoutDiscriminator].description("successful operation"))
 
-  lazy val postAdtTest =
+  type PostAdtTestEndpoint = Endpoint[Unit, ADTWithDiscriminatorNoMapping, Unit, ADTWithDiscriminator, Any]
+  lazy val postAdtTest: PostAdtTestEndpoint =
     endpoint
       .post
       .in(("adt" / "test"))
       .in(jsonBody[ADTWithDiscriminatorNoMapping])
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 
+  type PutInlineSimpleObjectEndpoint = Endpoint[Unit, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
+  lazy val putInlineSimpleObject: PutInlineSimpleObjectEndpoint =
+    endpoint
+      .put
+      .in(("inline" / "simple" / "object"))
+      .in(multipartBody[PutInlineSimpleObjectRequest])
+      .errorOut(oneOf[Array[Byte]](
+        oneOfVariant[Array[Byte]](sttp.model.StatusCode(400), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position")),
+        oneOfVariant[Array[Byte]](sttp.model.StatusCode(401), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position 2"))))
+      .out(multipartBody[PutInlineSimpleObjectResponse].description("An object"))
 
-  lazy val generatedEndpoints = List(putAdtTest, postAdtTest)
+  type PostInlineSimpleObjectEndpoint = Endpoint[Unit, Option[PostInlineSimpleObjectRequest], Unit, Unit, Any]
+  lazy val postInlineSimpleObject: PostInlineSimpleObjectEndpoint =
+    endpoint
+      .post
+      .in(("inline" / "simple" / "object"))
+      .in(jsonBody[Option[PostInlineSimpleObjectRequest]])
+
+  type DeleteInlineSimpleObjectEndpoint = Endpoint[Unit, Unit, Unit, Unit, Any]
+  lazy val deleteInlineSimpleObject: DeleteInlineSimpleObjectEndpoint =
+    endpoint
+      .delete
+      .in(("inline" / "simple" / "object"))
+      .errorOut(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("empty response 3"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(402), emptyOutput.description("empty response 4"))(())))
+      .out(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(200), emptyOutput.description("empty response 1"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(201), emptyOutput.description("empty response 2"))(())))
+
+  type PatchInlineSimpleObjectEndpoint = Endpoint[Unit, Option[ListType], ListType, ListType, Any]
+  lazy val patchInlineSimpleObject: PatchInlineSimpleObjectEndpoint =
+    endpoint
+      .patch
+      .in(("inline" / "simple" / "object"))
+      .in(jsonBody[Option[ListType]])
+      .errorOut(jsonBody[ListType].description("list type error").and(statusCode(sttp.model.StatusCode(400))))
+      .out(jsonBody[ListType].description("list type out"))
+
+  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/ExpectedJsonSerdes.scala.txt
@@ -64,4 +64,6 @@ object TapirGeneratedEndpointsJsonSerdes {
       zio.json.JsonDecoder[SubtypeWithoutD2].asInstanceOf[zio.json.JsonDecoder[ADTWithoutDiscriminator]],
       zio.json.JsonDecoder[SubtypeWithoutD3].asInstanceOf[zio.json.JsonDecoder[ADTWithoutDiscriminator]]
     ).reduceLeft(_ orElse _)
+  implicit lazy val postInlineSimpleObjectRequestJsonDecoder: zio.json.JsonDecoder[PostInlineSimpleObjectRequest] = zio.json.DeriveJsonDecoder.gen[PostInlineSimpleObjectRequest]
+  implicit lazy val postInlineSimpleObjectRequestJsonEncoder: zio.json.JsonEncoder[PostInlineSimpleObjectRequest] = zio.json.DeriveJsonEncoder.gen[PostInlineSimpleObjectRequest]
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/ExpectedSchemas.scala.txt
@@ -4,6 +4,7 @@ object TapirGeneratedEndpointsSchemas {
   import sttp.tapir.generated.TapirGeneratedEndpoints._
   import sttp.tapir.generic.auto._
   implicit lazy val anEnumTapirSchema: sttp.tapir.Schema[AnEnum] = sttp.tapir.Schema.derived
+  implicit lazy val notNullableThingyTapirSchema: sttp.tapir.Schema[NotNullableThingy] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD1TapirSchema: sttp.tapir.Schema[SubtypeWithD1] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD2TapirSchema: sttp.tapir.Schema[SubtypeWithD2] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithoutD1TapirSchema: sttp.tapir.Schema[SubtypeWithoutD1] = sttp.tapir.Schema.derived

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/build.sbt
@@ -7,12 +7,13 @@ lazy val root = (project in file("."))
   )
 
 libraryDependencies ++= Seq(
-  "com.softwaremill.sttp.tapir" %% "tapir-json-zio" % "1.10.0",
-  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.10.0",
-  "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.8.0",
+  "com.softwaremill.sttp.tapir" %% "tapir-json-zio" % "1.11.16",
+  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.11.16",
+  "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.11.7",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
-  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.10.0" % Test
+  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.11.16" % Test
 )
+openapiGenerateEndpointTypes := true
 
 import scala.io.Source
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/swagger.yaml
@@ -38,6 +38,107 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ADTWithoutDiscriminator'
+  '/inline/simple/object':
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - foo
+              properties:
+                foo:
+                  type: string
+                bar:
+                  type: string
+                  format: uuid
+      responses:
+        "200":
+          description: An object
+          content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - foo
+              properties:
+                foo:
+                  type: string
+                bar:
+                  type: string
+                  format: uuid
+    put:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - foo
+              properties:
+                foo:
+                  type: string
+                bar:
+                  type: string
+                  format: uuid
+      responses:
+        "200":
+          description: An object
+          content:
+            multipart/form-data:
+              schema:
+                type: object
+                required:
+                  - foo
+                properties:
+                  foo:
+                    type: string
+                  bar:
+                    type: string
+                    format: uuid
+        "400":
+          description: application/octet-stream in error position
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/NotNullableThingy'
+        "401":
+          description: application/octet-stream in error position 2
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/NotNullableThingy'
+    delete:
+      responses:
+        "200":
+          description: empty response 1
+        "201":
+          description: empty response 2
+        "401":
+          description: empty response 3
+        "402":
+          description: empty response 4
+    patch:
+      requestBody:
+        description: list type in
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListType'
+      responses:
+        "200":
+          description: list type out
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListType'
+        "400":
+          description: list type error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListType'
 
 components:
   schemas:
@@ -136,3 +237,17 @@ components:
         - Foo
         - Bar
         - Baz
+    NotNullableThingy:
+      title: NotNullableThingy
+      type: object
+      required:
+        - uuid
+      properties:
+        uuid:
+          type: string
+          format: uuid
+    ListType:
+      title: ListType
+      type: array
+      items:
+        type: string

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -12,7 +12,6 @@ object TapirGeneratedEndpoints {
   import sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes._
   import TapirGeneratedEndpointsSchemas._
 
-
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
   trait ExtraParamSupport[T] {
@@ -142,8 +141,21 @@ object TapirGeneratedEndpoints {
     case object Bar extends AnEnum
     case object Baz extends AnEnum
   }
+  type ListType = List[String]
   case class NullableThingy (
     uuid: java.util.UUID
+  )
+  case class PutInlineSimpleObjectRequest (
+    foo: String,
+    bar: java.util.UUID
+  )
+  case class PutInlineSimpleObjectResponse (
+    foo: String,
+    bar: java.util.UUID
+  )
+  case class PostInlineSimpleObjectRequest (
+    foo: String,
+    bar: java.util.UUID
   )
 
 
@@ -201,8 +213,8 @@ object TapirGeneratedEndpoints {
       .get
       .in(("oneof" / "error" / "test"))
       .errorOut(oneOf[Error](
-        oneOfVariant(sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")),
-        oneOfVariant(sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
+        oneOfVariant[NotFoundError](sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")),
+        oneOfVariant[SimpleError](sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
       .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
 
   type GetOneofOptionTestEndpoint = Endpoint[Unit, Unit, Unit, Option[AnyObjectWithInlineEnum], Any]
@@ -267,6 +279,46 @@ object TapirGeneratedEndpoints {
       extraCodecSupport[PostInlineEnumTestQueryOptSeqEnum]("PostInlineEnumTestQueryOptSeqEnum", PostInlineEnumTestQueryOptSeqEnum)
   }
 
-  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, putAdtTest, postAdtTest, getOneofErrorTest, getOneofOptionTest, postInlineEnumTest)
+  type PutInlineSimpleObjectEndpoint = Endpoint[Unit, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
+  lazy val putInlineSimpleObject: PutInlineSimpleObjectEndpoint =
+    endpoint
+      .put
+      .in(("inline" / "simple" / "object"))
+      .in(multipartBody[PutInlineSimpleObjectRequest])
+      .errorOut(oneOf[Array[Byte]](
+        oneOfVariant[Array[Byte]](sttp.model.StatusCode(400), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position")),
+        oneOfVariant[Array[Byte]](sttp.model.StatusCode(401), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position 2"))))
+      .out(multipartBody[PutInlineSimpleObjectResponse].description("An object"))
+
+  type PostInlineSimpleObjectEndpoint = Endpoint[Unit, Option[PostInlineSimpleObjectRequest], Unit, Unit, Any]
+  lazy val postInlineSimpleObject: PostInlineSimpleObjectEndpoint =
+    endpoint
+      .post
+      .in(("inline" / "simple" / "object"))
+      .in(jsonBody[Option[PostInlineSimpleObjectRequest]])
+
+  type DeleteInlineSimpleObjectEndpoint = Endpoint[Unit, Unit, Unit, Unit, Any]
+  lazy val deleteInlineSimpleObject: DeleteInlineSimpleObjectEndpoint =
+    endpoint
+      .delete
+      .in(("inline" / "simple" / "object"))
+      .errorOut(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("empty response 3"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(402), emptyOutput.description("empty response 4"))(())))
+      .out(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(200), emptyOutput.description("empty response 1"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(201), emptyOutput.description("empty response 2"))(())))
+
+  type PatchInlineSimpleObjectEndpoint = Endpoint[Unit, Option[ListType], ListType, ListType, Any]
+  lazy val patchInlineSimpleObject: PatchInlineSimpleObjectEndpoint =
+    endpoint
+      .patch
+      .in(("inline" / "simple" / "object"))
+      .in(jsonBody[Option[ListType]])
+      .errorOut(jsonBody[ListType].description("list type error").and(statusCode(sttp.model.StatusCode(400))))
+      .out(jsonBody[ListType].description("list type out"))
+
+  
+  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, putAdtTest, postAdtTest, getOneofErrorTest, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -147,15 +147,15 @@ object TapirGeneratedEndpoints {
   )
   case class PutInlineSimpleObjectRequest (
     foo: String,
-    bar: java.util.UUID
+    bar: Option[java.util.UUID] = None
   )
   case class PutInlineSimpleObjectResponse (
     foo: String,
-    bar: java.util.UUID
+    bar: Option[java.util.UUID] = None
   )
   case class PostInlineSimpleObjectRequest (
     foo: String,
-    bar: java.util.UUID
+    bar: Option[java.util.UUID] = None
   )
 
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
@@ -64,4 +64,6 @@ object TapirGeneratedEndpointsJsonSerdes {
     ).reduceLeft(_ or _)
   implicit lazy val nullableThingyJsonDecoder: io.circe.Decoder[NullableThingy] = io.circe.generic.semiauto.deriveDecoder[NullableThingy]
   implicit lazy val nullableThingyJsonEncoder: io.circe.Encoder[NullableThingy] = io.circe.generic.semiauto.deriveEncoder[NullableThingy]
+  implicit lazy val postInlineSimpleObjectRequestJsonDecoder: io.circe.Decoder[PostInlineSimpleObjectRequest] = io.circe.generic.semiauto.deriveDecoder[PostInlineSimpleObjectRequest]
+  implicit lazy val postInlineSimpleObjectRequestJsonEncoder: io.circe.Encoder[PostInlineSimpleObjectRequest] = io.circe.generic.semiauto.deriveEncoder[PostInlineSimpleObjectRequest]
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -195,6 +195,108 @@ paths:
               schema:
                 $ref: '#/components/schemas/ObjectWithInlineEnum2'
 
+  '/inline/simple/object':
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - foo
+              properties:
+                foo:
+                  type: string
+                bar:
+                  type: string
+                  format: uuid
+      responses:
+        "200":
+          description: An object
+          content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - foo
+              properties:
+                foo:
+                  type: string
+                bar:
+                  type: string
+                  format: uuid
+    put:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - foo
+              properties:
+                foo:
+                  type: string
+                bar:
+                  type: string
+                  format: uuid
+      responses:
+        "200":
+          description: An object
+          content:
+            multipart/form-data:
+              schema:
+                type: object
+                required:
+                  - foo
+                properties:
+                  foo:
+                    type: string
+                  bar:
+                    type: string
+                    format: uuid
+        "400":
+          description: application/octet-stream in error position
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/NotNullableThingy'
+        "401":
+          description: application/octet-stream in error position 2
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/NotNullableThingy'
+    delete:
+      responses:
+        "200":
+          description: empty response 1
+        "201":
+          description: empty response 2
+        "401":
+          description: empty response 3
+        "402":
+          description: empty response 4
+    patch:
+      requestBody:
+        description: list type in
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListType'
+      responses:
+        "200":
+          description: list type out
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListType'
+        "400":
+          description: list type error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListType'
+
 
 components:
   schemas:
@@ -386,3 +488,8 @@ components:
       properties:
         message:
           type: string
+    ListType:
+      title: ListType
+      type: array
+      items:
+        type: string

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -66,6 +66,9 @@ object TapirGeneratedEndpoints {
   sealed trait ADTWithoutDiscriminator
   sealed trait ADTWithDiscriminator
   sealed trait ADTWithDiscriminatorNoMapping
+  case class NotNullableThingy (
+    uuid: java.util.UUID
+  )
   case class SubtypeWithoutD1 (
     s: String,
     i: Option[Int] = None,
@@ -101,6 +104,20 @@ object TapirGeneratedEndpoints {
     implicit val enumCodecSupportAnEnum: ExtraParamSupport[AnEnum] =
       extraCodecSupport[AnEnum]("AnEnum", AnEnum)
   }
+  type ListType = List[String]
+  case class PutInlineSimpleObjectRequest (
+    foo: String,
+    bar: java.util.UUID
+  )
+  case class PutInlineSimpleObjectResponse (
+    foo: String,
+    bar: java.util.UUID
+  )
+  case class PostInlineSimpleObjectRequest (
+    foo: String,
+    bar: java.util.UUID
+  )
+
 
 
   type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
@@ -137,6 +154,45 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[Option[io.circe.Json]])
       .out(jsonBody[io.circe.Json].description("anything back"))
 
-  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, getOneofOptionTest, postGenericJson)
+  type PutInlineSimpleObjectEndpoint = Endpoint[Unit, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
+  lazy val putInlineSimpleObject: PutInlineSimpleObjectEndpoint =
+    endpoint
+      .put
+      .in(("inline" / "simple" / "object"))
+      .in(multipartBody[PutInlineSimpleObjectRequest])
+      .errorOut(oneOf[Array[Byte]](
+        oneOfVariant[Array[Byte]](sttp.model.StatusCode(400), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position")),
+        oneOfVariant[Array[Byte]](sttp.model.StatusCode(401), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position 2"))))
+      .out(multipartBody[PutInlineSimpleObjectResponse].description("An object"))
+
+  type PostInlineSimpleObjectEndpoint = Endpoint[Unit, Option[PostInlineSimpleObjectRequest], Unit, Unit, Any]
+  lazy val postInlineSimpleObject: PostInlineSimpleObjectEndpoint =
+    endpoint
+      .post
+      .in(("inline" / "simple" / "object"))
+      .in(jsonBody[Option[PostInlineSimpleObjectRequest]])
+
+  type DeleteInlineSimpleObjectEndpoint = Endpoint[Unit, Unit, Unit, Unit, Any]
+  lazy val deleteInlineSimpleObject: DeleteInlineSimpleObjectEndpoint =
+    endpoint
+      .delete
+      .in(("inline" / "simple" / "object"))
+      .errorOut(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("empty response 3"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(402), emptyOutput.description("empty response 4"))(())))
+      .out(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(200), emptyOutput.description("empty response 1"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(201), emptyOutput.description("empty response 2"))(())))
+
+  type PatchInlineSimpleObjectEndpoint = Endpoint[Unit, Option[ListType], ListType, ListType, Any]
+  lazy val patchInlineSimpleObject: PatchInlineSimpleObjectEndpoint =
+    endpoint
+      .patch
+      .in(("inline" / "simple" / "object"))
+      .in(jsonBody[Option[ListType]])
+      .errorOut(jsonBody[ListType].description("list type error").and(statusCode(sttp.model.StatusCode(400))))
+      .out(jsonBody[ListType].description("list type out"))
+  
+  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, getOneofOptionTest, postGenericJson, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -107,15 +107,15 @@ object TapirGeneratedEndpoints {
   type ListType = List[String]
   case class PutInlineSimpleObjectRequest (
     foo: String,
-    bar: java.util.UUID
+    bar: Option[java.util.UUID] = None
   )
   case class PutInlineSimpleObjectResponse (
     foo: String,
-    bar: java.util.UUID
+    bar: Option[java.util.UUID] = None
   )
   case class PostInlineSimpleObjectRequest (
     foo: String,
-    bar: java.util.UUID
+    bar: Option[java.util.UUID] = None
   )
 
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
@@ -73,6 +73,107 @@ paths:
           content:
             application/json:
               schema: { }
+  '/inline/simple/object':
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - foo
+              properties:
+                foo:
+                  type: string
+                bar:
+                  type: string
+                  format: uuid
+      responses:
+        "200":
+          description: An object
+          content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - foo
+              properties:
+                foo:
+                  type: string
+                bar:
+                  type: string
+                  format: uuid
+    put:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - foo
+              properties:
+                foo:
+                  type: string
+                bar:
+                  type: string
+                  format: uuid
+      responses:
+        "200":
+          description: An object
+          content:
+            multipart/form-data:
+              schema:
+                type: object
+                required:
+                  - foo
+                properties:
+                  foo:
+                    type: string
+                  bar:
+                    type: string
+                    format: uuid
+        "400":
+          description: application/octet-stream in error position
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/NotNullableThingy'
+        "401":
+          description: application/octet-stream in error position 2
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/NotNullableThingy'
+    delete:
+      responses:
+        "200":
+          description: empty response 1
+        "201":
+          description: empty response 2
+        "401":
+          description: empty response 3
+        "402":
+          description: empty response 4
+    patch:
+      requestBody:
+        description: list type in
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListType'
+      responses:
+        "200":
+          description: list type out
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListType'
+        "400":
+          description: list type error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListType'
 
 components:
   schemas:
@@ -172,3 +273,17 @@ components:
         - Foo
         - Bar
         - Baz
+    NotNullableThingy:
+      title: NotNullableThingy
+      type: object
+      required:
+        - uuid
+      properties:
+        uuid:
+          type: string
+          format: uuid
+    ListType:
+      title: ListType
+      type: array
+      items:
+        type: string

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -71,6 +71,9 @@ object TapirGeneratedEndpoints {
   sealed trait ADTWithoutDiscriminator
   sealed trait ADTWithDiscriminator
   sealed trait ADTWithDiscriminatorNoMapping
+  case class NotNullableThingy (
+    uuid: java.util.UUID
+  )
   case class ObjectWithInlineEnum2 (
     inlineEnum: ObjectWithInlineEnum2InlineEnum
   ) extends AnyObjectWithInlineEnum
@@ -115,23 +118,40 @@ object TapirGeneratedEndpoints {
   enum AnEnum derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec {
     case Foo, Bar, Baz
   }
+  type ListType = List[String]
+  case class PutInlineSimpleObjectRequest (
+    foo: String,
+    bar: java.util.UUID
+  )
+  case class PutInlineSimpleObjectResponse (
+    foo: String,
+    bar: java.util.UUID
+  )
+  case class PostInlineSimpleObjectRequest (
+    foo: String,
+    bar: java.util.UUID
+  )
 
 
-  lazy val putAdtTest =
+
+  type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
+  lazy val putAdtTest: PutAdtTestEndpoint =
     endpoint
       .put
       .in(("adt" / "test"))
       .in(jsonBody[ADTWithoutDiscriminator])
       .out(jsonBody[ADTWithoutDiscriminator].description("successful operation"))
 
-  lazy val postAdtTest =
+  type PostAdtTestEndpoint = Endpoint[Unit, ADTWithDiscriminatorNoMapping, Unit, ADTWithDiscriminator, Any]
+  lazy val postAdtTest: PostAdtTestEndpoint =
     endpoint
       .post
       .in(("adt" / "test"))
       .in(jsonBody[ADTWithDiscriminatorNoMapping])
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 
-  lazy val postInlineEnumTest =
+  type PostInlineEnumTestEndpoint = Endpoint[Unit, (PostInlineEnumTestQueryEnum, Option[PostInlineEnumTestQueryOptEnum], List[PostInlineEnumTestQuerySeqEnum], List[PostInlineEnumTestQueryOptSeqEnum], ObjectWithInlineEnum), Unit, Unit, Any]
+  lazy val postInlineEnumTest: PostInlineEnumTestEndpoint =
     endpoint
       .post
       .in(("inline" / "enum" / "test"))
@@ -174,7 +194,8 @@ object TapirGeneratedEndpoints {
     case baz1, baz2, baz3
   }
 
-  lazy val getOneofOptionTest =
+  type GetOneofOptionTestEndpoint = Endpoint[Unit, Unit, Unit, Option[AnyObjectWithInlineEnum], Any]
+  lazy val getOneofOptionTest: GetOneofOptionTestEndpoint =
     endpoint
       .get
       .in(("oneof" / "option" / "test"))
@@ -183,6 +204,45 @@ object TapirGeneratedEndpoints {
         oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object")){ case Some(_: ObjectWithInlineEnum) => true },
         oneOfVariantValueMatcher(sttp.model.StatusCode(201), jsonBody[Option[ObjectWithInlineEnum2]].description("Another object")){ case Some(_: ObjectWithInlineEnum2) => true }))
 
-  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, postInlineEnumTest, getOneofOptionTest)
+  type PutInlineSimpleObjectEndpoint = Endpoint[Unit, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
+  lazy val putInlineSimpleObject: PutInlineSimpleObjectEndpoint =
+    endpoint
+      .put
+      .in(("inline" / "simple" / "object"))
+      .in(multipartBody[PutInlineSimpleObjectRequest])
+      .errorOut(oneOf[Array[Byte]](
+        oneOfVariant[Array[Byte]](sttp.model.StatusCode(400), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position")),
+        oneOfVariant[Array[Byte]](sttp.model.StatusCode(401), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position 2"))))
+      .out(multipartBody[PutInlineSimpleObjectResponse].description("An object"))
+
+  type PostInlineSimpleObjectEndpoint = Endpoint[Unit, Option[PostInlineSimpleObjectRequest], Unit, Unit, Any]
+  lazy val postInlineSimpleObject: PostInlineSimpleObjectEndpoint =
+    endpoint
+      .post
+      .in(("inline" / "simple" / "object"))
+      .in(jsonBody[Option[PostInlineSimpleObjectRequest]])
+
+  type DeleteInlineSimpleObjectEndpoint = Endpoint[Unit, Unit, Unit, Unit, Any]
+  lazy val deleteInlineSimpleObject: DeleteInlineSimpleObjectEndpoint =
+    endpoint
+      .delete
+      .in(("inline" / "simple" / "object"))
+      .errorOut(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("empty response 3"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(402), emptyOutput.description("empty response 4"))(())))
+      .out(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(200), emptyOutput.description("empty response 1"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(201), emptyOutput.description("empty response 2"))(())))
+
+  type PatchInlineSimpleObjectEndpoint = Endpoint[Unit, Option[ListType], ListType, ListType, Any]
+  lazy val patchInlineSimpleObject: PatchInlineSimpleObjectEndpoint =
+    endpoint
+      .patch
+      .in(("inline" / "simple" / "object"))
+      .in(jsonBody[Option[ListType]])
+      .errorOut(jsonBody[ListType].description("list type error").and(statusCode(sttp.model.StatusCode(400))))
+      .out(jsonBody[ListType].description("list type out"))
+
+  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, postInlineEnumTest, getOneofOptionTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -121,15 +121,15 @@ object TapirGeneratedEndpoints {
   type ListType = List[String]
   case class PutInlineSimpleObjectRequest (
     foo: String,
-    bar: java.util.UUID
+    bar: Option[java.util.UUID] = None
   )
   case class PutInlineSimpleObjectResponse (
     foo: String,
-    bar: java.util.UUID
+    bar: Option[java.util.UUID] = None
   )
   case class PostInlineSimpleObjectRequest (
     foo: String,
-    bar: java.util.UUID
+    bar: Option[java.util.UUID] = None
   )
 
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/build.sbt
@@ -15,6 +15,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
   "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.11.16" % Test
 )
+openapiGenerateEndpointTypes := true
 
 import scala.io.Source
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/project/plugins.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/project/plugins.sbt
@@ -1,11 +1,3 @@
 {
-  val pluginVersion = System.getProperty("plugin.version")
-  if (pluginVersion == null)
-    throw new RuntimeException("""|
-                                  |
-                                  |The system property 'plugin.version' is not defined.
-                                  |Specify this property using the scriptedLaunchOpts -D.
-                                  |
-                                  |""".stripMargin)
-  else addSbtPlugin("com.softwaremill.sttp.tapir" % "sbt-openapi-codegen" % pluginVersion)
+  addSbtPlugin("com.softwaremill.sttp.tapir" % "sbt-openapi-codegen" % "1.11.17.34-LOCAL")
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/project/plugins.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/project/plugins.sbt
@@ -1,3 +1,11 @@
 {
-  addSbtPlugin("com.softwaremill.sttp.tapir" % "sbt-openapi-codegen" % "1.11.17.34-LOCAL")
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|
+                                  |
+                                  |The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.
+                                  |
+                                  |""".stripMargin)
+  else addSbtPlugin("com.softwaremill.sttp.tapir" % "sbt-openapi-codegen" % pluginVersion)
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/swagger.yaml
@@ -115,6 +115,107 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ObjectWithInlineEnum2'
+  '/inline/simple/object':
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - foo
+              properties:
+                foo:
+                  type: string
+                bar:
+                  type: string
+                  format: uuid
+      responses:
+        "200":
+          description: An object
+          content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - foo
+              properties:
+                foo:
+                  type: string
+                bar:
+                  type: string
+                  format: uuid
+    put:
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - foo
+              properties:
+                foo:
+                  type: string
+                bar:
+                  type: string
+                  format: uuid
+      responses:
+        "200":
+          description: An object
+          content:
+            multipart/form-data:
+              schema:
+                type: object
+                required:
+                  - foo
+                properties:
+                  foo:
+                    type: string
+                  bar:
+                    type: string
+                    format: uuid
+        "400":
+          description: application/octet-stream in error position
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/NotNullableThingy'
+        "401":
+          description: application/octet-stream in error position 2
+          content:
+            application/octet-stream:
+              schema:
+                $ref: '#/components/schemas/NotNullableThingy'
+    delete:
+      responses:
+        "200":
+          description: empty response 1
+        "201":
+          description: empty response 2
+        "401":
+          description: empty response 3
+        "402":
+          description: empty response 4
+    patch:
+      requestBody:
+        description: list type in
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListType'
+      responses:
+        "200":
+          description: list type out
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListType'
+        "400":
+          description: list type error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListType'
 externalDocs:
   description: Find out more about Swagger
   url: 'http://swagger.io'
@@ -248,3 +349,17 @@ components:
       oneOf:
         - $ref: '#/components/schemas/ObjectWithInlineEnum'
         - $ref: '#/components/schemas/ObjectWithInlineEnum2'
+    NotNullableThingy:
+      title: NotNullableThingy
+      type: object
+      required:
+        - uuid
+      properties:
+        uuid:
+          type: string
+          format: uuid
+    ListType:
+      title: ListType
+      type: array
+      items:
+        type: string


### PR DESCRIPTION
Adds: 
- support in-line req object defns with simple fields for multipart/form-data
- support in-line req object defns with simple fields for application/json
- support multiple empty responses with no aligned defined response
- support ref aliases for lists
- support application/octet-stream in error position

Tests for all new support added for circe/zio/jsoniter (scala 2), and just circe (scala 3)

Probably the endpoint generator should be able to delegate to the class generator for inline defns, or else we should be pulling the inline defns out of the paths and passing it straight to the class generator at the root, but either refactor might be a little way out... I haven't encountered endpoints that nest inline definitions yet, but there shouldn't be a reason we can't support them in principle.

This still leaves me wanting support for content negotiation and security schemas, but it adds several handy capabilities nonetheless 