### PR TITLE
codegen: Support custom content types

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -169,6 +169,24 @@ object BasicGenerator {
       }
       .mkString("\n")
 
+    val expectedTypes = Set("text/plain", "text/html", "application/json", "multipart/form-data", "application/octet-stream")
+    val mediaType = "([^/]+)/(.+)".r
+    val customTypes = doc.paths
+      .flatMap(
+        _.methods.flatMap(m =>
+          m.requestBody.toSeq.flatMap(_.content.map(_.contentType)) ++ m.responses.flatMap(_.content.map(_.contentType))
+        )
+      )
+      .distinct
+      .sorted
+      .filterNot(expectedTypes.contains)
+      .map {
+        case ct @ mediaType(mainType, subType) =>
+          s"""case class `${ct}CodecFormat`() extends CodecFormat {
+           |  override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "$mainType", subType = "$subType")
+           |}""".stripMargin
+        case ct => throw new NotImplementedError(s"Cannot handle content type '$ct'")
+      }.mkString("\n")
     val extraImports = if (endpointsInMain.nonEmpty) s"$maybeJsonImport$maybeSchemaImport" else ""
     val queryParamSupport =
       """
@@ -211,6 +229,7 @@ object BasicGenerator {
         |
         |${indent(2)(imports(normalisedJsonLib) + extraImports)}
         |
+        |${indent(2)(customTypes)}
         |${indent(2)(queryParamSupport)}
         |
         |${indent(2)(classDefns)}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -12,6 +12,9 @@ object TapirGeneratedEndpoints {
   import sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes._
   import TapirGeneratedEndpointsSchemas._
 
+  case class `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`() extends CodecFormat {
+    override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "application", subType = "vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+  }
 
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
@@ -105,6 +108,9 @@ object TapirGeneratedEndpoints {
       extraCodecSupport[AnEnum]("AnEnum", AnEnum)
   }
   type ListType = List[String]
+  case class SomeBinaryType (
+
+  )
   case class PutInlineSimpleObjectRequest (
     foo: String,
     bar: Option[java.util.UUID] = None
@@ -117,8 +123,24 @@ object TapirGeneratedEndpoints {
     foo: String,
     bar: Option[java.util.UUID] = None
   )
+  case class PostInlineSimpleObjectResponse (
+    foo: String,
+    bar: Option[java.util.UUID] = None
+  )
 
+  type GetContentTypeNegotiationEndpoint = Endpoint[Unit, Unit, Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
+  lazy val getContentTypeNegotiation: GetContentTypeNegotiationEndpoint =
+    endpoint
+      .get
+      .in(("content-type" / "negotiation"))
+      .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()).description("Download the upload"))
 
+  type PostContentTypeNegotiationEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, Unit, Unit, sttp.capabilities.pekko.PekkoStreams]
+  lazy val postContentTypeNegotiation: PostContentTypeNegotiationEndpoint =
+    endpoint
+      .post
+      .in(("content-type" / "negotiation"))
+      .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()))
 
   type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
   lazy val putAdtTest: PutAdtTestEndpoint =
@@ -136,15 +158,6 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[ADTWithDiscriminatorNoMapping])
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 
-  type GetOneofOptionTestEndpoint = Endpoint[Unit, Unit, Unit, Option[AnEnum], Any]
-  lazy val getOneofOptionTest: GetOneofOptionTestEndpoint =
-    endpoint
-      .get
-      .in(("oneof" / "option" / "test"))
-      .out(oneOf[Option[AnEnum]](
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None),
-        oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[AnEnum]].description("An enum")){ case Some(_: AnEnum) => true }))
-
   type PostGenericJsonEndpoint = Endpoint[Unit, (Option[List[AnEnum]], Option[io.circe.Json]), Unit, io.circe.Json, Any]
   lazy val postGenericJson: PostGenericJsonEndpoint =
     endpoint
@@ -153,6 +166,15 @@ object TapirGeneratedEndpoints {
       .in(query[Option[CommaSeparatedValues[AnEnum]]]("aTrickyParam").map(_.map(_.values))(_.map(CommaSeparatedValues(_))).description("A very thorough description"))
       .in(jsonBody[Option[io.circe.Json]])
       .out(jsonBody[io.circe.Json].description("anything back"))
+
+  type GetOneofOptionTestEndpoint = Endpoint[Unit, Unit, Unit, Option[AnEnum], Any]
+  lazy val getOneofOptionTest: GetOneofOptionTestEndpoint =
+    endpoint
+      .get
+      .in(("oneof" / "option" / "test"))
+      .out(oneOf[Option[AnEnum]](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None),
+        oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[AnEnum]].description("An enum")){ case Some(_: AnEnum) => true }))
 
   type PutInlineSimpleObjectEndpoint = Endpoint[Unit, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
   lazy val putInlineSimpleObject: PutInlineSimpleObjectEndpoint =
@@ -165,12 +187,13 @@ object TapirGeneratedEndpoints {
         oneOfVariant[Array[Byte]](sttp.model.StatusCode(401), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position 2"))))
       .out(multipartBody[PutInlineSimpleObjectResponse].description("An object"))
 
-  type PostInlineSimpleObjectEndpoint = Endpoint[Unit, Option[PostInlineSimpleObjectRequest], Unit, Unit, Any]
+  type PostInlineSimpleObjectEndpoint = Endpoint[Unit, Option[PostInlineSimpleObjectRequest], Unit, PostInlineSimpleObjectResponse, Any]
   lazy val postInlineSimpleObject: PostInlineSimpleObjectEndpoint =
     endpoint
       .post
       .in(("inline" / "simple" / "object"))
       .in(jsonBody[Option[PostInlineSimpleObjectRequest]])
+      .out(jsonBody[PostInlineSimpleObjectResponse].description("An object"))
 
   type DeleteInlineSimpleObjectEndpoint = Endpoint[Unit, Unit, Unit, Unit, Any]
   lazy val deleteInlineSimpleObject: DeleteInlineSimpleObjectEndpoint =
@@ -192,7 +215,7 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[Option[ListType]])
       .errorOut(jsonBody[ListType].description("list type error").and(statusCode(sttp.model.StatusCode(400))))
       .out(jsonBody[ListType].description("list type out"))
-  
-  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, getOneofOptionTest, postGenericJson, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+
+  lazy val generatedEndpoints = List(getContentTypeNegotiation, postContentTypeNegotiation, putAdtTest, postAdtTest, postGenericJson, getOneofOptionTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -1,3 +1,4 @@
+
 package sttp.tapir.generated
 
 object TapirGeneratedEndpoints {
@@ -14,6 +15,9 @@ object TapirGeneratedEndpoints {
 
   case class `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`() extends CodecFormat {
     override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "application", subType = "vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+  }
+  case class `text/csvCodecFormat`() extends CodecFormat {
+    override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "text", subType = "csv")
   }
 
   case class CommaSeparatedValues[T](values: List[T])
@@ -128,20 +132,6 @@ object TapirGeneratedEndpoints {
     bar: Option[java.util.UUID] = None
   )
 
-  type GetContentTypeNegotiationEndpoint = Endpoint[Unit, Unit, Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
-  lazy val getContentTypeNegotiation: GetContentTypeNegotiationEndpoint =
-    endpoint
-      .get
-      .in(("content-type" / "negotiation"))
-      .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()).description("Download the upload"))
-
-  type PostContentTypeNegotiationEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, Unit, Unit, sttp.capabilities.pekko.PekkoStreams]
-  lazy val postContentTypeNegotiation: PostContentTypeNegotiationEndpoint =
-    endpoint
-      .post
-      .in(("content-type" / "negotiation"))
-      .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()))
-
   type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
   lazy val putAdtTest: PutAdtTestEndpoint =
     endpoint
@@ -175,6 +165,24 @@ object TapirGeneratedEndpoints {
       .out(oneOf[Option[AnEnum]](
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None),
         oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[AnEnum]].description("An enum")){ case Some(_: AnEnum) => true }))
+
+  type PutCustomContentTypesEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, String, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
+  lazy val putCustomContentTypes: PutCustomContentTypesEndpoint =
+    endpoint
+      .put
+      .in(("custom" / "content-types"))
+      .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `text/csvCodecFormat`()))
+      .errorOut(stringBodyUtf8AnyFormat(Codec.id[String, `text/csvCodecFormat`](`text/csvCodecFormat`(), Schema.schemaForString)).description("text error").and(statusCode(sttp.model.StatusCode(400))))
+      .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()).description("binary success"))
+
+  type PostCustomContentTypesEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, Array[Byte], sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
+  lazy val postCustomContentTypes: PostCustomContentTypesEndpoint =
+    endpoint
+      .post
+      .in(("custom" / "content-types"))
+      .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()))
+      .errorOut(EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`](`application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).description("binary error").and(statusCode(sttp.model.StatusCode(400))))
+      .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `text/csvCodecFormat`()).description("text success"))
 
   type PutInlineSimpleObjectEndpoint = Endpoint[Unit, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
   lazy val putInlineSimpleObject: PutInlineSimpleObjectEndpoint =
@@ -216,6 +224,6 @@ object TapirGeneratedEndpoints {
       .errorOut(jsonBody[ListType].description("list type error").and(statusCode(sttp.model.StatusCode(400))))
       .out(jsonBody[ListType].description("list type out"))
 
-  lazy val generatedEndpoints = List(getContentTypeNegotiation, postContentTypeNegotiation, putAdtTest, postAdtTest, postGenericJson, getOneofOptionTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, postGenericJson, getOneofOptionTest, putCustomContentTypes, postCustomContentTypes, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/build.sbt
@@ -4,19 +4,22 @@ lazy val root = (project in file("."))
     scalaVersion := "2.13.16",
     version := "0.1",
     openapiJsonSerdeLib := "jsoniter",
+    openapiStreamingImplementation := "pekko",
     openapiGenerateEndpointTypes := true
   )
 
+val tapirVersion = "1.11.17"
 libraryDependencies ++= Seq(
-  "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % "1.11.16",
-  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.11.16",
+  "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % tapirVersion,
+  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % tapirVersion,
+  "com.softwaremill.sttp.tapir" %% "tapir-pekko-http-server" % tapirVersion,
   "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.11.7",
   "com.beachape" %% "enumeratum" % "1.7.5",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.33.2",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.33.2" % "compile-internal",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-circe" % "2.33.2",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
-  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.11.16" % Test
+  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % tapirVersion % Test
 )
 
 import sttp.tapir.sbt.OpenapiCodegenPlugin.autoImport.{openapiJsonSerdeLib, openapiUseHeadTagForObjectName}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
@@ -92,17 +92,17 @@ paths:
         "200":
           description: An object
           content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - foo
-              properties:
-                foo:
-                  type: string
-                bar:
-                  type: string
-                  format: uuid
+            application/json:
+              schema:
+                type: object
+                required:
+                  - foo
+                properties:
+                  foo:
+                    type: string
+                  bar:
+                    type: string
+                    format: uuid
     put:
       requestBody:
         content:
@@ -174,6 +174,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListType'
+  '/content-type/negotiation':
+    post:
+      requestBody:
+        content:
+#          text/csv:
+#            schema:
+#              type: object
+          application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+            schema:
+              $ref: '#/components/schemas/SomeBinaryType'
+      responses:
+        "200":
+          description: Upload succeeded
+    get:
+      responses:
+        "200":
+          description: Download the upload
+          content:
+#            text/csv:
+#              schema:
+#                type: object
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                $ref: '#/components/schemas/SomeBinaryType'
 
 components:
   schemas:
@@ -287,3 +311,6 @@ components:
       type: array
       items:
         type: string
+    SomeBinaryType:
+      title: SomeBinaryType
+      type: object

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
@@ -174,28 +174,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListType'
-  '/content-type/negotiation':
+  '/custom/content-types':
     post:
       requestBody:
         content:
-#          text/csv:
-#            schema:
-#              type: object
           application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
             schema:
               $ref: '#/components/schemas/SomeBinaryType'
       responses:
         "200":
-          description: Upload succeeded
-    get:
+          description: text success
+          content:
+            text/csv:
+              schema:
+                $ref: '#/components/schemas/SomeBinaryType'
+        "400":
+          description: binary error
+          content:
+            application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                $ref: '#/components/schemas/SomeBinaryType'
+    put:
+      requestBody:
+        content:
+          text/csv:
+            schema:
+              $ref: '#/components/schemas/SomeBinaryType'
       responses:
         "200":
-          description: Download the upload
+          description: binary success
           content:
-#            text/csv:
-#              schema:
-#                type: object
             application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+              schema:
+                $ref: '#/components/schemas/SomeBinaryType'
+        "400":
+          description: text error
+          content:
+            text/csv:
               schema:
                 $ref: '#/components/schemas/SomeBinaryType'
 


### PR DESCRIPTION
Adds support for custom codecs to codegen. Everything in 'error' position is assumed to be 'eager' - if text/foo, then a utf8 string; if anything else, then a byte array. Everything in 'success' position is assumed to be a stream of bytes, whether text/ or not.

Without injection of custom codecs, this does not lend itself to content-type negotiation yet... I'll try to figure something out there since (as this pr probably makes clear) what I _really_ want is content-negotiation on different binary stream formats. Still, pr-ing as-is since it's new functionality even without that.