### PR TITLE
Update ZIO HTTP to 3.1.0

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -37,7 +37,7 @@ object Versions {
   val iron = "2.6.0"
   val enumeratum = "1.7.5"
   val zio = "2.1.15"
-  val zioHttp = "3.0.1"
+  val zioHttp = "3.1.0"
   val zioInteropCats = "23.1.0.4"
   val zioInteropReactiveStreams = "2.0.2"
   val zioJson = "0.7.39"


### PR DESCRIPTION
In tests, `route.runZIO` now asks for a Scope so it was just a matter of providing one in order to make the failing tests pass