### PR TITLE
Adds support for otel4s server tracing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,6 +187,7 @@ lazy val rawAllAggregates = core.projectRefs ++
   datadogMetrics.projectRefs ++
   zioMetrics.projectRefs ++
   opentelemetryTracing.projectRefs ++
+  otel4sTracing.projectRefs ++
   json4s.projectRefs ++
   playJson.projectRefs ++
   play29Json.projectRefs ++
@@ -1088,6 +1089,20 @@ lazy val opentelemetryTracing: ProjectMatrix = (projectMatrix in file("tracing/o
   )
   .jvmPlatform(scalaVersions = scala2And3Versions, settings = commonJvmSettings)
   .dependsOn(serverCore % CompileAndTest)
+
+lazy val otel4sTracing: ProjectMatrix = (projectMatrix in file("tracing/otel4s-tracing"))
+  .settings(commonSettings)
+  .settings(
+    name := "tapir-otel4s-tracing",
+    libraryDependencies ++= Seq(
+      "io.opentelemetry.semconv" % "opentelemetry-semconv" % Versions.openTelemetrySemconvVersion,
+      "org.typelevel" %% "otel4s-oteljava" % Versions.otel4s,
+      "org.typelevel" %% "otel4s-oteljava-testkit" % Versions.otel4s % Test,
+      scalaTest.value % Test
+    )
+  )
+  .jvmPlatform(scalaVersions = scala2And3Versions, settings = commonJvmSettings)
+  .dependsOn(serverCore % CompileAndTest, catsEffect % Test)
 
 // docs
 
@@ -2126,6 +2141,7 @@ lazy val examples: ProjectMatrix = (projectMatrix in file("examples"))
     nettyServerZio,
     opentelemetryMetrics,
     opentelemetryTracing,
+    otel4sTracing,
     pekkoHttpServer,
     picklerJson,
     prometheusMetrics,
@@ -2194,6 +2210,7 @@ lazy val documentation: ProjectMatrix = (projectMatrix in file("generated-doc"))
     openapiVerifier,
     opentelemetryMetrics,
     opentelemetryTracing,
+    otel4sTracing,
     pekkoHttpServer,
     picklerJson,
     playClient,

--- a/build.sbt
+++ b/build.sbt
@@ -1101,7 +1101,7 @@ lazy val otel4sTracing: ProjectMatrix = (projectMatrix in file("tracing/otel4s-t
       scalaTest.value % Test
     )
   )
-  .jvmPlatform(scalaVersions = scala2And3Versions, settings = commonJvmSettings)
+  .jvmPlatform(scalaVersions = scala2_13And3Versions, settings = commonJvmSettings)
   .dependsOn(serverCore % CompileAndTest, catsEffect % Test)
 
 // docs

--- a/doc/server/observability.md
+++ b/doc/server/observability.md
@@ -319,3 +319,45 @@ val serverOptions: NettySyncServerOptions =
 
 NettySyncServer().options(serverOptions).addEndpoint(???).startAndWait()
 ```
+
+## otel4s OpenTelemetry tracing
+
+Add the following dependency:
+
+```scala
+"com.softwaremill.sttp.tapir" %% "tapir-otel4s-tracing" % "@VERSION@"
+```
+
+The `Otel4sTracing` interceptor provides integration with the [otel4s](https://typelevel.org/otel4s/) library for OpenTelemetry tracing.
+This allows you to create traces for your tapir endpoints using a purely functional API.
+
+`Otel4sTracing` creates a span for each request, extracts context from request headers, and populates spans with relevant metadata (request method, path, status code).
+All spans created as part of the request processing will be properly correlated into a single trace.
+
+For details on context propagation with otel4s, see the [official documentation](https://typelevel.org/otel4s/oteljava/tracing-context-propagation.html).
+
+The interceptor should be added before any others to ensure it handles the request early:
+
+Example using Http4s:
+```scala mdoc:compile-only
+import cats.effect.IO
+import org.typelevel.otel4s.oteljava.OtelJava
+import sttp.tapir.server.http4s.Http4sServerInterpreter
+import sttp.tapir.server.http4s.Http4sServerOptions
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.tracing.otel4sTracing.Otel4sTracing
+
+OtelJava
+  .autoConfigured[IO]()
+  .use { otel4s =>
+    otel4s.tracerProvider.get("tracer-name").flatMap { tracer =>
+      val endpoints: List[ServerEndpoint[Any, IO]] = ???
+      val routes =
+        Http4sServerInterpreter[IO](Http4sServerOptions.default[IO].prependInterceptor(Otel4sTracing(tracer)))
+          .toRoutes(endpoints)
+      // start your server
+      ???
+    }
+  }
+```
+

--- a/doc/server/observability.md
+++ b/doc/server/observability.md
@@ -345,7 +345,7 @@ import org.typelevel.otel4s.oteljava.OtelJava
 import sttp.tapir.server.http4s.Http4sServerInterpreter
 import sttp.tapir.server.http4s.Http4sServerOptions
 import sttp.tapir.server.ServerEndpoint
-import sttp.tapir.server.tracing.otel4sTracing.Otel4sTracing
+import sttp.tapir.server.tracing.otel4s.Otel4sTracing
 
 OtelJava
   .autoConfigured[IO]()

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -69,5 +69,5 @@ object Versions {
   val logback = "1.5.17"
   val slf4j = "2.0.17"
   val jsoniter = "2.33.2"
-  val otel4s = "0.11.2"
+  val otel4s = "0.12.0-RC3"
 }

--- a/tracing/otel4s-tracing/src/main/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracing.scala
+++ b/tracing/otel4s-tracing/src/main/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracing.scala
@@ -1,0 +1,114 @@
+package sttp.tapir.server.tracing.otel4s
+
+import org.typelevel.otel4s.context.propagation.TextMapGetter
+import org.typelevel.otel4s.trace
+import org.typelevel.otel4s.trace.{Span, Tracer}
+import sttp.monad.MonadError
+import sttp.monad.syntax.MonadErrorOps
+import sttp.tapir.AnyEndpoint
+import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.interceptor.RequestResult.{Failure, Response}
+import sttp.tapir.server.interceptor._
+import sttp.tapir.server.interpreter.BodyListener
+import sttp.tapir.server.model.ServerResponse
+
+/** Interceptor which traces requests using otel4s.
+  *
+  * Span names and attributes are calculated using the provided [[Otel4sTracingConfig]].
+  *
+  * To use, customize the interceptors of the server interpreter you are using, and prepend this interceptor, so that it runs as early as
+  * possible, e.g.:
+  *
+  * {{{
+  * OtelJava
+  *   .autoConfigured[IO]()
+  *   .use { otel4s =>
+  *     otel4s.tracerProvider.get("tracer name").flatMap { tracer =>
+  *       def endpoints: List[ServerEndpoint[Any, IO]] = ???
+  *       val routes =
+  *         Http4sServerInterpreter[IO](Http4sServerOptions.default[IO].prependInterceptor(Otel4sTracing(tracing)))
+  *           .toRoutes(endpoints)
+  *        //...
+  *   }
+  * }
+  * }}}
+  * See https://typelevel.org/otel4s/oteljava/tracing-context-propagation.html for details on context propagation.
+  */
+class Otel4sTracing[F[_]](config: Otel4sTracingConfig[F]) extends RequestInterceptor[F] {
+  import config._
+
+  // https://typelevel.org/otel4s/instrumentation/tracing-cross-service-propagation.html
+  implicit private val getter: TextMapGetter[ServerRequest] = new TextMapGetter[ServerRequest] {
+    override def get(carrier: ServerRequest, key: String): Option[String] = carrier.header(key)
+    override def keys(carrier: ServerRequest): Iterable[String] = carrier.headers.map(_.name)
+  }
+
+  override def apply[R, B](
+      responder: Responder[F, B],
+      requestHandler: EndpointInterceptor[F] => RequestHandler[F, R, B]
+  ): RequestHandler[F, R, B] = new RequestHandler[F, R, B] {
+    override def apply(request: ServerRequest, endpoints: List[ServerEndpoint[R, F]])(implicit
+        monad: MonadError[F]
+    ): F[RequestResult[B]] = {
+      tracer.joinOrRoot(request)(
+        tracer
+          .span(spanName(request), requestAttributes(request))
+          .use(span =>
+            (for {
+              requestResult <- requestHandler(knownEndpointInterceptor(request, span))(request, endpoints)
+              _ <- requestResult match {
+                case Response(response) =>
+                  span
+                    .addAttributes(responseAttributes(request, response))
+                    .flatMap(_ =>
+                      if (response.isServerError)
+                        span.setStatus(trace.StatusCode.Error).flatMap(_ => span.addAttributes(errorAttributes(Left(response.code))))
+                      else monad.unit(())
+                    )
+                case Failure(_) => span.addAttributes(noEndpointsMatchAttributes)
+              }
+            } yield requestResult)
+              .handleError { case e: Exception =>
+                span
+                  .setStatus(trace.StatusCode.Error)
+                  .flatMap(_ => span.addAttributes(errorAttributes(Right(e))))
+                  .flatMap(_ => monad.error(e))
+              }
+          )
+      )
+    }
+  }
+
+  private def knownEndpointInterceptor(request: ServerRequest, span: Span[F]) = new EndpointInterceptor[F] {
+    def apply[B](responder: Responder[F, B], endpointHandler: EndpointHandler[F, B]): EndpointHandler[F, B] = new EndpointHandler[F, B] {
+      def onDecodeFailure(
+          ctx: DecodeFailureContext
+      )(implicit monad: MonadError[F], bodyListener: BodyListener[F, B]): F[Option[ServerResponse[B]]] =
+        endpointHandler.onDecodeFailure(ctx).flatMap {
+          case result @ Some(_) => knownEndpoint(ctx.endpoint).map(_ => result)
+          case None             => monad.unit(None)
+        }
+
+      def onDecodeSuccess[A, U, I](
+          ctx: DecodeSuccessContext[F, A, U, I]
+      )(implicit monad: MonadError[F], bodyListener: BodyListener[F, B]): F[ServerResponse[B]] =
+        knownEndpoint(ctx.endpoint).flatMap(_ => endpointHandler.onDecodeSuccess(ctx))
+
+      def onSecurityFailure[A](
+          ctx: SecurityFailureContext[F, A]
+      )(implicit monad: MonadError[F], bodyListener: BodyListener[F, B]): F[ServerResponse[B]] =
+        knownEndpoint(ctx.endpoint).flatMap(_ => endpointHandler.onSecurityFailure(ctx))
+
+      def knownEndpoint(e: AnyEndpoint)(implicit monad: MonadError[F]): F[Unit] = {
+        val (name, attributes) = spanNameFromEndpointAndAttributes(request, e)
+        span.updateName(name).flatMap(_ => span.addAttributes(attributes))
+      }
+    }
+  }
+}
+
+object Otel4sTracing {
+  def apply[F[_]](config: Otel4sTracingConfig[F]): Otel4sTracing[F] = new Otel4sTracing(config)
+  def apply[F[_]](tracer: Tracer[F]): Otel4sTracing[F] = new Otel4sTracing(Otel4sTracingConfig(tracer))
+}

--- a/tracing/otel4s-tracing/src/main/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracingConfig.scala
+++ b/tracing/otel4s-tracing/src/main/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracingConfig.scala
@@ -1,0 +1,115 @@
+package sttp.tapir.server.tracing.otel4s
+
+import io.opentelemetry.semconv.{ErrorAttributes, HttpAttributes, ServerAttributes, UrlAttributes}
+import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.{Attribute, Attributes}
+import sttp.model.headers.{Forwarded, Host}
+import sttp.model.{HeaderNames, StatusCode}
+import sttp.tapir.AnyEndpoint
+import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.model.ServerResponse
+
+/** Configuration for OpenTelemetry Otel4s tracing of server requests, used by [[Otel4sTracing]]. Use the [[apply]] method to override only
+  * some of the configuration options, while using the defaults for the rest.
+  *
+  * The default values follow OpenTelemetry semantic conventions, as described in [their
+  * documentation](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name).
+  *
+  * @param tracer
+  *   The tracer instance to use. To obtain it see https://typelevel.org/otel4s/#getting-started
+  * @param spanName
+  *   Calculates the name of the span, given an incoming request.
+  * @param requestAttributes
+  *   Calculates the attributes of the span, given an incoming request.
+  * @param spanNameFromEndpointAndAttributes
+  *   Calculates an updated name of the span and additional attributes, once (and if) an endpoint is determined to handle the request. By
+  *   default, the span name includes the request's method and the route, which is created by rendering the endpoint's path template.
+  * @param responseAttributes
+  *   Calculates additional attributes of the span, given a response that will be sent back.
+  * @param noEndpointsMatchAttributes
+  *   Calculates additional attributes of the span if no endpoints match the incoming request. By default, this sets the response status to
+  *   404, which mirrors the behavior of most servers. If there are other routes matched by the server after Tapir determines that the
+  *   request matched to any endpoint, this should be set to an empty set of attributes.
+  * @param errorAttributes
+  *   Calculates additional attributes of the span, given an error that occurred while processing the request (an exception); although
+  *   usually, exceptions are translated into 5xx responses earlier in the interceptor chain.
+  */
+case class Otel4sTracingConfig[F[_]](
+    tracer: Tracer[F],
+    spanName: ServerRequest => String,
+    requestAttributes: ServerRequest => Attributes,
+    spanNameFromEndpointAndAttributes: (ServerRequest, AnyEndpoint) => (String, Attributes),
+    responseAttributes: (ServerRequest, ServerResponse[_]) => Attributes,
+    noEndpointsMatchAttributes: Attributes,
+    errorAttributes: Either[StatusCode, Throwable] => Attributes
+)
+
+object Otel4sTracingConfig {
+  def apply[F[_]](
+      tracer: Tracer[F],
+      spanName: ServerRequest => String = Defaults.spanName,
+      requestAttributes: ServerRequest => Attributes = Defaults.requestAttributes,
+      spanNameFromEndpointAndAttributes: (ServerRequest, AnyEndpoint) => (String, Attributes) = Defaults.spanNameFromEndpointAndAttributes,
+      responseAttributes: (ServerRequest, ServerResponse[_]) => Attributes = Defaults.responseAttributes,
+      noEndpointsMatchAttributes: Attributes = Defaults.noEndpointsMatchAttributes,
+      errorAttributes: Either[StatusCode, Throwable] => Attributes = Defaults.errorAttributes
+  ): Otel4sTracingConfig[F] =
+    new Otel4sTracingConfig(
+      tracer,
+      spanName,
+      requestAttributes,
+      spanNameFromEndpointAndAttributes,
+      responseAttributes,
+      noEndpointsMatchAttributes,
+      errorAttributes
+    )
+
+  /** @see
+    *   https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name
+    * @see
+    *   https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server
+    */
+  object Defaults {
+    def spanNameFromEndpointAndAttributes(request: ServerRequest, endpoint: AnyEndpoint): (String, Attributes) = {
+      val route = endpoint.showPathTemplate(showQueryParam = None)
+      val name = s"${request.method.method} $route"
+      (name, Attributes(Attribute(HttpAttributes.HTTP_ROUTE.getKey, route)))
+    }
+
+    def requestAttributes(request: ServerRequest): Attributes = {
+      val hostHeader: String = request
+        .header(HeaderNames.Forwarded)
+        .flatMap(f => Forwarded.parse(f).toOption.flatMap(_.headOption).flatMap(_.host))
+        .orElse(request.header(HeaderNames.XForwardedHost))
+        .orElse(request.header(":authority"))
+        .orElse(request.header(HeaderNames.Host))
+        .getOrElse("unknown")
+
+      val (host, _) = Host.parseHostAndPort(hostHeader)
+
+      Attributes(
+        Attribute(HttpAttributes.HTTP_REQUEST_METHOD.getKey, request.method.method),
+        Attribute(UrlAttributes.URL_PATH.getKey, request.uri.pathToString),
+        Attribute(UrlAttributes.URL_SCHEME.getKey, request.uri.scheme.getOrElse("http")),
+        Attribute(ServerAttributes.SERVER_ADDRESS.getKey, host)
+      )
+    }
+
+    def spanName(request: ServerRequest): String = s"${request.method.method}"
+
+    def responseAttributes(request: ServerRequest, response: ServerResponse[_]): Attributes =
+      Attributes(Attribute(HttpAttributes.HTTP_RESPONSE_STATUS_CODE.getKey, response.code.code.toLong))
+
+    val noEndpointsMatchAttributes: Attributes =
+      Attributes(Attribute(HttpAttributes.HTTP_RESPONSE_STATUS_CODE.getKey, StatusCode.NotFound.code.toLong))
+
+    def errorAttributes(e: Either[StatusCode, Throwable]): Attributes = Attributes(e match {
+      case Left(statusCode) =>
+        // see footnote for error.type
+        Attribute(ErrorAttributes.ERROR_TYPE.getKey, statusCode.code.toString)
+      case Right(exception) =>
+        val errorType = exception.getClass.getSimpleName
+        Attribute(ErrorAttributes.ERROR_TYPE.getKey, errorType)
+    })
+  }
+}

--- a/tracing/otel4s-tracing/src/test/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracingTest.scala
+++ b/tracing/otel4s-tracing/src/test/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracingTest.scala
@@ -1,0 +1,142 @@
+package sttp.tapir.server.tracing.otel4s
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.sdk.trace.data.SpanData
+import io.opentelemetry.semconv.{HttpAttributes, ServerAttributes, UrlAttributes}
+import org.scalatest.compatible.Assertion
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.typelevel.otel4s.oteljava.testkit.OtelJavaTestkit
+import sttp.capabilities.Streams
+import sttp.model.*
+import sttp.model.Uri.*
+import sttp.model.headers.Forwarded
+import sttp.monad.MonadError
+import sttp.tapir.*
+import sttp.tapir.TestUtil.serverRequestFromUri
+import sttp.tapir.capabilities.NoStreams
+import sttp.tapir.integ.cats.effect.CatsMonadError
+import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.TestUtil.StringToResponseBody
+import sttp.tapir.server.interpreter.*
+
+import scala.util.{Success, Try}
+
+class Otel4sTracingTest extends AsyncFlatSpec with Matchers {
+  implicit val bodyListener: BodyListener[IO, String] = new BodyListener[IO, String] {
+    override def onComplete(body: String)(cb: Try[Unit] => IO[Unit]): IO[String] = cb(Success(())).map(_ => body)
+  }
+  implicit val ioErr: MonadError[IO] = new CatsMonadError[IO]()
+
+  def testEndpointWithSpan(endpoint: ServerEndpoint[Any, IO], request: ServerRequest)(verify: SpanData => Assertion): IO[Assertion] =
+    OtelJavaTestkit
+      // these are the default propagators when no propagators are specified via env
+      // https://typelevel.org/otel4s/instrumentation/tracing-cross-service-propagation.html
+      .inMemory[IO](textMapPropagators = List(W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance()))
+      .use(testkit =>
+        for {
+          tracer <- testkit.tracerProvider.get("Test Tracer")
+          interpreter = new ServerInterpreter[Any, IO, String, NoStreams](
+            _ => List(endpoint),
+            IOTestRequestBody,
+            StringToResponseBody,
+            List(Otel4sTracing(Otel4sTracingConfig(tracer))),
+            _ => IO.pure(())
+          )
+          _ <- interpreter(request)
+          spans <- testkit.finishedSpans
+        } yield {
+          spans should have size 1
+          verify(spans.head)
+        }
+      )
+
+  it should "report a simple trace" in {
+    testEndpointWithSpan(
+      endpoint
+        .in("person")
+        .in(query[String]("name"))
+        .out(stringBody)
+        .errorOut(stringBody)
+        .serverLogic[IO](_ => IO(Right("hello"))),
+      serverRequestFromUri(uri"http://example.com/person?name=Adam")
+    ) { span =>
+      span.getName shouldBe "GET /person"
+      span.getAttributes.get(HttpAttributes.HTTP_RESPONSE_STATUS_CODE) shouldBe 200L
+      span.getAttributes.get(UrlAttributes.URL_PATH) shouldBe "/person"
+    }.unsafeToFuture()
+  }
+
+  it should "report a 404 span when the endpoint is not found" in {
+    testEndpointWithSpan(
+      endpoint
+        .in("person")
+        .out(stringBody)
+        .errorOut(stringBody)
+        .serverLogic[IO](_ => IO(Right("hello"))),
+      serverRequestFromUri(uri"http://example.com/other")
+    ) { span =>
+      span.getName shouldBe "GET"
+      span.getAttributes.get(HttpAttributes.HTTP_RESPONSE_STATUS_CODE) shouldBe 404L
+      span.getAttributes.get(UrlAttributes.URL_PATH) shouldBe "/other"
+    }.unsafeToFuture()
+  }
+
+  it should "use the rendered path template as the span name" in {
+    testEndpointWithSpan(
+      endpoint
+        .in("person" / path[String]("name") / path[String]("surname") / "info")
+        .out(stringBody)
+        .errorOut(stringBody)
+        .serverLogic[IO](_ => IO(Right("hello"))),
+      serverRequestFromUri(uri"http://example.com/person/Adam/Smith/info")
+    ) { span =>
+      span.getName shouldBe "GET /person/{name}/{surname}/info"
+      span.getAttributes.get(HttpAttributes.HTTP_RESPONSE_STATUS_CODE) shouldBe 200L
+      span.getAttributes.get(UrlAttributes.URL_PATH) shouldBe "/person/Adam/Smith/info"
+    }.unsafeToFuture()
+  }
+
+  it should "use the host from the forwarded header" in {
+    testEndpointWithSpan(
+      endpoint
+        .in("person")
+        .in(query[String]("name"))
+        .out(stringBody)
+        .errorOut(stringBody)
+        .serverLogic[IO](_ => IO(Right("hello"))),
+      serverRequestFromUri(
+        uri"http://example.com/person?name=Adam",
+        _headers = List(Header(HeaderNames.Forwarded, Forwarded(None, None, Some("softwaremill.com"), None).toString))
+      )
+    ) { span =>
+      span.getAttributes.get(ServerAttributes.SERVER_ADDRESS) shouldBe "softwaremill.com"
+    }.unsafeToFuture()
+  }
+
+  it should "extract the context attributes from the headers" in {
+    testEndpointWithSpan(
+      endpoint
+        .in("hello")
+        .out(stringBody)
+        .errorOut(stringBody)
+        .serverLogic[IO](_ => IO(Right("hello"))),
+      serverRequestFromUri(
+        uri"http://example.com/hello",
+        _headers = List(Header("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"))
+      )
+    ) { span =>
+      span.getTraceId shouldBe "4bf92f3577b34da6a3ce929d0e0e4736"
+    }.unsafeToFuture()
+  }
+}
+
+object IOTestRequestBody extends RequestBody[IO, NoStreams] {
+  override def toRaw[R](serverRequest: ServerRequest, bodyType: RawBodyType[R], maxBytes: Option[Long]): IO[RawValue[R]] = ???
+  override val streams: Streams[NoStreams] = NoStreams
+  override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = ???
+}

--- a/tracing/otel4s-tracing/src/test/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracingTest.scala
+++ b/tracing/otel4s-tracing/src/test/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracingTest.scala
@@ -11,18 +11,18 @@ import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.typelevel.otel4s.oteljava.testkit.OtelJavaTestkit
 import sttp.capabilities.Streams
-import sttp.model.*
-import sttp.model.Uri.*
+import sttp.model._
+import sttp.model.Uri._
 import sttp.model.headers.Forwarded
 import sttp.monad.MonadError
-import sttp.tapir.*
+import sttp.tapir._
 import sttp.tapir.TestUtil.serverRequestFromUri
 import sttp.tapir.capabilities.NoStreams
 import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.TestUtil.StringToResponseBody
-import sttp.tapir.server.interpreter.*
+import sttp.tapir.server.interpreter._
 
 import scala.util.{Success, Try}
 


### PR DESCRIPTION
# Adding otel4s OpenTelemetry integration for Tapir

This PR adds support for OpenTelemetry integration with Tapir using the [otel4s](https://typelevel.org/otel4s/) library.

It adds a new module `tapir-otel4s-tracing` which is highly inspired by the existing `tapir-opentelemetry-tracing` module.
It fullfils the same testuite.

## Implementation Details
- `Otel4sTracing` - Main interceptor class that handles span creation and management
- `Otel4sTracingConfig` - Configuration class for customizing span names and attributes
- Proper error handling and status code reporting
- Support for W3C context propagation

This closes https://github.com/softwaremill/tapir/issues/4427.

Due [to](https://typelevel.org/otel4s/oteljava/tracing-context-propagation.html):
> Cats Effect 3.6.0 introduced a new method of fiber context tracking, which can be integrated almost seamlessly with the OpenTelemetry Java SDK.

Should this wait until otels4s `0.12.0` is released?

