### PR TITLE
Codegen: serialize inline enums on schema definitions as strings when using jsoniter

### DIFF
--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -88,11 +88,20 @@ object TapirGeneratedEndpoints {
     d: Option[Double] = None
   ) extends ADTWithDiscriminator with ADTWithDiscriminatorNoMapping
   case class SubtypeWithoutD3 (
+    absent: Option[String] = None,
     s: String,
     i: Option[Int] = None,
-    e: Option[AnEnum] = None,
-    absent: Option[String] = None
+    e2: Option[SubtypeWithoutD3E2] = None,
+    e: Option[AnEnum] = None
   ) extends ADTWithoutDiscriminator
+
+  sealed trait SubtypeWithoutD3E2 extends enumeratum.EnumEntry
+  object SubtypeWithoutD3E2 extends enumeratum.Enum[SubtypeWithoutD3E2] {
+    val values = findValues
+    case object A extends SubtypeWithoutD3E2
+    case object B extends SubtypeWithoutD3E2
+    case object C extends SubtypeWithoutD3E2
+  }
   case class SubtypeWithoutD2 (
     a: Seq[String],
     absent: Option[String] = None
@@ -131,6 +140,8 @@ object TapirGeneratedEndpoints {
     foo: String,
     bar: Option[java.util.UUID] = None
   )
+
+
 
   type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
   lazy val putAdtTest: PutAdtTestEndpoint =

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/JsonRoundtrip.scala
@@ -77,8 +77,8 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
       val reqJsonBody = writeToString(reqBody)
       val respBody = SubtypeWithoutD3(s = "a string+SubtypeWithoutD3", i = Some(123), e = Some(AnEnum.Foo), e2 = Some(SubtypeWithoutD3E2.A))
       val respJsonBody = writeToString(respBody)
-      reqJsonBody shouldEqual """{"s":"a string","i":123,"e":"Foo","e2":"A"}"""
-      respJsonBody shouldEqual """{"s":"a string+SubtypeWithoutD3","i":123,"e":"Foo","e2":"A"}"""
+      reqJsonBody shouldEqual """{"s":"a string","i":123,"e2":"A","e":"Foo"}"""
+      respJsonBody shouldEqual """{"s":"a string+SubtypeWithoutD3","i":123,"e2":"A","e":"Foo"}"""
       Await.result(
         sttp.client3.basicRequest
           .put(uri"http://test.com/adt/test")

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/JsonRoundtrip.scala
@@ -6,6 +6,7 @@ import sttp.client3.UriContext
 import sttp.client3.testing.SttpBackendStub
 import sttp.tapir.generated.{TapirGeneratedEndpoints, TapirGeneratedEndpointsJsonSerdes}
 import TapirGeneratedEndpointsJsonSerdes._
+import sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithoutD3E2.A
 import sttp.tapir.generated.TapirGeneratedEndpoints._
 import sttp.tapir.server.stub.TapirStubInterpreter
 
@@ -20,7 +21,9 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
         Future successful Right[Unit, ADTWithoutDiscriminator](SubtypeWithoutD1(foo.s + "+SubtypeWithoutD1", foo.i, foo.a))
       case foo: SubtypeWithoutD2 => Future successful Right[Unit, ADTWithoutDiscriminator](SubtypeWithoutD2(foo.a :+ "+SubtypeWithoutD2"))
       case foo: SubtypeWithoutD3 =>
-        Future successful Right[Unit, ADTWithoutDiscriminator](SubtypeWithoutD3(foo.s + "+SubtypeWithoutD3", foo.i, foo.e))
+        Future successful Right[Unit, ADTWithoutDiscriminator](
+          SubtypeWithoutD3(s = foo.s + "+SubtypeWithoutD3", i = foo.i, e = foo.e, e2 = foo.e2)
+        )
     })
 
     val stub = TapirStubInterpreter(SttpBackendStub.asynchronousFuture)
@@ -70,12 +73,12 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
     }
 
     locally {
-      val reqBody = SubtypeWithoutD3("a string", Some(123), Some(AnEnum.Foo))
+      val reqBody = SubtypeWithoutD3(s = "a string", i = Some(123), e = Some(AnEnum.Foo), e2 = Some(SubtypeWithoutD3E2.A))
       val reqJsonBody = writeToString(reqBody)
-      val respBody = SubtypeWithoutD3("a string+SubtypeWithoutD3", Some(123), Some(AnEnum.Foo))
+      val respBody = SubtypeWithoutD3(s = "a string+SubtypeWithoutD3", i = Some(123), e = Some(AnEnum.Foo), e2 = Some(SubtypeWithoutD3E2.A))
       val respJsonBody = writeToString(respBody)
-      reqJsonBody shouldEqual """{"s":"a string","i":123,"e":"Foo"}"""
-      respJsonBody shouldEqual """{"s":"a string+SubtypeWithoutD3","i":123,"e":"Foo"}"""
+      reqJsonBody shouldEqual """{"s":"a string","i":123,"e":"Foo","e2":"A"}"""
+      respJsonBody shouldEqual """{"s":"a string+SubtypeWithoutD3","i":123,"e":"Foo","e2":"A"}"""
       Await.result(
         sttp.client3.basicRequest
           .put(uri"http://test.com/adt/test")

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
@@ -303,6 +303,12 @@ components:
           type: integer
         e:
           $ref: '#/components/schemas/AnEnum'
+        e2:
+          type: string
+          enum:
+            - A
+            - B
+            - C
         absent:
           type: string
     AnEnum:


### PR DESCRIPTION
Not supporting recursion down to enums defined on further-inlined objects here. Just at top level of the schema. Previously would've looked something like `{"type":"A"}` instead of `"A"`