### PR TITLE
Codegen: oauth2 security schemas support

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -5,6 +5,7 @@ import cats.syntax.either._
 import OpenapiSchemaType.OpenapiSchemaRef
 import io.circe.Json
 import sttp.tapir.codegen.BasicGenerator.strippedToCamelCase
+import sttp.tapir.codegen.util.MapUtils
 // https://swagger.io/specification/
 object OpenapiModels {
 
@@ -45,7 +46,7 @@ object OpenapiModels {
       parameters: Seq[Resolvable[OpenapiParameter]],
       responses: Seq[OpenapiResponse],
       requestBody: Option[OpenapiRequestBody],
-      security: Seq[Seq[String]] = Nil,
+      security: Map[String, Seq[String]] = Map.empty,
       summary: Option[String] = None,
       tags: Option[Seq[String]] = None,
       operationId: Option[String] = None,
@@ -194,7 +195,9 @@ object OpenapiModels {
         parameters,
         responses,
         requestBody,
-        security.map(_.keys.toSeq),
+        // This probably isn't the right semantics -- since it's a list of name-array pairs rather than a map, I assume
+        // that the intended semantics are DNF. But we don't do anything with the scopes anyway for now.
+        security.foldLeft(Map.empty[String, Seq[String]])(MapUtils.merge),
         summary,
         tags,
         operationId,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSecuritySchemeType.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSecuritySchemeType.scala
@@ -6,6 +6,13 @@ object OpenapiSecuritySchemeType {
   case object OpenapiSecuritySchemeBearerType extends OpenapiSecuritySchemeType
   case object OpenapiSecuritySchemeBasicType extends OpenapiSecuritySchemeType
   case class OpenapiSecuritySchemeApiKeyType(in: String, name: String) extends OpenapiSecuritySchemeType
+  case class OpenapiSecuritySchemeOAuth2Type(flows: Map[OAuth2FlowType.OAuth2FlowType, OAuth2Flow]) extends OpenapiSecuritySchemeType
+
+  object OAuth2FlowType extends Enumeration {
+    val authorizationCode, `implicit`, password, clientCredentials = Value
+    type OAuth2FlowType = Value
+  }
+  case class OAuth2Flow(authorizationUrl: Option[String], tokenUrl: Option[String], refreshUrl: Option[String], scopes: Map[String, String])
 
   import io.circe._
   import cats.implicits._
@@ -40,10 +47,42 @@ object OpenapiSecuritySchemeType {
     }
   }
 
+  private implicit val OAuth2FlowDecoder: Decoder[OAuth2Flow] = { (c: HCursor) =>
+    for {
+      a <- c.get[Option[String]]("authorizationUrl")
+      t <- c.get[Option[String]]("tokenUrl")
+      r <- c.get[Option[String]]("refreshUrl")
+      s <- c.get[Map[String, String]]("scopes")
+    } yield {
+      OAuth2Flow(a, t, r, s)
+    }
+  }
+
+  private implicit val OpenapiSecuritySchemeOAuth2TypeDecoder: Decoder[OpenapiSecuritySchemeOAuth2Type] = { (c: HCursor) =>
+    for {
+      fs <- c
+        .get[JsonObject]("flows")
+        .ensure(DecodingFailure("Only authorizationCode, implicit, password and clientCredentials flows are supported", c.history))(
+          _.keys.toSet.--(Set("authorizationCode", "implicit", "password", "clientCredentials")).isEmpty
+        )
+      parsedFs <- fs.toMap.toList
+        .traverse {
+          case ("authorizationCode", v) => v.as[OAuth2Flow].map(OAuth2FlowType.authorizationCode -> _)
+          case ("implicit", v)          => v.as[OAuth2Flow].map(OAuth2FlowType.`implicit` -> _)
+          case ("password", v)          => v.as[OAuth2Flow].map(OAuth2FlowType.password -> _)
+          case ("clientCredentials", v) => v.as[OAuth2Flow].map(OAuth2FlowType.clientCredentials -> _)
+        }
+        .map(_.toMap)
+    } yield {
+      OpenapiSecuritySchemeOAuth2Type(parsedFs)
+    }
+  }
+
   implicit val OpenapiSecuritySchemeTypeDecoder: Decoder[OpenapiSecuritySchemeType] =
     List[Decoder[OpenapiSecuritySchemeType]](
       Decoder[OpenapiSecuritySchemeBearerType.type].widen,
       Decoder[OpenapiSecuritySchemeBasicType.type].widen,
-      Decoder[OpenapiSecuritySchemeApiKeyType].widen
+      Decoder[OpenapiSecuritySchemeApiKeyType].widen,
+      Decoder[OpenapiSecuritySchemeOAuth2Type].widen
     ).reduceLeft(_ or _)
 }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/util/MapUtils.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/util/MapUtils.scala
@@ -1,0 +1,12 @@
+package sttp.tapir.codegen.util
+
+object MapUtils {
+
+  def merge[A, B](m1: Map[A, Seq[B]], m2: Map[A, Seq[B]]): Map[A, Seq[B]] =
+    m2.iterator.foldLeft(m1) { case (m, (k, v)) =>
+      m.get(k) match {
+        case Some(value) => m + (k -> (value ++ v))
+        case None => m + (k -> v)
+      }
+    }
+}

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -91,7 +91,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               parameters = Seq(),
               responses = Seq(),
               requestBody = None,
-              security = Seq(Seq("httpBearer")),
+              security = Map("httpBearer" -> Seq()),
               summary = None,
               tags = None
             ),
@@ -100,7 +100,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               parameters = Seq(),
               responses = Seq(),
               requestBody = None,
-              security = Seq(Seq("httpBasic")),
+              security = Map("httpBasic" -> Seq()),
               summary = None,
               tags = None
             ),
@@ -109,7 +109,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               parameters = Seq(),
               responses = Seq(),
               requestBody = None,
-              security = Seq(Seq("apiKeyHeader")),
+              security = Map("httpBearer" -> Seq()),
               summary = None,
               tags = None
             ),
@@ -118,7 +118,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               parameters = Seq(),
               responses = Seq(),
               requestBody = None,
-              security = Seq(Seq("apiKeyCookie")),
+              security = Map("apiKeyCookie" -> Seq()),
               summary = None,
               tags = None
             ),
@@ -127,7 +127,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               parameters = Seq(),
               responses = Seq(),
               requestBody = None,
-              security = Seq(Seq("apiKeyQuery")),
+              security = Map("apiKeyQuery" -> Seq()),
               summary = None,
               tags = None
             )

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -495,7 +495,7 @@ object TestHelpers {
             parameters = Seq(),
             responses = Seq(),
             requestBody = None,
-            security = Seq(Seq("basicAuth"))
+            security = Map("basicAuth" -> Nil)
           )
         )
       )
@@ -531,7 +531,7 @@ object TestHelpers {
             parameters = Seq(),
             responses = Seq(),
             requestBody = None,
-            security = Seq(Seq("bearerAuth"), Seq("basicAuth", "apiKeyAuth"))
+            security = Map("bearerAuth" -> Nil, "basicAuth" -> Nil, "apiKeyAuth" -> Nil)
           )
         )
       )
@@ -759,7 +759,7 @@ object TestHelpers {
                 List(OpenapiRequestBodyContent("application/json", OpenapiSchemaRef("#/components/schemas/ReqWithDefaults")))
               )
             ),
-            List(),
+            Map.empty,
             None,
             None,
             None
@@ -1052,7 +1052,7 @@ object TestHelpers {
                 List(OpenapiRequestBodyContent("application/json", OpenapiSchemaRef("#/components/schemas/ReqWithVariants")))
               )
             ),
-            List(),
+            Map.empty,
             None,
             None,
             None

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -12,6 +12,8 @@ object TapirGeneratedEndpoints {
   import sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes._
   import TapirGeneratedEndpointsSchemas._
 
+
+
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
   trait ExtraParamSupport[T] {
@@ -105,11 +107,9 @@ object TapirGeneratedEndpoints {
     e: Option[AnEnum] = None,
     absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
-
   case class NullableThingy2 (
     uuid: java.util.UUID
   )
-
   case class ObjectWithInlineEnum (
     id: java.util.UUID,
     inlineEnum: ObjectWithInlineEnumInlineEnum = ObjectWithInlineEnumInlineEnum.foo3
@@ -160,18 +160,20 @@ object TapirGeneratedEndpoints {
 
 
 
-  type GetBinaryTestEndpoint = Endpoint[Unit, Unit, Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
+  type GetBinaryTestEndpoint = Endpoint[String, Unit, Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
   lazy val getBinaryTest: GetBinaryTestEndpoint =
     endpoint
       .get
       .in(("binary" / "test"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
       .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Array[Byte]], CodecFormat.OctetStream()).description("Response CSV body"))
 
-  type PostBinaryTestEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, Unit, String, sttp.capabilities.pekko.PekkoStreams]
+  type PostBinaryTestEndpoint = Endpoint[String, sttp.capabilities.pekko.PekkoStreams.BinaryStream, Unit, String, sttp.capabilities.pekko.PekkoStreams]
   lazy val postBinaryTest: PostBinaryTestEndpoint =
     endpoint
       .post
       .in(("binary" / "test"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
       .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Array[Byte]], CodecFormat.OctetStream()))
       .out(jsonBody[String].description("successful operation"))
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -165,7 +165,7 @@ object TapirGeneratedEndpoints {
     endpoint
       .get
       .in(("binary" / "test"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .securityIn(auth.bearer[String]())
       .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Array[Byte]], CodecFormat.OctetStream()).description("Response CSV body"))
 
   type PostBinaryTestEndpoint = Endpoint[String, sttp.capabilities.pekko.PekkoStreams.BinaryStream, Unit, String, sttp.capabilities.pekko.PekkoStreams]
@@ -201,11 +201,12 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[ADTWithoutDiscriminator])
       .out(jsonBody[ADTWithoutDiscriminator].description("successful operation"))
 
-  type PostAdtTestEndpoint = Endpoint[Unit, ADTWithDiscriminatorNoMapping, Unit, ADTWithDiscriminator, Any]
+  type PostAdtTestEndpoint = Endpoint[String, ADTWithDiscriminatorNoMapping, Unit, ADTWithDiscriminator, Any]
   lazy val postAdtTest: PostAdtTestEndpoint =
     endpoint
       .post
       .in(("adt" / "test"))
+      .securityIn(auth.apiKey(header[String]("api_key")))
       .in(jsonBody[ADTWithDiscriminatorNoMapping])
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -9,6 +9,10 @@ tags: [ ]
 paths:
   '/binary/test':
     get:
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
       responses:
         "200":
           description: "Response CSV body"
@@ -35,6 +39,10 @@ paths:
               description: "csv file"
               type: string
               format: binary
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
   '/optional/test':
     post:
       responses:
@@ -299,6 +307,19 @@ paths:
 
 
 components:
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://petstore3.swagger.io/oauth/authorize
+          scopes:
+            "write:pets": modify pets in your account
+            "read:pets": read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
   schemas:
     ADTWithDiscriminator:
       type: object

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -13,6 +13,7 @@ paths:
         - petstore_auth:
             - write:pets
             - read:pets
+        - BearerAuth: [ ]
       responses:
         "200":
           description: "Response CSV body"
@@ -76,6 +77,8 @@ paths:
               $ref: '#/components/schemas/NotNullableThingy'
   '/adt/test':
     post:
+      security:
+        - api_key: []
       responses:
         '200':
           description: successful operation
@@ -320,6 +323,10 @@ components:
       type: apiKey
       name: api_key
       in: header
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     ADTWithDiscriminator:
       type: object


### PR DESCRIPTION
Supports oauth2 flow security schema declarations. Also supports multiple security declarations on an endpoint, as long as they all reasolve to bearer auth (which is not enough to support the petstore yaml yet because that declares api_key and oauth2 security on the same endpoint, but still deals with some real-world cases such as defining both oauth2 and bearer auth schemas on the same endpoint).

Doesn't yet do anything with scopes. Not sure what would be useful there. What might be cool would be some sort of static typing on the security token so you had a `case class Token[Scope1 & Scope2](value: String)` and then require the type param to be a subset of required scopes? Could also be a nightmare. I haven't really played with the idea yet though and I'm deeming it out-of-scope (haha. Puns!)