### PR TITLE
codegen: support components/requestBodies and components/responses

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -192,7 +192,8 @@ object BasicGenerator {
     val customTypes = doc.paths
       .flatMap(
         _.methods.flatMap(m =>
-          m.requestBody.toSeq.flatMap(_.content.map(_.contentType)) ++ m.responses.flatMap(_.content.map(_.contentType))
+          m.requestBody.toSeq.flatMap(_.resolve(doc).content.map(_.contentType)) ++
+            m.responses.flatMap(_.resolve(doc).content.map(_.contentType))
         )
       )
       .distinct

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
@@ -112,11 +112,11 @@ object JsonSerdeGenerator {
   private def inlineEndpointSchemas(doc: OpenapiDocument): Seq[(String, OpenapiSchemaType, Boolean)] =
     doc.paths.flatMap(p =>
       p.methods.flatMap(m =>
-        m.responses
+        m.responses.map(_.resolve(doc))
           .flatMap(_.content)
           .filter(o => o.contentType == "application/json" && o.schema.isInstanceOf[OpenapiSchemaObject])
           .map(c => (m.name(p.url).capitalize + "Response", c.schema, true)) ++
-          m.requestBody.toSeq
+          m.requestBody.toSeq.map(_.resolve(doc))
             .flatMap(_.content)
             .filter(o => o.contentType == "application/json" && o.schema.isInstanceOf[OpenapiSchemaObject])
             .map(c => (m.name(p.url).capitalize + "Request", c.schema, true))

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
@@ -5,7 +5,9 @@ import OpenapiModels.OpenapiParameter
 case class OpenapiComponent(
     schemas: Map[String, OpenapiSchemaType],
     securitySchemes: Map[String, OpenapiSecuritySchemeType] = Map.empty,
-    parameters: Map[String, OpenapiParameter] = Map.empty
+    parameters: Map[String, OpenapiParameter] = Map.empty,
+    responses: Map[String, OpenapiResponseDefn] = Map.empty,
+    requestBodies: Map[String, OpenapiRequestBody] = Map.empty
 )
 
 object OpenapiComponent {
@@ -16,11 +18,15 @@ object OpenapiComponent {
       schemas <- c.getOrElse[Map[String, OpenapiSchemaType]]("schemas")(Map.empty)
       securitySchemes <- c.getOrElse[Map[String, OpenapiSecuritySchemeType]]("securitySchemes")(Map.empty)
       parameters <- c.getOrElse[Map[String, OpenapiParameter]]("parameters")(Map.empty)
+      responses <- c.getOrElse[Map[String, OpenapiResponseDefn]]("responses")(Map.empty)
+      requestBodies <- c.getOrElse[Map[String, OpenapiRequestBody]]("requestBodies")(Map.empty)
     } yield {
       OpenapiComponent(
         schemas,
         securitySchemes,
-        parameters.map { case (k, v) => s"#/components/parameters/$k" -> v }
+        parameters.map { case (k, v) => s"#/components/parameters/$k" -> v },
+        responses,
+        requestBodies
       )
     }
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -96,7 +96,7 @@ object OpenapiModels {
       code: String,
       $ref: OpenapiSchemaRef
   ) extends OpenapiResponse {
-    def strippedRef: String = $ref.name.stripPrefix("#/components/responses")
+    def strippedRef: String = $ref.name.stripPrefix("#/components/responses/")
     def resolve(doc: OpenapiDocument): OpenapiResponseDef =
       doc.components
         .flatMap(_.responses.get(strippedRef))
@@ -117,7 +117,7 @@ object OpenapiModels {
   case class OpenapiRequestRef(
       $ref: OpenapiSchemaRef
   ) extends OpenapiRequestBody {
-    def strippedRef: String = $ref.name.stripPrefix("#/components/requestBodies")
+    def strippedRef: String = $ref.name.stripPrefix("#/components/requestBodies/")
     def resolve(doc: OpenapiDocument): OpenapiRequestBodyDefn =
       doc.components
         .flatMap(_.requestBodies.get(strippedRef))

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiReqResp.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiReqResp.scala
@@ -1,0 +1,38 @@
+package sttp.tapir.codegen.openapi.models
+
+import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiRequestBodyContent, OpenapiResponseContent}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.OpenapiSchemaRef
+
+case class OpenapiResponseDefn(
+    description: String,
+    headers: Map[String, OpenapiSchemaRef],
+    content: Seq[OpenapiResponseContent]
+)
+
+object OpenapiResponseDefn {
+  import io.circe._
+  implicit val OpenapiResponseDefnDecoder: Decoder[OpenapiResponseDefn] = { (c: HCursor) =>
+    for {
+      description <- c.downField("description").as[String]
+      headers <- c.getOrElse[Map[String, OpenapiSchemaRef]]("headers")(Map.empty)
+      content <- c.getOrElse[Seq[OpenapiResponseContent]]("content")(Nil)
+    } yield OpenapiResponseDefn(description, headers, content)
+  }
+}
+
+case class OpenapiRequestBody(
+    description: String,
+    content: Seq[OpenapiRequestBodyContent],
+    required: Boolean
+)
+
+object OpenapiRequestBody {
+  import io.circe._
+  implicit val OpenapiRequestBodyDecoder: Decoder[OpenapiRequestBody] = { (c: HCursor) =>
+    for {
+      description <- c.downField("description").as[String]
+      content <- c.getOrElse[Seq[OpenapiRequestBodyContent]]("content")(Nil)
+      required <- c.getOrElse[Boolean]("required")(false)
+    } yield OpenapiRequestBody(description, content, required)
+  }
+}

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -8,14 +8,16 @@ import sttp.tapir.codegen.openapi.models.OpenapiModels.{
   OpenapiPathMethod,
   OpenapiRequestBody,
   OpenapiRequestBodyContent,
+  OpenapiRequestBodyDefn,
   OpenapiResponse,
   OpenapiResponseContent,
+  OpenapiResponseDef,
   Resolved
 }
 import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType.{
-  OpenapiSecuritySchemeBearerType,
+  OpenapiSecuritySchemeApiKeyType,
   OpenapiSecuritySchemeBasicType,
-  OpenapiSecuritySchemeApiKeyType
+  OpenapiSecuritySchemeBearerType
 }
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaArray,
@@ -45,12 +47,12 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
                 Resolved(OpenapiParameter("jkl-id", "header", Some(false), None, OpenapiSchemaString(false)))
               ),
               responses = Seq(
-                OpenapiResponse(
+                OpenapiResponseDef(
                   "200",
                   "",
                   Seq(OpenapiResponseContent("application/json", OpenapiSchemaArray(OpenapiSchemaString(false), false)))
                 ),
-                OpenapiResponse("default", "", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false))))
+                OpenapiResponseDef("default", "", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false))))
               ),
               requestBody = None,
               summary = None,
@@ -174,8 +176,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               methodType = "get",
               parameters = Seq(Resolved(OpenapiParameter("id", "path", Some(true), None, OpenapiSchemaString(true)))),
               responses = Seq(
-                OpenapiResponse("202", "Processing", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false)))),
-                OpenapiResponse("404", "couldn't find thing", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false))))
+                OpenapiResponseDef("202", "Processing", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false)))),
+                OpenapiResponseDef("404", "couldn't find thing", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false))))
               ),
               requestBody = None,
               summary = None,
@@ -190,8 +192,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               methodType = "get",
               parameters = Seq(Resolved(OpenapiParameter("id", "path", Some(true), None, OpenapiSchemaString(true)))),
               responses = Seq(
-                OpenapiResponse("204", "No body", Nil),
-                OpenapiResponse("403", "Not authorised", Nil)
+                OpenapiResponseDef("204", "No body", Nil),
+                OpenapiResponseDef("403", "Not authorised", Nil)
               ),
               requestBody = None,
               summary = None,
@@ -238,9 +240,9 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
             OpenapiPathMethod(
               methodType = "post",
               parameters = Seq(),
-              responses = Seq(OpenapiResponse("204", "No body", Nil)),
+              responses = Seq(OpenapiResponseDef("204", "No body", Nil)),
               requestBody = Some(
-                OpenapiRequestBody(
+                OpenapiRequestBodyDefn(
                   required = true,
                   description = None,
                   content = Seq(

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -177,13 +177,13 @@ object TestHelpers {
               Resolved(OpenapiParameter("X-Auth-Token", "header", Some(true), None, OpenapiSchemaString(false)))
             ),
             responses = Seq(
-              OpenapiResponse(
+              OpenapiResponseDef(
                 "200",
                 "",
                 Seq(OpenapiResponseContent("application/json", OpenapiSchemaArray(OpenapiSchemaRef("#/components/schemas/Book"), false)))
               ),
-              OpenapiResponse("401", "unauthorized", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false)))),
-              OpenapiResponse("default", "", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false))))
+              OpenapiResponseDef("401", "unauthorized", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false)))),
+              OpenapiResponseDef("default", "", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false))))
             ),
             requestBody = None,
             summary = None,
@@ -194,7 +194,7 @@ object TestHelpers {
             methodType = "put",
             parameters = Nil,
             responses = Seq(
-              OpenapiResponse("200", "returns some html", Seq(OpenapiResponseContent("text/html", OpenapiSchemaString(false))))
+              OpenapiResponseDef("200", "returns some html", Seq(OpenapiResponseContent("text/html", OpenapiSchemaString(false))))
             ),
             requestBody = None,
             summary = None,
@@ -211,14 +211,14 @@ object TestHelpers {
               Resolved(OpenapiParameter("X-Auth-Token", "header", Some(true), None, OpenapiSchemaString(false)))
             ),
             responses = Seq(
-              OpenapiResponse(
+              OpenapiResponseDef(
                 "200",
                 "",
                 Seq(OpenapiResponseContent("application/json", OpenapiSchemaArray(OpenapiSchemaRef("#/components/schemas/Book"), false)))
               )
             ),
             requestBody = Option(
-              OpenapiRequestBody(
+              OpenapiRequestBodyDefn(
                 required = true,
                 content = Seq(
                   OpenapiRequestBodyContent(
@@ -237,8 +237,8 @@ object TestHelpers {
             methodType = "delete",
             parameters = Nil,
             responses = Seq(
-              OpenapiResponse("200", "deletion was successful", Nil),
-              OpenapiResponse("default", "deletion failed", Nil)
+              OpenapiResponseDef("200", "deletion was successful", Nil),
+              OpenapiResponseDef("default", "deletion failed", Nil)
             ),
             requestBody = None,
             summary = None,
@@ -346,12 +346,12 @@ object TestHelpers {
               Resolved(OpenapiParameter("name", "query", Some(true), None, OpenapiSchemaString(false)))
             ),
             responses = Seq(
-              OpenapiResponse(
+              OpenapiResponseDef(
                 "200",
                 "",
                 Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false)))
               ),
-              OpenapiResponse(
+              OpenapiResponseDef(
                 code = "400",
                 description = "Invalid value for: query parameter name",
                 content = Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false)))
@@ -371,7 +371,7 @@ object TestHelpers {
             methodType = "get",
             parameters = Seq(),
             responses = Seq(
-              OpenapiResponse(
+              OpenapiResponseDef(
                 code = "200",
                 description = "",
                 content =
@@ -447,12 +447,12 @@ object TestHelpers {
               Resolved(OpenapiParameter("name", "path", Some(true), None, OpenapiSchemaString(false)))
             ),
             responses = Seq(
-              OpenapiResponse(
+              OpenapiResponseDef(
                 "200",
                 "",
                 Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false)))
               ),
-              OpenapiResponse(
+              OpenapiResponseDef(
                 code = "400",
                 description = "Invalid value for: query parameter name",
                 content = Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false)))
@@ -741,7 +741,7 @@ object TestHelpers {
             "post",
             List(),
             List(
-              OpenapiResponse(
+              OpenapiResponseDef(
                 "200",
                 "Bar",
                 List(
@@ -753,7 +753,7 @@ object TestHelpers {
               )
             ),
             Some(
-              OpenapiRequestBody(
+              OpenapiRequestBodyDefn(
                 true,
                 Some("Foo"),
                 List(OpenapiRequestBodyContent("application/json", OpenapiSchemaRef("#/components/schemas/ReqWithDefaults")))
@@ -1039,14 +1039,14 @@ object TestHelpers {
             "post",
             List(),
             List(
-              OpenapiResponse(
+              OpenapiResponseDef(
                 "200",
                 "Bar",
                 List(OpenapiResponseContent("application/json", OpenapiSchemaString(false)))
               )
             ),
             Some(
-              OpenapiRequestBody(
+              OpenapiRequestBodyDefn(
                 true,
                 Some("Foo"),
                 List(OpenapiRequestBodyContent("application/json", OpenapiSchemaRef("#/components/schemas/ReqWithVariants")))

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.codegen.openapi.models
 
 import sttp.tapir.codegen.TestHelpers
-import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiDocument, OpenapiResponse, OpenapiResponseContent}
+import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiDocument, OpenapiResponse, OpenapiResponseContent, OpenapiResponseDef}
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaArray,
   OpenapiSchemaConstantString,
@@ -43,12 +43,12 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers {
 
     res shouldBe Right(
       Seq(
-        OpenapiResponse(
+        OpenapiResponseDef(
           "200",
           "",
           Seq(OpenapiResponseContent("application/json", OpenapiSchemaArray(OpenapiSchemaRef("#/components/schemas/Book"), false)))
         ),
-        OpenapiResponse("default", "", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false))))
+        OpenapiResponseDef("default", "", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false))))
       )
     )
 
@@ -141,12 +141,12 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers {
 
     res shouldBe Right(
       Seq(
-        OpenapiResponse(
+        OpenapiResponseDef(
           "200",
           "",
           Seq(OpenapiResponseContent("application/json", OpenapiSchemaArray(OpenapiSchemaRef("#/components/schemas/Book"), false)))
         ),
-        OpenapiResponse("default", "", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaUUID(false))))
+        OpenapiResponseDef("default", "", Seq(OpenapiResponseContent("text/plain", OpenapiSchemaUUID(false))))
       )
     )
   }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -63,22 +63,13 @@ paths:
     put:
       responses:
         '200':
-          description: a non-optional response body
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NotNullableThingy'
+          $ref: '#/components/responses/optionalityTest'
       requestBody:
-        required: false
-        description: an optional request body (not required)
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/NotNullableThingy'
+        $ref: '#/components/requestBodies/optionalityTest'
   '/adt/test':
     post:
       security:
-        - api_key: []
+        - api_key: [ ]
       responses:
         '200':
           description: successful operation
@@ -310,6 +301,21 @@ paths:
 
 
 components:
+  responses:
+    optionalityTest:
+      description: a non-optional response body
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NotNullableThingy'
+  requestBodies:
+    optionalityTest:
+      required: false
+      description: an optional request body (not required)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NotNullableThingy'
   securitySchemes:
     petstore_auth:
       type: oauth2


### PR DESCRIPTION
Supports requestBody and response definitions in the 'components' section of openapi yaml.

Nothing very clever here, there are probably more map lookups than there could be if we had an earlier single-pass resolve step, but the refs are still resolved relatively early and I can't envisage this ever producing particular egregious performance characteristics 