### PR TITLE
Codegen: Support response headers

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -664,13 +664,6 @@ class EndpointGenerator {
     val mappedOuts = outDecls.map(s => s".out($s)")
     val (errDecls, errTypes, inlineErrDefns) = mappedGroup(errorOuts, true)
     val mappedErrorOuts = errDecls.map(s => s".errorOut($s)")
-//    val outHeaders = outs.map(_.headers.map { case (k, v) => k -> v.resolved(doc) })
-//    val requiredOutHeaders = outHeaders.map(_.keySet).reduceOption(_ intersect _)
-//    val optionalOutHeaders = outHeaders.map(_.keySet).reduceOption(_ union _).map(_ -- requiredOutHeaders.get)
-//    requiredOutHeaders.toSet.flatten.map{ headerName => outHeaders.map(_(headerName)).reduce((l, r) => if (l.param.))}
-//    val errHeaders = errorOuts.map(_.headers.map { case (k, v) => k -> v.resolved(doc) })
-//    val requiredErrHeaders = errHeaders.map(_.keySet).reduceOption(_ intersect _)
-//    val optionalErrHeaders = errHeaders.map(_.keySet).reduceOption(_ union _).map(_ -- requiredErrHeaders.get)
 
     (Seq(mappedErrorOuts, mappedOuts).flatten.mkString("\n"), outTypes, errTypes, combine(inlineOutDefns, inlineErrDefns))
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -2,7 +2,7 @@ package sttp.tapir.codegen.openapi.models
 
 import cats.implicits.toTraverseOps
 import cats.syntax.either._
-import OpenapiSchemaType.{OpenapiSchemaRef, OpenapiSchemaRefDecoder}
+import OpenapiSchemaType.{OpenapiSchemaRef, OpenapiSchemaRefDecoder, OpenapiSchemaSimpleType}
 import io.circe.Json
 import sttp.tapir.codegen.BasicGenerator.strippedToCamelCase
 import sttp.tapir.codegen.util.MapUtils
@@ -81,6 +81,33 @@ object OpenapiModels {
     def isExploded: Boolean = in != "header" && !explode.contains(false)
   }
 
+  sealed trait OpenapiHeader {
+    def resolved(doc: OpenapiDocument): OpenapiHeaderDef
+  }
+  object OpenapiHeader {
+    import io.circe._
+    implicit val OpenapiHeaderDecoder: Decoder[OpenapiHeader] =
+      OpenapiSchemaRefDecoder
+        .map(OpenapiHeaderRef(_))
+        .or((c: HCursor) => {
+          OpenapiParameterDecoder
+            .tryDecode(c.withFocus(_.mapObject(("name" -> Json.fromString("inline")) +: ("in" -> Json.fromString("header")) +: _)))
+            .map(OpenapiHeaderDef(_))
+        })
+  }
+  case class OpenapiHeaderDef(param: OpenapiParameter) extends OpenapiHeader {
+    def resolved(doc: OpenapiDocument): OpenapiHeaderDef = this
+  }
+  case class OpenapiHeaderRef($ref: OpenapiSchemaRef) extends OpenapiHeader {
+    def strippedRef: String = $ref.name.stripPrefix("#/components/parameters/")
+    def resolved(doc: OpenapiDocument): OpenapiHeaderDef =
+      doc.components
+        .flatMap(_.parameters.get(strippedRef))
+        .map(b => if (b.in != "header") throw new IllegalStateException(s"Referenced parameter ${$ref.name} is not header") else b)
+        .map(b => OpenapiHeaderDef(b))
+        .getOrElse(throw new IllegalStateException(s"Response component ${$ref.name} is referenced but not found"))
+  }
+
   sealed trait OpenapiResponse {
     def code: String
     def resolve(doc: OpenapiDocument): OpenapiResponseDef
@@ -88,7 +115,8 @@ object OpenapiModels {
   case class OpenapiResponseDef(
       code: String,
       description: String,
-      content: Seq[OpenapiResponseContent]
+      content: Seq[OpenapiResponseContent],
+      headers: Map[String, OpenapiHeader] = Map.empty
   ) extends OpenapiResponse {
     def resolve(doc: OpenapiDocument): OpenapiResponseDef = this
   }
@@ -100,7 +128,7 @@ object OpenapiModels {
     def resolve(doc: OpenapiDocument): OpenapiResponseDef =
       doc.components
         .flatMap(_.responses.get(strippedRef))
-        .map(b => OpenapiResponseDef(code, b.description, b.content))
+        .map(b => OpenapiResponseDef(code, b.description, b.content, b.headers))
         .getOrElse(throw new IllegalStateException(s"Response component ${$ref.name} is referenced but not found"))
   }
 
@@ -159,23 +187,26 @@ object OpenapiModels {
   }
 
   implicit val OpenapiResponseDecoder: Decoder[Seq[OpenapiResponse]] = { (c: HCursor) =>
-    implicit val InnerDecoder: Decoder[(String, Option[Seq[OpenapiResponseContent]])] = { (c: HCursor) =>
+    implicit val InnerDecoder: Decoder[(String, Option[Seq[OpenapiResponseContent]], Map[String, OpenapiHeader])] = { (c: HCursor) =>
       for {
         description <- c.downField("description").as[String]
         content <- c.downField("content").as[Option[Seq[OpenapiResponseContent]]]
+        headers <- c.getOrElse[Map[String, OpenapiHeader]]("headers")(Map.empty)
       } yield {
-        (description, content)
+        (description, content, headers)
       }
     }
-    implicit val EitherDecoder: Decoder[Either[OpenapiSchemaRef, (String, Option[Seq[OpenapiResponseContent]])]] =
+    implicit val EitherDecoder
+        : Decoder[Either[OpenapiSchemaRef, (String, Option[Seq[OpenapiResponseContent]], Map[String, OpenapiHeader])]] =
       InnerDecoder.map(Right(_)).or(OpenapiSchemaRefDecoder.map(Left(_)))
 
     for {
-      schema <- c.as[Map[String, Either[OpenapiSchemaRef, (String, Option[Seq[OpenapiResponseContent]])]]]
+      schema <- c
+        .as[Map[String, Either[OpenapiSchemaRef, (String, Option[Seq[OpenapiResponseContent]], Map[String, OpenapiHeader])]]]
     } yield {
       schema.map {
-        case (code, Right((desc, content))) =>
-          OpenapiResponseDef(code, desc, content.getOrElse(Nil))
+        case (code, Right((desc, content, headers))) =>
+          OpenapiResponseDef(code, desc, content.getOrElse(Nil), headers)
         case (code, Left(ref)) =>
           OpenapiResponseRef(code, ref)
       }.toSeq

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -100,13 +100,13 @@ object OpenapiModels {
       if (name == param.name) this else OpenapiHeaderDef(param.copy(name = name))
   }
   case class OpenapiHeaderRef($ref: OpenapiSchemaRef) extends OpenapiHeader {
-    def strippedRef: String = $ref.name.stripPrefix("#/components/parameters/")
-    def resolved(name: String, doc: OpenapiDocument): OpenapiHeaderDef =
+    def resolved(name: String, doc: OpenapiDocument): OpenapiHeaderDef = {
       doc.components
-        .flatMap(_.parameters.get(strippedRef))
+        .flatMap(_.parameters.get($ref.name))
         .map(b => if (b.in != "header") throw new IllegalStateException(s"Referenced parameter ${$ref.name} is not header") else b)
         .map(b => OpenapiHeaderDef(b.copy(name = name)))
         .getOrElse(throw new IllegalStateException(s"Response component ${$ref.name} is referenced but not found"))
+    }
   }
 
   sealed trait OpenapiResponse {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiReqResp.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiReqResp.scala
@@ -1,11 +1,11 @@
 package sttp.tapir.codegen.openapi.models
 
-import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiRequestBodyContent, OpenapiResponseContent}
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.OpenapiSchemaRef
+import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiHeader, OpenapiRequestBodyContent, OpenapiResponseContent}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaRef, OpenapiSchemaSimpleType}
 
 case class OpenapiResponseDefn(
     description: String,
-    headers: Map[String, OpenapiSchemaRef],
+    headers: Map[String, OpenapiHeader],
     content: Seq[OpenapiResponseContent]
 )
 
@@ -14,7 +14,7 @@ object OpenapiResponseDefn {
   implicit val OpenapiResponseDefnDecoder: Decoder[OpenapiResponseDefn] = { (c: HCursor) =>
     for {
       description <- c.downField("description").as[String]
-      headers <- c.getOrElse[Map[String, OpenapiSchemaRef]]("headers")(Map.empty)
+      headers <- c.getOrElse[Map[String, OpenapiHeader]]("headers")(Map.empty)
       content <- c.getOrElse[Seq[OpenapiResponseContent]]("content")(Nil)
     } yield OpenapiResponseDefn(description, headers, content)
   }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -157,6 +157,10 @@ object TapirGeneratedEndpoints {
     foo: String,
     bar: Option[java.util.UUID] = None
   )
+  case class PostInlineSimpleObjectResponse (
+    foo: String,
+    bar: Option[java.util.UUID] = None
+  )
 
 
 
@@ -293,12 +297,13 @@ object TapirGeneratedEndpoints {
         oneOfVariant[Array[Byte]](sttp.model.StatusCode(401), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position 2"))))
       .out(multipartBody[PutInlineSimpleObjectResponse].description("An object"))
 
-  type PostInlineSimpleObjectEndpoint = Endpoint[Unit, Option[PostInlineSimpleObjectRequest], Unit, Unit, Any]
+  type PostInlineSimpleObjectEndpoint = Endpoint[Unit, Option[PostInlineSimpleObjectRequest], Unit, PostInlineSimpleObjectResponse, Any]
   lazy val postInlineSimpleObject: PostInlineSimpleObjectEndpoint =
     endpoint
       .post
       .in(("inline" / "simple" / "object"))
       .in(jsonBody[Option[PostInlineSimpleObjectRequest]])
+      .out(jsonBody[PostInlineSimpleObjectResponse].description("An object"))
 
   type DeleteInlineSimpleObjectEndpoint = Endpoint[Unit, Unit, Unit, Unit, Any]
   lazy val deleteInlineSimpleObject: DeleteInlineSimpleObjectEndpoint =

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -13,7 +13,7 @@ object TapirGeneratedEndpoints {
   import TapirGeneratedEndpointsSchemas._
 
 
-
+  
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
   trait ExtraParamSupport[T] {
@@ -297,13 +297,13 @@ object TapirGeneratedEndpoints {
         oneOfVariant[Array[Byte]](sttp.model.StatusCode(401), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position 2"))))
       .out(multipartBody[PutInlineSimpleObjectResponse].description("An object"))
 
-  type PostInlineSimpleObjectEndpoint = Endpoint[Unit, Option[PostInlineSimpleObjectRequest], Unit, PostInlineSimpleObjectResponse, Any]
+  type PostInlineSimpleObjectEndpoint = Endpoint[Unit, Option[PostInlineSimpleObjectRequest], Unit, (PostInlineSimpleObjectResponse, String), Any]
   lazy val postInlineSimpleObject: PostInlineSimpleObjectEndpoint =
     endpoint
       .post
       .in(("inline" / "simple" / "object"))
       .in(jsonBody[Option[PostInlineSimpleObjectRequest]])
-      .out(jsonBody[PostInlineSimpleObjectResponse].description("An object"))
+      .out(jsonBody[PostInlineSimpleObjectResponse].description("An object").and(header[String]("x-combat-status").description("a response header")))
 
   type DeleteInlineSimpleObjectEndpoint = Endpoint[Unit, Unit, Unit, Unit, Any]
   lazy val deleteInlineSimpleObject: DeleteInlineSimpleObjectEndpoint =

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -13,7 +13,7 @@ object TapirGeneratedEndpoints {
   import TapirGeneratedEndpointsSchemas._
 
 
-  
+
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
   trait ExtraParamSupport[T] {
@@ -224,15 +224,15 @@ object TapirGeneratedEndpoints {
         oneOfVariant[SimpleError](sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
       .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
 
-  type GetOneofOptionTestEndpoint = Endpoint[Unit, Unit, Unit, Option[AnyObjectWithInlineEnum], Any]
+  type GetOneofOptionTestEndpoint = Endpoint[Unit, Unit, Unit, (Option[AnyObjectWithInlineEnum], Option[String]), Any]
   lazy val getOneofOptionTest: GetOneofOptionTestEndpoint =
     endpoint
       .get
       .in(("oneof" / "option" / "test"))
-      .out(oneOf[Option[AnyObjectWithInlineEnum]](
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None),
-        oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object")){ case Some(_: ObjectWithInlineEnum) => true },
-        oneOfVariantValueMatcher(sttp.model.StatusCode(201), jsonBody[Option[ObjectWithInlineEnum2]].description("Another object")){ case Some(_: ObjectWithInlineEnum2) => true }))
+      .out(oneOf[(Option[AnyObjectWithInlineEnum], Option[String])](
+        oneOfVariantValueMatcher(sttp.model.StatusCode(204), emptyOutputAs(None).description("No response").and(header[Option[String]]("common-response-header"))){ case (None, _) => true},
+        oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object").and(header[Option[String]]("common-response-header"))){ case (Some(_: ObjectWithInlineEnum), _) => true },
+        oneOfVariantValueMatcher(sttp.model.StatusCode(201), jsonBody[Option[ObjectWithInlineEnum2]].description("Another object").and(header[Option[String]]("common-response-header"))){ case (Some(_: ObjectWithInlineEnum2), _) => true }))
 
   type PostInlineEnumTestEndpoint = Endpoint[Unit, (PostInlineEnumTestQueryEnum, Option[PostInlineEnumTestQueryOptEnum], List[PostInlineEnumTestQuerySeqEnum], Option[List[PostInlineEnumTestQueryOptSeqEnum]], ObjectWithInlineEnum), Unit, Unit, Any]
   lazy val postInlineEnumTest: PostInlineEnumTestEndpoint =

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
@@ -64,6 +64,8 @@ object TapirGeneratedEndpointsJsonSerdes {
     ).reduceLeft(_ or _)
   implicit lazy val nullableThingyJsonDecoder: io.circe.Decoder[NullableThingy] = io.circe.generic.semiauto.deriveDecoder[NullableThingy]
   implicit lazy val nullableThingyJsonEncoder: io.circe.Encoder[NullableThingy] = io.circe.generic.semiauto.deriveEncoder[NullableThingy]
+  implicit lazy val postInlineSimpleObjectResponseJsonDecoder: io.circe.Decoder[PostInlineSimpleObjectResponse] = io.circe.generic.semiauto.deriveDecoder[PostInlineSimpleObjectResponse]
+  implicit lazy val postInlineSimpleObjectResponseJsonEncoder: io.circe.Encoder[PostInlineSimpleObjectResponse] = io.circe.generic.semiauto.deriveEncoder[PostInlineSimpleObjectResponse]
   implicit lazy val postInlineSimpleObjectRequestJsonDecoder: io.circe.Decoder[PostInlineSimpleObjectRequest] = io.circe.generic.semiauto.deriveDecoder[PostInlineSimpleObjectRequest]
   implicit lazy val postInlineSimpleObjectRequestJsonEncoder: io.circe.Encoder[PostInlineSimpleObjectRequest] = io.circe.generic.semiauto.deriveEncoder[PostInlineSimpleObjectRequest]
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/build.sbt
@@ -7,10 +7,11 @@ lazy val root = (project in file("."))
     openapiGenerateEndpointTypes := true
   )
 
+val tapirVersion = "1.11.20"
 libraryDependencies ++= Seq(
-  "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % "1.11.16",
-  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.11.16",
-  "com.softwaremill.sttp.tapir" %% "tapir-pekko-http-server" % "1.11.16",
+  "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % tapirVersion,
+  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % tapirVersion,
+  "com.softwaremill.sttp.tapir" %% "tapir-pekko-http-server" % tapirVersion,
   "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.11.7",
   "io.circe" %% "circe-generic" % "0.14.12",
   "com.beachape" %% "enumeratum" % "1.7.5",

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/JsonRoundtrip.scala
@@ -229,7 +229,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
       case 2 => Some(someResponse2)
     }
     val route = TapirGeneratedEndpoints.getOneofOptionTest.serverLogic[Future]({ _: Unit =>
-      Future successful Right[Unit, Option[AnyObjectWithInlineEnum]](responseVariant)
+      Future successful Right[Unit, (Option[AnyObjectWithInlineEnum], Option[String])](responseVariant -> Some("ok"))
     })
     val stub = TapirStubInterpreter(SttpBackendStub.asynchronousFuture)
       .whenServerEndpoint(route)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -184,14 +184,23 @@ paths:
       responses:
         "204":
           description: "No response"
+          headers:
+            common-response-header:
+              $ref: '#/components/parameters/common-response-header'
         "200":
           description: An object
+          headers:
+            common-response-header:
+              $ref: '#/components/parameters/common-response-header'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ObjectWithInlineEnum'
         "201":
           description: Another object
+          headers:
+            common-response-header:
+              $ref: '#/components/parameters/common-response-header'
           content:
             application/json:
               schema:
@@ -307,6 +316,12 @@ paths:
 
 
 components:
+  parameters:
+    common-response-header:
+      in: header
+      name: x-common
+      schema:
+        type: string
   responses:
     optionalityTest:
       description: a non-optional response body

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -215,18 +215,24 @@ paths:
       responses:
         "200":
           description: An object
+          headers:
+            x-combat-status:
+              description: "a response header"
+              required: true
+              schema:
+                type: string
           content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - foo
-              properties:
-                foo:
-                  type: string
-                bar:
-                  type: string
-                  format: uuid
+            application/json:
+              schema:
+                type: object
+                required:
+                  - foo
+                properties:
+                  foo:
+                    type: string
+                  bar:
+                    type: string
+                    format: uuid
     put:
       requestBody:
         content:


### PR DESCRIPTION
Support defining 'headers' on responses.

Depends on https://github.com/softwaremill/tapir/pull/4457, since that started to parse the response headers from the openapi yaml in some places.

Doesn't handle the situation where differing headers are defined for multiple response codes in same 'bucket' (i.e. multiple error, or multiple success, status codes). I _think_ that in order to be able to do that, we'd need to introduce something a bit more elaborate to the endpoint defns... possibly something like
```scala
sealed trait MyEndpointNameResponseType
case class MyEndpointNameResponse200(body: SomeType, headerName1: String) extends MyEndpointNameResponseType
case class MyEndpointNameResponse201(headerName2: String) extends MyEndpointNameResponseType
```
so that we could get an appropriate parent type for the `oneOf` declaration... not sure how else we could really do it.