### PR TITLE
Adds tracing interceptor to otel4s tracing example code

### DIFF
--- a/examples/src/main/scala/sttp/tapir/examples/observability/Otel4sTracingExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/Otel4sTracingExample.scala
@@ -1,23 +1,25 @@
 // {cat=Observability; effects=cats-effect; server=Netty; json=circe}: Otel4s collecting traces
 
-//> using dep com.softwaremill.sttp.tapir::tapir-core:1.11.17
-//> using dep com.softwaremill.sttp.tapir::tapir-netty-server-cats:1.11.17
-//> using dep com.softwaremill.sttp.tapir::tapir-json-circe:1.11.17
-//> using dep com.softwaremill.sttp.tapir::tapir-opentelemetry-metrics:1.11.17
-//> using dep "org.typelevel::otel4s-oteljava:0.11.2"
+//> using dep com.softwaremill.sttp.tapir::tapir-core:1.11.20
+//> using dep com.softwaremill.sttp.tapir::tapir-netty-server-cats:1.11.20
+//> using dep com.softwaremill.sttp.tapir::tapir-json-circe:1.11.20
+//> using dep com.softwaremill.sttp.tapir::tapir-opentelemetry-metrics:1.11.20
+//> using dep com.softwaremill.sttp.tapir::tapir-otel4s-tracing:1.11.20
+//> using dep "org.typelevel::otel4s-oteljava:0.12.0-RC3"
 //> using dep "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.47.0"
 //> using dep ch.qos.logback:logback-classic:1.5.17
 
 package sttp.tapir.examples.observability
 
 import cats.effect
-import cats.effect.std.{Console, Random}
+import cats.effect.std.{Console, Dispatcher, Random}
 import cats.effect.{Async, IO, IOApp}
 import io.circe.generic.auto.*
 import sttp.tapir.*
 import sttp.tapir.generic.auto.*
 import sttp.tapir.json.circe.jsonBody
-import sttp.tapir.server.netty.cats.NettyCatsServer
+import sttp.tapir.server.netty.cats.{NettyCatsServer, NettyCatsServerOptions}
+import sttp.tapir.server.tracing.otel4s.Otel4sTracing
 import org.slf4j.{Logger, LoggerFactory}
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.trace.Tracer
@@ -29,6 +31,7 @@ import io.opentelemetry.sdk.resources.Resource
 
 import scala.concurrent.duration.*
 import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.netty.NettyConfig
 
 import scala.io.StdIn
 
@@ -52,9 +55,16 @@ object Otel4sTracingExample extends IOApp.Simple:
         .flatMap { case given Tracer[IO] => server(HttpApi[IO](Service[IO])) }
     }
 
-  private def server(httpApi: HttpApi[IO]): IO[Unit] =
-    NettyCatsServer
-      .io()
+  private def server(httpApi: HttpApi[IO])(using tracer: Tracer[IO]): IO[Unit] =
+    Dispatcher
+      .parallel[IO]
+      .map(dispatcher =>
+        NettyCatsServer(
+          NettyCatsServerOptions
+            .default[IO](dispatcher)
+            .prependInterceptor(Otel4sTracing(tracer))
+        )
+      )
       .use { server =>
         for {
           bind <- server


### PR DESCRIPTION
As mentioned here https://github.com/softwaremill/tapir/issues/4456#issuecomment-2764563333 this adds a tracing interceptor to the otel4s tracing example code.

Looks not so nice though, is there a better way to modify the `NettyCatsServerOptions`?