### PR TITLE
codegen: fix type declaration for basic auth security

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -324,14 +324,15 @@ class EndpointGenerator {
       }
     }.toList
     inner.distinct match {
-      case Nil           => "" -> None
-      case (h, _) +: Nil => s".securityIn($h)" -> Some("String")
+      case Nil                                               => "" -> None
+      case (h, _) +: Nil if h.contains("[UsernamePassword]") => s".securityIn($h)" -> Some("UsernamePassword")
+      case (h, _) +: Nil                                     => s".securityIn($h)" -> Some("String")
       case s =>
         s.map(_._2).distinct match {
           case h +: Nil =>
             h match {
               case "Bearer" => ".securityIn(auth.bearer[String]())" -> Some("String")
-              case "Basic"  => ".securityIn(auth.basic[UsernamePassword]())" -> Some("String")
+              case "Basic"  => ".securityIn(auth.basic[UsernamePassword]())" -> Some("UsernamePassword")
               case "ApiKey" => bail("Cannot support multiple api key authentication declarations on same endpoint")
             }
           case _ =>

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -324,9 +324,9 @@ class EndpointGenerator {
       }
     }.toList
     inner.distinct match {
-      case Nil                                               => "" -> None
-      case (h, _) +: Nil if h.contains("[UsernamePassword]") => s".securityIn($h)" -> Some("UsernamePassword")
-      case (h, _) +: Nil                                     => s".securityIn($h)" -> Some("String")
+      case Nil                 => "" -> None
+      case (h, "Basic") +: Nil => s".securityIn($h)" -> Some("UsernamePassword")
+      case (h, _) +: Nil       => s".securityIn($h)" -> Some("String")
       case s =>
         s.map(_._2).distinct match {
           case h +: Nil =>

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -1,4 +1,4 @@
-openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txtpackage sttp.tapir.generated
+package sttp.tapir.generated
 
 object TapirGeneratedEndpoints {
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -1,4 +1,4 @@
-package sttp.tapir.generated
+openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txtpackage sttp.tapir.generated
 
 object TapirGeneratedEndpoints {
 
@@ -204,11 +204,12 @@ object TapirGeneratedEndpoints {
         oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object")){ case Some(_: ObjectWithInlineEnum) => true },
         oneOfVariantValueMatcher(sttp.model.StatusCode(201), jsonBody[Option[ObjectWithInlineEnum2]].description("Another object")){ case Some(_: ObjectWithInlineEnum2) => true }))
 
-  type PutInlineSimpleObjectEndpoint = Endpoint[Unit, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
+  type PutInlineSimpleObjectEndpoint = Endpoint[UsernamePassword, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
   lazy val putInlineSimpleObject: PutInlineSimpleObjectEndpoint =
     endpoint
       .put
       .in(("inline" / "simple" / "object"))
+      .securityIn(auth.basic[UsernamePassword]())
       .in(multipartBody[PutInlineSimpleObjectRequest])
       .errorOut(oneOf[Array[Byte]](
         oneOfVariant[Array[Byte]](sttp.model.StatusCode(400), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position")),

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/swagger.yaml
@@ -5,7 +5,7 @@ info:
   description: File for testing json roundtripping of oneOf defns in scala 3 with circe
   version: 1.0.20-SNAPSHOT
   title: OneOf Json test for scala 3
-tags: []
+tags: [ ]
 paths:
   '/adt/test':
     post:
@@ -146,6 +146,8 @@ paths:
                   type: string
                   format: uuid
     put:
+      security:
+        - basic: [ ]
       requestBody:
         content:
           multipart/form-data:
@@ -363,3 +365,7 @@ components:
       type: array
       items:
         type: string
+  securitySchemes:
+    basic:
+      type: http
+      scheme: basic


### PR DESCRIPTION
The codegen was treating all security schemas as having a type of `String`, but `auth.basic[UsernamePassword]()` does not. This fixes type generation when `openapiGenerateEndpointTypes := true`

Shouldn't imagine this will have any conflicts with my other pr, so can go in first