### PR TITLE
codegen: Add support for multiple security declarations on an endpoint ('full' petstore support)

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -79,7 +79,15 @@ object BasicGenerator {
         StreamingImplementation.FS2
     }
 
-    val EndpointDefs(endpointsByTag, queryOrPathParamRefs, jsonParamRefs, enumsDefinedOnEndpointParams, inlineDefns, xmlParamRefs) =
+    val EndpointDefs(
+      endpointsByTag,
+      queryOrPathParamRefs,
+      jsonParamRefs,
+      enumsDefinedOnEndpointParams,
+      inlineDefns,
+      xmlParamRefs,
+      securityWrappers
+    ) =
       endpointGenerator.endpointDefs(
         doc,
         useHeadTagForObjectNames,
@@ -242,6 +250,21 @@ object BasicGenerator {
       |  support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)
       |}
       |""".stripMargin
+
+    val securityTypes = {
+      val allTpes = securityWrappers.flatMap(_.schemas).toSeq.sorted
+      val tpesWithParents = allTpes.map { t =>
+        t -> securityWrappers.filter(_.schemas.contains(t)).map(_.traitName).toSeq.sorted.mkString(" with ")
+      }
+      val traits = securityWrappers.map(_.traitName).toSeq.sorted.map(tn => s"sealed trait $tn").mkString("\n")
+      val classes = tpesWithParents
+        .map {
+          case ("Basic", ps) => s"case class BasicSecurityIn(value: UsernamePassword) extends $ps"
+          case (n, ps)       => s"case class ${n.capitalize}SecurityIn(value: String) extends $ps"
+        }
+        .mkString("\n")
+      traits + "\n" + classes
+    }
     val mainObj = s"""
         |package $packagePath
         |
@@ -250,6 +273,7 @@ object BasicGenerator {
         |${indent(2)(imports(normalisedJsonLib) + extraImports)}
         |
         |${indent(2)(customTypes)}
+        |${indent(2)(securityTypes)}
         |${indent(2)(queryParamSupport)}
         |  implicit class RichBody[A, T](bod: EndpointIO.Body[A, T]) {
         |    def widenBody[TT >: T]: EndpointIO.Body[A, TT] = bod.map(_.asInstanceOf[TT])(_.asInstanceOf[T])

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -17,6 +17,10 @@ object TapirGeneratedEndpoints {
   }
 
 
+  sealed trait Basic_or_Bearer_SecurityIn
+  case class BasicSecurityIn(value: UsernamePassword) extends Basic_or_Bearer_SecurityIn
+  case class BearerSecurityIn(value: String) extends Basic_or_Bearer_SecurityIn
+
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
   trait ExtraParamSupport[T] {
@@ -227,12 +231,23 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(200), emptyOutput.description("empty response 1"))(()),
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(201), emptyOutput.description("empty response 2"))(())))
 
-  type PutInlineSimpleObjectEndpoint = Endpoint[UsernamePassword, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
+  type PutInlineSimpleObjectEndpoint = Endpoint[Basic_or_Bearer_SecurityIn, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
   lazy val putInlineSimpleObject: PutInlineSimpleObjectEndpoint =
     endpoint
       .put
       .in(("inline" / "simple" / "object"))
-      .securityIn(auth.basic[UsernamePassword]())
+      .securityIn(auth.basic[Option[UsernamePassword]]())
+      .securityIn(auth.bearer[Option[String]]())
+      .mapSecurityInDecode[Basic_or_Bearer_SecurityIn]{
+        case (Some(x), None) => DecodeResult.Value(BasicSecurityIn(x))
+        case (None, Some(x)) => DecodeResult.Value(BearerSecurityIn(x))
+        case other =>
+          val count = other.productIterator.count(_.isInstanceOf[Some[?]])
+          DecodeResult.Error(s"2 security inputs", new RuntimeException(s"Expected a single security input, found 2"))
+      }{
+        case BasicSecurityIn(x) => (Some(x), None)
+        case BearerSecurityIn(x) => (None, Some(x))
+      }
       .in(multipartBody[PutInlineSimpleObjectRequest])
       .errorOut(oneOf[Array[Byte]](
         oneOfVariant[Array[Byte]](sttp.model.StatusCode(400), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position")),

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -243,7 +243,7 @@ object TapirGeneratedEndpoints {
         case (None, Some(x)) => DecodeResult.Value(BearerSecurityIn(x))
         case other =>
           val count = other.productIterator.count(_.isInstanceOf[Some[?]])
-          DecodeResult.Error(s"2 security inputs", new RuntimeException(s"Expected a single security input, found 2"))
+          DecodeResult.Error(s"$count security inputs", new RuntimeException(s"Expected a single security input, found $count"))
       }{
         case BasicSecurityIn(x) => (Some(x), None)
         case BearerSecurityIn(x) => (None, Some(x))

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/swagger.yaml
@@ -148,6 +148,7 @@ paths:
     put:
       security:
         - basic: [ ]
+        - bearer: [ ]
       requestBody:
         content:
           multipart/form-data:
@@ -387,3 +388,6 @@ components:
     basic:
       type: http
       scheme: basic
+    bearer:
+      type: http
+      scheme: bearer

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
@@ -16,6 +16,9 @@ object TapirGeneratedEndpoints {
   case class `application/x-www-form-urlencodedCodecFormat`() extends CodecFormat {
     override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "application", subType = "x-www-form-urlencoded")
   }
+  sealed trait Bearer_or_api_key_SecurityIn
+  case class BearerSecurityIn(value: String) extends Bearer_or_api_key_SecurityIn
+  case class Api_keySecurityIn(value: String) extends Bearer_or_api_key_SecurityIn
 
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
@@ -367,12 +370,23 @@ object TapirGeneratedEndpoints {
       .tags(List("user"))
       .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "UserController")
 
-  type GetPetByIdEndpoint = Endpoint[String, Long, Unit, Pet, Any]
+  type GetPetByIdEndpoint = Endpoint[Bearer_or_api_key_SecurityIn, Long, Unit, Pet, Any]
   lazy val getPetById: GetPetByIdEndpoint =
     endpoint
       .get
       .in(("pet" / path[Long]("petId").description("ID of pet to return")))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .securityIn(auth.apiKey(header[Option[String]]("api_key")))
+      .securityIn(auth.bearer[Option[String]]())
+      .mapSecurityInDecode[Bearer_or_api_key_SecurityIn]{
+        case (Some(x), None) => DecodeResult.Value(Api_keySecurityIn(x))
+        case (None, Some(x)) => DecodeResult.Value(BearerSecurityIn(x))
+        case other =>
+          val count = other.productIterator.count(_.isInstanceOf[Some[?]])
+          DecodeResult.Error(s"$count security inputs", new RuntimeException(s"Expected a single security input, found $count"))
+      }{
+        case Api_keySecurityIn(x) => (Some(x), None)
+        case BearerSecurityIn(x) => (None, Some(x))
+      }
       .errorOut(oneOf[Unit](
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid ID supplied"))(()),
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(404), emptyOutput.description("Pet not found"))(()),

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/swagger.yaml
@@ -230,7 +230,7 @@ paths:
         default:
           description: Unexpected error
       security:
-#        - api_key: []
+        - api_key: []
         - petstore_auth:
             - write:pets
             - read:pets


### PR DESCRIPTION
Follow-up to https://github.com/softwaremill/tapir/pull/4464

With this, an unmodified petstore.yml will generate some pretty reasonable, usable code.

Some things are still missing -- we do nothing with security scopes, I've just realised we never '.name(..)' our endpoints in the generated code, we should support x-www-form-urlencoded directly with the tapir built-in codec, there's nothing generated to reify the 'servers' and 'infos' fields, ... but we shouldn't throw errors or generate unusable code