### PR TITLE
codegen: Add support for generating stringJsonBody

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -60,6 +60,36 @@ import sttp.tapir.docs.openapi.*
 val docs = TapirGeneratedEndpoints.generatedEndpoints.toOpenAPI("My Bookshop", "1.0")
 ```
 
+### Support specification extensions
+
+Generator behaviour can be further configured by specifications on the input openapi spec. Example:
+```yaml
+  '/my-endpoint':
+    post:
+      x-tapir-codegen-directives: [ 'json-body-as-string' ] # This will customise what the codegen generates for this endpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MyModel'
+      responses:
+        "204":
+          description: "No response"
+```
+
+Supported specifications are:
+
+- x-tapir-codegen-directives: supported on openapi operations. This is an array of string flags. Supported values are:
+```{eval-rst}
+==================== ===================================================================================================================================
+name                 description
+==================== ===================================================================================================================================
+json-body-as-string  If present on an operation, all application/json requests and responses will be interpreted mapped to a string with stringJsonBody
+==================== ===================================================================================================================================
+```
+
+
 ### Output files
 
 To expand on the `openapiUseHeadTagForObjectName` setting a little more, suppose we have the following endpoints:

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/GenerationDirectives.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/GenerationDirectives.scala
@@ -1,0 +1,6 @@
+package sttp.tapir.codegen.openapi.models
+
+object GenerationDirectives {
+  val extensionKey = "tapir-codegen-directives"
+  val jsonBodyAsString = "json-body-as-string"
+}

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -67,6 +67,12 @@ object OpenapiModels {
       if (parentDuplicates.nonEmpty) throw new IllegalArgumentException(s"Duplicate parameters ${parentDuplicates.mkString(", ")}")
       this.copy(parameters = filteredParents ++ resolved)
     }
+    val tapirCodegenDirectives: Set[String] = {
+      specificationExtensions
+        .collect { case (GenerationDirectives.extensionKey, json) => json.asArray.toSeq.flatMap(_.flatMap(_.asString)) }
+        .flatten
+        .toSet
+    }
   }
 
   case class OpenapiParameter(

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -13,6 +13,9 @@ object TapirGeneratedEndpoints {
   import TapirGeneratedEndpointsSchemas._
 
 
+  case class `application/zipCodecFormat`() extends CodecFormat {
+    override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "application", subType = "zip")
+  }
 
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
@@ -151,6 +154,23 @@ object TapirGeneratedEndpoints {
   case class NullableThingy (
     uuid: java.util.UUID
   )
+  sealed trait PostJsonStringJsonBodyBodyIn extends Product with java.io.Serializable
+  case class PostJsonStringJsonBodyBodyOption_String_In(value: Option[String]) extends PostJsonStringJsonBodyBodyIn
+  case class PostJsonStringJsonBodyBody1In(value: Array[Byte]) extends PostJsonStringJsonBodyBodyIn
+  sealed trait PostJsonStringJsonBodyBodyOut extends Product with java.io.Serializable {
+    def `application/json`: () => Option[String] = () => throw new RuntimeException("Body for content type application/json not provided")
+    def `application/zip`: () => Array[Byte] = () => throw new RuntimeException("Body for content type application/zip not provided")
+  }
+  case class PostJsonStringJsonBodyBodyOutFull (
+    override val `application/json`: () => Option[String],
+    override val `application/zip`: () => Array[Byte],
+  ) extends PostJsonStringJsonBodyBodyOut
+  case class PostJsonStringJsonBodyBodyOption_String_Out(value: Option[String]) extends PostJsonStringJsonBodyBodyOut{
+    override def `application/json`: () => Option[String] = () => value
+  }
+  case class PostJsonStringJsonBodyBody1Out(value: Array[Byte]) extends PostJsonStringJsonBodyBodyOut{
+    override def `application/zip`: () => Array[Byte] = () => value
+  }
   case class PutInlineSimpleObjectRequest (
     foo: String,
     bar: Option[java.util.UUID] = None
@@ -168,7 +188,8 @@ object TapirGeneratedEndpoints {
     bar: Option[java.util.UUID] = None
   )
 
-
+  type TapirCodegenDirectivesExtension = Seq[String]
+  val tapirCodegenDirectivesExtensionKey = new sttp.tapir.AttributeKey[TapirCodegenDirectivesExtension]("sttp.tapir.generated.TapirGeneratedEndpoints.TapirCodegenDirectivesExtension")
 
   type GetBinaryTestEndpoint = Endpoint[String, Unit, Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
   lazy val getBinaryTest: GetBinaryTestEndpoint =
@@ -202,6 +223,32 @@ object TapirGeneratedEndpoints {
       .in(("optional" / "test"))
       .in(jsonBody[Option[NullableThingy2]].description("an optional request body (nullable)"))
       .out(jsonBody[Option[NullableThingy]].description("an optional response body"))
+
+  type PostJsonStringJsonBodyEndpoint = Endpoint[Unit, PostJsonStringJsonBodyBodyIn, Unit, Option[PostJsonStringJsonBodyBodyOut], Any]
+  lazy val postJsonStringJsonBody: PostJsonStringJsonBodyEndpoint =
+    endpoint
+      .post
+      .in(("json" / "stringJsonBody"))
+      .in(oneOfBody[PostJsonStringJsonBodyBodyIn](
+        stringJsonBody.map(Option(_))(_.orNull).map(PostJsonStringJsonBodyBodyOption_String_In(_))(_.value).widenBody[PostJsonStringJsonBodyBodyIn],
+        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/zipCodecFormat`](`application/zipCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(PostJsonStringJsonBodyBody1In(_))(_.value).widenBody[PostJsonStringJsonBodyBodyIn]))
+      .out(oneOf[Option[PostJsonStringJsonBodyBodyOut]](
+        oneOfVariantValueMatcher(sttp.model.StatusCode(200), oneOfBody[PostJsonStringJsonBodyBodyOut](
+        stringJsonBody.map(Option(_))(_.orNull).map(PostJsonStringJsonBodyBodyOption_String_Out(_))(_.`application/json`())
+        .map(_.asInstanceOf[PostJsonStringJsonBodyBodyOut])(p => PostJsonStringJsonBodyBodyOption_String_Out(p.`application/json`())).description("Possibly-invalid json"),
+        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/zipCodecFormat`](`application/zipCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(PostJsonStringJsonBodyBody1Out(_))(_.`application/zip`())
+        .map(_.asInstanceOf[PostJsonStringJsonBodyBodyOut])(p => PostJsonStringJsonBodyBody1Out(p.`application/zip`())).description("Possibly-invalid json")).map(Some(_))(_.orNull)){ case Some(_: PostJsonStringJsonBodyBodyOut) => true },
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None)))
+      .attribute[TapirCodegenDirectivesExtension](tapirCodegenDirectivesExtensionKey, Vector("json-body-as-string"))
+
+  type PostJsonStringJsonBodySimpleEndpoint = Endpoint[Unit, String, Unit, String, Any]
+  lazy val postJsonStringJsonBodySimple: PostJsonStringJsonBodySimpleEndpoint =
+    endpoint
+      .post
+      .in(("json" / "stringJsonBody" / "simple"))
+      .in(stringJsonBody)
+      .out(stringJsonBody.description("Possibly-invalid json"))
+      .attribute[TapirCodegenDirectivesExtension](tapirCodegenDirectivesExtensionKey, Vector("json-body-as-string"))
 
   type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
   lazy val putAdtTest: PutAdtTestEndpoint =
@@ -333,6 +380,6 @@ object TapirGeneratedEndpoints {
       .out(jsonBody[ListType].description("list type out"))
 
 
-  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, putAdtTest, postAdtTest, getOneofErrorTest, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, putAdtTest, postAdtTest, getOneofErrorTest, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -178,7 +178,45 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SimpleError'
-
+  '/json/stringJsonBody':
+    post:
+      x-tapir-codegen-directives: [ 'json-body-as-string' ]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ObjectWithInlineEnum'
+          application/zip:
+            schema:
+              $ref: '#/components/schemas/ObjectWithInlineEnum'
+      responses:
+        "200":
+          description: "Possibly-invalid json"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectWithInlineEnum'
+            application/zip:
+              schema:
+                $ref: '#/components/schemas/ObjectWithInlineEnum'
+        "204":
+          description: "No response"
+  '/json/stringJsonBody/simple':
+    post:
+      x-tapir-codegen-directives: [ 'json-body-as-string' ]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ObjectWithInlineEnum'
+      responses:
+        "200":
+          description: "Possibly-invalid json"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectWithInlineEnum'
   '/oneof/option/test':
     get:
       responses:


### PR DESCRIPTION
Adds 'x-tapir-codegen-directives' with corresponding value 'json-body-as-string', for when you absolutely have to treat the json on a particular endpoint as a String. I'm introducing it as a flagset rather than a single extension with a boolean since it feels more extensible and I have other extensions in mind for future prs... (I think in particular being able to specify whether an endpoint use streaming or eager content would be a useful flag)

Sometimes you just really need `stringJsonBody` (e.g. if you absolutely need to satisfy the requirement that some data be saved and retrieved in char-for-char identical formats, even if invalid json).

The only sane way I could see to support this was to add a new extension. I've chosen to enable it at the operation ('path+method') level; perhaps support at a more granular level (e.g. on specific req/resp objects) would also be nice, but this approach was easy to implement and keeps the detail defined in the endpoint rather than the schema, which feels right 