### PR TITLE
codegen: Support top-level security declarations

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -27,12 +27,8 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
 }
 import sttp.tapir.codegen.openapi.models._
 import sttp.tapir.codegen.openapi.models.GenerationDirectives.jsonBodyAsString
-import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType.OAuth2FlowType
-import sttp.tapir.codegen.util.JavaEscape
-
-case class Location(path: String, method: String) {
-  override def toString: String = s"${method.toUpperCase} ${path}"
-}
+import sttp.tapir.codegen.util.ErrUtils.bail
+import sttp.tapir.codegen.util.{JavaEscape, Location}
 
 case class EndpointTypes(security: Seq[String], in: Seq[String], err: Seq[String], out: Seq[String]) {
   private def toType(types: Seq[String]) = types match {
@@ -91,8 +87,6 @@ case class SecurityDefn(
 )
 
 class EndpointGenerator {
-  private def bail(msg: String)(implicit location: Location): Nothing = throw new NotImplementedError(s"$msg at $location")
-
   private def combine(inlineDefn1: Option[String], inlineDefn2: Option[String], separator: String = "\n") =
     (inlineDefn1, inlineDefn2) match {
       case (None, None)               => None
@@ -194,7 +188,8 @@ class EndpointGenerator {
           val name = m.name(p.url)
           val maybeName = m.operationId.map(n => s"""\n  .name("${JavaEscape.escapeString(n)}")""").getOrElse("")
           val (pathDecl, pathTypes) = urlMapper(p.url, m.resolvedParameters)
-          val SecurityDefn(securityDecl, securityTypes, securityWrappers) = security(securitySchemes, m.security)
+          val SecurityDefn(securityDecl, securityTypes, securityWrappers) =
+            SecurityGenerator.security(securitySchemes, m.security.getOrElse(doc.security))
           val (inParams, maybeLocalEnums, inTypes, inlineInDefns) =
             ins(
               m.resolvedParameters,
@@ -313,94 +308,6 @@ class EndpointGenerator {
       }
       .unzip
     ".in((" + inPath.mkString(" / ") + "))" -> tpes.toSeq.flatten
-  }
-
-  private def security(securitySchemes: Map[String, OpenapiSecuritySchemeType], security: Map[String, Seq[String]])(implicit
-      location: Location
-  ): SecurityDefn = {
-
-    // Would be nice to do something to respect scopes here
-    def inner(multi: Boolean = false) = security.flatMap { case (schemeName, _ /*scopes*/ ) =>
-      def wrap(s: String): String = if (multi) s"Option[$s]" else s
-      securitySchemes.get(schemeName) match {
-        case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeBearerType) =>
-          Seq((s"auth.bearer[${wrap("String")}]()", "Bearer", schemeName))
-
-        case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeBasicType) =>
-          Seq(("auth.basic[UsernamePassword]()", "Basic", schemeName))
-
-        case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeApiKeyType(in, name)) =>
-          Seq((s"""auth.apiKey($in[${wrap("String")}]("$name"))""", "ApiKey", schemeName))
-
-        case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeOAuth2Type(flows)) if flows.isEmpty => Nil
-        case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeOAuth2Type(flows)) =>
-          flows.map {
-            case (_, _) if multi              => (s"auth.bearer[${wrap("String")}]()", "Bearer", schemeName)
-            case (OAuth2FlowType.password, _) => (s"auth.bearer[${wrap("String")}]()", "Bearer", schemeName)
-            case (OAuth2FlowType.`implicit`, f) =>
-              val authUrl = f.authorizationUrl.getOrElse(bail("authorizationUrl required for implicit flow"))
-              val refreshUrl = f.refreshUrl.map(u => s"""Some("$u")""").getOrElse("None")
-              (s"""auth.oauth2.implicitFlow("$authUrl", $refreshUrl)""", "Bearer", schemeName)
-            case (OAuth2FlowType.clientCredentials, f) =>
-              val tokenUrl = f.tokenUrl.getOrElse(bail("tokenUrl required for clientCredentials flow"))
-              val refreshUrl = f.refreshUrl.map(u => s"""Some("$u")""").getOrElse("None")
-              (s"""auth.oauth2.clientCredentialsFlow("$tokenUrl", $refreshUrl)""", "Bearer", schemeName)
-            case (OAuth2FlowType.authorizationCode, f) =>
-              val authUrl = f.authorizationUrl.getOrElse(bail("authorizationUrl required for authorizationCode flow"))
-              val tokenUrl = f.tokenUrl.getOrElse(bail("tokenUrl required for authorizationCode flow"))
-              val refreshUrl = f.refreshUrl.map(u => s"""Some("$u")""").getOrElse("None")
-              (s"""auth.oauth2.authorizationCodeFlow("$authUrl", "$tokenUrl", $refreshUrl)""", "Bearer", schemeName)
-          }
-
-        case None =>
-          bail(s"Unknown security scheme $schemeName!")
-      }
-    }.toList
-    inner().distinct match {
-      case Nil                    => SecurityDefn(None, None, None)
-      case (h, "Basic", _) +: Nil => SecurityDefn(Some(s".securityIn($h)"), Some("UsernamePassword"), None)
-      case (h, _, _) +: Nil       => SecurityDefn(Some(s".securityIn($h)"), Some("String"), None)
-      case s =>
-        def handleMultiple = {
-          val optionally = inner(true).distinct.groupBy(_._2)
-          val namesAndImpls = optionally.toList.sortBy(_._1).flatMap {
-            case ("Bearer", _)  => Seq("Bearer" -> s".securityIn(auth.bearer[Option[String]]())")
-            case ("Basic", _)   => Seq("Basic" -> s".securityIn(auth.basic[Option[UsernamePassword]]())")
-            case ("ApiKey", vs) => vs.map { case (impl, _, name) => name -> s".securityIn($impl)" }.sortBy(_._1)
-          }
-          val impls = namesAndImpls.map(_._2).mkString("\n")
-          val traitName = SecurityWrapperDefn(namesAndImpls.map(_._1).toSet).traitName
-          val count = namesAndImpls.size
-          def someAt(idx: Int) = (0 to count - 1)
-            .map { case `idx` => "Some(x)"; case _ => "None" }
-            .mkString("(", ", ", ")")
-          val mapDecodes = namesAndImpls.zipWithIndex.map { case ((name, _), idx) =>
-            s"case ${someAt(idx)} => DecodeResult.Value(${name.capitalize}SecurityIn(x))"
-          }
-          val mapEncodes = namesAndImpls.zipWithIndex.map { case ((name, _), idx) =>
-            s"case ${name.capitalize}SecurityIn(x) => ${someAt(idx)}"
-          }
-          val mapImpl =
-            s""".mapSecurityInDecode[$traitName]{
-               |${indent(2)(mapDecodes.mkString("\n"))}
-               |  case other =>
-               |    val count = other.productIterator.count(_.isInstanceOf[Some[?]])
-               |    DecodeResult.Error(s"$$count security inputs", new RuntimeException(s"Expected a single security input, found $$count"))
-               |}{
-               |${indent(2)(mapEncodes.mkString("\n"))}
-               |}""".stripMargin
-          SecurityDefn(Some(s"$impls\n$mapImpl"), Some(traitName), Some(SecurityWrapperDefn(namesAndImpls.map(_._1).toSet)))
-        }
-        s.map(_._2).distinct match {
-          case h +: Nil =>
-            h match {
-              case "Bearer" => SecurityDefn(Some(".securityIn(auth.bearer[String]())"), Some("String"), None)
-              case "Basic"  => SecurityDefn(Some(".securityIn(auth.basic[UsernamePassword]())"), Some("UsernamePassword"), None)
-              case _        => handleMultiple
-            }
-          case _ => handleMultiple
-        }
-    }
   }
 
   private def toOutType(baseType: String, isArray: Boolean, noOptionWrapper: Boolean) = (isArray, noOptionWrapper) match {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SecurityGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SecurityGenerator.scala
@@ -1,0 +1,110 @@
+package sttp.tapir.codegen
+
+import sttp.tapir.codegen.BasicGenerator.indent
+import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType
+import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType.OAuth2FlowType
+import sttp.tapir.codegen.util.ErrUtils.bail
+import sttp.tapir.codegen.util.Location
+
+import scala.collection.immutable
+
+object SecurityGenerator {
+
+  def security(securitySchemes: Map[String, OpenapiSecuritySchemeType], security: Seq[Map[String, Seq[String]]])(implicit
+      location: Location
+  ): SecurityDefn = {
+    if (security.forall(_.isEmpty)) return SecurityDefn(None, None, None)
+    if (security.exists(_.size > 1)) bail("Multiple schemes on same security requirement not yet supported")
+    if (security.exists(_.size == 1) && security.exists(_.isEmpty))
+      bail("Anonymous access not supported on endpoints with other security requirement declarations")
+    if (security.map(_.head._1).distinct.size != security.size)
+      bail("Multiple security requirements are only supported if schemes differ between requirements")
+
+    // Would be nice to do something to respect scopes here
+    def inner(multi: Boolean = false): immutable.Seq[(String, String, String)] = security
+      .map(_.head) // we know, at this point, that all security decls have a since scheme
+      .flatMap { case (schemeName, _ /*scopes*/ ) =>
+        def wrap(s: String): String = if (multi) s"Option[$s]" else s
+        securitySchemes.get(schemeName) match {
+          case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeBearerType) =>
+            Seq((s"auth.bearer[${wrap("String")}]()", "Bearer", schemeName))
+
+          case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeBasicType) =>
+            Seq(("auth.basic[UsernamePassword]()", "Basic", schemeName))
+
+          case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeApiKeyType(in, name)) =>
+            Seq((s"""auth.apiKey($in[${wrap("String")}]("$name"))""", "ApiKey", schemeName))
+
+          case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeOAuth2Type(flows)) if flows.isEmpty => Nil
+          case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeOAuth2Type(flows)) =>
+            flows.map {
+              case (_, _) if multi              => (s"auth.bearer[${wrap("String")}]()", "Bearer", schemeName)
+              case (OAuth2FlowType.password, _) => (s"auth.bearer[${wrap("String")}]()", "Bearer", schemeName)
+              case (OAuth2FlowType.`implicit`, f) =>
+                val authUrl = f.authorizationUrl.getOrElse(bail("authorizationUrl required for implicit flow"))
+                val refreshUrl = f.refreshUrl.map(u => s"""Some("$u")""").getOrElse("None")
+                (s"""auth.oauth2.implicitFlow("$authUrl", $refreshUrl)""", "Bearer", schemeName)
+              case (OAuth2FlowType.clientCredentials, f) =>
+                val tokenUrl = f.tokenUrl.getOrElse(bail("tokenUrl required for clientCredentials flow"))
+                val refreshUrl = f.refreshUrl.map(u => s"""Some("$u")""").getOrElse("None")
+                (s"""auth.oauth2.clientCredentialsFlow("$tokenUrl", $refreshUrl)""", "Bearer", schemeName)
+              case (OAuth2FlowType.authorizationCode, f) =>
+                val authUrl = f.authorizationUrl.getOrElse(bail("authorizationUrl required for authorizationCode flow"))
+                val tokenUrl = f.tokenUrl.getOrElse(bail("tokenUrl required for authorizationCode flow"))
+                val refreshUrl = f.refreshUrl.map(u => s"""Some("$u")""").getOrElse("None")
+                (s"""auth.oauth2.authorizationCodeFlow("$authUrl", "$tokenUrl", $refreshUrl)""", "Bearer", schemeName)
+            }
+
+          case None =>
+            bail(s"Unknown security scheme $schemeName!")
+        }
+      }
+      .toList
+
+    inner().distinct match {
+      case Nil                    => SecurityDefn(None, None, None)
+      case (h, "Basic", _) +: Nil => SecurityDefn(Some(s".securityIn($h)"), Some("UsernamePassword"), None)
+      case (h, _, _) +: Nil       => SecurityDefn(Some(s".securityIn($h)"), Some("String"), None)
+      case s =>
+        def handleMultiple = {
+          val optionally = inner(true).distinct.groupBy(_._2)
+          val namesAndImpls = optionally.toList.sortBy(_._1).flatMap {
+            case ("Bearer", _)  => Seq("Bearer" -> s".securityIn(auth.bearer[Option[String]]())")
+            case ("Basic", _)   => Seq("Basic" -> s".securityIn(auth.basic[Option[UsernamePassword]]())")
+            case ("ApiKey", vs) => vs.map { case (impl, _, name) => name -> s".securityIn($impl)" }.sortBy(_._1)
+          }
+          val impls = namesAndImpls.map(_._2).mkString("\n")
+          val traitName = SecurityWrapperDefn(namesAndImpls.map(_._1).toSet).traitName
+          val count = namesAndImpls.size
+          def someAt(idx: Int) = (0 to count - 1)
+            .map { case `idx` => "Some(x)"; case _ => "None" }
+            .mkString("(", ", ", ")")
+          val mapDecodes = namesAndImpls.zipWithIndex.map { case ((name, _), idx) =>
+            s"case ${someAt(idx)} => DecodeResult.Value(${name.capitalize}SecurityIn(x))"
+          }
+          val mapEncodes = namesAndImpls.zipWithIndex.map { case ((name, _), idx) =>
+            s"case ${name.capitalize}SecurityIn(x) => ${someAt(idx)}"
+          }
+          val mapImpl =
+            s""".mapSecurityInDecode[$traitName]{
+               |${indent(2)(mapDecodes.mkString("\n"))}
+               |  case other =>
+               |    val count = other.productIterator.count(_.isInstanceOf[Some[?]])
+               |    DecodeResult.Error(s"$$count security inputs", new RuntimeException(s"Expected a single security input, found $$count"))
+               |}{
+               |${indent(2)(mapEncodes.mkString("\n"))}
+               |}""".stripMargin
+          SecurityDefn(Some(s"$impls\n$mapImpl"), Some(traitName), Some(SecurityWrapperDefn(namesAndImpls.map(_._1).toSet)))
+        }
+        s.map(_._2).distinct match {
+          case h +: Nil =>
+            h match {
+              case "Bearer" => SecurityDefn(Some(".securityIn(auth.bearer[String]())"), Some("String"), None)
+              case "Basic"  => SecurityDefn(Some(".securityIn(auth.basic[UsernamePassword]())"), Some("UsernamePassword"), None)
+              case _        => handleMultiple
+            }
+          case _ => handleMultiple
+        }
+    }
+  }
+}

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/util/ErrUtils.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/util/ErrUtils.scala
@@ -1,0 +1,9 @@
+package sttp.tapir.codegen.util
+
+case class Location(path: String, method: String) {
+  override def toString: String = s"${method.toUpperCase} ${path}"
+}
+
+object ErrUtils {
+  def bail(msg: String)(implicit location: Location): Nothing = throw new NotImplementedError(s"$msg at $location")
+}

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -26,7 +26,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             "Test" -> OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(false))), Seq("text"), false)
           )
         )
-      )
+      ),
+      Nil
     )
 
     new ClassDefinitionGenerator().classDefs(doc).get.classRepr shouldCompile ()
@@ -48,7 +49,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             )
           )
         )
-      )
+      ),
+      Nil
     )
     // the enumeratum import should be included by the BasicGenerator iff we generated enums
     new ClassDefinitionGenerator().classDefs(doc).get.classRepr shouldCompile ()
@@ -66,7 +68,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             "Test" -> OpenapiSchemaObject(Map("type" -> noDefault(OpenapiSchemaString(false))), Seq("type"), false)
           )
         )
-      )
+      ),
+      Nil
     )
 
     new ClassDefinitionGenerator().classDefs(doc).get.classRepr shouldCompile ()
@@ -88,7 +91,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             )
           )
         )
-      )
+      ),
+      Nil
     )
 
     new ClassDefinitionGenerator().classDefs(doc).get.classRepr shouldCompile ()
@@ -110,7 +114,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             )
           )
         )
-      )
+      ),
+      Nil
     )
 
     new ClassDefinitionGenerator().classDefs(doc).get.classRepr shouldCompile ()
@@ -128,7 +133,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             "Test" -> OpenapiSchemaObject(Map("anyType" -> noDefault(OpenapiSchemaAny(false))), Seq("anyType"), false)
           )
         )
-      )
+      ),
+      Nil
     )
 
     new ClassDefinitionGenerator().classDefs(doc).get.classRepr shouldCompile ()
@@ -152,7 +158,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             )
           )
         )
-      )
+      ),
+      Nil
     )
 
     new ClassDefinitionGenerator().classDefs(doc).get.classRepr shouldCompile ()
@@ -182,7 +189,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
               )
           )
         )
-      )
+      ),
+      Nil
     )
 
     new ClassDefinitionGenerator().classDefs(doc).get.classRepr shouldCompile ()
@@ -212,7 +220,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
               )
           )
         )
-      )
+      ),
+      Nil
     )
 
     new ClassDefinitionGenerator().classDefs(doc).get.classRepr shouldCompile ()
@@ -230,7 +239,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             "Test" -> OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(false))), Seq.empty, false)
           )
         )
-      )
+      ),
+      Nil
     )
     val doc2 = OpenapiDocument(
       "",
@@ -243,7 +253,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             "Test" -> OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(false))), Seq("text"), false)
           )
         )
-      )
+      ),
+      Nil
     )
     val gen = new ClassDefinitionGenerator()
     val res1 = gen.classDefs(doc1).map(_.classRepr)
@@ -264,7 +275,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             "Test" -> OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(false))), Seq.empty, false)
           )
         )
-      )
+      ),
+      Nil
     )
     val doc2 = OpenapiDocument(
       "",
@@ -277,7 +289,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             "Test" -> OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(true))), Seq("text"), false)
           )
         )
-      )
+      ),
+      Nil
     )
     val gen = new ClassDefinitionGenerator()
     val res1 = gen.classDefs(doc1).map(_.classRepr)
@@ -297,7 +310,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             "Test" -> OpenapiSchemaEnum("string", Seq(OpenapiSchemaConstantString("enum1"), OpenapiSchemaConstantString("enum2")), false)
           )
         )
-      )
+      ),
+      Nil
     )
 
     val gen = new ClassDefinitionGenerator()
@@ -362,7 +376,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             "MyMapEnum" -> OpenapiSchemaMap(OpenapiSchemaRef("#/components/schemas/MyEnum"), false)
           )
         )
-      )
+      ),
+      Nil
     )
 
     val gen = new ClassDefinitionGenerator()
@@ -505,7 +520,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       .toTry
       .get
     val gen = new ClassDefinitionGenerator()
-    val res1 = Try(gen.classDefs(OpenapiDocument("", Nil, null, Nil, Some(doc)))).toEither
+    val res1 = Try(gen.classDefs(OpenapiDocument("", Nil, null, Nil, Some(doc), Nil))).toEither
 
     res1.left.get.getMessage shouldEqual "Generating class for ReqWithDefaults: Cannot render a number as type sttp.tapir.codegen.openapi.models.OpenapiSchemaType$OpenapiSchemaString."
 

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -62,7 +62,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           )
         )
       ),
-      null
+      null,
+      Nil
     )
     val generatedCode = BasicGenerator.imports(JsonSerdeLib.Circe) ++
       new EndpointGenerator()
@@ -96,7 +97,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               parameters = Seq(),
               responses = Seq(),
               requestBody = None,
-              security = Map("httpBearer" -> Seq()),
+              security = Some(Seq(Map("httpBearer" -> Seq()))),
               summary = None,
               tags = None
             ),
@@ -105,7 +106,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               parameters = Seq(),
               responses = Seq(),
               requestBody = None,
-              security = Map("httpBasic" -> Seq()),
+              security = Some(Seq(Map("httpBasic" -> Seq()))),
               summary = None,
               tags = None
             ),
@@ -114,7 +115,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               parameters = Seq(),
               responses = Seq(),
               requestBody = None,
-              security = Map("httpBearer" -> Seq()),
+              security = Some(Seq(Map("httpBearer" -> Seq()))),
               summary = None,
               tags = None
             ),
@@ -123,7 +124,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               parameters = Seq(),
               responses = Seq(),
               requestBody = None,
-              security = Map("apiKeyCookie" -> Seq()),
+              security = Some(Seq(Map("apiKeyCookie" -> Seq()))),
               summary = None,
               tags = None
             ),
@@ -132,7 +133,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
               parameters = Seq(),
               responses = Seq(),
               requestBody = None,
-              security = Map("apiKeyQuery" -> Seq()),
+              security = Some(Seq(Map("apiKeyQuery" -> Seq()))),
               summary = None,
               tags = None
             )
@@ -150,7 +151,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
             "apiKeyQuery" -> OpenapiSecuritySchemeApiKeyType("query", "api-key")
           )
         )
-      )
+      ),
+      Nil
     )
     BasicGenerator.imports(JsonSerdeLib.Circe) ++
       new EndpointGenerator()
@@ -205,7 +207,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           )
         )
       ),
-      null
+      null,
+      Nil
     )
     val generatedCode = BasicGenerator.imports(JsonSerdeLib.Circe) ++
       new EndpointGenerator()
@@ -273,7 +276,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
             )
           )
         )
-      )
+      ),
+      Nil
     )
     val generatedCode = BasicGenerator.generateObjects(
       doc,

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -265,7 +265,8 @@ object TestHelpers {
           "#/components/parameters/year" -> OpenapiParameter("year", "path", Some(true), None, OpenapiSchemaInt(false))
         )
       )
-    )
+    ),
+    Nil
   )
 
   val generatedBookshopYaml =
@@ -403,7 +404,8 @@ object TestHelpers {
           )
         )
       )
-    )
+    ),
+    Nil
   )
 
   val helloYaml =
@@ -469,7 +471,8 @@ object TestHelpers {
         )
       )
     ),
-    None
+    None,
+    Nil
   )
 
   val simpleSecurityYaml =
@@ -499,12 +502,13 @@ object TestHelpers {
             parameters = Seq(),
             responses = Seq(),
             requestBody = None,
-            security = Map("basicAuth" -> Nil)
+            security = Some(Seq(Map("basicAuth" -> Nil)))
           )
         )
       )
     ),
-    None
+    None,
+    Nil
   )
 
   val complexSecurityYaml =
@@ -536,12 +540,13 @@ object TestHelpers {
             parameters = Seq(),
             responses = Seq(),
             requestBody = None,
-            security = Map("bearerAuth" -> Nil, "basicAuth" -> Nil, "apiKeyAuth" -> Nil)
+            security = Some(Seq(Map("bearerAuth" -> Nil), Map("basicAuth" -> Nil, "apiKeyAuth" -> Nil)))
           )
         )
       )
     ),
-    None
+    None,
+    Nil
   )
 
   val enumQueryParamYaml =
@@ -641,7 +646,8 @@ object TestHelpers {
           )
         )
       )
-    )
+    ),
+    Nil
   )
 
   val withDefaultsYaml =
@@ -766,7 +772,7 @@ object TestHelpers {
                 List(OpenapiRequestBodyContent("application/json", OpenapiSchemaRef("#/components/schemas/ReqWithDefaults")))
               )
             ),
-            Map.empty,
+            None,
             None,
             None,
             None
@@ -836,7 +842,8 @@ object TestHelpers {
         Map(),
         Map()
       )
-    )
+    ),
+    Nil
   )
 
   val specificationExtensionYaml =
@@ -950,7 +957,8 @@ object TestHelpers {
         )
       )
     ),
-    None
+    None,
+    Nil
   )
 
   val oneOfYaml =
@@ -1061,7 +1069,7 @@ object TestHelpers {
                 List(OpenapiRequestBodyContent("application/json", OpenapiSchemaRef("#/components/schemas/ReqWithVariants")))
               )
             ),
-            Map.empty,
+            None,
             None,
             None,
             None
@@ -1116,7 +1124,8 @@ object TestHelpers {
         Map(),
         Map()
       )
-    )
+    ),
+    Nil
   )
   val oneOfDocsWithMapping = genOneOfDocs(withDiscriminator = true, withMapping = true)
   val oneOfDocsWithDiscriminatorNoMapping = genOneOfDocs(withDiscriminator = true, withMapping = false)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -12,10 +12,10 @@ object TapirGeneratedEndpoints {
   import sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes._
   import TapirGeneratedEndpointsSchemas._
 
-
   case class `application/zipCodecFormat`() extends CodecFormat {
     override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "application", subType = "zip")
   }
+
 
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
@@ -154,9 +154,12 @@ object TapirGeneratedEndpoints {
   case class NullableThingy (
     uuid: java.util.UUID
   )
+
   sealed trait PostJsonStringJsonBodyBodyIn extends Product with java.io.Serializable
   case class PostJsonStringJsonBodyBodyOption_String_In(value: Option[String]) extends PostJsonStringJsonBodyBodyIn
   case class PostJsonStringJsonBodyBody1In(value: Array[Byte]) extends PostJsonStringJsonBodyBodyIn
+
+
   sealed trait PostJsonStringJsonBodyBodyOut extends Product with java.io.Serializable {
     def `application/json`: () => Option[String] = () => throw new RuntimeException("Body for content type application/json not provided")
     def `application/zip`: () => Array[Byte] = () => throw new RuntimeException("Body for content type application/zip not provided")
@@ -171,6 +174,7 @@ object TapirGeneratedEndpoints {
   case class PostJsonStringJsonBodyBody1Out(value: Array[Byte]) extends PostJsonStringJsonBodyBodyOut{
     override def `application/zip`: () => Array[Byte] = () => value
   }
+
   case class PutInlineSimpleObjectRequest (
     foo: String,
     bar: Option[java.util.UUID] = None
@@ -208,27 +212,30 @@ object TapirGeneratedEndpoints {
       .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Array[Byte]], CodecFormat.OctetStream()).description("Upload a csv"))
       .out(jsonBody[String].description("successful operation"))
 
-  type PutOptionalTestEndpoint = Endpoint[Unit, Option[NotNullableThingy], Unit, NotNullableThingy, Any]
+  type PutOptionalTestEndpoint = Endpoint[String, Option[NotNullableThingy], Unit, NotNullableThingy, Any]
   lazy val putOptionalTest: PutOptionalTestEndpoint =
     endpoint
       .put
       .in(("optional" / "test"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
       .in(jsonBody[Option[NotNullableThingy]].description("an optional request body (not required)"))
       .out(jsonBody[NotNullableThingy].description("a non-optional response body"))
 
-  type PostOptionalTestEndpoint = Endpoint[Unit, Option[NullableThingy2], Unit, Option[NullableThingy], Any]
+  type PostOptionalTestEndpoint = Endpoint[String, Option[NullableThingy2], Unit, Option[NullableThingy], Any]
   lazy val postOptionalTest: PostOptionalTestEndpoint =
     endpoint
       .post
       .in(("optional" / "test"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
       .in(jsonBody[Option[NullableThingy2]].description("an optional request body (nullable)"))
       .out(jsonBody[Option[NullableThingy]].description("an optional response body"))
 
-  type PostJsonStringJsonBodyEndpoint = Endpoint[Unit, PostJsonStringJsonBodyBodyIn, Unit, Option[PostJsonStringJsonBodyBodyOut], Any]
+  type PostJsonStringJsonBodyEndpoint = Endpoint[String, PostJsonStringJsonBodyBodyIn, Unit, Option[PostJsonStringJsonBodyBodyOut], Any]
   lazy val postJsonStringJsonBody: PostJsonStringJsonBodyEndpoint =
     endpoint
       .post
       .in(("json" / "stringJsonBody"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
       .in(oneOfBody[PostJsonStringJsonBodyBodyIn](
         stringJsonBody.map(Option(_))(_.orNull).map(PostJsonStringJsonBodyBodyOption_String_In(_))(_.value).widenBody[PostJsonStringJsonBodyBodyIn],
         EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/zipCodecFormat`](`application/zipCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(PostJsonStringJsonBodyBody1In(_))(_.value).widenBody[PostJsonStringJsonBodyBodyIn]))
@@ -241,11 +248,12 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None)))
       .attribute[TapirCodegenDirectivesExtension](tapirCodegenDirectivesExtensionKey, Vector("json-body-as-string"))
 
-  type PostJsonStringJsonBodySimpleEndpoint = Endpoint[Unit, String, Unit, String, Any]
+  type PostJsonStringJsonBodySimpleEndpoint = Endpoint[String, String, Unit, String, Any]
   lazy val postJsonStringJsonBodySimple: PostJsonStringJsonBodySimpleEndpoint =
     endpoint
       .post
       .in(("json" / "stringJsonBody" / "simple"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
       .in(stringJsonBody)
       .out(stringJsonBody.description("Possibly-invalid json"))
       .attribute[TapirCodegenDirectivesExtension](tapirCodegenDirectivesExtensionKey, Vector("json-body-as-string"))
@@ -267,21 +275,23 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[ADTWithDiscriminatorNoMapping].description("Update an existent user in the store"))
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 
-  type GetOneofErrorTestEndpoint = Endpoint[Unit, Unit, Error, Unit, Any]
+  type GetOneofErrorTestEndpoint = Endpoint[String, Unit, Error, Unit, Any]
   lazy val getOneofErrorTest: GetOneofErrorTestEndpoint =
     endpoint
       .get
       .in(("oneof" / "error" / "test"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
       .errorOut(oneOf[Error](
         oneOfVariant[NotFoundError](sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")),
         oneOfVariant[SimpleError](sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
       .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
 
-  type GetOneofOptionTestEndpoint = Endpoint[Unit, Unit, Unit, (Option[AnyObjectWithInlineEnum], Option[String]), Any]
+  type GetOneofOptionTestEndpoint = Endpoint[String, Unit, Unit, (Option[AnyObjectWithInlineEnum], Option[String]), Any]
   lazy val getOneofOptionTest: GetOneofOptionTestEndpoint =
     endpoint
       .get
       .in(("oneof" / "option" / "test"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
       .out(oneOf[(Option[AnyObjectWithInlineEnum], Option[String])](
         oneOfVariantValueMatcher(sttp.model.StatusCode(204), emptyOutputAs(None).description("No response").and(header[Option[String]]("common-response-header"))){ case (None, _) => true},
         oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object").and(header[Option[String]]("common-response-header"))){ case (Some(_: ObjectWithInlineEnum), _) => true },
@@ -339,30 +349,33 @@ object TapirGeneratedEndpoints {
       extraCodecSupport[PostInlineEnumTestQueryOptSeqEnum]("PostInlineEnumTestQueryOptSeqEnum", PostInlineEnumTestQueryOptSeqEnum)
   }
 
-  type PutInlineSimpleObjectEndpoint = Endpoint[Unit, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
+  type PutInlineSimpleObjectEndpoint = Endpoint[String, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
   lazy val putInlineSimpleObject: PutInlineSimpleObjectEndpoint =
     endpoint
       .put
       .in(("inline" / "simple" / "object"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
       .in(multipartBody[PutInlineSimpleObjectRequest])
       .errorOut(oneOf[Array[Byte]](
         oneOfVariant[Array[Byte]](sttp.model.StatusCode(400), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position")),
         oneOfVariant[Array[Byte]](sttp.model.StatusCode(401), rawBinaryBody(sttp.tapir.RawBodyType.ByteArrayBody).description("application/octet-stream in error position 2"))))
       .out(multipartBody[PutInlineSimpleObjectResponse].description("An object"))
 
-  type PostInlineSimpleObjectEndpoint = Endpoint[Unit, Option[PostInlineSimpleObjectRequest], Unit, (PostInlineSimpleObjectResponse, String), Any]
+  type PostInlineSimpleObjectEndpoint = Endpoint[String, Option[PostInlineSimpleObjectRequest], Unit, (PostInlineSimpleObjectResponse, String), Any]
   lazy val postInlineSimpleObject: PostInlineSimpleObjectEndpoint =
     endpoint
       .post
       .in(("inline" / "simple" / "object"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
       .in(jsonBody[Option[PostInlineSimpleObjectRequest]])
       .out(jsonBody[PostInlineSimpleObjectResponse].description("An object").and(header[String]("x-combat-status").description("a response header")))
 
-  type DeleteInlineSimpleObjectEndpoint = Endpoint[Unit, Unit, Unit, Unit, Any]
+  type DeleteInlineSimpleObjectEndpoint = Endpoint[String, Unit, Unit, Unit, Any]
   lazy val deleteInlineSimpleObject: DeleteInlineSimpleObjectEndpoint =
     endpoint
       .delete
       .in(("inline" / "simple" / "object"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
       .errorOut(oneOf[Unit](
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("empty response 3"))(()),
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(402), emptyOutput.description("empty response 4"))(())))
@@ -370,17 +383,19 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(200), emptyOutput.description("empty response 1"))(()),
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(201), emptyOutput.description("empty response 2"))(())))
 
-  type PatchInlineSimpleObjectEndpoint = Endpoint[Unit, Option[ListType], ListType, ListType, Any]
+  type PatchInlineSimpleObjectEndpoint = Endpoint[String, Option[ListType], ListType, ListType, Any]
   lazy val patchInlineSimpleObject: PatchInlineSimpleObjectEndpoint =
     endpoint
       .patch
       .in(("inline" / "simple" / "object"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
       .in(jsonBody[Option[ListType]].description("list type in"))
       .errorOut(jsonBody[ListType].description("list type error").and(statusCode(sttp.model.StatusCode(400))))
       .out(jsonBody[ListType].description("list type out"))
 
 
   lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, putAdtTest, postAdtTest, getOneofErrorTest, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+
 
   object Servers {
     import sttp.model.Uri.UriContext

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/JsonRoundtrip.scala
@@ -228,9 +228,11 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
       case 1 => Some(someResponse1)
       case 2 => Some(someResponse2)
     }
-    val route = TapirGeneratedEndpoints.getOneofOptionTest.serverLogic[Future]({ _: Unit =>
-      Future successful Right[Unit, (Option[AnyObjectWithInlineEnum], Option[String])](responseVariant -> Some("ok"))
-    })
+    val route = TapirGeneratedEndpoints.getOneofOptionTest
+      .serverSecurityLogicSuccess[Unit, Future](_ => Future.successful(()))
+      .serverLogic({ _ => _: Unit =>
+        Future successful Right[Unit, (Option[AnyObjectWithInlineEnum], Option[String])](responseVariant -> Some("ok"))
+      })
     val stub = TapirStubInterpreter(SttpBackendStub.asynchronousFuture)
       .whenServerEndpoint(route)
       .thenRunLogic()
@@ -238,6 +240,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
     Await.result(
       sttp.client3.basicRequest
         .get(uri"http://test.com/oneof/option/test")
+        .header("Authorization", "Bearer some.jwt.probably")
         .send(stub)
         .map { resp =>
           resp.code.code shouldEqual 204
@@ -249,6 +252,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
     Await.result(
       sttp.client3.basicRequest
         .get(uri"http://test.com/oneof/option/test")
+        .header("Authorization", "Bearer some.jwt.probably")
         .send(stub)
         .map { resp =>
           resp.code.code shouldEqual 200
@@ -260,6 +264,7 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
     Await.result(
       sttp.client3.basicRequest
         .get(uri"http://test.com/oneof/option/test")
+        .header("Authorization", "Bearer some.jwt.probably")
         .send(stub)
         .map { resp =>
           resp.code.code shouldEqual 201

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -31,6 +31,10 @@ info:
   version: 1.0.20-SNAPSHOT
   title: OneOf Json test for scala 2
 tags: [ ]
+security: # Default security on all endpoints without explicit declarations
+  - petstore_auth:
+      - write:pets
+      - read:pets
 paths:
   '/binary/test':
     get:
@@ -110,6 +114,8 @@ paths:
             schema:
               $ref: '#/components/schemas/ADTWithDiscriminatorNoMapping'
     put:
+      security: # overriding default security on this endpoint to permit anonymous access via list containing empty map
+        - { }
       responses:
         '200':
           description: successful operation
@@ -126,6 +132,7 @@ paths:
               $ref: '#/components/schemas/ADTWithoutDiscriminator'
   '/inline/enum/test':
     post:
+      security: [ ] # overriding default security on this endpoint to permit anonymous access via empty list
       parameters:
         - name: query-enum
           in: query


### PR DESCRIPTION
Supports declaring 'security' at the top level of the openapi doc. This will be applied to all routes, unless a route explicitly overrides the auth requirement.

This also sanitises the parsing and security declaration somewhat; previously, we were performing completely illegal transformations on the security requirement, and would have generated invalid code in the case where multiple schemes were declared on same security requirement. We will now throw an error instead.