### PR TITLE
Swagger Initializer Options

### DIFF
--- a/docs/swagger-ui/src/main/scala/sttp/tapir/swagger/SwaggerUI.scala
+++ b/docs/swagger-ui/src/main/scala/sttp/tapir/swagger/SwaggerUI.scala
@@ -60,16 +60,47 @@ object SwaggerUI {
     val swaggerInitializerJsWithReplacedUrl =
       swaggerInitializerJs.replace("https://petstore.swagger.io/v2/swagger.json", s"${concat(fullPathPrefix, options.yamlName)}")
 
-    val swaggerInitializerJsWithOptions =
-      swaggerInitializerJsWithReplacedUrl.replace(
-        "window.ui = SwaggerUIBundle({",
-        s"""window.ui = SwaggerUIBundle({
-           |    showExtensions: ${options.showExtensions},""".stripMargin
+    val swaggerInitializerJsWithExtensions = swaggerInitializerJsWithReplacedUrl.replace(
+      "window.ui = SwaggerUIBundle({",
+      s"""window.ui = SwaggerUIBundle({
+         |    showExtensions: ${options.showExtensions},""".stripMargin
+    )
+
+    val swaggerInitializerJsWithOptions = options.initializerOptions
+      .map(_.foldRight(swaggerInitializerJsWithExtensions)({ (option, accumulator) =>
+        accumulator.replace(
+          "window.ui = SwaggerUIBundle({",
+          s"""window.ui = SwaggerUIBundle({
+           |    ${option._1}: ${option._2},""".stripMargin
+        )
+      }))
+      .getOrElse(swaggerInitializerJsWithExtensions)
+
+    val swaggerInitializerJsWithOAuthInit = options.oAuthInitOptions
+      .map(
+        _.foldRight(
+          // injecting initOAuth call
+          swaggerInitializerJsWithOptions.replace(
+            "});",
+            s"""});
+         |window.ui.initOAuth({
+         |});
+         |""".stripMargin
+          )
+        )({ (option, accumulator) =>
+          accumulator.replace(
+            // injecting options for initOAuth call
+            "window.ui.initOAuth({",
+            s"""window.ui.initOAuth({
+           |${option._1}: ${option._2},""".stripMargin
+          )
+        })
       )
+      .getOrElse(swaggerInitializerJsWithOptions)
 
     val textJavascriptUtf8: EndpointIO.Body[String, String] = stringBodyUtf8AnyFormat(Codec.string.format(CodecFormat.TextJavascript()))
     val swaggerInitializerJsEndpoint =
-      baseEndpoint.in("swagger-initializer.js").out(textJavascriptUtf8).serverLogicSuccessPure[F](_ => swaggerInitializerJsWithOptions)
+      baseEndpoint.in("swagger-initializer.js").out(textJavascriptUtf8).serverLogicSuccessPure[F](_ => swaggerInitializerJsWithOAuthInit)
 
     val resourcesEndpoint = staticResourcesGetServerEndpoint[F](prefixInput)(
       SwaggerUI.getClass.getClassLoader,

--- a/docs/swagger-ui/src/main/scala/sttp/tapir/swagger/SwaggerUIOptions.scala
+++ b/docs/swagger-ui/src/main/scala/sttp/tapir/swagger/SwaggerUIOptions.scala
@@ -21,7 +21,9 @@ case class SwaggerUIOptions(
     yamlName: String,
     contextPath: List[String],
     useRelativePaths: Boolean,
-    showExtensions: Boolean
+    showExtensions: Boolean,
+    initializerOptions: Option[Map[String, String]],
+    oAuthInitOptions: Option[Map[String, String]]
 ) {
   def pathPrefix(pathPrefix: List[String]): SwaggerUIOptions = copy(pathPrefix = pathPrefix)
   def yamlName(yamlName: String): SwaggerUIOptions = copy(yamlName = yamlName)
@@ -33,5 +35,5 @@ case class SwaggerUIOptions(
 }
 
 object SwaggerUIOptions {
-  val default: SwaggerUIOptions = SwaggerUIOptions(List("docs"), "docs.yaml", Nil, useRelativePaths = true, showExtensions = false)
+  val default: SwaggerUIOptions = SwaggerUIOptions(List("docs"), "docs.yaml", Nil, useRelativePaths = true, showExtensions = false, None, None)
 }


### PR DESCRIPTION
See #4424 . We add the option to serve Swagger with customizable **swaggerInitializers.js**. 

This change allows for adding arbitrary options to the `SwaggerUIBundle({...})` call using a new `initializerOptions` field in **SwaggerUIOptions.scala** and allows the addition of an `initOAuth({...}))` call also with custom options as specified in the `oAuthInitOptions` field from **SwaggerUIOptions.scala**.

Example Usage: 
```Scala
val client_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx"
val scope = s"api://$client_id/user_impersonation"
val initOptions = List(("oauth2RedirectUrl", s"\"http://localhost/callback"\"")).toMap[String,String]

val oAuthOptions = List(
("clientId",s"\"$client_id\""), 
("usePkceWithAuthorizationCodeGrant", "true"), 
("scopes", s"\"$scope\"")
).toMap[String,String] 

val swagger = SwaggerInterpreter(
  swaggerUIOptions = SwaggerUIOptions.default.copy(
    initializerOptions=Some(initOptions), 
    oAuthInitOptions = Some(oAuthOptions)
  )
)
```