### PR TITLE
codegen: support multiple security schemes on same declaration

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -251,20 +251,7 @@ object BasicGenerator {
       |}
       |""".stripMargin
 
-    val securityTypes = {
-      val allTpes = securityWrappers.flatMap(_.schemas).toSeq.sorted
-      val tpesWithParents = allTpes.map { t =>
-        t -> securityWrappers.filter(_.schemas.contains(t)).map(_.traitName).toSeq.sorted.mkString(" with ")
-      }
-      val traits = securityWrappers.map(_.traitName).toSeq.sorted.map(tn => s"sealed trait $tn").mkString("\n")
-      val classes = tpesWithParents
-        .map {
-          case ("Basic", ps) => s"case class BasicSecurityIn(value: UsernamePassword) extends $ps"
-          case (n, ps)       => s"case class ${n.capitalize}SecurityIn(value: String) extends $ps"
-        }
-        .mkString("\n")
-      traits + "\n" + classes
-    }
+    val securityTypes = SecurityGenerator.genSecurityTypes(securityWrappers)
     val mainObj = s"""
         |package $packagePath
         |

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -77,15 +77,6 @@ case class EndpointDefs(
     securityWrappers: Set[SecurityWrapperDefn]
 )
 
-case class SecurityWrapperDefn(schemas: Set[String]) {
-  lazy val traitName: String = schemas.toSeq.sorted.mkString("_or_") + "_SecurityIn"
-}
-case class SecurityDefn(
-    inDecl: Option[String],
-    tpe: Option[String],
-    wrapperDefinitions: Option[SecurityWrapperDefn]
-)
-
 class EndpointGenerator {
   private def combine(inlineDefn1: Option[String], inlineDefn2: Option[String], separator: String = "\n") =
     (inlineDefn1, inlineDefn2) match {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SecurityGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SecurityGenerator.scala
@@ -60,7 +60,7 @@ object SecurityGenerator {
       .mkString("\n")
 
     val mappings = allSchemes
-      .filterNot(_.isSingleton)
+      .filterNot(s => s.isSingleton || s.isEmpty)
       .map { t =>
         val mapImpl = mkMapImpl(t.schemas)
         s"""val ${t.typeName}Mapping = $mapImpl"""
@@ -162,7 +162,7 @@ object SecurityGenerator {
               val mapEncodes = nonEmptyDeclarations.zipWithIndex.map { case ((name, _, _), idx) =>
                 s"case ${name.typeName}(x) => ${someAt(idx, true)}"
               }
-              val encodeNone = if (securityIsOptional) s"\ncase EmptySecurityIn => DecodeResult.Value($allNones)" else ""
+              val encodeNone = if (securityIsOptional) s"\ncase EmptySecurityIn => $allNones" else ""
               s"""
                  |.mapSecurityInDecode[$traitName]{
                  |${indent(2)(mapDecodes.mkString("\n") + decodeNone)}

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SecurityGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SecurityGenerator.scala
@@ -8,22 +8,74 @@ import sttp.tapir.codegen.util.Location
 
 import scala.collection.immutable
 
+case class SecurityInnerDefn(schemas: Seq[String]) {
+  lazy val isSingleton: Boolean = schemas.size == 1
+  lazy val partialTypeName: String = if (isSingleton) schemas.head else schemas.mkString("_and_")
+  lazy val typeName: String = s"${partialTypeName.capitalize}SecurityIn"
+  lazy val argType: String =
+    if (isSingleton) schemas.head match { case "Basic" => "UsernamePassword"; case _ => "String" }
+    else schemas.map { case "Basic" => "UsernamePassword"; case _ => "String" }.mkString("(", ", ", ")")
+  lazy val unzippedArgTypes: String =
+    schemas.map { case "Basic" => "Option[UsernamePassword]"; case _ => "Option[String]" }.mkString("(", ", ", ")")
+}
+case class SecurityWrapperDefn(schemas: Set[SecurityInnerDefn]) {
+  lazy val traitName: String = schemas.map(_.partialTypeName).toSeq.sorted.mkString("_or_") + "_SecurityIn"
+}
+case class SecurityDefn(
+    inDecl: Option[String],
+    tpe: Option[String],
+    wrapperDefinitions: Option[SecurityWrapperDefn]
+)
+
 object SecurityGenerator {
+  def typeFromAuthType(s: String) = if (s == "Basic") "UsernamePassword" else "String"
+  def mkMapImpl(as: Seq[String]) = {
+    val innerDefn = SecurityInnerDefn(as)
+    val unzippedSomes = innerDefn.schemas.zipWithIndex.map { case (x, i) => s"Some(v$i: ${typeFromAuthType(x)})" }.mkString(", ")
+    val unzippedNones = innerDefn.schemas.map(_ => "None").mkString(", ")
+    val zippedArgs = innerDefn.schemas.zipWithIndex.map { case (x, i) => s"v$i: ${typeFromAuthType(x)}" }.mkString("(", ", ", ")")
+    s"""sttp.tapir.Mapping.from[${innerDefn.unzippedArgTypes}, Option[${innerDefn.argType}]] {
+       |    case ($unzippedSomes) => Some($zippedArgs)
+       |    case _ => None
+       |  } {
+       |    case Some($zippedArgs) => ($unzippedSomes)
+       |    case None => ($unzippedNones)
+       |  }""".stripMargin
+  }
+
+  def genSecurityTypes(securityWrappers: Set[SecurityWrapperDefn]): String = {
+    val allSchemes = securityWrappers.flatMap(_.schemas)
+    val allTpes = allSchemes.toSeq.sortBy(_.typeName)
+    val tpesWithParents = allTpes.map { t =>
+      t -> securityWrappers.filter(_.schemas.contains(t)).map(_.traitName).toSeq.sorted.mkString(" with ")
+    }
+    val traits = securityWrappers.map(_.traitName).toSeq.sorted.map(tn => s"sealed trait $tn").mkString("\n")
+    val classes = tpesWithParents
+      .map { case (d, ps) =>
+        s"case class ${d.typeName}(value: ${d.argType}) extends $ps"
+      }
+      .mkString("\n")
+
+    val mappings = allSchemes
+      .filterNot(_.isSingleton)
+      .map { t =>
+        val mapImpl = mkMapImpl(t.schemas)
+        s"""val ${t.typeName}Mapping = $mapImpl"""
+      }
+      .mkString("\n")
+    s"$traits\n$classes\n$mappings"
+  }
 
   def security(securitySchemes: Map[String, OpenapiSecuritySchemeType], security: Seq[Map[String, Seq[String]]])(implicit
       location: Location
   ): SecurityDefn = {
     if (security.forall(_.isEmpty)) return SecurityDefn(None, None, None)
-    if (security.exists(_.size > 1)) bail("Multiple schemes on same security requirement not yet supported")
-    if (security.exists(_.size == 1) && security.exists(_.isEmpty))
+    if (security.exists(_.nonEmpty) && security.exists(_.isEmpty))
       bail("Anonymous access not supported on endpoints with other security requirement declarations")
-    if (security.map(_.head._1).distinct.size != security.size)
-      bail("Multiple security requirements are only supported if schemes differ between requirements")
 
     // Would be nice to do something to respect scopes here
-    def inner(multi: Boolean = false): immutable.Seq[(String, String, String)] = security
-      .map(_.head) // we know, at this point, that all security decls have a since scheme
-      .flatMap { case (schemeName, _ /*scopes*/ ) =>
+    def inner(multi: Boolean = false): immutable.Seq[Seq[(String, String, String)]] = security
+      .map(_.flatMap { case (schemeName, _ /*scopes*/ ) =>
         def wrap(s: String): String = if (multi) s"Option[$s]" else s
         securitySchemes.get(schemeName) match {
           case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeBearerType) =>
@@ -33,7 +85,7 @@ object SecurityGenerator {
             Seq(("auth.basic[UsernamePassword]()", "Basic", schemeName))
 
           case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeApiKeyType(in, name)) =>
-            Seq((s"""auth.apiKey($in[${wrap("String")}]("$name"))""", "ApiKey", schemeName))
+            Seq((s"""auth.apiKey($in[${wrap("String")}]("$name"))""", schemeName, schemeName))
 
           case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeOAuth2Type(flows)) if flows.isEmpty => Nil
           case Some(OpenapiSecuritySchemeType.OpenapiSecuritySchemeOAuth2Type(flows)) =>
@@ -58,35 +110,52 @@ object SecurityGenerator {
           case None =>
             bail(s"Unknown security scheme $schemeName!")
         }
-      }
+      }.toList)
       .toList
 
     inner().distinct match {
-      case Nil                    => SecurityDefn(None, None, None)
-      case (h, "Basic", _) +: Nil => SecurityDefn(Some(s".securityIn($h)"), Some("UsernamePassword"), None)
-      case (h, _, _) +: Nil       => SecurityDefn(Some(s".securityIn($h)"), Some("String"), None)
+      case Nil                          => SecurityDefn(None, None, None)
+      case Seq((h, authType, _)) +: Nil => SecurityDefn(Some(s".securityIn($h)"), Some(typeFromAuthType(authType)), None)
       case s =>
         def handleMultiple = {
-          val optionally = inner(true).distinct.groupBy(_._2)
-          val namesAndImpls = optionally.toList.sortBy(_._1).flatMap {
-            case ("Bearer", _)  => Seq("Bearer" -> s".securityIn(auth.bearer[Option[String]]())")
-            case ("Basic", _)   => Seq("Basic" -> s".securityIn(auth.basic[Option[UsernamePassword]]())")
-            case ("ApiKey", vs) => vs.map { case (impl, _, name) => name -> s".securityIn($impl)" }.sortBy(_._1)
+          val isMultiOr: Boolean = s.size > 1
+          def wrapT(s: String): String = if (isMultiOr) s"Option[$s]" else s
+          val optionally = inner(isMultiOr).groupBy(_.map(_._2).sorted.distinct).values.map(_.head).toSeq
+          val namesImplsAndTypes = optionally.map(_.sortBy(_._1)).toList.sortBy(_.map(_._1).mkString(",")).map { x =>
+            val y = x.map {
+              case (_, authType @ ("Basic" | "Bearer"), _) =>
+                val tpe = typeFromAuthType(authType)
+                (authType, s"auth.bearer[${wrapT(tpe)}]()", tpe)
+              case (impl, _, name) => (name, impl, "String")
+            }
+            if (y.size == 1) {
+              val (a, b, c) = y.head
+              (SecurityInnerDefn(Seq(a)), s".securityIn($b)", wrapT(c))
+            } else {
+              val (as, bs, _) = y.unzip3
+              val innerDefn = SecurityInnerDefn(as)
+              val unmappedImpl = bs.reduceLeft((a, n) => s"$a\n  .and($n)")
+              val mapImpl = if (isMultiOr) s".map(${innerDefn.typeName}Mapping)" else ""
+              val impl = s"$unmappedImpl$mapImpl"
+              (innerDefn, s".securityIn($impl)", wrapT(innerDefn.argType))
+            }
           }
-          val impls = namesAndImpls.map(_._2).mkString("\n")
-          val traitName = SecurityWrapperDefn(namesAndImpls.map(_._1).toSet).traitName
-          val count = namesAndImpls.size
-          def someAt(idx: Int) = (0 to count - 1)
-            .map { case `idx` => "Some(x)"; case _ => "None" }
+          val impls = namesImplsAndTypes.map(_._2).mkString("\n")
+          val traitName = SecurityWrapperDefn(namesImplsAndTypes.map(_._1).toSet).traitName
+          val count = namesImplsAndTypes.size
+          def someAt(idx: Int, othersAreNone: Boolean) = (0 to count - 1)
+            .map { case `idx` => "Some(x)"; case _ => if (othersAreNone) "None" else "_" }
             .mkString("(", ", ", ")")
-          val mapDecodes = namesAndImpls.zipWithIndex.map { case ((name, _), idx) =>
-            s"case ${someAt(idx)} => DecodeResult.Value(${name.capitalize}SecurityIn(x))"
+          val mapDecodes = namesImplsAndTypes.zipWithIndex.map { case ((name, _, _), idx) =>
+            s"case ${someAt(idx, name.isSingleton)} => DecodeResult.Value(${name.typeName.capitalize}(x))"
           }
-          val mapEncodes = namesAndImpls.zipWithIndex.map { case ((name, _), idx) =>
-            s"case ${name.capitalize}SecurityIn(x) => ${someAt(idx)}"
+          val mapEncodes = namesImplsAndTypes.zipWithIndex.map { case ((name, _, _), idx) =>
+            s"case ${name.typeName}(x) => ${someAt(idx, true)}"
           }
           val mapImpl =
-            s""".mapSecurityInDecode[$traitName]{
+            if (isMultiOr)
+              s"""
+               |.mapSecurityInDecode[$traitName]{
                |${indent(2)(mapDecodes.mkString("\n"))}
                |  case other =>
                |    val count = other.productIterator.count(_.isInstanceOf[Some[?]])
@@ -94,14 +163,17 @@ object SecurityGenerator {
                |}{
                |${indent(2)(mapEncodes.mkString("\n"))}
                |}""".stripMargin
-          SecurityDefn(Some(s"$impls\n$mapImpl"), Some(traitName), Some(SecurityWrapperDefn(namesAndImpls.map(_._1).toSet)))
+            else ""
+          val securityWrappers = if (isMultiOr) Some(SecurityWrapperDefn(namesImplsAndTypes.map(_._1).toSet)) else None
+          val tpe = if (isMultiOr) Some(traitName) else namesImplsAndTypes.map(_._1.argType).headOption
+          SecurityDefn(Some(s"$impls$mapImpl"), tpe, securityWrappers)
         }
-        s.map(_._2).distinct match {
+        s.map(_.map(_._2).distinct).distinct match {
           case h +: Nil =>
             h match {
-              case "Bearer" => SecurityDefn(Some(".securityIn(auth.bearer[String]())"), Some("String"), None)
-              case "Basic"  => SecurityDefn(Some(".securityIn(auth.basic[UsernamePassword]())"), Some("UsernamePassword"), None)
-              case _        => handleMultiple
+              case Seq("Bearer") => SecurityDefn(Some(".securityIn(auth.bearer[String]())"), Some("String"), None)
+              case Seq("Basic")  => SecurityDefn(Some(".securityIn(auth.basic[UsernamePassword]())"), Some("UsernamePassword"), None)
+              case _             => handleMultiple
             }
           case _ => handleMultiple
         }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -15,7 +15,17 @@ object TapirGeneratedEndpoints {
   case class `application/zipCodecFormat`() extends CodecFormat {
     override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "application", subType = "zip")
   }
-
+  sealed trait Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn
+  case class Api_keySecurityIn(value: String) extends Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn
+  case class Api_key_and_BearerSecurityIn(value: (String, String)) extends Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn
+  case class BearerSecurityIn(value: String) extends Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn
+  val Api_key_and_BearerSecurityInMapping = sttp.tapir.Mapping.from[(Option[String], Option[String]), Option[(String, String)]] {
+      case (Some(v0: String), Some(v1: String)) => Some((v0: String, v1: String))
+      case _ => None
+    } {
+      case Some((v0: String, v1: String)) => (Some(v0: String), Some(v1: String))
+      case None => (None, None)
+    }
 
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
@@ -212,21 +222,37 @@ object TapirGeneratedEndpoints {
       .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Array[Byte]], CodecFormat.OctetStream()).description("Upload a csv"))
       .out(jsonBody[String].description("successful operation"))
 
-  type PutOptionalTestEndpoint = Endpoint[String, Option[NotNullableThingy], Unit, NotNullableThingy, Any]
+  type PutOptionalTestEndpoint = Endpoint[Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn, Option[NotNullableThingy], Unit, NotNullableThingy, Any]
   lazy val putOptionalTest: PutOptionalTestEndpoint =
     endpoint
       .put
       .in(("optional" / "test"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .securityIn(auth.apiKey(header[Option[String]]("api_key")))
+      .securityIn(auth.apiKey(header[Option[String]]("api_key"))
+        .and(auth.bearer[Option[String]]()).map(Api_key_and_BearerSecurityInMapping))
+      .securityIn(auth.bearer[Option[String]]())
+      .mapSecurityInDecode[Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn]{
+        case (Some(x), None, None) => DecodeResult.Value(Api_keySecurityIn(x))
+        case (_, Some(x), _) => DecodeResult.Value(Api_key_and_BearerSecurityIn(x))
+        case (None, None, Some(x)) => DecodeResult.Value(BearerSecurityIn(x))
+        case other =>
+          val count = other.productIterator.count(_.isInstanceOf[Some[?]])
+          DecodeResult.Error(s"$count security inputs", new RuntimeException(s"Expected a single security input, found $count"))
+      }{
+        case Api_keySecurityIn(x) => (Some(x), None, None)
+        case Api_key_and_BearerSecurityIn(x) => (None, Some(x), None)
+        case BearerSecurityIn(x) => (None, None, Some(x))
+      }
       .in(jsonBody[Option[NotNullableThingy]].description("an optional request body (not required)"))
       .out(jsonBody[NotNullableThingy].description("a non-optional response body"))
 
-  type PostOptionalTestEndpoint = Endpoint[String, Option[NullableThingy2], Unit, Option[NullableThingy], Any]
+  type PostOptionalTestEndpoint = Endpoint[(String, String), Option[NullableThingy2], Unit, Option[NullableThingy], Any]
   lazy val postOptionalTest: PostOptionalTestEndpoint =
     endpoint
       .post
       .in(("optional" / "test"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .securityIn(auth.apiKey(header[String]("api_key"))
+        .and(auth.bearer[String]()))
       .in(jsonBody[Option[NullableThingy2]].description("an optional request body (nullable)"))
       .out(jsonBody[Option[NullableThingy]].description("an optional response body"))
 
@@ -434,5 +460,6 @@ object TapirGeneratedEndpoints {
       Locally
     */
     val `/`: sttp.model.Uri = uri"/"
+
   }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -1,4 +1,4 @@
-
+openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
 package sttp.tapir.generated
 
 object TapirGeneratedEndpoints {
@@ -15,10 +15,12 @@ object TapirGeneratedEndpoints {
   case class `application/zipCodecFormat`() extends CodecFormat {
     override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "application", subType = "zip")
   }
+  sealed trait Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn
   sealed trait Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn
-  case class Api_keySecurityIn(value: String) extends Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn
-  case class Api_key_and_BearerSecurityIn(value: (String, String)) extends Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn
-  case class BearerSecurityIn(value: String) extends Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn
+  case class Api_keySecurityIn(value: String) extends Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn with Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn
+  case class Api_key_and_BearerSecurityIn(value: (String, String)) extends Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn with Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn
+  case class BearerSecurityIn(value: String) extends Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn with Bearer_or_api_key_or_api_key_and_Bearer_SecurityIn
+  case object EmptySecurityIn extends Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn
   val Api_key_and_BearerSecurityInMapping = sttp.tapir.Mapping.from[(Option[String], Option[String]), Option[(String, String)]] {
       case (Some(v0: String), Some(v1: String)) => Some((v0: String, v1: String))
       case _ => None
@@ -301,12 +303,29 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[ADTWithDiscriminatorNoMapping].description("Update an existent user in the store"))
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 
-  type GetOneofErrorTestEndpoint = Endpoint[String, Unit, Error, Unit, Any]
+  type GetOneofErrorTestEndpoint = Endpoint[Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn, Unit, Error, Unit, Any]
   lazy val getOneofErrorTest: GetOneofErrorTestEndpoint =
     endpoint
       .get
       .in(("oneof" / "error" / "test"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .securityIn(auth.apiKey(header[Option[String]]("api_key")))
+      .securityIn(auth.apiKey(header[Option[String]]("api_key"))
+        .and(auth.bearer[Option[String]]()).map(Api_key_and_BearerSecurityInMapping))
+      .securityIn(auth.bearer[Option[String]]())
+      .mapSecurityInDecode[Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn]{
+        case (Some(x), None, None) => DecodeResult.Value(Api_keySecurityIn(x))
+        case (_, Some(x), _) => DecodeResult.Value(Api_key_and_BearerSecurityIn(x))
+        case (None, None, Some(x)) => DecodeResult.Value(BearerSecurityIn(x))
+        case (None, None, None) => DecodeResult.Value(EmptySecurityIn)
+        case other =>
+          val count = other.productIterator.count(_.isInstanceOf[Some[?]])
+          DecodeResult.Error(s"$count security inputs", new RuntimeException(s"Expected a single security input, found $count"))
+      }{
+        case Api_keySecurityIn(x) => (Some(x), None, None)
+        case Api_key_and_BearerSecurityIn(x) => (None, Some(x), None)
+        case BearerSecurityIn(x) => (None, None, Some(x))
+        case EmptySecurityIn => (None, None, None)
+      }
       .errorOut(oneOf[Error](
         oneOfVariant[NotFoundError](sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")),
         oneOfVariant[SimpleError](sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -246,22 +246,22 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[Option[NotNullableThingy]].description("an optional request body (not required)"))
       .out(jsonBody[NotNullableThingy].description("a non-optional response body"))
 
-  type PostOptionalTestEndpoint = Endpoint[(String, String), Option[NullableThingy2], Unit, Option[NullableThingy], Any]
+  type PostOptionalTestEndpoint = Endpoint[Option[(String, String)], Option[NullableThingy2], Unit, Option[NullableThingy], Any]
   lazy val postOptionalTest: PostOptionalTestEndpoint =
     endpoint
       .post
       .in(("optional" / "test"))
-      .securityIn(auth.apiKey(header[String]("api_key"))
-        .and(auth.bearer[String]()))
+      .securityIn(auth.apiKey(header[Option[String]]("api_key"))
+        .and(auth.bearer[Option[String]]()).map(Api_key_and_BearerSecurityInMapping))
       .in(jsonBody[Option[NullableThingy2]].description("an optional request body (nullable)"))
       .out(jsonBody[Option[NullableThingy]].description("an optional response body"))
 
-  type PostJsonStringJsonBodyEndpoint = Endpoint[String, PostJsonStringJsonBodyBodyIn, Unit, Option[PostJsonStringJsonBodyBodyOut], Any]
+  type PostJsonStringJsonBodyEndpoint = Endpoint[Option[String], PostJsonStringJsonBodyBodyIn, Unit, Option[PostJsonStringJsonBodyBodyOut], Any]
   lazy val postJsonStringJsonBody: PostJsonStringJsonBodyEndpoint =
     endpoint
       .post
       .in(("json" / "stringJsonBody"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .securityIn(auth.bearer[Option[String]]())
       .in(oneOfBody[PostJsonStringJsonBodyBodyIn](
         stringJsonBody.map(Option(_))(_.orNull).map(PostJsonStringJsonBodyBodyOption_String_In(_))(_.value).widenBody[PostJsonStringJsonBodyBodyIn],
         EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/zipCodecFormat`](`application/zipCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(PostJsonStringJsonBodyBody1In(_))(_.value).widenBody[PostJsonStringJsonBodyBodyIn]))

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -1,4 +1,3 @@
-openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
 package sttp.tapir.generated
 
 object TapirGeneratedEndpoints {

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -81,6 +81,7 @@ paths:
             - write:pets
             - read:pets
           api_key: [ ]
+        - {}
       responses:
         '200':
           description: an optional response body
@@ -228,6 +229,11 @@ paths:
   '/json/stringJsonBody':
     post:
       x-tapir-codegen-directives: [ 'json-body-as-string' ]
+      security:
+        - {}
+        - petstore_auth:
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/json:

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -81,7 +81,7 @@ paths:
             - write:pets
             - read:pets
           api_key: [ ]
-        - {}
+        - { }
       responses:
         '200':
           description: an optional response body
@@ -211,6 +211,15 @@ paths:
               $ref: '#/components/schemas/ObjectWithInlineEnum'
   '/oneof/error/test':
     get:
+      security: # Requires two or one or none
+        - { }
+        - petstore_auth: [ ]
+        - api_key: [ ]
+        - BearerAuth: [ ]
+        - petstore_auth:
+            - write:pets
+            - read:pets
+          api_key: [ ]
       responses:
         "204":
           description: "No response"
@@ -230,7 +239,7 @@ paths:
     post:
       x-tapir-codegen-directives: [ 'json-body-as-string' ]
       security:
-        - {}
+        - { }
         - petstore_auth:
             - write:pets
             - read:pets

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -75,6 +75,12 @@ paths:
             - read:pets
   '/optional/test':
     post:
+      security:
+        # Requires _both_
+        - petstore_auth:
+            - write:pets
+            - read:pets
+          api_key: [ ]
       responses:
         '200':
           description: an optional response body
@@ -90,6 +96,15 @@ paths:
             schema:
               $ref: '#/components/schemas/NullableThingy2'
     put:
+      security:
+        # Requires two or one
+        - petstore_auth: [ ]
+        - api_key: [ ]
+        - BearerAuth: [ ]
+        - petstore_auth:
+            - write:pets
+            - read:pets
+          api_key: [ ]
       responses:
         '200':
           $ref: '#/components/responses/optionalityTest'

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
@@ -17,8 +17,8 @@ object TapirGeneratedEndpoints {
     override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "application", subType = "x-www-form-urlencoded")
   }
   sealed trait Bearer_or_api_key_SecurityIn
-  case class BearerSecurityIn(value: String) extends Bearer_or_api_key_SecurityIn
   case class Api_keySecurityIn(value: String) extends Bearer_or_api_key_SecurityIn
+  case class BearerSecurityIn(value: String) extends Bearer_or_api_key_SecurityIn
 
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])


### PR DESCRIPTION
Also supports 'optional' Auth if declarations contains an empty map

Will just transform inputs to the first matching declaration if multiple declarations support multiple security params, and a superset of both of them is present in the request. That could presumably be improved, if required, by refining the match implementations a bit so that supersets weren't matched on multi-declaration sites, but the extra complexity hardly seems worth it...