### PR TITLE
codegen: Support security path declarations

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -63,7 +63,11 @@ val docs = TapirGeneratedEndpoints.generatedEndpoints.toOpenAPI("My Bookshop", "
 ### Support specification extensions
 
 Generator behaviour can be further configured by specifications on the input openapi spec. Example:
+
 ```yaml
+paths:
+  x-tapir-codegen-security-path-prefixes:
+    - '/security-group/{securityGroupName}' # any path prefixes matching this pattern will be considered 'securityIn' 
   '/my-endpoint':
     post:
       x-tapir-codegen-directives: [ 'json-body-as-string' ] # This will customise what the codegen generates for this endpoint
@@ -80,7 +84,11 @@ Generator behaviour can be further configured by specifications on the input ope
 
 Supported specifications are:
 
+- x-tapir-codegen-security-path-prefixes: supported on the paths object. This is an array of strings representing path
+  prefixes. The longest matching prefix of each path will be treated as a security input, rather than as a standard 'in'
+  value.
 - x-tapir-codegen-directives: supported on openapi operations. This is an array of string flags. Supported values are:
+
 ```{eval-rst}
 ==================== ===================================================================================================================================
 name                 description
@@ -88,7 +96,6 @@ name                 description
 json-body-as-string  If present on an operation, all application/json requests and responses will be interpreted mapped to a string with stringJsonBody
 ==================== ===================================================================================================================================
 ```
-
 
 ### Output files
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/BasicGenerator.scala
@@ -82,11 +82,8 @@ object BasicGenerator {
     val EndpointDefs(
       endpointsByTag,
       queryOrPathParamRefs,
-      jsonParamRefs,
       enumsDefinedOnEndpointParams,
-      inlineDefns,
-      xmlParamRefs,
-      securityWrappers
+      EndpointDetails(jsonParamRefs, inlineDefns, xmlParamRefs, securityWrappers)
     ) =
       endpointGenerator.endpointDefs(
         doc,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -225,8 +225,8 @@ class EndpointGenerator {
           val definition =
             s"""|endpoint$maybeName
                 |  .${m.methodType}
-                |  $pathDecl$securityPathDecl
-                |$sec${indent(2)(inParams)}
+                |  $pathDecl
+                |$sec${indent(2)(inParams)}$securityPathDecl
                 |${indent(2)(outDecl)}
                 |${indent(2)(tags(m.tags))}
                 |$attributeString
@@ -323,7 +323,7 @@ class EndpointGenerator {
     val (inPath, tpes) = toPathDecl(inUrl)
     val inPathDecl = if (inPath.nonEmpty) ".in((" + inPath.mkString(" / ") + "))" else ""
     val secPathDecl =
-      maxSecurityPrefix.map(toPathDecl).map { case (ds, ts) => ".securityIn(" + ds.mkString(" / ") + ")" -> ts.toSeq.flatten }
+      maxSecurityPrefix.map(toPathDecl).map { case (ds, ts) => ".prependSecurityIn(" + ds.mkString(" / ") + ")" -> ts.toSeq.flatten }
     (inPathDecl, tpes.toSeq.flatten, secPathDecl)
   }
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/GenerationDirectives.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/GenerationDirectives.scala
@@ -3,4 +3,5 @@ package sttp.tapir.codegen.openapi.models
 object GenerationDirectives {
   val extensionKey = "tapir-codegen-directives"
   val jsonBodyAsString = "json-body-as-string"
+  val securityPrefixKey = "tapir-codegen-security-path-prefixes"
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -1,3 +1,4 @@
+
 package sttp.tapir.generated
 
 object TapirGeneratedEndpoints {
@@ -285,6 +286,14 @@ object TapirGeneratedEndpoints {
       .out(stringJsonBody.description("Possibly-invalid json"))
       .attribute[TapirCodegenDirectivesExtension](tapirCodegenDirectivesExtensionKey, Vector("json-body-as-string"))
 
+  type GetSecurityGroupSecurityGroupNameEndpoint = Endpoint[(String, String), Unit, Unit, Unit, Any]
+  lazy val getSecurityGroupSecurityGroupName: GetSecurityGroupSecurityGroupNameEndpoint =
+    endpoint
+      .get
+      .securityIn("security-group" / path[String]("securityGroupName").description("used by security logic"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .out(statusCode(sttp.model.StatusCode(204)).description("OK"))
+
   type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
   lazy val putAdtTest: PutAdtTestEndpoint =
     endpoint
@@ -329,6 +338,15 @@ object TapirGeneratedEndpoints {
         oneOfVariant[NotFoundError](sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")),
         oneOfVariant[SimpleError](sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
       .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
+
+  type GetSecurityGroupSecurityGroupNameMorePathEndpoint = Endpoint[(String, String), Unit, Unit, Unit, Any]
+  lazy val getSecurityGroupSecurityGroupNameMorePath: GetSecurityGroupSecurityGroupNameMorePathEndpoint =
+    endpoint
+      .get
+      .in(("more-path"))
+      .securityIn("security-group" / path[String]("securityGroupName").description("used by security logic"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .out(statusCode(sttp.model.StatusCode(204)).description("OK"))
 
   type GetOneofOptionTestEndpoint = Endpoint[String, Unit, Unit, (Option[AnyObjectWithInlineEnum], Option[String]), Any]
   lazy val getOneofOptionTest: GetOneofOptionTestEndpoint =
@@ -438,7 +456,7 @@ object TapirGeneratedEndpoints {
       .out(jsonBody[ListType].description("list type out"))
 
 
-  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, putAdtTest, postAdtTest, getOneofErrorTest, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, getSecurityGroupSecurityGroupName, putAdtTest, postAdtTest, getOneofErrorTest, getSecurityGroupSecurityGroupNameMorePath, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
 
   object Servers {
@@ -462,7 +480,7 @@ object TapirGeneratedEndpoints {
       def uri(_environment: environment = environment.default, _port: String = defaultPort, _customer: String = defaultCustomer): sttp.model.Uri =
         uri"https://${_environment}.my-co.org:${_port}/api/${_customer}/prefix"
     }
-
+    
     /*
       Legacy endpoint that doesn't require TLS
       Doesn't work, retained for completely mysterious reasons lost to the winds of time
@@ -473,7 +491,7 @@ object TapirGeneratedEndpoints {
       def uri(_port: String = defaultPort, _scoped: String = defaultScoped): sttp.model.Uri =
         uri"http://testing.my-co.org:${_port}/api/${_scoped}/prefix"
     }
-
+    
     /*
       Locally
     */

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -290,8 +290,8 @@ object TapirGeneratedEndpoints {
   lazy val getSecurityGroupSecurityGroupName: GetSecurityGroupSecurityGroupNameEndpoint =
     endpoint
       .get
-      .securityIn("security-group" / path[String]("securityGroupName").description("used by security logic"))
       .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .prependSecurityIn("security-group" / path[String]("securityGroupName").description("used by security logic"))
       .out(statusCode(sttp.model.StatusCode(204)).description("OK"))
 
   type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
@@ -311,11 +311,11 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[ADTWithDiscriminatorNoMapping].description("Update an existent user in the store"))
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 
-  type GetOneofErrorTestEndpoint = Endpoint[Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn, Unit, Error, Unit, Any]
-  lazy val getOneofErrorTest: GetOneofErrorTestEndpoint =
+  type GetOneofErrorSecParamTestEndpoint = Endpoint[(String, Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn), Unit, Error, Unit, Any]
+  lazy val getOneofErrorSecParamTest: GetOneofErrorSecParamTestEndpoint =
     endpoint
       .get
-      .in(("oneof" / "error" / "test"))
+      .in(("test"))
       .securityIn(auth.apiKey(header[Option[String]]("api_key")))
       .securityIn(auth.apiKey(header[Option[String]]("api_key"))
         .and(auth.bearer[Option[String]]()).map(Api_key_and_BearerSecurityInMapping))
@@ -334,6 +334,7 @@ object TapirGeneratedEndpoints {
         case BearerSecurityIn(x) => (None, None, Some(x))
         case EmptySecurityIn => (None, None, None)
       }
+      .prependSecurityIn("oneof" / "error" / path[String]("secParam"))
       .errorOut(oneOf[Error](
         oneOfVariant[NotFoundError](sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")),
         oneOfVariant[SimpleError](sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
@@ -344,8 +345,8 @@ object TapirGeneratedEndpoints {
     endpoint
       .get
       .in(("more-path"))
-      .securityIn("security-group" / path[String]("securityGroupName").description("used by security logic"))
       .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .prependSecurityIn("security-group" / path[String]("securityGroupName").description("used by security logic"))
       .out(statusCode(sttp.model.StatusCode(204)).description("OK"))
 
   type GetOneofOptionTestEndpoint = Endpoint[String, Unit, Unit, (Option[AnyObjectWithInlineEnum], Option[String]), Any]
@@ -456,7 +457,7 @@ object TapirGeneratedEndpoints {
       .out(jsonBody[ListType].description("list type out"))
 
 
-  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, getSecurityGroupSecurityGroupName, putAdtTest, postAdtTest, getOneofErrorTest, getSecurityGroupSecurityGroupNameMorePath, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, getSecurityGroupSecurityGroupName, putAdtTest, postAdtTest, getOneofErrorSecParamTest, getSecurityGroupSecurityGroupNameMorePath, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
 
   object Servers {

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -37,7 +37,8 @@ security: # Default security on all endpoints without explicit declarations
       - read:pets
 paths:
   x-tapir-codegen-security-path-prefixes:
-    - '/security-group/{securityGroupName}'
+    - /security-group/{securityGroupName}
+    - /oneof/error/{secParam}
   '/security-group/{securityGroupName}':
     parameters:
       - $ref: '#/components/parameters/securityGroupName'
@@ -225,7 +226,13 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ObjectWithInlineEnum'
-  '/oneof/error/test':
+  '/oneof/error/{secParam}/test':
+    parameters:
+      - name: secParam
+        in: path
+        required: true
+        schema:
+          type: string
     get:
       security: # Requires two or one or none
         - { }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -36,6 +36,22 @@ security: # Default security on all endpoints without explicit declarations
       - write:pets
       - read:pets
 paths:
+  x-tapir-codegen-security-path-prefixes:
+    - '/security-group/{securityGroupName}'
+  '/security-group/{securityGroupName}':
+    parameters:
+      - $ref: '#/components/parameters/securityGroupName'
+    get:
+      responses:
+        204:
+          description: OK
+  '/security-group/{securityGroupName}/more-path':
+    parameters:
+      - $ref: '#/components/parameters/securityGroupName'
+    get:
+      responses:
+        204:
+          description: OK
   '/binary/test':
     get:
       security:
@@ -420,6 +436,13 @@ components:
     common-response-header:
       in: header
       name: x-common
+      schema:
+        type: string
+    securityGroupName:
+      name: securityGroupName
+      in: path
+      description: used by security logic
+      required: true
       schema:
         type: string
   responses:


### PR DESCRIPTION
Adds a new custom extension 'x-tapir-codegen-security-path-prefixes', for when your auth logic wants to know some prefix of the path (e.g. for validating that a jwt contains perms for the segment)

The path security input will be prepended after any other security inputs are declared and mapped, so that the security path will appear before other security inputs in the signature. This matches the non-security inputs, where path is also first.

There may be a neater way to do this that I've missed, but my understanding is that security inputs are _always_ parsed before non-security input, so if you want to know about the path in the security logic this is the only approach that works...