### PR TITLE
Codegen: import models (WIP)

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/GenerationDirectives.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/GenerationDirectives.scala
@@ -4,4 +4,5 @@ object GenerationDirectives {
   val extensionKey = "tapir-codegen-directives"
   val jsonBodyAsString = "json-body-as-string"
   val securityPrefixKey = "tapir-codegen-security-path-prefixes"
+  val importedModels = "tapir-codegen-imported-models"
 }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/GenerationDirectives.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/GenerationDirectives.scala
@@ -5,4 +5,6 @@ object GenerationDirectives {
   val jsonBodyAsString = "json-body-as-string"
   val securityPrefixKey = "tapir-codegen-security-path-prefixes"
   val importedModels = "tapir-codegen-imported-models"
+  val importedSerdes = "tapir-codegen-imported-serdes"
+  val importedSchemas = "tapir-codegen-imported-schemas"
 }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
@@ -7,7 +7,8 @@ case class OpenapiComponent(
     securitySchemes: Map[String, OpenapiSecuritySchemeType] = Map.empty,
     parameters: Map[String, OpenapiParameter] = Map.empty,
     responses: Map[String, OpenapiResponseDefn] = Map.empty,
-    requestBodies: Map[String, OpenapiRequestBody] = Map.empty
+    requestBodies: Map[String, OpenapiRequestBody] = Map.empty,
+    importedModels: Map[String, Seq[String]] = Map.empty
 )
 
 object OpenapiComponent {
@@ -20,13 +21,15 @@ object OpenapiComponent {
       parameters <- c.getOrElse[Map[String, OpenapiParameter]]("parameters")(Map.empty)
       responses <- c.getOrElse[Map[String, OpenapiResponseDefn]]("responses")(Map.empty)
       requestBodies <- c.getOrElse[Map[String, OpenapiRequestBody]]("requestBodies")(Map.empty)
+      importedModels <- c.getOrElse[Map[String, Seq[String]]]("x-" + GenerationDirectives.importedModels)(Map.empty)
     } yield {
       OpenapiComponent(
         schemas,
         securitySchemes,
         parameters.map { case (k, v) => s"#/components/parameters/$k" -> v },
         responses,
-        requestBodies
+        requestBodies,
+        importedModels
       )
     }
   }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -11,6 +11,7 @@ object TapirGeneratedEndpoints {
 
   import sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes._
   import TapirGeneratedEndpointsSchemas._
+  import to.inject.MyModels.{StringWrapper, IntWrapper}
 
   case class `application/zipCodecFormat`() extends CodecFormat {
     override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "application", subType = "zip")
@@ -206,6 +207,15 @@ object TapirGeneratedEndpoints {
 
   type TapirCodegenDirectivesExtension = Seq[String]
   val tapirCodegenDirectivesExtensionKey = new sttp.tapir.AttributeKey[TapirCodegenDirectivesExtension]("sttp.tapir.generated.TapirGeneratedEndpoints.TapirCodegenDirectivesExtension")
+
+  type PostImportedModelsEndpoint = Endpoint[String, Option[StringWrapper], Unit, IntWrapper, Any]
+  lazy val postImportedModels: PostImportedModelsEndpoint =
+    endpoint
+      .post
+      .in(("imported" / "models"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .in(jsonBody[Option[StringWrapper]])
+      .out(jsonBody[IntWrapper].description("An object"))
 
   type GetBinaryTestEndpoint = Endpoint[String, Unit, Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
   lazy val getBinaryTest: GetBinaryTestEndpoint =
@@ -457,7 +467,7 @@ object TapirGeneratedEndpoints {
       .out(jsonBody[ListType].description("list type out"))
 
 
-  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, getSecurityGroupSecurityGroupName, putAdtTest, postAdtTest, getOneofErrorSecParamTest, getSecurityGroupSecurityGroupNameMorePath, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+  lazy val generatedEndpoints = List(postImportedModels, getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, getSecurityGroupSecurityGroupName, putAdtTest, postAdtTest, getOneofErrorSecParamTest, getSecurityGroupSecurityGroupNameMorePath, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
 
   object Servers {
@@ -481,7 +491,7 @@ object TapirGeneratedEndpoints {
       def uri(_environment: environment = environment.default, _port: String = defaultPort, _customer: String = defaultCustomer): sttp.model.Uri =
         uri"https://${_environment}.my-co.org:${_port}/api/${_customer}/prefix"
     }
-    
+
     /*
       Legacy endpoint that doesn't require TLS
       Doesn't work, retained for completely mysterious reasons lost to the winds of time
@@ -492,7 +502,7 @@ object TapirGeneratedEndpoints {
       def uri(_port: String = defaultPort, _scoped: String = defaultScoped): sttp.model.Uri =
         uri"http://testing.my-co.org:${_port}/api/${_scoped}/prefix"
     }
-    
+
     /*
       Locally
     */

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
@@ -52,10 +52,6 @@ object TapirGeneratedEndpointsJsonSerdes {
   implicit lazy val subtypeWithoutD2JsonEncoder: io.circe.Encoder[SubtypeWithoutD2] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithoutD2]
   implicit lazy val subtypeWithD2JsonDecoder: io.circe.Decoder[SubtypeWithD2] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithD2]
   implicit lazy val subtypeWithD2JsonEncoder: io.circe.Encoder[SubtypeWithD2] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithD2]
-  implicit lazy val stringWrapperJsonDecoder: io.circe.Decoder[StringWrapper] = io.circe.generic.semiauto.deriveDecoder[StringWrapper]
-  implicit lazy val stringWrapperJsonEncoder: io.circe.Encoder[StringWrapper] = io.circe.generic.semiauto.deriveEncoder[StringWrapper]
-  implicit lazy val intWrapperJsonDecoder: io.circe.Decoder[IntWrapper] = io.circe.generic.semiauto.deriveDecoder[IntWrapper]
-  implicit lazy val intWrapperJsonEncoder: io.circe.Encoder[IntWrapper] = io.circe.generic.semiauto.deriveEncoder[IntWrapper]
 
   implicit lazy val aDTWithoutDiscriminatorJsonEncoder: io.circe.Encoder[ADTWithoutDiscriminator] = io.circe.Encoder.instance {
     case x: SubtypeWithoutD1 => io.circe.Encoder[SubtypeWithoutD1].apply(x)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
@@ -1,5 +1,6 @@
 package sttp.tapir.generated
 
+import to.inject.MyModels.{StringWrapper, IntWrapper}
 object TapirGeneratedEndpointsJsonSerdes {
   import sttp.tapir.generated.TapirGeneratedEndpoints._
   import sttp.tapir.generic.auto._
@@ -51,6 +52,11 @@ object TapirGeneratedEndpointsJsonSerdes {
   implicit lazy val subtypeWithoutD2JsonEncoder: io.circe.Encoder[SubtypeWithoutD2] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithoutD2]
   implicit lazy val subtypeWithD2JsonDecoder: io.circe.Decoder[SubtypeWithD2] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithD2]
   implicit lazy val subtypeWithD2JsonEncoder: io.circe.Encoder[SubtypeWithD2] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithD2]
+  implicit lazy val stringWrapperJsonDecoder: io.circe.Decoder[StringWrapper] = io.circe.generic.semiauto.deriveDecoder[StringWrapper]
+  implicit lazy val stringWrapperJsonEncoder: io.circe.Encoder[StringWrapper] = io.circe.generic.semiauto.deriveEncoder[StringWrapper]
+  implicit lazy val intWrapperJsonDecoder: io.circe.Decoder[IntWrapper] = io.circe.generic.semiauto.deriveDecoder[IntWrapper]
+  implicit lazy val intWrapperJsonEncoder: io.circe.Encoder[IntWrapper] = io.circe.generic.semiauto.deriveEncoder[IntWrapper]
+
   implicit lazy val aDTWithoutDiscriminatorJsonEncoder: io.circe.Encoder[ADTWithoutDiscriminator] = io.circe.Encoder.instance {
     case x: SubtypeWithoutD1 => io.circe.Encoder[SubtypeWithoutD1].apply(x)
     case x: SubtypeWithoutD2 => io.circe.Encoder[SubtypeWithoutD2].apply(x)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
@@ -5,7 +5,6 @@ object TapirGeneratedEndpointsSchemas {
   import sttp.tapir.generated.TapirGeneratedEndpoints._
   import sttp.tapir.generic.auto._
   implicit lazy val anEnumTapirSchema: sttp.tapir.Schema[AnEnum] = sttp.tapir.Schema.derived
-  implicit lazy val intWrapperTapirSchema: sttp.tapir.Schema[IntWrapper] = sttp.tapir.Schema.derived
   implicit lazy val notFoundErrorTapirSchema: sttp.tapir.Schema[NotFoundError] = sttp.tapir.Schema.derived
   implicit lazy val notNullableThingyTapirSchema: sttp.tapir.Schema[NotNullableThingy] = sttp.tapir.Schema.derived
   implicit lazy val nullableThingyTapirSchema: sttp.tapir.Schema[NullableThingy] = sttp.tapir.Schema.derived
@@ -15,7 +14,6 @@ object TapirGeneratedEndpointsSchemas {
   implicit lazy val objectWithInlineEnum2InlineEnumTapirSchema: sttp.tapir.Schema[ObjectWithInlineEnum2InlineEnum] = sttp.tapir.Schema.derived
   implicit lazy val objectWithInlineEnum2TapirSchema: sttp.tapir.Schema[ObjectWithInlineEnum2] = sttp.tapir.Schema.derived
   implicit lazy val simpleErrorTapirSchema: sttp.tapir.Schema[SimpleError] = sttp.tapir.Schema.derived
-  implicit lazy val stringWrapperTapirSchema: sttp.tapir.Schema[StringWrapper] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD1TapirSchema: sttp.tapir.Schema[SubtypeWithD1] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD2TapirSchema: sttp.tapir.Schema[SubtypeWithD2] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithoutD1TapirSchema: sttp.tapir.Schema[SubtypeWithoutD1] = sttp.tapir.Schema.derived

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
@@ -1,9 +1,11 @@
 package sttp.tapir.generated
 
+import to.inject.MyModels.{StringWrapper, IntWrapper}
 object TapirGeneratedEndpointsSchemas {
   import sttp.tapir.generated.TapirGeneratedEndpoints._
   import sttp.tapir.generic.auto._
   implicit lazy val anEnumTapirSchema: sttp.tapir.Schema[AnEnum] = sttp.tapir.Schema.derived
+  implicit lazy val intWrapperTapirSchema: sttp.tapir.Schema[IntWrapper] = sttp.tapir.Schema.derived
   implicit lazy val notFoundErrorTapirSchema: sttp.tapir.Schema[NotFoundError] = sttp.tapir.Schema.derived
   implicit lazy val notNullableThingyTapirSchema: sttp.tapir.Schema[NotNullableThingy] = sttp.tapir.Schema.derived
   implicit lazy val nullableThingyTapirSchema: sttp.tapir.Schema[NullableThingy] = sttp.tapir.Schema.derived
@@ -13,6 +15,7 @@ object TapirGeneratedEndpointsSchemas {
   implicit lazy val objectWithInlineEnum2InlineEnumTapirSchema: sttp.tapir.Schema[ObjectWithInlineEnum2InlineEnum] = sttp.tapir.Schema.derived
   implicit lazy val objectWithInlineEnum2TapirSchema: sttp.tapir.Schema[ObjectWithInlineEnum2] = sttp.tapir.Schema.derived
   implicit lazy val simpleErrorTapirSchema: sttp.tapir.Schema[SimpleError] = sttp.tapir.Schema.derived
+  implicit lazy val stringWrapperTapirSchema: sttp.tapir.Schema[StringWrapper] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD1TapirSchema: sttp.tapir.Schema[SubtypeWithD1] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD2TapirSchema: sttp.tapir.Schema[SubtypeWithD2] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithoutD1TapirSchema: sttp.tapir.Schema[SubtypeWithoutD1] = sttp.tapir.Schema.derived

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/project/plugins.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/project/plugins.sbt
@@ -1,11 +1,3 @@
 {
-  val pluginVersion = System.getProperty("plugin.version")
-  if (pluginVersion == null)
-    throw new RuntimeException("""|
-                                  |
-                                  |The system property 'plugin.version' is not defined.
-                                  |Specify this property using the scriptedLaunchOpts -D.
-                                  |
-                                  |""".stripMargin)
-  else addSbtPlugin("com.softwaremill.sttp.tapir" % "sbt-openapi-codegen" % pluginVersion)
+  addSbtPlugin("com.softwaremill.sttp.tapir" % "sbt-openapi-codegen" % "1.11.23.5-LOCAL")
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/main/scala/MyModels.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/main/scala/MyModels.scala
@@ -1,0 +1,6 @@
+package to.inject
+
+object MyModels {
+  case class StringWrapper(s: String) extends AnyVal
+  case class IntWrapper(s: Int) extends AnyVal
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/main/scala/MyModels.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/main/scala/MyModels.scala
@@ -3,4 +3,12 @@ package to.inject
 object MyModels {
   case class StringWrapper(s: String) extends AnyVal
   case class IntWrapper(s: Int) extends AnyVal
+
+  implicit val stringWrapperJsonDecoder: io.circe.Decoder[StringWrapper] = io.circe.generic.semiauto.deriveDecoder[StringWrapper]
+  implicit val stringWrapperJsonEncoder: io.circe.Encoder[StringWrapper] = io.circe.generic.semiauto.deriveEncoder[StringWrapper]
+  implicit val intWrapperJsonDecoder: io.circe.Decoder[IntWrapper] = io.circe.generic.semiauto.deriveDecoder[IntWrapper]
+  implicit val intWrapperJsonEncoder: io.circe.Encoder[IntWrapper] = io.circe.generic.semiauto.deriveEncoder[IntWrapper]
+
+  implicit val intWrapperTapirSchema: sttp.tapir.Schema[IntWrapper] = sttp.tapir.Schema.derived
+  implicit val stringWrapperTapirSchema: sttp.tapir.Schema[StringWrapper] = sttp.tapir.Schema.derived
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -436,9 +436,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListType'
-
+  '/imported/models':
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StringWrapper'
+      responses:
+        "200":
+          description: An object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntWrapper'
 
 components:
+  x-tapir-codegen-imported-models:
+    to.inject.MyModels:
+      - StringWrapper
+      - IntWrapper
   parameters:
     common-response-header:
       in: header
@@ -678,3 +695,19 @@ components:
       type: array
       items:
         type: string
+    IntWrapper:
+      title: IntWrapper
+      type: object
+      required:
+        - s
+      properties:
+        s:
+          type: string
+    StringWrapper:
+      title: StringWrapper
+      type: object
+      required:
+        - s
+      properties:
+        s:
+          type: integer


### PR DESCRIPTION
Very much a work-in-progress at the moment.

My eventual goal here is to target a very specific use-case: in a world where an openapi specification can represent a version of an API, it's currently possible to specify a separate file for each version and automatically generate endpoints for all versions. HOWEVER. This is actually really annoying behaviour. Ideally, it'd be nice for all models that are completely consistent between versions to not need redeclaration, nor for their serdes or schemas to be regenerated, otherwise there's potentially a _lot_ of redundant redeclaration.

My first run at this was to permit declaration of 'model injections', where custom directives will permit specifying that some models are defined elsewhere, and further specify the location of serdes and schemas that may need importing.
Example:
```yaml
components:
  x-tapir-codegen-imported-models:
    sttp.tapir.generated.TapirGeneratedEndpoints:
      - ModelA
      - ModelB
...
  x-tapir-codegen-imported-serdes:
    - sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes
  x-tapir-codegen-imported-schemas:
    - sttp.tapir.generated.TapirGeneratedEndpointsSchemas1
    - sttp.tapir.generated.TapirGeneratedEndpointsSchemas2
    - sttp.tapir.generated.TapirGeneratedEndpointsSchemas3
```

That was my first idea, and seems much more general; and with some hacking can be made to support the use-case I have in mind (as well as, potentially, being a route towards supporting other things, like alternative xml codecs or custom codecs or what-have-you). HOWEVER. This requires somehow maintaining a list of 'common' models between the different APIs, and doesn't do anything to avoid _endpoint_ redeclaration. It would be much neater if I could simply declare an optional seq of parents for each file, and have some sort of declaration-inheritance structure be automatically inferred. Example:
```scala
openapiDeclarationInheritance := Map(
  "sttp.tapir.generated.V2" -> Seq("sttp.tapir.V1")
  "sttp.tapir.generated.V3" -> Seq("sttp.tapir.V2")
)
```
In order for this to be principled, we'd probably need to pass a bunch of information from the V1 to V2, and from V2 to V3, and also do something about the helper classes (custom codec formats, CommaSeparatedValues, ExtraParamSupport etc) so that we don't have conflicts and deduplication there.

Anyway, still needs much thought. Some thoughts I've had already:
- Perhaps we don't want to avoid the regeneration entirely, but just make suitable aliases to the fully-qualified inherited model, so that expected references still worked.
- Whether a serde needs to be redeclared is potentially contingent not only on whether a model is inherited, but also on whether its endpoint usage is different in the new schema - e.g. a model used only in JSON position for V3 wouldnt have a V1 JSON serdes declared.
- Perhaps only model imports is a legitimate usecase, and the idea of inheritance without redeclaration is insufficiently general

A seemingly-unrelated fact is that when I use this library locally, amongst other munges to the initial output of the tool, I convert the output from a normal list to a custom HList variant specialised for containing endpoint definitions. And what I really really want is a way to ensure a total binding over all versions with a bare minimum of redeclaration without having to do that sorta downstream shenanigans, whilst still retaining appropriate levels of generality... 🤔 

Tbc