### PR TITLE
codegen: fix placement of 'description' call in edgecase

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -696,10 +696,10 @@ class EndpointGenerator {
               (
                 resp.code match {
                   case "200" | "default" if outHeaderDefns.isEmpty => None
-                  case "200"                                       => Some(s"statusCode(sttp.model.StatusCode(200))$hs$d")
-                  case "default"                                   => Some(s"statusCode(sttp.model.StatusCode(400))$hs$d")
-                  case okStatus(s)                                 => Some(s"statusCode(sttp.model.StatusCode($s))$hs$d")
-                  case errorStatus(s)                              => Some(s"statusCode(sttp.model.StatusCode($s))$hs$d")
+                  case "200"                                       => Some(s"statusCode(sttp.model.StatusCode(200))$d$hs")
+                  case "default"                                   => Some(s"statusCode(sttp.model.StatusCode(400))$d$hs")
+                  case okStatus(s)                                 => Some(s"statusCode(sttp.model.StatusCode($s))$d$hs")
+                  case errorStatus(s)                              => Some(s"statusCode(sttp.model.StatusCode($s))$d$hs")
                 },
                 ht(),
                 inlineHeaderEnumDefns

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -311,6 +311,14 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[ADTWithDiscriminatorNoMapping].description("Update an existent user in the store"))
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 
+  type GetHeadersTestsEndpoint = Endpoint[String, Unit, Unit, Option[String], Any]
+  lazy val getHeadersTests: GetHeadersTestsEndpoint =
+    endpoint
+      .get
+      .in(("headers" / "tests"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .out(statusCode(sttp.model.StatusCode(302)).description("response").and(header[Option[String]]("foo").description("a description")))
+
   type GetOneofErrorSecParamTestEndpoint = Endpoint[(String, Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn), Unit, Error, Unit, Any]
   lazy val getOneofErrorSecParamTest: GetOneofErrorSecParamTestEndpoint =
     endpoint
@@ -457,7 +465,7 @@ object TapirGeneratedEndpoints {
       .out(jsonBody[ListType].description("list type out"))
 
 
-  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, getSecurityGroupSecurityGroupName, putAdtTest, postAdtTest, getOneofErrorSecParamTest, getSecurityGroupSecurityGroupNameMorePath, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, getSecurityGroupSecurityGroupName, putAdtTest, postAdtTest, getHeadersTests, getOneofErrorSecParamTest, getSecurityGroupSecurityGroupNameMorePath, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
 
   object Servers {

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -329,6 +329,17 @@ paths:
               schema:
                 $ref: '#/components/schemas/ObjectWithInlineEnum2'
 
+  '/headers/tests':
+    get:
+      responses:
+        "302":
+          description: response
+          headers:
+            foo:
+              description: a description
+              schema:
+                type: string
+
   '/inline/simple/object':
     post:
       requestBody:


### PR DESCRIPTION
Fixes placement of 'description' field on endpoint with a header but no body, and with no other response status codes of same type. Before, would occasionally produce code than can't compile. E.g. would generate
```scala
.out(statusCode(sttp.model.StatusCode(302)).and(header[Option[String]]("foo").description("bar.")).description(""))
```
which will fail to compile with `value description is not a member of sttp.tapir.EndpointOutput[Option[String]]`