### PR TITLE
feat(files): added extraHeaders to server endpoints for files/resources

### DIFF
--- a/doc/endpoint/static.md
+++ b/doc/endpoint/static.md
@@ -62,7 +62,9 @@ Similarly, the `staticResourcesGetServerEndpoint` can be used to expose the appl
 
 A single resource can be exposed using `staticResourceGetServerEndpoint`.
 
-## FileOptions
+## Additional Configuration
+
+### FileOptions
 
 Endpoint constructor methods for files and resources can receive optional `FileOptions`, which allow to configure additional settings:
 
@@ -89,6 +91,29 @@ val options: FilesOptions[Identity] =
 
 val endpoint = staticFilesGetServerEndpoint[Identity](emptyInput)("/var/www", options)
 ```
+
+### Static Headers
+
+In addition to the `FileOptions`, zero or more `Header`s  can also be provided to a server endpoint
+as a `List[Header]`. These can be used to attached fixed headers to the responses. As an example:
+
+```scala mdoc:compile-only
+import sttp.model.Header
+import sttp.model.headers.CacheDirective
+import sttp.tapir.emptyInput
+import sttp.tapir.*
+import sttp.tapir.files.*
+import sttp.shared.Identity
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.TimeUnit
+
+val headers = List(Header.cacheControl(CacheDirective.MaxAge(FiniteDuration(365, TimeUnit.DAYS))))
+
+val endpoint = staticFilesGetServerEndpoint[Identity](emptyInput)("/var/www", extraHeaders = headers)
+```
+
+The above `cacheControl` header makes this resource eligible for caching for up to a year on the
+client machine. The headers which can be provided are not limited to just caching, however.
 
 ## Endpoint description and server logic
 

--- a/files/src/main/scalajvm/sttp/tapir/files/TapirStaticContentEndpoints.scala
+++ b/files/src/main/scalajvm/sttp/tapir/files/TapirStaticContentEndpoints.scala
@@ -7,13 +7,10 @@ import sttp.model.StatusCode
 import sttp.model.headers.ETag
 import sttp.model.headers.Range
 import sttp.monad.MonadError
-import sttp.tapir.FileRange
 import sttp.tapir._
-import sttp.tapir.files.FilesOptions
 import sttp.tapir.server.ServerEndpoint
 
 import java.time.Instant
-import sttp.tapir.files.StaticInput
 
 /** Static content endpoints, including files and resources. */
 trait TapirStaticContentEndpoints {
@@ -145,9 +142,9 @@ trait TapirStaticContentEndpoints {
   @scala.annotation.tailrec
   private def addHeaders[O](
       ep: PublicEndpoint[StaticInput, StaticErrorOutput, StaticOutput[O], Any],
-      headers: List[Header],
+      headers: List[Header]
   ): PublicEndpoint[StaticInput, StaticErrorOutput, StaticOutput[O], Any] = headers match {
-    case Nil => ep
+    case Nil     => ep
     case h :: hs => addHeaders(ep.out(header(h)), hs)
   }
 
@@ -163,7 +160,7 @@ trait TapirStaticContentEndpoints {
   def staticFilesGetServerEndpoint[F[_]](prefix: EndpointInput[Unit])(
       systemPath: String,
       options: FilesOptions[F] = FilesOptions.default[F],
-      extraHeaders: List[Header] = Nil,
+      extraHeaders: List[Header] = Nil
   ): ServerEndpoint[Any, F] =
     ServerEndpoint.public(addHeaders(staticFilesGetEndpoint.prependIn(prefix), extraHeaders), Files.get(systemPath, options))
 
@@ -175,9 +172,12 @@ trait TapirStaticContentEndpoints {
     */
   def staticFileGetServerEndpoint[F[_]](prefix: EndpointInput[Unit])(
       systemPath: String,
-      extraHeaders: List[Header] = Nil,
+      extraHeaders: List[Header] = Nil
   ): ServerEndpoint[Any, F] =
-    ServerEndpoint.public(removePath(addHeaders(staticFilesGetEndpoint(prefix), extraHeaders)), (m: MonadError[F]) => Files.get(systemPath)(m))
+    ServerEndpoint.public(
+      removePath(addHeaders(staticFilesGetEndpoint(prefix), extraHeaders)),
+      (m: MonadError[F]) => Files.get(systemPath)(m)
+    )
 
   /** A server endpoint, used to verify if sever supports range requests for file under particular path Additionally it verify file
     * existence and returns its size
@@ -185,7 +185,7 @@ trait TapirStaticContentEndpoints {
   def staticFilesHeadServerEndpoint[F[_]](prefix: EndpointInput[Unit])(
       systemPath: String,
       options: FilesOptions[F] = FilesOptions.default[F],
-      extraHeaders: List[Header] = Nil,
+      extraHeaders: List[Header] = Nil
   ): ServerEndpoint[Any, F] =
     ServerEndpoint.public(addHeaders(staticHeadEndpoint.prependIn(prefix), extraHeaders), Files.head(systemPath, options))
 
@@ -201,9 +201,12 @@ trait TapirStaticContentEndpoints {
   def staticFilesServerEndpoints[F[_]](prefix: EndpointInput[Unit])(
       systemPath: String,
       options: FilesOptions[F] = FilesOptions.default[F],
-      extraHeaders: List[Header] = Nil,
+      extraHeaders: List[Header] = Nil
   ): List[ServerEndpoint[Any, F]] =
-    List(staticFilesHeadServerEndpoint(prefix)(systemPath, options, extraHeaders), staticFilesGetServerEndpoint(prefix)(systemPath, options, extraHeaders))
+    List(
+      staticFilesHeadServerEndpoint(prefix)(systemPath, options, extraHeaders),
+      staticFilesGetServerEndpoint(prefix)(systemPath, options, extraHeaders)
+    )
 
   /** A server endpoint, which exposes resources available from the given `classLoader`, using the given `prefix`. Typically, the prefix is
     * a path, but it can also contain other inputs. For example:
@@ -218,7 +221,7 @@ trait TapirStaticContentEndpoints {
       classLoader: ClassLoader,
       resourcePrefix: String,
       options: FilesOptions[F] = FilesOptions.default[F],
-      extraHeaders: List[Header] = Nil,
+      extraHeaders: List[Header] = Nil
   ): ServerEndpoint[Any, F] =
     ServerEndpoint.public[StaticInput, StaticErrorOutput, StaticOutput[InputStreamRange], Any, F](
       addHeaders(staticResourcesGetEndpoint(prefix), extraHeaders),
@@ -235,7 +238,7 @@ trait TapirStaticContentEndpoints {
       classLoader: ClassLoader,
       resourcePath: String,
       options: FilesOptions[F] = FilesOptions.default[F],
-      extraHeaders: List[Header] = Nil,
+      extraHeaders: List[Header] = Nil
   ): ServerEndpoint[Any, F] =
     ServerEndpoint.public(
       removePath(addHeaders(staticResourcesGetEndpoint(prefix), extraHeaders)),
@@ -248,9 +251,12 @@ trait TapirStaticContentEndpoints {
       classLoader: ClassLoader,
       resourcePath: String,
       options: FilesOptions[F] = FilesOptions.default[F],
-      extraHeaders: List[Header] = Nil,
+      extraHeaders: List[Header] = Nil
   ): ServerEndpoint[Any, F] =
-    ServerEndpoint.public(addHeaders(staticHeadEndpoint.prependIn(prefix), extraHeaders), Resources.head(classLoader, resourcePath, options))
+    ServerEndpoint.public(
+      addHeaders(staticHeadEndpoint.prependIn(prefix), extraHeaders),
+      Resources.head(classLoader, resourcePath, options)
+    )
 
   private def removePath[T](e: Endpoint[Unit, StaticInput, StaticErrorOutput, StaticOutput[T], Any]) =
     e.mapIn(i => i.copy(path = Nil))(i => i.copy(path = Nil))
@@ -265,13 +271,13 @@ trait TapirStaticContentEndpoints {
     * A request to `/static/files/css/styles.css` will try to read the `/app/css/styles.css` resource.
     */
   def staticResourcesServerEndpoints[F[_]](prefix: EndpointInput[Unit])(
-    classLoader: ClassLoader,
-    resourcePath: String,
-    options: FilesOptions[F] = FilesOptions.default[F],
-    extraHeaders: List[Header] = Nil,
+      classLoader: ClassLoader,
+      resourcePath: String,
+      options: FilesOptions[F] = FilesOptions.default[F],
+      extraHeaders: List[Header] = Nil
   ): List[ServerEndpoint[Any, F]] =
     List(
       staticResourcesHeadServerEndpoint(prefix)(classLoader, resourcePath, options, extraHeaders),
-      staticResourcesGetServerEndpoint(prefix)(classLoader, resourcePath, options, extraHeaders),
+      staticResourcesGetServerEndpoint(prefix)(classLoader, resourcePath, options, extraHeaders)
     )
 }

--- a/files/src/main/scalajvm/sttp/tapir/files/TapirStaticContentEndpoints.scala
+++ b/files/src/main/scalajvm/sttp/tapir/files/TapirStaticContentEndpoints.scala
@@ -142,6 +142,15 @@ trait TapirStaticContentEndpoints {
   ): PublicEndpoint[StaticInput, StaticErrorOutput, StaticOutput[InputStreamRange], Any] =
     staticResourcesGetEndpoint.prependIn(prefix)
 
+  @scala.annotation.tailrec
+  private def addHeaders[O](
+      ep: PublicEndpoint[StaticInput, StaticErrorOutput, StaticOutput[O], Any],
+      headers: List[Header],
+  ): PublicEndpoint[StaticInput, StaticErrorOutput, StaticOutput[O], Any] = headers match {
+    case Nil => ep
+    case h :: hs => addHeaders(ep.out(header(h)), hs)
+  }
+
   /** A server endpoint, which exposes files from local storage found at `systemPath`, using the given `prefix`. Typically, the prefix is a
     * path, but it can also contain other inputs. For example:
     *
@@ -151,10 +160,12 @@ trait TapirStaticContentEndpoints {
     *
     * A request to `/static/files/css/styles.css` will try to read the `/home/app/static/css/styles.css` file.
     */
-  def staticFilesGetServerEndpoint[F[_]](
-      prefix: EndpointInput[Unit]
-  )(systemPath: String, options: FilesOptions[F] = FilesOptions.default[F]): ServerEndpoint[Any, F] =
-    ServerEndpoint.public(staticFilesGetEndpoint.prependIn(prefix), Files.get(systemPath, options))
+  def staticFilesGetServerEndpoint[F[_]](prefix: EndpointInput[Unit])(
+      systemPath: String,
+      options: FilesOptions[F] = FilesOptions.default[F],
+      extraHeaders: List[Header] = Nil,
+  ): ServerEndpoint[Any, F] =
+    ServerEndpoint.public(addHeaders(staticFilesGetEndpoint.prependIn(prefix), extraHeaders), Files.get(systemPath, options))
 
   /** A server endpoint, which exposes a single file from local storage found at `systemPath`, using the given `path`.
     *
@@ -162,16 +173,21 @@ trait TapirStaticContentEndpoints {
     * staticFileGetServerEndpoint("static" / "hello.html")("/home/app/static/data.html")
     * }}}
     */
-  def staticFileGetServerEndpoint[F[_]](prefix: EndpointInput[Unit])(systemPath: String): ServerEndpoint[Any, F] =
-    ServerEndpoint.public(removePath(staticFilesGetEndpoint(prefix)), (m: MonadError[F]) => Files.get(systemPath)(m))
+  def staticFileGetServerEndpoint[F[_]](prefix: EndpointInput[Unit])(
+      systemPath: String,
+      extraHeaders: List[Header] = Nil,
+  ): ServerEndpoint[Any, F] =
+    ServerEndpoint.public(removePath(addHeaders(staticFilesGetEndpoint(prefix), extraHeaders)), (m: MonadError[F]) => Files.get(systemPath)(m))
 
   /** A server endpoint, used to verify if sever supports range requests for file under particular path Additionally it verify file
     * existence and returns its size
     */
-  def staticFilesHeadServerEndpoint[F[_]](
-      prefix: EndpointInput[Unit]
-  )(systemPath: String, options: FilesOptions[F] = FilesOptions.default[F]): ServerEndpoint[Any, F] =
-    ServerEndpoint.public(staticHeadEndpoint.prependIn(prefix), Files.head(systemPath, options))
+  def staticFilesHeadServerEndpoint[F[_]](prefix: EndpointInput[Unit])(
+      systemPath: String,
+      options: FilesOptions[F] = FilesOptions.default[F],
+      extraHeaders: List[Header] = Nil,
+  ): ServerEndpoint[Any, F] =
+    ServerEndpoint.public(addHeaders(staticHeadEndpoint.prependIn(prefix), extraHeaders), Files.head(systemPath, options))
 
   /** Create a pair of endpoints (head, get) for exposing files from local storage found at `systemPath`, using the given `prefix`.
     * Typically, the prefix is a path, but it can also contain other inputs. For example:
@@ -182,10 +198,12 @@ trait TapirStaticContentEndpoints {
     *
     * A request to `/static/files/css/styles.css` will try to read the `/home/app/static/css/styles.css` file.
     */
-  def staticFilesServerEndpoints[F[_]](
-      prefix: EndpointInput[Unit]
-  )(systemPath: String, options: FilesOptions[F] = FilesOptions.default[F]): List[ServerEndpoint[Any, F]] =
-    List(staticFilesHeadServerEndpoint(prefix)(systemPath, options), staticFilesGetServerEndpoint(prefix)(systemPath, options))
+  def staticFilesServerEndpoints[F[_]](prefix: EndpointInput[Unit])(
+      systemPath: String,
+      options: FilesOptions[F] = FilesOptions.default[F],
+      extraHeaders: List[Header] = Nil,
+  ): List[ServerEndpoint[Any, F]] =
+    List(staticFilesHeadServerEndpoint(prefix)(systemPath, options, extraHeaders), staticFilesGetServerEndpoint(prefix)(systemPath, options, extraHeaders))
 
   /** A server endpoint, which exposes resources available from the given `classLoader`, using the given `prefix`. Typically, the prefix is
     * a path, but it can also contain other inputs. For example:
@@ -199,10 +217,11 @@ trait TapirStaticContentEndpoints {
   def staticResourcesGetServerEndpoint[F[_]](prefix: EndpointInput[Unit])(
       classLoader: ClassLoader,
       resourcePrefix: String,
-      options: FilesOptions[F] = FilesOptions.default[F]
+      options: FilesOptions[F] = FilesOptions.default[F],
+      extraHeaders: List[Header] = Nil,
   ): ServerEndpoint[Any, F] =
     ServerEndpoint.public[StaticInput, StaticErrorOutput, StaticOutput[InputStreamRange], Any, F](
-      staticResourcesGetEndpoint(prefix),
+      addHeaders(staticResourcesGetEndpoint(prefix), extraHeaders),
       (m: MonadError[F]) => Resources.get(classLoader, resourcePrefix, options)(m)
     )
 
@@ -215,19 +234,23 @@ trait TapirStaticContentEndpoints {
   def staticResourceGetServerEndpoint[F[_]](prefix: EndpointInput[Unit])(
       classLoader: ClassLoader,
       resourcePath: String,
-      options: FilesOptions[F] = FilesOptions.default[F]
+      options: FilesOptions[F] = FilesOptions.default[F],
+      extraHeaders: List[Header] = Nil,
   ): ServerEndpoint[Any, F] =
     ServerEndpoint.public(
-      removePath(staticResourcesGetEndpoint(prefix)),
+      removePath(addHeaders(staticResourcesGetEndpoint(prefix), extraHeaders)),
       (m: MonadError[F]) => Resources.get(classLoader, resourcePath, options)(m)
     )
 
   /** A server endpoint, which can be used to verify the existence of a resource under given path.
     */
-  def staticResourcesHeadServerEndpoint[F[_]](
-      prefix: EndpointInput[Unit]
-  )(classLoader: ClassLoader, resourcePath: String, options: FilesOptions[F] = FilesOptions.default[F]): ServerEndpoint[Any, F] =
-    ServerEndpoint.public(staticHeadEndpoint.prependIn(prefix), Resources.head(classLoader, resourcePath, options))
+  def staticResourcesHeadServerEndpoint[F[_]](prefix: EndpointInput[Unit])(
+      classLoader: ClassLoader,
+      resourcePath: String,
+      options: FilesOptions[F] = FilesOptions.default[F],
+      extraHeaders: List[Header] = Nil,
+  ): ServerEndpoint[Any, F] =
+    ServerEndpoint.public(addHeaders(staticHeadEndpoint.prependIn(prefix), extraHeaders), Resources.head(classLoader, resourcePath, options))
 
   private def removePath[T](e: Endpoint[Unit, StaticInput, StaticErrorOutput, StaticOutput[T], Any]) =
     e.mapIn(i => i.copy(path = Nil))(i => i.copy(path = Nil))
@@ -241,11 +264,14 @@ trait TapirStaticContentEndpoints {
     *
     * A request to `/static/files/css/styles.css` will try to read the `/app/css/styles.css` resource.
     */
-  def staticResourcesServerEndpoints[F[_]](
-      prefix: EndpointInput[Unit]
-  )(classLoader: ClassLoader, resourcePath: String, options: FilesOptions[F] = FilesOptions.default[F]): List[ServerEndpoint[Any, F]] =
+  def staticResourcesServerEndpoints[F[_]](prefix: EndpointInput[Unit])(
+    classLoader: ClassLoader,
+    resourcePath: String,
+    options: FilesOptions[F] = FilesOptions.default[F],
+    extraHeaders: List[Header] = Nil,
+  ): List[ServerEndpoint[Any, F]] =
     List(
-      staticResourcesHeadServerEndpoint(prefix)(classLoader, resourcePath, options),
-      staticResourcesGetServerEndpoint(prefix)(classLoader, resourcePath, options)
+      staticResourcesHeadServerEndpoint(prefix)(classLoader, resourcePath, options, extraHeaders),
+      staticResourcesGetServerEndpoint(prefix)(classLoader, resourcePath, options, extraHeaders),
     )
 }

--- a/generated-doc/out/endpoint/static.md
+++ b/generated-doc/out/endpoint/static.md
@@ -62,8 +62,7 @@ Similarly, the `staticResourcesGetServerEndpoint` can be used to expose the appl
 
 A single resource can be exposed using `staticResourceGetServerEndpoint`.
 
-## Additional Configuration
-### FileOptions
+## FileOptions
 
 Endpoint constructor methods for files and resources can receive optional `FileOptions`, which allow to configure additional settings:
 
@@ -90,28 +89,6 @@ val options: FilesOptions[Identity] =
 
 val endpoint = staticFilesGetServerEndpoint[Identity](emptyInput)("/var/www", options)
 ```
-
-### Static Headers
-In addition to the `FileOptions`, zero or more `Header`s  can also be provided to a server endpoint
-as a `List[Header]`. These can be used to attached fixed headers to the responses. As an example:
-
-```scala
-import sttp.model.Header
-import sttp.model.headers.CacheDirective
-import sttp.tapir.emptyInput
-import sttp.tapir.*
-import sttp.tapir.files.*
-import sttp.shared.Identity
-import scala.concurrent.duration.FiniteDuration
-import java.util.concurrent.TimeUnit
-
-val headers = List(Header.cacheControl(CacheDirective.MaxAge(FiniteDuration(365, TimeUnit.DAYS))))
-
-val endpoint = staticFilesGetServerEndpoint[Identity](emptyInput)("/var/www", extraHeaders = headers)
-```
-
-The above `cacheControl` header makes this resource eligible for caching for up to a year on the
-client machine. The headers which can be provided are not limited to just caching, however.
 
 ## Endpoint description and server logic
 

--- a/generated-doc/out/endpoint/static.md
+++ b/generated-doc/out/endpoint/static.md
@@ -35,7 +35,7 @@ NettySyncServer()
 Using the above endpoint, a request to `/site/static/css/styles.css` will try to read the
 `/home/static/data/css/styles.css` file.
 
-To expose files without a prefix, use `emptyInput`. For example, below exposes the content of `/var/www` at 
+To expose files without a prefix, use `emptyInput`. For example, below exposes the content of `/var/www` at
 `http://localhost:8080`:
 
 ```scala
@@ -62,7 +62,8 @@ Similarly, the `staticResourcesGetServerEndpoint` can be used to expose the appl
 
 A single resource can be exposed using `staticResourceGetServerEndpoint`.
 
-## FileOptions
+## Additional Configuration
+### FileOptions
 
 Endpoint constructor methods for files and resources can receive optional `FileOptions`, which allow to configure additional settings:
 
@@ -89,6 +90,28 @@ val options: FilesOptions[Identity] =
 
 val endpoint = staticFilesGetServerEndpoint[Identity](emptyInput)("/var/www", options)
 ```
+
+### Static Headers
+In addition to the `FileOptions`, zero or more `Header`s  can also be provided to a server endpoint
+as a `List[Header]`. These can be used to attached fixed headers to the responses. As an example:
+
+```scala
+import sttp.model.Header
+import sttp.model.headers.CacheDirective
+import sttp.tapir.emptyInput
+import sttp.tapir.*
+import sttp.tapir.files.*
+import sttp.shared.Identity
+import scala.concurrent.duration.FiniteDuration
+import java.util.concurrent.TimeUnit
+
+val headers = List(Header.cacheControl(CacheDirective.MaxAge(FiniteDuration(365, TimeUnit.DAYS))))
+
+val endpoint = staticFilesGetServerEndpoint[Identity](emptyInput)("/var/www", extraHeaders = headers)
+```
+
+The above `cacheControl` header makes this resource eligible for caching for up to a year on the
+client machine. The headers which can be provided are not limited to just caching, however.
 
 ## Endpoint description and server logic
 


### PR DESCRIPTION
Fixes #4529: adds `extraHeaders` to each of the server endpoint descriptions (defaulting to `Nil`), which can then be used to do things like cache control.