### PR TITLE
Add server span kind for otel4s tracing

### DIFF
--- a/tracing/opentelemetry-tracing/src/main/scala/sttp/tapir/server/tracing/opentelemetry/OpenTelemetryTracing.scala
+++ b/tracing/opentelemetry-tracing/src/main/scala/sttp/tapir/server/tracing/opentelemetry/OpenTelemetryTracing.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.server.tracing.opentelemetry
 
 import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.trace.{Span, Tracer}
+import io.opentelemetry.api.trace.{Span, SpanKind, Tracer}
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.propagation.{ContextPropagators, TextMapGetter}
 import sttp.monad.MonadError
@@ -63,6 +63,7 @@ class OpenTelemetryTracing[F[_]](config: OpenTelemetryTracingConfig) extends Req
       val span = config.tracer
         .spanBuilder(config.spanName(request))
         .setAllAttributes(config.requestAttributes(request))
+        .setSpanKind(SpanKind.SERVER)
         .startSpan()
 
       withSpan(span) {

--- a/tracing/opentelemetry-tracing/src/test/scala/sttp/tapir/server/tracing/opentelemetry/OpenTelemetryTracingTest.scala
+++ b/tracing/opentelemetry-tracing/src/test/scala/sttp/tapir/server/tracing/opentelemetry/OpenTelemetryTracingTest.scala
@@ -1,5 +1,6 @@
 package sttp.tapir.server.tracing.opentelemetry
 
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.propagation.ContextPropagators
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -66,6 +67,7 @@ class OpenTelemetrySyncTracingTest extends AnyFlatSpec with Matchers {
         .handle(_ => Right("hello")),
       serverRequestFromUri(uri"http://example.com/person?name=Adam")
     ) { span =>
+      span.getKind shouldBe SpanKind.SERVER
       span.getName() shouldBe "GET /person"
       span.getAttributes().get(HttpAttributes.HTTP_RESPONSE_STATUS_CODE) shouldBe 200L
       span.getAttributes().get(UrlAttributes.URL_PATH) shouldBe "/person"

--- a/tracing/otel4s-tracing/src/test/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracingTest.scala
+++ b/tracing/otel4s-tracing/src/test/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracingTest.scala
@@ -3,27 +3,27 @@ package sttp.tapir.server.tracing.otel4s
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.sdk.trace.data.SpanData
 import io.opentelemetry.semconv.{HttpAttributes, ServerAttributes, UrlAttributes}
 import org.scalatest.compatible.Assertion
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.oteljava.testkit.OtelJavaTestkit
 import sttp.capabilities.Streams
-import sttp.model._
-import sttp.model.Uri._
+import sttp.model.*
+import sttp.model.Uri.*
 import sttp.model.headers.Forwarded
 import sttp.monad.MonadError
-import sttp.tapir._
+import sttp.tapir.*
 import sttp.tapir.TestUtil.serverRequestFromUri
 import sttp.tapir.capabilities.NoStreams
 import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.TestUtil.StringToResponseBody
-import sttp.tapir.server.interpreter._
+import sttp.tapir.server.interpreter.*
 
 import scala.util.{Success, Try}
 
@@ -66,7 +66,7 @@ class Otel4sTracingTest extends AsyncFlatSpec with Matchers {
         .serverLogic[IO](_ => IO(Right("hello"))),
       serverRequestFromUri(uri"http://example.com/person?name=Adam")
     ) { span =>
-      span.getKind shouldBe SpanKind.Server
+      span.getKind shouldBe SpanKind.SERVER
       span.getName shouldBe "GET /person"
       span.getAttributes.get(HttpAttributes.HTTP_RESPONSE_STATUS_CODE) shouldBe 200L
       span.getAttributes.get(UrlAttributes.URL_PATH) shouldBe "/person"
@@ -82,7 +82,7 @@ class Otel4sTracingTest extends AsyncFlatSpec with Matchers {
         .serverLogic[IO](_ => IO(Right("hello"))),
       serverRequestFromUri(uri"http://example.com/person/Adam/Smith/info")
     ) { span =>
-      span.getKind shouldBe SpanKind.Server
+      span.getKind shouldBe SpanKind.SERVER
       span.getName shouldBe "GET /person/{name}/{surname}/info"
       span.getAttributes.get(HttpAttributes.HTTP_RESPONSE_STATUS_CODE) shouldBe 200L
       span.getAttributes.get(UrlAttributes.URL_PATH) shouldBe "/person/Adam/Smith/info"
@@ -102,7 +102,7 @@ class Otel4sTracingTest extends AsyncFlatSpec with Matchers {
         _headers = List(Header(HeaderNames.Forwarded, Forwarded(None, None, Some("softwaremill.com"), None).toString))
       )
     ) { span =>
-      span.getKind shouldBe SpanKind.Server
+      span.getKind shouldBe SpanKind.SERVER
       span.getAttributes.get(ServerAttributes.SERVER_ADDRESS) shouldBe "softwaremill.com"
     }.unsafeToFuture()
   }
@@ -119,7 +119,7 @@ class Otel4sTracingTest extends AsyncFlatSpec with Matchers {
         _headers = List(Header("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"))
       )
     ) { span =>
-      span.getKind shouldBe SpanKind.Server
+      span.getKind shouldBe SpanKind.SERVER
       span.getTraceId shouldBe "4bf92f3577b34da6a3ce929d0e0e4736"
     }.unsafeToFuture()
   }

--- a/tracing/otel4s-tracing/src/test/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracingTest.scala
+++ b/tracing/otel4s-tracing/src/test/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracingTest.scala
@@ -12,18 +12,18 @@ import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.typelevel.otel4s.oteljava.testkit.OtelJavaTestkit
 import sttp.capabilities.Streams
-import sttp.model.*
-import sttp.model.Uri.*
+import sttp.model._
+import sttp.model.Uri._
 import sttp.model.headers.Forwarded
 import sttp.monad.MonadError
-import sttp.tapir.*
+import sttp.tapir._
 import sttp.tapir.TestUtil.serverRequestFromUri
 import sttp.tapir.capabilities.NoStreams
 import sttp.tapir.integ.cats.effect.CatsMonadError
 import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.TestUtil.StringToResponseBody
-import sttp.tapir.server.interpreter.*
+import sttp.tapir.server.interpreter._
 
 import scala.util.{Success, Try}
 
@@ -82,7 +82,6 @@ class Otel4sTracingTest extends AsyncFlatSpec with Matchers {
         .serverLogic[IO](_ => IO(Right("hello"))),
       serverRequestFromUri(uri"http://example.com/person/Adam/Smith/info")
     ) { span =>
-      span.getKind shouldBe SpanKind.SERVER
       span.getName shouldBe "GET /person/{name}/{surname}/info"
       span.getAttributes.get(HttpAttributes.HTTP_RESPONSE_STATUS_CODE) shouldBe 200L
       span.getAttributes.get(UrlAttributes.URL_PATH) shouldBe "/person/Adam/Smith/info"
@@ -102,7 +101,6 @@ class Otel4sTracingTest extends AsyncFlatSpec with Matchers {
         _headers = List(Header(HeaderNames.Forwarded, Forwarded(None, None, Some("softwaremill.com"), None).toString))
       )
     ) { span =>
-      span.getKind shouldBe SpanKind.SERVER
       span.getAttributes.get(ServerAttributes.SERVER_ADDRESS) shouldBe "softwaremill.com"
     }.unsafeToFuture()
   }
@@ -119,7 +117,6 @@ class Otel4sTracingTest extends AsyncFlatSpec with Matchers {
         _headers = List(Header("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"))
       )
     ) { span =>
-      span.getKind shouldBe SpanKind.SERVER
       span.getTraceId shouldBe "4bf92f3577b34da6a3ce929d0e0e4736"
     }.unsafeToFuture()
   }

--- a/tracing/otel4s-tracing/src/test/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracingTest.scala
+++ b/tracing/otel4s-tracing/src/test/scala/sttp/tapir/server/tracing/otel4s/Otel4sTracingTest.scala
@@ -9,6 +9,7 @@ import io.opentelemetry.semconv.{HttpAttributes, ServerAttributes, UrlAttributes
 import org.scalatest.compatible.Assertion
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.oteljava.testkit.OtelJavaTestkit
 import sttp.capabilities.Streams
 import sttp.model._
@@ -65,6 +66,7 @@ class Otel4sTracingTest extends AsyncFlatSpec with Matchers {
         .serverLogic[IO](_ => IO(Right("hello"))),
       serverRequestFromUri(uri"http://example.com/person?name=Adam")
     ) { span =>
+      span.getKind shouldBe SpanKind.Server
       span.getName shouldBe "GET /person"
       span.getAttributes.get(HttpAttributes.HTTP_RESPONSE_STATUS_CODE) shouldBe 200L
       span.getAttributes.get(UrlAttributes.URL_PATH) shouldBe "/person"
@@ -80,6 +82,7 @@ class Otel4sTracingTest extends AsyncFlatSpec with Matchers {
         .serverLogic[IO](_ => IO(Right("hello"))),
       serverRequestFromUri(uri"http://example.com/person/Adam/Smith/info")
     ) { span =>
+      span.getKind shouldBe SpanKind.Server
       span.getName shouldBe "GET /person/{name}/{surname}/info"
       span.getAttributes.get(HttpAttributes.HTTP_RESPONSE_STATUS_CODE) shouldBe 200L
       span.getAttributes.get(UrlAttributes.URL_PATH) shouldBe "/person/Adam/Smith/info"
@@ -99,6 +102,7 @@ class Otel4sTracingTest extends AsyncFlatSpec with Matchers {
         _headers = List(Header(HeaderNames.Forwarded, Forwarded(None, None, Some("softwaremill.com"), None).toString))
       )
     ) { span =>
+      span.getKind shouldBe SpanKind.Server
       span.getAttributes.get(ServerAttributes.SERVER_ADDRESS) shouldBe "softwaremill.com"
     }.unsafeToFuture()
   }
@@ -115,6 +119,7 @@ class Otel4sTracingTest extends AsyncFlatSpec with Matchers {
         _headers = List(Header("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"))
       )
     ) { span =>
+      span.getKind shouldBe SpanKind.Server
       span.getTraceId shouldBe "4bf92f3577b34da6a3ce929d0e0e4736"
     }.unsafeToFuture()
   }


### PR DESCRIPTION
Currently, all spans created through requests are set with the `span kind` as `internal`. I'm not sure if this is the correct behavior, it should be set to `server`. This happens because the default value for the `span kind` is set to `internal`.