### PR TITLE
codegen: support allOf

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -1,7 +1,9 @@
 # Generate endpoint definitions from an OpenAPI YAML
 
 ```{note}
-This is a really early alpha implementation.
+This is a relatively mature implementation that should be sufficiently capable for the majority of use-cases, but
+nonetheless does not yet completely cover the openapi spec. Pull requests or issues for missing or
+incorrectly-implemented functionality are highly encouraged.
 ```
 
 ## Installation steps
@@ -178,10 +180,9 @@ param serdes.
 Models containing binary data cannot be re-used between json and multi-part form endpoints, due to having different
 representation types for the binary data
 
-We currently miss a lot of OpenApi features like:
+We currently miss a few OpenApi features. Notably are:
 
-- tags
-- anyOf/allOf
-- missing model types and meta descriptions (like date, minLength)
-- file handling
+- anyOf
+- validation (minLength, pattern, etc)
+- missing model types (date, duration, etc)
 

--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import com.monovore.decline._
 
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
-import sttp.tapir.codegen.{BasicGenerator, YamlParser}
+import sttp.tapir.codegen.{RootGenerator, YamlParser}
 
 import java.io.File
 import java.nio.charset.StandardCharsets
@@ -117,7 +117,7 @@ object GenScala {
 
           def generateCode(doc: OpenapiDocument): IO[Unit] = for {
             contents <- IO.pure(
-              BasicGenerator.generateObjects(
+              RootGenerator.generateObjects(
                 doc,
                 packageName,
                 objectName,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.codegen
 
-import sttp.tapir.codegen.BasicGenerator.{indent, mapSchemaSimpleTypeToType}
+import sttp.tapir.codegen.RootGenerator.{indent, mapSchemaSimpleTypeToType}
 import sttp.tapir.codegen.JsonSerdeLib.{Circe, Jsoniter}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.{DefaultValueRenderer, OpenapiSchemaType, RenderConfig}
@@ -214,7 +214,7 @@ class ClassDefinitionGenerator {
       valueSchema: OpenapiSchemaType
   ): Seq[String] = {
     val valueSchemaName = valueSchema match {
-      case simpleType: OpenapiSchemaSimpleType => BasicGenerator.mapSchemaSimpleTypeToType(simpleType)._1
+      case simpleType: OpenapiSchemaSimpleType => RootGenerator.mapSchemaSimpleTypeToType(simpleType)._1
       case otherType => throw new NotImplementedError(s"Only simple value types and refs are implemented for named maps (found $otherType)")
     }
     Seq(s"""type $name = Map[String, $valueSchemaName]""")
@@ -225,7 +225,7 @@ class ClassDefinitionGenerator {
       valueSchema: OpenapiSchemaType
   ): Seq[String] = {
     val valueSchemaName = valueSchema match {
-      case simpleType: OpenapiSchemaSimpleType => BasicGenerator.mapSchemaSimpleTypeToType(simpleType)._1
+      case simpleType: OpenapiSchemaSimpleType => RootGenerator.mapSchemaSimpleTypeToType(simpleType)._1
       case otherType =>
         throw new NotImplementedError(s"Only simple value types and refs are implemented for named arrays (found $otherType)")
     }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.codegen
 import io.circe.Json
-import sttp.tapir.codegen.BasicGenerator.{indent, mapSchemaSimpleTypeToType, strippedToCamelCase}
+import sttp.tapir.codegen.RootGenerator.{indent, mapSchemaSimpleTypeToType, strippedToCamelCase}
 import sttp.tapir.codegen.JsonSerdeLib.JsonSerdeLib
 import sttp.tapir.codegen.StreamingImplementation.StreamingImplementation
 import sttp.tapir.codegen.XmlSerdeLib.XmlSerdeLib
@@ -253,12 +253,12 @@ class EndpointGenerator {
               case OpenapiSchemaArray(OpenapiSchemaAny(_), _, _) =>
                 bail("Cannot generate schema for 'Any' with jsoniter library")
               case OpenapiSchemaArray(simple: OpenapiSchemaSimpleType, _, _) =>
-                val name = BasicGenerator.mapSchemaSimpleTypeToType(simple)._1
+                val name = RootGenerator.mapSchemaSimpleTypeToType(simple)._1
                 s"List[$name]"
               case simple: OpenapiSchemaSimpleType =>
-                BasicGenerator.mapSchemaSimpleTypeToType(simple)._1
+                RootGenerator.mapSchemaSimpleTypeToType(simple)._1
               case OpenapiSchemaMap(simple: OpenapiSchemaSimpleType, _) =>
-                val name = BasicGenerator.mapSchemaSimpleTypeToType(simple)._1
+                val name = RootGenerator.mapSchemaSimpleTypeToType(simple)._1
                 s"Map[String, $name]"
             }
             .toSet

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EnumGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EnumGenerator.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.codegen
 
-import sttp.tapir.codegen.BasicGenerator.indent
+import sttp.tapir.codegen.RootGenerator.indent
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.OpenapiSchemaEnum
 
 object EnumGenerator {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.codegen
 
-import sttp.tapir.codegen.BasicGenerator.indent
+import sttp.tapir.codegen.RootGenerator.indent
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
@@ -167,7 +167,7 @@ object JsonSerdeGenerator {
       case Nil => ""
       case s   => s.mkString("", "\n", "\n")
     }
-    val uncapitalisedName = BasicGenerator.uncapitalise(name)
+    val uncapitalisedName = RootGenerator.uncapitalise(name)
     s"""${subs}implicit lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] = io.circe.generic.semiauto.deriveDecoder[$name]
        |implicit lazy val ${uncapitalisedName}JsonEncoder: io.circe.Encoder[$name] = io.circe.generic.semiauto.deriveEncoder[$name]""".stripMargin
   }
@@ -185,7 +185,7 @@ object JsonSerdeGenerator {
       name: String,
       validateNonDiscriminatedOneOfs: Boolean
   ): String = {
-    val uncapitalisedName = BasicGenerator.uncapitalise(name)
+    val uncapitalisedName = RootGenerator.uncapitalise(name)
 
     schema match {
       case OpenapiSchemaOneOf(_, Some(discriminator)) =>
@@ -332,7 +332,7 @@ object JsonSerdeGenerator {
   }
 
   private def genJsoniterClassSerde(supertypes: Seq[OpenapiSchemaOneOf])(name: String): String = {
-    val uncapitalisedName = BasicGenerator.uncapitalise(name)
+    val uncapitalisedName = RootGenerator.uncapitalise(name)
     if (supertypes.exists(_.discriminator.isDefined))
       throw new NotImplementedError(
         s"A class cannot be used both in a oneOf with discriminator and at the top level when using jsoniter serdes at $name"
@@ -342,13 +342,13 @@ object JsonSerdeGenerator {
   }
 
   private def genJsoniterEnumSerde(name: String): String = {
-    val uncapitalisedName = BasicGenerator.uncapitalise(name)
+    val uncapitalisedName = RootGenerator.uncapitalise(name)
     s"""
        |implicit lazy val ${uncapitalisedName}JsonCodec: $jsoniterPkgCore.JsonValueCodec[${name}] = $jsoniterPkgMacros.JsonCodecMaker.make($jsoniteEnumConfig.withDiscriminatorFieldName(scala.None))""".stripMargin
   }
 
   private def genJsoniterNamedSerde(name: String): String = {
-    val uncapitalisedName = BasicGenerator.uncapitalise(name)
+    val uncapitalisedName = RootGenerator.uncapitalise(name)
     s"""
        |implicit lazy val ${uncapitalisedName}JsonCodec: $jsoniterPkgCore.JsonValueCodec[$name] = $jsoniterPkgMacros.JsonCodecMaker.make($jsoniterBaseConfig)""".stripMargin
   }
@@ -359,7 +359,7 @@ object JsonSerdeGenerator {
       schema: OpenapiSchemaOneOf,
       validateNonDiscriminatedOneOfs: Boolean
   ): String = {
-    val uncapitalisedName = BasicGenerator.uncapitalise(name)
+    val uncapitalisedName = RootGenerator.uncapitalise(name)
     schema match {
       case OpenapiSchemaOneOf(_, Some(discriminator)) =>
         def subtypeNames = schema.types.map {
@@ -395,7 +395,7 @@ object JsonSerdeGenerator {
         if (validateNonDiscriminatedOneOfs) checkForSoundness(allSchemas)(schema.types.map(_.asInstanceOf[OpenapiSchemaRef]))
         val childNameAndSerde = schemas.collect { case ref: OpenapiSchemaRef =>
           val name = ref.stripped
-          name -> s"${BasicGenerator.uncapitalise(name)}JsonCodec"
+          name -> s"${RootGenerator.uncapitalise(name)}JsonCodec"
         }
         val childSerdes = childNameAndSerde.map(_._2)
         val doDecode = childSerdes.mkString("List(\n  ", ",\n  ", ")\n") +
@@ -469,7 +469,7 @@ object JsonSerdeGenerator {
       case Nil => ""
       case s   => s.mkString("", "\n", "\n")
     }
-    val uncapitalisedName = BasicGenerator.uncapitalise(name)
+    val uncapitalisedName = RootGenerator.uncapitalise(name)
     s"""${subs}implicit lazy val ${uncapitalisedName}JsonDecoder: zio.json.JsonDecoder[$name] = zio.json.DeriveJsonDecoder.gen[$name]
        |implicit lazy val ${uncapitalisedName}JsonEncoder: zio.json.JsonEncoder[$name] = zio.json.DeriveJsonEncoder.gen[$name]""".stripMargin
   }
@@ -483,7 +483,7 @@ object JsonSerdeGenerator {
   }
 
   private def genZioEnumSerde(name: String): String = {
-    val uncapitalisedName = BasicGenerator.uncapitalise(name)
+    val uncapitalisedName = RootGenerator.uncapitalise(name)
     s"""
        |implicit lazy val ${uncapitalisedName}JsonCodec: zio.json.JsonCodec[$name] = zio.json.JsonCodec[$name](
        |  zio.json.JsonEncoder[String].contramap[$name](_.entryName),
@@ -497,7 +497,7 @@ object JsonSerdeGenerator {
       name: String,
       validateNonDiscriminatedOneOfs: Boolean
   ): String = {
-    val uncapitalisedName = BasicGenerator.uncapitalise(name)
+    val uncapitalisedName = RootGenerator.uncapitalise(name)
 
     schema match {
       case OpenapiSchemaOneOf(_, Some(discriminator)) =>

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -30,13 +30,13 @@ object StreamingImplementation extends Enumeration {
   type StreamingImplementation = Value
 }
 
-object BasicGenerator {
+object RootGenerator {
 
   val classGenerator = new ClassDefinitionGenerator()
   val endpointGenerator = new EndpointGenerator()
 
   def generateObjects(
-      doc: OpenapiDocument,
+      unNormalisedDoc: OpenapiDocument,
       packagePath: String,
       objName: String,
       targetScala3: Boolean,
@@ -48,6 +48,7 @@ object BasicGenerator {
       maxSchemasPerFile: Int,
       generateEndpointTypes: Boolean
   ): Map[String, String] = {
+    val doc = unNormalisedDoc.resolveAllOfSchemas
     val normalisedJsonLib = jsonSerdeLib.toLowerCase match {
       case "circe"    => JsonSerdeLib.Circe
       case "jsoniter" => JsonSerdeLib.Jsoniter

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.codegen
 
-import sttp.tapir.codegen.BasicGenerator.indent
+import sttp.tapir.codegen.RootGenerator.indent
 import sttp.tapir.codegen.JsonSerdeLib.JsonSerdeLib
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
@@ -45,7 +45,7 @@ object SchemaGenerator {
       .map(_.schemas.flatMap {
         case (name, _: OpenapiSchemaEnum) =>
           Some(
-            name -> s"implicit lazy val ${BasicGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
+            name -> s"implicit lazy val ${RootGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
           )
         case (name, obj: OpenapiSchemaObject)   => Some(name -> schemaForObject(name, obj))
         case (name, schema: OpenapiSchemaMap)   => Some(name -> schemaForMapOrArray(name, schema.items))
@@ -196,7 +196,7 @@ object SchemaGenerator {
       case Nil => ""
       case s   => s.mkString("", "\n", "\n")
     }
-    s"${subs}implicit lazy val ${BasicGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
+    s"${subs}implicit lazy val ${RootGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
   }
   private def schemaForMapOrArray(name: String, schema: OpenapiSchemaType): String = {
     val subs = schema match {
@@ -206,7 +206,7 @@ object SchemaGenerator {
     subs.fold("")("\n" + _)
   }
   private def schemaForEnum(name: String): String =
-    s"""implicit lazy val ${BasicGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"""
+    s"""implicit lazy val ${RootGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"""
 
   private def genADTSchema(name: String, schema: OpenapiSchemaOneOf, fullModelPath: Option[String]): String = {
     val schemaImpl = schema match {
@@ -242,6 +242,6 @@ object SchemaGenerator {
            |}""".stripMargin
     }
 
-    s"implicit lazy val ${BasicGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = ${schemaImpl}"
+    s"implicit lazy val ${RootGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = ${schemaImpl}"
   }
 }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SecurityGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SecurityGenerator.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.codegen
 
-import sttp.tapir.codegen.BasicGenerator.indent
+import sttp.tapir.codegen.RootGenerator.indent
 import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType
 import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType.OAuth2FlowType
 import sttp.tapir.codegen.util.ErrUtils.bail

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ServersGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ServersGenerator.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.codegen
 
-import sttp.tapir.codegen.BasicGenerator.indent
+import sttp.tapir.codegen.RootGenerator.indent
 import sttp.tapir.codegen.openapi.models.OpenapiServer
 import sttp.tapir.codegen.util.NameHelpers.safeVariableName
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/XmlSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/XmlSerdeGenerator.scala
@@ -1,6 +1,6 @@
 package sttp.tapir.codegen
 
-import sttp.tapir.codegen.BasicGenerator.{indent, mapSchemaSimpleTypeToType}
+import sttp.tapir.codegen.RootGenerator.{indent, mapSchemaSimpleTypeToType}
 import sttp.tapir.codegen.XmlSerdeLib.XmlSerdeLib
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
@@ -61,7 +61,7 @@ object XmlSerdeGenerator {
                   _.collect {
                     case (_, (n, OpenapiSchemaField(t: OpenapiSchemaRef, _)), r)
                         if doc.components.exists(_.schemas.get(t.stripped).exists(_.isInstanceOf[OpenapiSchemaEnum])) =>
-                      val tpe = BasicGenerator.mapSchemaSimpleTypeToType(t)._1
+                      val tpe = RootGenerator.mapSchemaSimpleTypeToType(t)._1
                       val d = if (!r || t.nullable) s"Option[$tpe]" else tpe
                       ScopedAuxCodecParams(n, d, tpe, EnumType, None)
                     case (ref, (n, OpenapiSchemaField(t: OpenapiSchemaEnum, _)), r) =>
@@ -69,10 +69,10 @@ object XmlSerdeGenerator {
                       val d = if (!r || t.nullable) s"Option[$tpe]" else tpe
                       ScopedAuxCodecParams(n, d, tpe, EnumType, None)
                     case (_, (n, OpenapiSchemaField(OpenapiSchemaArray(t: OpenapiSchemaSimpleType, _, maybeXml), _)), _) =>
-                      val tpe = BasicGenerator.mapSchemaSimpleTypeToType(t)._1
+                      val tpe = RootGenerator.mapSchemaSimpleTypeToType(t)._1
                       ScopedAuxCodecParams(n, tpe, tpe, ArrayType, maybeXml)
                     case (_, (n, OpenapiSchemaField(t: OpenapiSchemaRef, _)), r) =>
-                      val tpe = BasicGenerator.mapSchemaSimpleTypeToType(t)._1
+                      val tpe = RootGenerator.mapSchemaSimpleTypeToType(t)._1
                       val d = if (!r || t.nullable) s"Option[$tpe]" else tpe
                       ScopedAuxCodecParams(n, d, tpe, OtherType, None)
                   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
@@ -30,7 +30,7 @@ object OpenapiSchemaType {
   }
 
   case class OpenapiSchemaAllOf(
-      types: Seq[OpenapiSchemaSimpleType]
+      types: Seq[OpenapiSchemaType]
   ) extends OpenapiSchemaMixedType {
     val nullable: Boolean = false
   }
@@ -244,7 +244,7 @@ object OpenapiSchemaType {
 
   implicit val OpenapiSchemaAllOfDecoder: Decoder[OpenapiSchemaAllOf] = { (c: HCursor) =>
     for {
-      d <- c.downField("allOf").as[Seq[OpenapiSchemaSimpleType]]
+      d <- c.downField("allOf").as[Seq[OpenapiSchemaType]]
     } yield {
       OpenapiSchemaAllOf(d)
     }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -65,7 +65,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       null,
       Nil
     )
-    val generatedCode = BasicGenerator.imports(JsonSerdeLib.Circe) ++
+    val generatedCode = RootGenerator.imports(JsonSerdeLib.Circe) ++
       new EndpointGenerator()
         .endpointDefs(
           doc,
@@ -154,7 +154,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       ),
       Nil
     )
-    BasicGenerator.imports(JsonSerdeLib.Circe) ++
+    RootGenerator.imports(JsonSerdeLib.Circe) ++
       new EndpointGenerator()
         .endpointDefs(
           doc,
@@ -210,7 +210,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       null,
       Nil
     )
-    val generatedCode = BasicGenerator.imports(JsonSerdeLib.Circe) ++
+    val generatedCode = RootGenerator.imports(JsonSerdeLib.Circe) ++
       new EndpointGenerator()
         .endpointDefs(
           doc,
@@ -279,7 +279,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       ),
       Nil
     )
-    val generatedCode = BasicGenerator.generateObjects(
+    val generatedCode = RootGenerator.generateObjects(
       doc,
       "sttp.tapir.generated",
       "TapirGeneratedEndpoints",
@@ -303,7 +303,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
 
   it should "generate attributes for specification extensions on path and operation objects" in {
     val doc = TestHelpers.specificationExtensionDocs
-    val generatedCode = BasicGenerator.generateObjects(
+    val generatedCode = RootGenerator.generateObjects(
       doc,
       "sttp.tapir.generated",
       "TapirGeneratedEndpoints",

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/RootGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/RootGeneratorSpec.scala
@@ -3,13 +3,13 @@ package sttp.tapir.codegen
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.testutils.CompileCheckTestBase
 
-class BasicGeneratorSpec extends CompileCheckTestBase {
+class RootGeneratorSpec extends CompileCheckTestBase {
   def genMap(
       doc: OpenapiDocument,
       useHeadTagForObjectNames: Boolean,
       jsonSerdeLib: String
   ) = {
-    BasicGenerator.generateObjects(
+    RootGenerator.generateObjects(
       doc,
       "sttp.tapir.generated",
       "TapirGeneratedEndpoints",

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -3,7 +3,7 @@ package sttp.tapir.sbt
 import sbt._
 import sbt.util.FileInfo.hash
 import sbt.util.Tracked.inputChanged
-import sttp.tapir.codegen.{BasicGenerator, YamlParser}
+import sttp.tapir.codegen.{RootGenerator, YamlParser}
 
 case class OpenapiCodegenTask(
     inputYaml: File,
@@ -51,7 +51,7 @@ case class OpenapiCodegenTask(
         .parseFile(IO.readLines(inputYaml).mkString("\n"))
         .left
         .map(d => new RuntimeException(_root_.io.circe.Error.showError.show(d)))
-      BasicGenerator
+      RootGenerator
         .generateObjects(
           parsed.toTry.get,
           packageName,

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -181,9 +181,6 @@ object TapirGeneratedEndpoints {
   case class NullableThingy (
     uuid: java.util.UUID
   )
-  case class HasQuux (
-    quux: Option[Int] = None
-  )
 
   sealed trait PostJsonStringJsonBodyBodyIn extends Product with java.io.Serializable
   case class PostJsonStringJsonBodyBodyOption_String_In(value: Option[String]) extends PostJsonStringJsonBodyBodyIn

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -109,12 +109,18 @@ object TapirGeneratedEndpoints {
   case class NotFoundError (
     reason: String
   ) extends Error
+  case class HasBar (
+    bar: String
+  )
   case class SubtypeWithoutD1 (
     s: String,
     i: Option[Int] = None,
     a: Seq[String],
     absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
+  case class HasBaz (
+    baz: Int
+  )
   case class SubtypeWithD1 (
     s: String,
     i: Option[Int] = None,
@@ -148,6 +154,12 @@ object TapirGeneratedEndpoints {
     a: Seq[String],
     absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
+  case class HasFooBarBazQuux (
+    foo: Option[String] = None,
+    bar: String,
+    baz: Int,
+    quux: Option[Int] = None
+  )
   case class SubtypeWithD2 (
     s: String,
     a: Option[Seq[String]] = None
@@ -162,9 +174,15 @@ object TapirGeneratedEndpoints {
     case object Bar extends AnEnum
     case object Baz extends AnEnum
   }
+  case class HasFoo (
+    foo: Option[String] = None
+  )
   type ListType = List[String]
   case class NullableThingy (
     uuid: java.util.UUID
+  )
+  case class HasQuux (
+    quux: Option[Int] = None
   )
 
   sealed trait PostJsonStringJsonBodyBodyIn extends Product with java.io.Serializable
@@ -348,6 +366,15 @@ object TapirGeneratedEndpoints {
         oneOfVariant[SimpleError](sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
       .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
 
+  type PostAllOfEndpoint = Endpoint[String, Option[HasFooBarBazQuux], Unit, Unit, Any]
+  lazy val postAllOf: PostAllOfEndpoint =
+    endpoint
+      .post
+      .in(("allOf"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .in(jsonBody[Option[HasFooBarBazQuux]].description("list type in"))
+      .out(statusCode(sttp.model.StatusCode(204)).description("fine"))
+
   type GetSecurityGroupSecurityGroupNameMorePathEndpoint = Endpoint[(String, String), Unit, Unit, Unit, Any]
   lazy val getSecurityGroupSecurityGroupNameMorePath: GetSecurityGroupSecurityGroupNameMorePathEndpoint =
     endpoint
@@ -465,7 +492,7 @@ object TapirGeneratedEndpoints {
       .out(jsonBody[ListType].description("list type out"))
 
 
-  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, getSecurityGroupSecurityGroupName, putAdtTest, postAdtTest, getHeadersTests, getOneofErrorSecParamTest, getSecurityGroupSecurityGroupNameMorePath, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, getSecurityGroupSecurityGroupName, putAdtTest, postAdtTest, getHeadersTests, getOneofErrorSecParamTest, postAllOf, getSecurityGroupSecurityGroupNameMorePath, getOneofOptionTest, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
 
   object Servers {

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedJsonSerdes.scala.txt
@@ -49,8 +49,11 @@ object TapirGeneratedEndpointsJsonSerdes {
   implicit lazy val objectWithInlineEnumJsonEncoder: io.circe.Encoder[ObjectWithInlineEnum] = io.circe.generic.semiauto.deriveEncoder[ObjectWithInlineEnum]
   implicit lazy val subtypeWithoutD2JsonDecoder: io.circe.Decoder[SubtypeWithoutD2] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithoutD2]
   implicit lazy val subtypeWithoutD2JsonEncoder: io.circe.Encoder[SubtypeWithoutD2] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithoutD2]
+  implicit lazy val hasFooBarBazQuuxJsonDecoder: io.circe.Decoder[HasFooBarBazQuux] = io.circe.generic.semiauto.deriveDecoder[HasFooBarBazQuux]
+  implicit lazy val hasFooBarBazQuuxJsonEncoder: io.circe.Encoder[HasFooBarBazQuux] = io.circe.generic.semiauto.deriveEncoder[HasFooBarBazQuux]
   implicit lazy val subtypeWithD2JsonDecoder: io.circe.Decoder[SubtypeWithD2] = io.circe.generic.semiauto.deriveDecoder[SubtypeWithD2]
   implicit lazy val subtypeWithD2JsonEncoder: io.circe.Encoder[SubtypeWithD2] = io.circe.generic.semiauto.deriveEncoder[SubtypeWithD2]
+
   implicit lazy val aDTWithoutDiscriminatorJsonEncoder: io.circe.Encoder[ADTWithoutDiscriminator] = io.circe.Encoder.instance {
     case x: SubtypeWithoutD1 => io.circe.Encoder[SubtypeWithoutD1].apply(x)
     case x: SubtypeWithoutD2 => io.circe.Encoder[SubtypeWithoutD2].apply(x)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
@@ -8,7 +8,6 @@ object TapirGeneratedEndpointsSchemas {
   implicit lazy val hasBazTapirSchema: sttp.tapir.Schema[HasBaz] = sttp.tapir.Schema.derived
   implicit lazy val hasFooTapirSchema: sttp.tapir.Schema[HasFoo] = sttp.tapir.Schema.derived
   implicit lazy val hasFooBarBazQuuxTapirSchema: sttp.tapir.Schema[HasFooBarBazQuux] = sttp.tapir.Schema.derived
-  implicit lazy val hasQuuxTapirSchema: sttp.tapir.Schema[HasQuux] = sttp.tapir.Schema.derived
 
   implicit lazy val notFoundErrorTapirSchema: sttp.tapir.Schema[NotFoundError] = sttp.tapir.Schema.derived
   implicit lazy val notNullableThingyTapirSchema: sttp.tapir.Schema[NotNullableThingy] = sttp.tapir.Schema.derived

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedSchemas.scala.txt
@@ -4,6 +4,12 @@ object TapirGeneratedEndpointsSchemas {
   import sttp.tapir.generated.TapirGeneratedEndpoints._
   import sttp.tapir.generic.auto._
   implicit lazy val anEnumTapirSchema: sttp.tapir.Schema[AnEnum] = sttp.tapir.Schema.derived
+  implicit lazy val hasBarTapirSchema: sttp.tapir.Schema[HasBar] = sttp.tapir.Schema.derived
+  implicit lazy val hasBazTapirSchema: sttp.tapir.Schema[HasBaz] = sttp.tapir.Schema.derived
+  implicit lazy val hasFooTapirSchema: sttp.tapir.Schema[HasFoo] = sttp.tapir.Schema.derived
+  implicit lazy val hasFooBarBazQuuxTapirSchema: sttp.tapir.Schema[HasFooBarBazQuux] = sttp.tapir.Schema.derived
+  implicit lazy val hasQuuxTapirSchema: sttp.tapir.Schema[HasQuux] = sttp.tapir.Schema.derived
+
   implicit lazy val notFoundErrorTapirSchema: sttp.tapir.Schema[NotFoundError] = sttp.tapir.Schema.derived
   implicit lazy val notNullableThingyTapirSchema: sttp.tapir.Schema[NotNullableThingy] = sttp.tapir.Schema.derived
   implicit lazy val nullableThingyTapirSchema: sttp.tapir.Schema[NullableThingy] = sttp.tapir.Schema.derived

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -722,16 +722,14 @@ components:
       properties:
         baz:
           type: integer
-    HasQuux:
-      title: HasQuux
-      type: object
-      properties:
-        quux:
-          type: integer
     HasFooBarBazQuux:
       title: HasFooBarBazQuux
       allOf:
         - $ref: '#/components/schemas/HasFoo'
         - $ref: '#/components/schemas/HasBar'
         - $ref: '#/components/schemas/HasBaz'
-        - $ref: '#/components/schemas/HasQuux'
+        - title: HasQuux
+          type: object
+          properties:
+            quux:
+              type: integer

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -447,6 +447,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListType'
+  '/allOf':
+    post:
+      requestBody:
+        description: list type in
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HasFooBarBazQuux'
+      responses:
+        "204":
+          description: fine
 
 
 components:
@@ -689,3 +700,38 @@ components:
       type: array
       items:
         type: string
+    HasFoo:
+      title: HasFoo
+      type: object
+      properties:
+        foo:
+          type: string
+    HasBar:
+      title: HasBar
+      type: object
+      required:
+        - bar
+      properties:
+        bar:
+          type: string
+    HasBaz:
+      title: HasBaz
+      type: object
+      required:
+        - baz
+      properties:
+        baz:
+          type: integer
+    HasQuux:
+      title: HasQuux
+      type: object
+      properties:
+        quux:
+          type: integer
+    HasFooBarBazQuux:
+      title: HasFooBarBazQuux
+      allOf:
+        - $ref: '#/components/schemas/HasFoo'
+        - $ref: '#/components/schemas/HasBar'
+        - $ref: '#/components/schemas/HasBaz'
+        - $ref: '#/components/schemas/HasQuux'


### PR DESCRIPTION
Supports allOf, a bit, should permit reusing parameter set declarations between models.

Only objects and refs to objects are supported. I think that's the only usecase for allOf until validation is implemented anyway so that sounds fine to me.

Errors seem sensible enough in cases where incompatible fields are declared in the members -- e.g. trying to use two different schemas in an allOf with different properties with the same name and different types will give something like
`[error] java.lang.IllegalStateException: Non-matching conflicting fields found on allOf declaration. For HasFooBarBazQuux.bar found both OpenapiSchemaString(false) and OpenapiSchemaInt(false)`

There may be other use-cases for allOf but I'm keeping this quite limited in scope

I've also updated the doc comments because I don't think this is really a 'really early alpha implementation' any more