### PR TITLE
codegen: Support uniqueItems on array defns

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -49,6 +49,7 @@ openapiMaxSchemasPerFile              400                                  Maxim
 openapiAdditionalPackages             Nil                                  Additional packageName/swaggerFile pairs for generating from multiple schemas 
 openapiStreamingImplementation        fs2                                  Implementation for streamTextBody. Supports: akka, fs2, pekko, zio
 openapiGenerateEndpointTypes          false                                Whether to emit explicit types for endpoint defns
+openapiDisableValidatorGeneration     false                                If true, we will not generate validation for constraints (min, max, pattern etc)
 ===================================== ==================================== ==================================================================================================
 ```
 
@@ -183,7 +184,7 @@ representation types for the binary data
 We currently miss a few OpenApi features. Notable are:
 
 - anyOf
-- not all validation is supported (readOnly/writeOnly, uniqueItems on arrays, and minProperties/maxProperties on
-  heterogeneous object schemas, are currently unsupported)
+- not all validation is supported (readOnly/writeOnly, and minProperties/maxProperties on heterogeneous object schemas,
+  are currently unsupported)
 - missing model types (date, duration, etc)
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/DefaultValueRenderer.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/DefaultValueRenderer.scala
@@ -102,8 +102,9 @@ object DefaultValueRenderer {
         jsonArray =>
           thisType match {
             case ref: OpenapiSchemaRef => render(allModels, lookup(allModels, ref), isOptional = false, config)(json)
-            case OpenapiSchemaArray(items, _, _, _) =>
-              s"Vector(${jsonArray.map(render(allModels, items, isOptional = false, config)).mkString(", ")})"
+            case OpenapiSchemaArray(items, _, _, rs) =>
+              val container = if (rs.uniqueItems.contains(true)) "Set" else "Vector"
+              s"$container(${jsonArray.map(render(allModels, items, isOptional = false, config)).mkString(", ")})"
             case other => fail("list", other)
           },
         jsonObject =>

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
@@ -130,9 +130,9 @@ object OpenapiSchemaType {
       nullable: Boolean
   ) extends OpenapiSchemaType
 
-  // no uniqueItems support
   case class ArrayRestrictions(minItems: Option[Int] = None, maxItems: Option[Int] = None, uniqueItems: Option[Boolean] = None) {
-    def hasRestriction: Boolean = minItems.isDefined || maxItems.isDefined || uniqueItems.isDefined
+    // We exclude 'uniqueItems' from this check because we don't use it to construct a validator -- rather, it results in us defining a Set instead of a Seq
+    def hasRestriction: Boolean = minItems.isDefined || maxItems.isDefined
   }
   case class OpenapiSchemaArray(
       items: OpenapiSchemaType,
@@ -164,7 +164,7 @@ object OpenapiSchemaType {
       xml: Option[OpenapiXml.XmlObjectConfiguration] = None
   ) extends OpenapiSchemaType
 
-  // no readOnly/writeOnly, minProperties/maxProperties support
+  // no readOnly/writeOnly support
   case class OpenapiSchemaMap(
       items: OpenapiSchemaType,
       nullable: Boolean,
@@ -383,7 +383,8 @@ object OpenapiSchemaType {
       }
       minItems <- c.downField("minItems").as[Option[Int]]
       maxItems <- c.downField("maxItems").as[Option[Int]]
-      restrictions = ArrayRestrictions(minItems, maxItems)
+      uniqueItems <- c.downField("uniqueItems").as[Option[Boolean]]
+      restrictions = ArrayRestrictions(minItems, maxItems, uniqueItems)
     } yield {
       OpenapiSchemaArray(f, nb, xml, restrictions)
     }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
@@ -64,6 +64,10 @@ object TapirGeneratedEndpoints {
     a: Seq[String],
     absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
+  case class HasASet (
+    setA: Set[String],
+    setB: Option[Set[Int]] = None
+  )
   case class SubtypeWithD1 (
     s: String,
     i: Option[Int] = None,
@@ -162,12 +166,19 @@ object TapirGeneratedEndpoints {
       .errorOut(jsonBody[ListType].description("list type error").and(statusCode(sttp.model.StatusCode(400))))
       .out(jsonBody[ListType].description("list type out"))
 
+  type PostUniqueItemsEndpoint = Endpoint[Unit, Option[HasASet], Unit, HasASet, Any]
+  lazy val postUniqueItems: PostUniqueItemsEndpoint =
+    endpoint
+      .post
+      .in(("unique-items"))
+      .in(jsonBody[Option[HasASet]])
+      .out(jsonBody[HasASet].description("OK"))
 
-  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject, postUniqueItems)
 
-   object Servers {
+  object Servers {
     import sttp.model.Uri.UriContext
 
-     val `/v3`: sttp.model.Uri = uri"/v3"
-   }
+    val `/v3`: sttp.model.Uri = uri"/v3"
+  }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/ExpectedJsonSerdes.scala.txt
@@ -21,6 +21,8 @@ object TapirGeneratedEndpointsJsonSerdes {
   }
   implicit lazy val subtypeWithoutD1JsonDecoder: zio.json.JsonDecoder[SubtypeWithoutD1] = zio.json.DeriveJsonDecoder.gen[SubtypeWithoutD1]
   implicit lazy val subtypeWithoutD1JsonEncoder: zio.json.JsonEncoder[SubtypeWithoutD1] = zio.json.DeriveJsonEncoder.gen[SubtypeWithoutD1]
+  implicit lazy val hasASetJsonDecoder: zio.json.JsonDecoder[HasASet] = zio.json.DeriveJsonDecoder.gen[HasASet]
+  implicit lazy val hasASetJsonEncoder: zio.json.JsonEncoder[HasASet] = zio.json.DeriveJsonEncoder.gen[HasASet]
   implicit lazy val subtypeWithD1JsonDecoder: zio.json.JsonDecoder[SubtypeWithD1] = zio.json.DeriveJsonDecoder.gen[SubtypeWithD1]
   implicit lazy val subtypeWithD1JsonEncoder: zio.json.JsonEncoder[SubtypeWithD1] = zio.json.DeriveJsonEncoder.gen[SubtypeWithD1]
   implicit lazy val aDTWithDiscriminatorNoMappingJsonEncoder: zio.json.JsonEncoder[ADTWithDiscriminatorNoMapping] = zio.json.JsonEncoder[zio.json.ast.Json].contramap {

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/ExpectedSchemas.scala.txt
@@ -4,6 +4,8 @@ object TapirGeneratedEndpointsSchemas {
   import sttp.tapir.generated.TapirGeneratedEndpoints._
   import sttp.tapir.generic.auto._
   implicit lazy val anEnumTapirSchema: sttp.tapir.Schema[AnEnum] = sttp.tapir.Schema.derived
+  implicit lazy val hasASetTapirSchema: sttp.tapir.Schema[HasASet] = sttp.tapir.Schema.derived
+
   implicit lazy val notNullableThingyTapirSchema: sttp.tapir.Schema[NotNullableThingy] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD1TapirSchema: sttp.tapir.Schema[SubtypeWithD1] = sttp.tapir.Schema.derived
   implicit lazy val subtypeWithD2TapirSchema: sttp.tapir.Schema[SubtypeWithD2] = sttp.tapir.Schema.derived

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/src/test/scala/JsonRoundtrip.scala
@@ -136,6 +136,33 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
         1.second
       )
     }
+  }
 
+  "set roundtrip" in {
+    val route = TapirGeneratedEndpoints.postUniqueItems.serverLogic[Future]({
+      case None =>
+        Future successful Right(HasASet(Set.empty, None))
+      case Some(hasASet) =>
+        Future successful Right(HasASet(hasASet.setB.map(_.map(_.toString())).getOrElse(Set.empty), Some(hasASet.setA.map(_.toInt))))
+    })
+    val stub = TapirStubInterpreter(SttpBackendStub.asynchronousFuture)
+      .whenServerEndpoint(route)
+      .thenRunLogic()
+      .backend()
+    val reqBody = HasASet(Set("1", "2"), Some(Set(3, 4)))
+    val reqJsonBody = reqBody.toJson(TapirGeneratedEndpointsJsonSerdes.hasASetJsonEncoder)
+    val respBody = HasASet(Set("3", "4"), Some(Set(1, 2)))
+    val respJsonBody = respBody.toJson(TapirGeneratedEndpointsJsonSerdes.hasASetJsonEncoder)
+    Await.result(
+      sttp.client3.basicRequest
+        .post(uri"http://test.com/unique-items")
+        .body(reqJsonBody)
+        .send(stub)
+        .map { resp =>
+          resp.code.code shouldEqual 200
+          resp.body shouldEqual Right(respJsonBody)
+        },
+      1.second
+    )
   }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/swagger.yaml
@@ -139,6 +139,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListType'
+  '/unique-items':
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HasASet'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HasASet'
 
 components:
   schemas:
@@ -251,3 +265,19 @@ components:
       type: array
       items:
         type: string
+    HasASet:
+      title: HasASet
+      type: object
+      required:
+        - setA
+      properties:
+        setA:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+        setB:
+          type: array
+          uniqueItems: true
+          items:
+            type: integer

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -97,6 +97,7 @@ object TapirGeneratedEndpoints {
     bar: ValidatedSubObj,
     foo: String,
     map: Option[Map[String, Int]] = None,
+    set: Option[Set[String]] = None,
     rec: Option[ValidatedRecursive] = None,
     arr: Option[Seq[Int]] = None,
     quux: Option[String] = None,

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedValidators.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedValidators.scala.txt
@@ -68,6 +68,14 @@ object TapirGeneratedEndpointsValidators {
           errs.flatMap(_.customMessage).toList
         ValidationResult.Invalid(msgs)
     }
+  ), Validator.custom(
+    (obj: ValidatedObj) => obj.set.toSeq.flatMap(ValidatedObjSetValidator.apply) match {
+      case Nil => ValidationResult.Valid
+      case errs =>
+        val msgs: List[String] = "Object element validation failed for ValidatedObj.set" +:
+          errs.flatMap(_.customMessage).toList
+        ValidationResult.Invalid(msgs)
+    }
   ))
   lazy val ValidatedObjArrValidator: Validator[Seq[Int]] = Validator.all(Validator.custom(
     (_: Seq[Int]).map(ValidatedObjArrItemValidator.apply).zipWithIndex.flatMap { case (l, i) => l.map(_ -> i) } match {
@@ -93,6 +101,7 @@ object TapirGeneratedEndpointsValidators {
   ), Validator.maxSize(12), Validator.minSize(3))
   lazy val ValidatedObjMapItemValidator: Validator[Int] = Validator.all(Validator.max(900, exclusive = true), Validator.min(0, exclusive = false))
   lazy val ValidatedObjQuuxValidator: Validator[String] = Validator.maxLength(128)
+  lazy val ValidatedObjSetValidator: Validator[Set[String]] = Validator.maxSize(9)
   lazy val ValidatedOneOfValidator: Validator[ValidatedOneOf] = Validator.custom(
     (obj: ValidatedOneOf) => (obj match {
       case o: ValidatedOneOfA => ValidatedOneOfAValidator.apply(o)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/ValidationSpec.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/ValidationSpec.scala
@@ -79,6 +79,7 @@ class ValidationSpec extends AnyFreeSpec with Matchers {
     checkSuccess(Some(minimalValidObj.copy(map = Some(Map("a" -> 1, "b" -> 2, "c" -> 2)))))
     checkSuccess(Some(minimalValidObj.copy(arr = Some(Seq(3, 6, 9)))))
     checkSuccess(Some(minimalValidObj.copy(baz = Some(ValidatedSubObj("i1")))))
+    checkSuccess(Some(minimalValidObj.copy(set = Some(Set("i1", "hi")))))
     /// FAILURES
     def checkFailure(v: Params) = {
       val req = runReq(v)
@@ -98,6 +99,7 @@ class ValidationSpec extends AnyFreeSpec with Matchers {
     checkFailure(Some(minimalValidObj.copy(arr = Some(Seq(0)))))
     checkFailure(Some(minimalValidObj.copy(arr = Some(Seq(15)))))
     checkFailure(Some(minimalValidObj.copy(baz = Some(ValidatedSubObj("1")))))
+    checkFailure(Some(minimalValidObj.copy(set = Some((1 to 20).map(_.toString).toSet))))
   }
 
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -871,6 +871,12 @@ components:
             exclusiveMinimum: true
             multipleOf: 3
           maxItems: 9
+        set:
+          type: array
+          items:
+            type: string
+          maxItems: 9
+          uniqueItems: true
         oneOf:
           $ref: '#/components/schemas/ValidatedOneOf'
         rec:

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -110,6 +110,10 @@ object TapirGeneratedEndpoints {
     a: Seq[String],
     absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
+  case class HasASet (
+    setA: Set[String],
+    setB: Option[Set[Int]] = None
+  )
   case class SubtypeWithD1 (
     s: String,
     i: Option[Int] = None,
@@ -165,7 +169,6 @@ object TapirGeneratedEndpoints {
   case class PostCustomContentNegotiationBody0In(value: sttp.capabilities.pekko.PekkoStreams.BinaryStream) extends PostCustomContentNegotiationBodyIn
   case class PostCustomContentNegotiationBody1In(value: sttp.capabilities.pekko.PekkoStreams.BinaryStream) extends PostCustomContentNegotiationBodyIn
 
-  
   sealed trait PostCustomContentNegotiationBodyOut extends Product with java.io.Serializable {
     def `text/csv`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream = () => throw new RuntimeException("Body for content type text/csv not provided")
     def `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream = () => throw new RuntimeException("Body for content type application/vnd.openxmlformats-officedocument.spreadsheetml.sheet not provided")
@@ -181,7 +184,6 @@ object TapirGeneratedEndpoints {
     override def `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream = () => value
   }
 
-  
   sealed trait PostCustomContentNegotiationBodyErr extends Product with java.io.Serializable {
     def `text/csv`: () => String = () => throw new RuntimeException("Body for content type text/csv not provided")
     def `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => Array[Byte] = () => throw new RuntimeException("Body for content type application/vnd.openxmlformats-officedocument.spreadsheetml.sheet not provided")
@@ -279,6 +281,14 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None),
         oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[AnEnum]].description("An enum")){ case Some(_: AnEnum) => true }))
 
+  type PostUniqueItemsEndpoint = Endpoint[Unit, Option[HasASet], Unit, HasASet, Any]
+  lazy val postUniqueItems: PostUniqueItemsEndpoint =
+    endpoint
+      .post
+      .in(("unique-items"))
+      .in(jsonBody[Option[HasASet]])
+      .out(jsonBody[HasASet].description("OK"))
+
   type PutCustomContentTypesEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, String, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
   lazy val putCustomContentTypes: PutCustomContentTypesEndpoint =
     endpoint
@@ -337,12 +347,11 @@ object TapirGeneratedEndpoints {
       .errorOut(jsonBody[ListType].description("list type error").and(statusCode(sttp.model.StatusCode(400))))
       .out(jsonBody[ListType].description("list type out"))
 
-  
-  lazy val generatedEndpoints = List(postXmlEndpoint, putAdtTest, postAdtTest, postGenericJson, postCustomContentNegotiation, getOneofOptionTest, putCustomContentTypes, postCustomContentTypes, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+  lazy val generatedEndpoints = List(postXmlEndpoint, putAdtTest, postAdtTest, postGenericJson, postCustomContentNegotiation, getOneofOptionTest, postUniqueItems, putCustomContentTypes, postCustomContentTypes, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
 
-   object Servers {
+  object Servers {
     import sttp.model.Uri.UriContext
 
-     val `/v3`: sttp.model.Uri = uri"/v3"
-   }
+    val `/v3`: sttp.model.Uri = uri"/v3"
+  }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/JsonRoundtrip.scala
@@ -179,4 +179,32 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
       1.second
     )
   }
+
+  "set roundtrip" in {
+    val route = TapirGeneratedEndpoints.postUniqueItems.serverLogic[Future]({
+      case None =>
+        Future successful Right(HasASet(Set.empty, None))
+      case Some(hasASet) =>
+        Future successful Right(HasASet(hasASet.setB.map(_.map(_.toString())).getOrElse(Set.empty), Some(hasASet.setA.map(_.toInt))))
+    })
+    val stub = TapirStubInterpreter(SttpBackendStub.asynchronousFuture)
+      .whenServerEndpoint(route)
+      .thenRunLogic()
+      .backend()
+    val reqBody = HasASet(Set("1", "2"), Some(Set(3, 4)))
+    val reqJsonBody = writeToString(reqBody)
+    val respBody = HasASet(Set("3", "4"), Some(Set(1, 2)))
+    val respJsonBody = writeToString(respBody)
+    Await.result(
+      sttp.client3.basicRequest
+        .post(uri"http://test.com/unique-items")
+        .body(reqJsonBody)
+        .send(stub)
+        .map { resp =>
+          resp.code.code shouldEqual 200
+          resp.body shouldEqual Right(respJsonBody)
+        },
+      1.second
+    )
+  }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/swagger.yaml
@@ -259,6 +259,20 @@ paths:
             text/csv:
               schema:
                 $ref: '#/components/schemas/SomeBinaryType'
+  '/unique-items':
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HasASet'
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HasASet'
 
 components:
   schemas:
@@ -466,3 +480,19 @@ components:
       xml:
         name: category
       type: object
+    HasASet:
+      title: HasASet
+      type: object
+      required:
+        - setA
+      properties:
+        setA:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+        setB:
+          type: array
+          uniqueItems: true
+          items:
+            type: integer


### PR DESCRIPTION
Follow-up to https://github.com/softwaremill/tapir/pull/4564. Supports `uniqueItems` by declaring the type as a Set rather than a Seq, when the value is true.