### PR TITLE
codegen: Add support for custom jsoniter-scala serde config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2109,8 +2109,8 @@ lazy val openapiCodegenCore: ProjectMatrix = (projectMatrix in file("openapi-cod
       scalaOrganization.value % "scala-compiler" % scalaVersion.value % Test,
       "com.beachape" %% "enumeratum" % "1.7.6" % Test,
       "com.beachape" %% "enumeratum-circe" % "1.7.5" % Test,
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.28.2" % Test,
-      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.28.2" % Provided
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.36.0" % Test,
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.36.0" % Provided
     )
   )
   .dependsOn(core % Test, circeJson % Test, jsoniterScala % Test, zioJson % Test)

--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -50,6 +50,7 @@ openapiAdditionalPackages             Nil                                  Addit
 openapiStreamingImplementation        fs2                                  Implementation for streamTextBody. Supports: akka, fs2, pekko, zio
 openapiGenerateEndpointTypes          false                                Whether to emit explicit types for endpoint defns
 openapiDisableValidatorGeneration     false                                If true, we will not generate validation for constraints (min, max, pattern etc)
+openapiUseCustomJsoniterSerdes        false                                If true and openapiJsonSerdeLib = jsoniter, serdes will be generated to use custom 'openapi' make defns. May help with flaky compilation, but requires jsoniter-scala >= 2.36.0+
 ===================================== ==================================== ==================================================================================================
 ```
 

--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -74,6 +74,9 @@ object GenScala {
   private val disableValidatorGenerationOpt: Opts[Boolean] =
     Opts.flag("disableValidatorGeneration", "Whether to disable validator declarations").orFalse
 
+  private val useCustomJsoniterSerdesOpt: Opts[Boolean] =
+    Opts.flag("useCustomJsoniterSerdesOpt", "Set to true to enable usage of custom jsoniter macros (mitigates compilation flakiness, compatible with jsoniter-scala versions >= 2.36.x)").orFalse
+
   private val destDirOpt: Opts[File] =
     Opts
       .option[String]("destdir", "Destination directory", "d")
@@ -100,7 +103,8 @@ object GenScala {
       maxSchemasPerFileOpt,
       streamingImplementationOpt,
       generateEndpointTypesOpt,
-      disableValidatorGenerationOpt
+      disableValidatorGenerationOpt,
+      useCustomJsoniterSerdesOpt
     )
       .mapN {
         case (
@@ -116,7 +120,8 @@ object GenScala {
               maxSchemasPerFile,
               streamingImplementation,
               generateEndpointTypes,
-              disableValidatorGeneration
+              disableValidatorGeneration,
+              useCustomJsoniterSerdes
             ) =>
           val objectName = maybeObjectName.getOrElse(DefaultObjectName)
 
@@ -134,7 +139,8 @@ object GenScala {
                 validateNonDiscriminatedOneOfs,
                 maxSchemasPerFile.getOrElse(400),
                 generateEndpointTypes,
-                !disableValidatorGeneration
+                !disableValidatorGeneration,
+                useCustomJsoniterSerdes
               )
             )
             destFiles <- contents.toVector.traverse { case (fileName, content) => writeGeneratedFile(destDir, fileName, content) }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -68,7 +68,7 @@ class ClassDefinitionGenerator {
       adtInheritanceMap.mapValues(_.map(_._1)),
       targetScala3,
       schemasContainAny,
-      useCustomJsoniterSerdes && !targetScala3
+      useCustomJsoniterSerdes
     )
     val allTransitiveXmlParamRefs = fetchTransitiveParamRefs(
       xmlParamRefs,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -29,7 +29,8 @@ class ClassDefinitionGenerator {
       validateNonDiscriminatedOneOfs: Boolean = true,
       maxSchemasPerFile: Int = 400,
       enumsDefinedOnEndpointParams: Boolean = false,
-      xmlParamRefs: Set[String] = Set.empty
+      xmlParamRefs: Set[String] = Set.empty,
+      useCustomJsoniterSerdes: Boolean = true
   ): Option[GeneratedClassDefinitions] = {
     val allSchemas: Map[String, OpenapiSchemaType] = doc.components.toSeq.flatMap(_.schemas).toMap
     val allOneOfSchemas = allSchemas.collect { case (name, oneOf: OpenapiSchemaOneOf) => name -> oneOf }.toSeq
@@ -66,7 +67,8 @@ class ClassDefinitionGenerator {
       validateNonDiscriminatedOneOfs,
       adtInheritanceMap.mapValues(_.map(_._1)),
       targetScala3,
-      schemasContainAny
+      schemasContainAny,
+      useCustomJsoniterSerdes && !targetScala3
     )
     val allTransitiveXmlParamRefs = fetchTransitiveParamRefs(
       xmlParamRefs,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
@@ -29,7 +29,8 @@ object JsonSerdeGenerator {
       validateNonDiscriminatedOneOfs: Boolean,
       adtInheritanceMap: Map[String, Seq[String]],
       targetScala3: Boolean,
-      schemasContainAny: Boolean
+      schemasContainAny: Boolean,
+      useCustomJsoniterSerdes: Boolean
   ): Option[String] = {
     val allSchemas: Map[String, OpenapiSchemaType] = doc.components.toSeq.flatMap(_.schemas).toMap
 
@@ -43,7 +44,8 @@ object JsonSerdeGenerator {
           allTransitiveJsonParamRefs,
           adtInheritanceMap,
           validateNonDiscriminatedOneOfs,
-          schemasContainAny
+          schemasContainAny,
+          useCustomJsoniterSerdes
         )
       case JsonSerdeLib.Zio => genZioSerdes(doc, allSchemas, allTransitiveJsonParamRefs, validateNonDiscriminatedOneOfs, targetScala3)
     }
@@ -156,8 +158,7 @@ object JsonSerdeGenerator {
         case (Some(a), b) => Some(a + "\n" + b)
         case (None, a)    => Some(a)
       }
-      .map(s =>
-        s"""implicit val byteStringJsonDecoder: io.circe.Decoder[ByteString] =
+      .map(s => s"""implicit val byteStringJsonDecoder: io.circe.Decoder[ByteString] =
            |  io.circe.Decoder.decodeString
            |    .map(java.util.Base64.getDecoder.decode)
            |    .map(toByteString)
@@ -260,7 +261,7 @@ object JsonSerdeGenerator {
   // - require presence of collections when decoding if 'required'
   private val jsoniterBaseConfig =
     s"$jsoniterPkgMacros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true)"
-  private val jsoniteEnumConfig = s"$jsoniterBaseConfig.withDiscriminatorFieldName(scala.None)"
+  private val jsoniterEnumConfig = s"$jsoniterBaseConfig.withDiscriminatorFieldName(scala.None)"
   private def genJsoniterSerdes(
       doc: OpenapiDocument,
       allSchemas: Map[String, OpenapiSchemaType],
@@ -268,7 +269,8 @@ object JsonSerdeGenerator {
       allTransitiveJsonParamRefs: Set[String],
       adtInheritanceMap: Map[String, Seq[String]],
       validateNonDiscriminatedOneOfs: Boolean,
-      schemasContainAny: Boolean
+      schemasContainAny: Boolean,
+      useCustomJsoniterSerdes: Boolean
   ): Option[String] = {
     // if schemas contain an 'any' (i.e. any json), we assume jsoniter-scala-circe is a dependency
     val maybeAnySerde =
@@ -303,27 +305,27 @@ object JsonSerdeGenerator {
       case (name, o: OpenapiSchemaObject, isJson) =>
         val inlinedEnumDefns = if (allTransitiveJsonParamRefs.contains(name)) {
           o.properties.collect { case (en, OpenapiSchemaField(_: OpenapiSchemaEnum, _, _)) =>
-            genJsoniterEnumSerde(name + en.capitalize)
+            genJsoniterEnumSerde(useCustomJsoniterSerdes, name + en.capitalize)
           }
         } else Nil
         val supertypes =
           adtInheritanceMap.getOrElse(name, Nil).map(allSchemas.apply).collect { case oneOf: OpenapiSchemaOneOf => oneOf }
         val topLevelDefn =
           if (isJson || jsonParamRefs.contains(name) || supertypes.exists(_.discriminator.isEmpty))
-            Seq(genJsoniterClassSerde(supertypes)(name))
+            Seq(genJsoniterClassSerde(useCustomJsoniterSerdes, supertypes)(name))
           else Nil
         topLevelDefn ++ inlinedEnumDefns
       // For named maps and arrays, only generate the schema if it's a 'top level' json schema
       case (name, _: OpenapiSchemaMap, isJson) if jsonParamRefs.contains(name) || isJson =>
-        Seq(genJsoniterNamedSerde(name))
+        Seq(genJsoniterNamedSerde(useCustomJsoniterSerdes, name))
       case (name, _: OpenapiSchemaArray, isJson) if jsonParamRefs.contains(name) || isJson =>
-        Seq(genJsoniterNamedSerde(name))
+        Seq(genJsoniterNamedSerde(useCustomJsoniterSerdes, name))
       // For enums, generate the serde if it's referenced in any json model
       case (name, _: OpenapiSchemaEnum, _) if allTransitiveJsonParamRefs.contains(name) =>
-        Seq(genJsoniterEnumSerde(name))
+        Seq(genJsoniterEnumSerde(useCustomJsoniterSerdes, name))
       // For ADTs, generate the serde if it's referenced in any json model
       case (name, schema: OpenapiSchemaOneOf, _) if allTransitiveJsonParamRefs.contains(name) =>
-        Seq(generateJsoniterAdtSerde(allSchemas, name, schema, validateNonDiscriminatedOneOfs))
+        Seq(generateJsoniterAdtSerde(allSchemas, name, schema, validateNonDiscriminatedOneOfs, useCustomJsoniterSerdes))
       case (
             _,
             _: OpenapiSchemaObject | _: OpenapiSchemaMap | _: OpenapiSchemaArray | _: OpenapiSchemaEnum | _: OpenapiSchemaOneOf |
@@ -348,36 +350,48 @@ object JsonSerdeGenerator {
            |  def encodeValue(x: ByteString, out: $jsoniterPkgCore.JsonWriter): _root_.scala.Unit =
            |    out.writeVal(java.util.Base64.getEncoder.encodeToString(x))
            |}
-           |$s""".stripMargin)
+           |$s""".stripMargin
+      )
   }
 
-  private def genJsoniterClassSerde(supertypes: Seq[OpenapiSchemaOneOf])(name: String): String = {
+  private def genJsoniterClassSerde(useCustomJsoniterSerdes: Boolean, supertypes: Seq[OpenapiSchemaOneOf])(name: String): String = {
     val uncapitalisedName = RootGenerator.uncapitalise(name)
     if (supertypes.exists(_.discriminator.isDefined))
       throw new NotImplementedError(
         s"A class cannot be used both in a oneOf with discriminator and at the top level when using jsoniter serdes at $name"
       )
-    else
-      s"""implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($jsoniterBaseConfig)"""
+    else {
+      if (useCustomJsoniterSerdes)
+        s"""implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike"""
+      else
+        s"""implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($jsoniterBaseConfig)"""
+    }
   }
 
-  private def genJsoniterEnumSerde(name: String): String = {
+  private def genJsoniterEnumSerde(useCustomJsoniterSerdes: Boolean, name: String): String = {
     val uncapitalisedName = RootGenerator.uncapitalise(name)
-    s"""
-       |implicit lazy val ${uncapitalisedName}JsonCodec: $jsoniterPkgCore.JsonValueCodec[${name}] = $jsoniterPkgMacros.JsonCodecMaker.make($jsoniteEnumConfig.withDiscriminatorFieldName(scala.None))""".stripMargin
+    if (useCustomJsoniterSerdes)
+      s"""
+         |implicit lazy val ${uncapitalisedName}JsonCodec: $jsoniterPkgCore.JsonValueCodec[$name] = $jsoniterPkgMacros.JsonCodecMaker.makeOpenapiLikeWithoutDiscriminator""".stripMargin
+    else s"""
+            |implicit lazy val ${uncapitalisedName}JsonCodec: $jsoniterPkgCore.JsonValueCodec[${name}] = $jsoniterPkgMacros.JsonCodecMaker.make($jsoniterEnumConfig)""".stripMargin
   }
 
-  private def genJsoniterNamedSerde(name: String): String = {
+  private def genJsoniterNamedSerde(useCustomJsoniterSerdes: Boolean, name: String): String = {
     val uncapitalisedName = RootGenerator.uncapitalise(name)
-    s"""
-       |implicit lazy val ${uncapitalisedName}JsonCodec: $jsoniterPkgCore.JsonValueCodec[$name] = $jsoniterPkgMacros.JsonCodecMaker.make($jsoniterBaseConfig)""".stripMargin
+    if (useCustomJsoniterSerdes)
+      s"""
+         |implicit lazy val ${uncapitalisedName}JsonCodec: $jsoniterPkgCore.JsonValueCodec[$name] = $jsoniterPkgMacros.JsonCodecMaker.makeOpenapiLike""".stripMargin
+    else s"""
+            |implicit lazy val ${uncapitalisedName}JsonCodec: $jsoniterPkgCore.JsonValueCodec[$name] = $jsoniterPkgMacros.JsonCodecMaker.make($jsoniterBaseConfig)""".stripMargin
   }
 
   private def generateJsoniterAdtSerde(
       allSchemas: Map[String, OpenapiSchemaType],
       name: String,
       schema: OpenapiSchemaOneOf,
-      validateNonDiscriminatedOneOfs: Boolean
+      validateNonDiscriminatedOneOfs: Boolean,
+      useCustomJsoniterSerdes: Boolean
   ): String = {
     val uncapitalisedName = RootGenerator.uncapitalise(name)
     schema match {
@@ -397,17 +411,25 @@ object JsonSerdeGenerator {
               .map { case (k, v) => s"""case "$k" => "$v"""" }
               .mkString("\n", "\n", "\n")
           )
-          val config =
-            s"""$jsoniterBaseConfig.withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("${discriminator.propertyName}")).withAdtLeafClassNameMapper(x => com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.simpleClassName(x) match {$discriminatorMap})"""
           val serde =
-            s"implicit lazy val ${uncapitalisedName}Codec: $jsoniterPkgCore.JsonValueCodec[$name] = $jsoniterPkgMacros.JsonCodecMaker.make($config)"
+            if (useCustomJsoniterSerdes)
+              s"""implicit lazy val ${uncapitalisedName}Codec: $jsoniterPkgCore.JsonValueCodec[$name] = $jsoniterPkgMacros.JsonCodecMaker.makeOpenapiLike("${discriminator.propertyName}", {$discriminatorMap})"""
+            else {
+              val config =
+                s"""$jsoniterBaseConfig.withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("${discriminator.propertyName}")).withAdtLeafClassNameMapper(x => com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.simpleClassName(x) match {$discriminatorMap})"""
+              s"implicit lazy val ${uncapitalisedName}Codec: $jsoniterPkgCore.JsonValueCodec[$name] = $jsoniterPkgMacros.JsonCodecMaker.make($config)"
+            }
 
           s"""$serde
              |""".stripMargin
         } else {
-          val config =
-            s"""$jsoniterBaseConfig.withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("${discriminator.propertyName}"))"""
-          s"implicit lazy val ${uncapitalisedName}Codec: $jsoniterPkgCore.JsonValueCodec[$name] = $jsoniterPkgMacros.JsonCodecMaker.make($config)"
+          if (useCustomJsoniterSerdes)
+            s"""implicit lazy val ${uncapitalisedName}Codec: $jsoniterPkgCore.JsonValueCodec[$name] = $jsoniterPkgMacros.JsonCodecMaker.makeOpenapiLike("${discriminator.propertyName}")"""
+          else {
+            val config =
+              s"""$jsoniterBaseConfig.withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("${discriminator.propertyName}"))"""
+            s"implicit lazy val ${uncapitalisedName}Codec: $jsoniterPkgCore.JsonValueCodec[$name] = $jsoniterPkgMacros.JsonCodecMaker.make($config)"
+          }
         }
         body
 
@@ -477,11 +499,12 @@ object JsonSerdeGenerator {
         case (None, a)    => Some(a)
       }
       .map(s =>
-      s"""implicit lazy val byteStringJsonCodec: zio.json.JsonCodec[ByteString] = zio.json.JsonCodec[ByteString](
+        s"""implicit lazy val byteStringJsonCodec: zio.json.JsonCodec[ByteString] = zio.json.JsonCodec[ByteString](
          |  zio.json.JsonEncoder[String].contramap[ByteString](java.util.Base64.getEncoder.encodeToString),
          |  zio.json.JsonDecoder[String].mapOrFail(s => scala.util.Try(java.util.Base64.getDecoder.decode(s)).toEither.map(toByteString).left.map(error => error.getMessage)),
          |)
-         |$s""".stripMargin)
+         |$s""".stripMargin
+      )
   }
 
   private def genZioObjectSerde(name: String, schema: OpenapiSchemaObject): String = {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -48,7 +48,8 @@ object RootGenerator {
       validateNonDiscriminatedOneOfs: Boolean,
       maxSchemasPerFile: Int,
       generateEndpointTypes: Boolean,
-      generateValidators: Boolean
+      generateValidators: Boolean,
+      useCustomJsoniterSerdes: Boolean
   ): Map[String, String] = {
     val doc = unNormalisedDoc.resolveAllOfSchemas
     val normalisedJsonLib = jsonSerdeLib.toLowerCase match {
@@ -114,7 +115,8 @@ object RootGenerator {
           validateNonDiscriminatedOneOfs = validateNonDiscriminatedOneOfs,
           maxSchemasPerFile = maxSchemasPerFile,
           enumsDefinedOnEndpointParams = enumsDefinedOnEndpointParams,
-          xmlParamRefs = xmlParamRefs
+          xmlParamRefs = xmlParamRefs,
+          useCustomJsoniterSerdes = useCustomJsoniterSerdes
         )
         .getOrElse(GeneratedClassDefinitions("", None, Nil, None))
     val hasJsonSerdes = jsonSerdes.nonEmpty

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/util/MapUtils.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/util/MapUtils.scala
@@ -6,7 +6,7 @@ object MapUtils {
     m2.iterator.foldLeft(m1) { case (m, (k, v)) =>
       m.get(k) match {
         case Some(value) => m + (k -> (value ++ v))
-        case None => m + (k -> v)
+        case None        => m + (k -> v)
       }
     }
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -536,7 +536,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
         |implicit def toByteString(ba: Array[Byte]): ByteString = ba.asInstanceOf[ByteString]
         |""".stripMargin
     val gen = new ClassDefinitionGenerator()
-    def testOK(doc: OpenapiDocument) = {
+    def testOK(useCustomMacros: Boolean, doc: OpenapiDocument) = {
       val GeneratedClassDefinitions(res, jsonSerdes, _, _) =
         gen
           .classDefs(
@@ -544,19 +544,25 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             false,
             jsonSerdeLib = JsonSerdeLib.Jsoniter,
             jsonParamRefs = Set("ReqWithVariants"),
-            fullModelPath = "foo.bar.baz"
+            fullModelPath = "foo.bar.baz",
+            useCustomJsoniterSerdes = useCustomMacros
           )
           .get
 
       val fullRes = imports + res + "\n" + jsonSerdes.get
       res shouldCompile ()
       fullRes shouldCompile ()
-      jsonSerdes.get should include(
+      if (useCustomMacros) jsonSerdes.get should include(
+        """implicit lazy val reqWithVariantsCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ReqWithVariants] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike("type")"""
+      )
+      else jsonSerdes.get should include(
         """implicit lazy val reqWithVariantsCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ReqWithVariants] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true).withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("type")))"""
       )
     }
-    testOK(TestHelpers.oneOfDocsWithMapping)
-    testOK(TestHelpers.oneOfDocsWithDiscriminatorNoMapping)
+    testOK(false, TestHelpers.oneOfDocsWithMapping)
+    testOK(false, TestHelpers.oneOfDocsWithDiscriminatorNoMapping)
+    testOK(true, TestHelpers.oneOfDocsWithMapping)
+    testOK(true, TestHelpers.oneOfDocsWithDiscriminatorNoMapping)
     val failed = Try(
       gen.classDefs(TestHelpers.oneOfDocsNoDiscriminator, false, jsonSerdeLib = JsonSerdeLib.Circe, jsonParamRefs = Set("ReqWithVariants"))
     )

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -552,12 +552,14 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       val fullRes = imports + res + "\n" + jsonSerdes.get
       res shouldCompile ()
       fullRes shouldCompile ()
-      if (useCustomMacros) jsonSerdes.get should include(
-        """implicit lazy val reqWithVariantsCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ReqWithVariants] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike("type")"""
-      )
-      else jsonSerdes.get should include(
-        """implicit lazy val reqWithVariantsCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ReqWithVariants] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true).withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("type")))"""
-      )
+      if (useCustomMacros)
+        jsonSerdes.get should include(
+          """implicit lazy val reqWithVariantsCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ReqWithVariants] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike("type")"""
+        )
+      else
+        jsonSerdes.get should include(
+          """implicit lazy val reqWithVariantsCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ReqWithVariants] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true).withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("type")))"""
+        )
     }
     testOK(false, TestHelpers.oneOfDocsWithMapping)
     testOK(false, TestHelpers.oneOfDocsWithDiscriminatorNoMapping)

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -297,7 +297,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       maxSchemasPerFile = 400,
       streamingImplementation = "fs2",
       generateEndpointTypes = false,
-      generateValidators = true
+      generateValidators = true,
+      useCustomJsoniterSerdes = true
     )("TapirGeneratedEndpoints")
     generatedCode should include(
       """file: sttp.model.Part[java.io.File]"""
@@ -322,7 +323,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       maxSchemasPerFile = 400,
       streamingImplementation = "fs2",
       generateEndpointTypes = false,
-      generateValidators = true
+      generateValidators = true,
+      useCustomJsoniterSerdes = true
     )("TapirGeneratedEndpoints")
     generatedCode shouldCompile ()
     val expectedAttrDecls = Seq(

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/RootGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/RootGeneratorSpec.scala
@@ -21,7 +21,8 @@ class RootGeneratorSpec extends CompileCheckTestBase {
       maxSchemasPerFile = 400,
       streamingImplementation = "fs2",
       generateEndpointTypes = false,
-      generateValidators = true
+      generateValidators = true,
+      useCustomJsoniterSerdes = true
     )
   }
   def gen(

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -14,6 +14,7 @@ case class OpenApiConfiguration(
     maxSchemasPerFile: Int,
     generateEndpointTypes: Boolean,
     disableValidatorGeneration: Boolean,
+    useCustomJsoniterSerdes: Boolean,
     additionalPackages: List[(String, File)]
 )
 
@@ -33,6 +34,7 @@ trait OpenapiCodegenKeys {
   lazy val openapiStreamingImplementation = settingKey[String]("Implementation for streamTextBody. Supports: akka, fs2, pekko, zio.")
   lazy val openapiGenerateEndpointTypes = settingKey[Boolean]("Whether to emit explicit types for endpoint defns")
   lazy val openapiDisableValidatorGeneration = settingKey[Boolean]("Set to true to disable validator generation")
+  lazy val openapiUseCustomJsoniterSerdes = settingKey[Boolean]("Set to true to enable usage of custom jsoniter macros (decreases compilation flakiness, compatible with jsoniter-scala versions >= 2.36.x)")
   lazy val openapiOpenApiConfiguration =
     settingKey[OpenApiConfiguration]("Aggregation of other settings. Manually set value will be disregarded.")
 

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -35,6 +35,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
       openapiMaxSchemasPerFile.value,
       openapiGenerateEndpointTypes.value,
       openapiDisableValidatorGeneration.value,
+      openapiUseCustomJsoniterSerdes.value,
       openapiAdditionalPackages.value
     )
   def openapiCodegenDefaultSettings: Seq[Setting[_]] = Seq(
@@ -49,6 +50,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
     openapiAdditionalPackages := Nil,
     openapiStreamingImplementation := "fs2",
     openapiGenerateEndpointTypes := false,
+    openapiUseCustomJsoniterSerdes := false,
     openapiDisableValidatorGeneration := false,
     standardParamSetting
   )
@@ -82,6 +84,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
               c.maxSchemasPerFile,
               c.generateEndpointTypes,
               c.disableValidatorGeneration,
+              c.useCustomJsoniterSerdes,
               srcDir,
               taskStreams.cacheDirectory,
               sv.startsWith("3"),

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -50,8 +50,8 @@ object OpenapiCodegenPlugin extends AutoPlugin {
     openapiAdditionalPackages := Nil,
     openapiStreamingImplementation := "fs2",
     openapiGenerateEndpointTypes := false,
-    openapiUseCustomJsoniterSerdes := false,
     openapiDisableValidatorGeneration := false,
+    openapiUseCustomJsoniterSerdes := false,
     standardParamSetting
   )
 

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -17,6 +17,7 @@ case class OpenapiCodegenTask(
     maxSchemasPerFile: Int,
     generateEndpointTypes: Boolean,
     disableValidatorGeneration: Boolean,
+    disableCustomJsoniterSerdes: Boolean,
     dir: File,
     cacheDir: File,
     targetScala3: Boolean,
@@ -65,7 +66,8 @@ case class OpenapiCodegenTask(
           validateNonDiscriminatedOneOfs,
           maxSchemasPerFile,
           generateEndpointTypes,
-          !disableValidatorGeneration
+          !disableValidatorGeneration,
+          !disableCustomJsoniterSerdes,
         )
         .map { case (objectName, fileBody) =>
           val file = directory / s"$objectName.scala"

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -17,7 +17,7 @@ case class OpenapiCodegenTask(
     maxSchemasPerFile: Int,
     generateEndpointTypes: Boolean,
     disableValidatorGeneration: Boolean,
-    disableCustomJsoniterSerdes: Boolean,
+    useCustomJsoniterSerdes: Boolean,
     dir: File,
     cacheDir: File,
     targetScala3: Boolean,
@@ -67,7 +67,7 @@ case class OpenapiCodegenTask(
           maxSchemasPerFile,
           generateEndpointTypes,
           !disableValidatorGeneration,
-          !disableCustomJsoniterSerdes,
+          useCustomJsoniterSerdes
         )
         .map { case (objectName, fileBody) =>
           val file = directory / s"$objectName.scala"

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/ExpectedJsonSerdes.scala.txt
@@ -1,0 +1,58 @@
+package sttp.tapir.generated
+
+object TapirGeneratedEndpointsJsonSerdes {
+  import sttp.tapir.generated.TapirGeneratedEndpoints._
+  import sttp.tapir.generic.auto._
+  implicit val byteStringJsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ByteString] = new com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ByteString] {
+    def nullValue: ByteString = Array.empty[Byte]
+    def decodeValue(in: com.github.plokhotnyuk.jsoniter_scala.core.JsonReader, default: ByteString): ByteString =
+      toByteString(java.util.Base64.getDecoder.decode(in.readString("")))
+    def encodeValue(x: ByteString, out: com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter): _root_.scala.Unit =
+      out.writeVal(java.util.Base64.getEncoder.encodeToString(x))
+  }
+
+  implicit def seqCodec[T: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec]: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[List[T]] =
+    com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[List[T]]
+  implicit def optionCodec[T: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec]: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[Option[T]] =
+    com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[Option[T]]
+  implicit lazy val anyJsonSupport: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[io.circe.Json] = com.github.plokhotnyuk.jsoniter_scala.circe.JsoniterScalaCodec.jsonCodec()
+  implicit lazy val aDTWithDiscriminatorCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ADTWithDiscriminator] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike("type", {
+    case "SubtypeWithD1" => "SubA"
+    case "SubtypeWithD2" => "SubB"})
+
+  implicit lazy val subtypeWithoutD1JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[SubtypeWithoutD1] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike
+  implicit lazy val hasASetJsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[HasASet] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike
+  implicit lazy val aDTWithDiscriminatorNoMappingCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ADTWithDiscriminatorNoMapping] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike("type")
+  implicit lazy val subtypeWithoutD3JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[SubtypeWithoutD3] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike
+
+  implicit lazy val subtypeWithoutD3E2JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[SubtypeWithoutD3E2] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLikeWithoutDiscriminator
+  implicit lazy val subtypeWithoutD2JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[SubtypeWithoutD2] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike
+
+  implicit lazy val anEnumJsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[AnEnum] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLikeWithoutDiscriminator
+
+  implicit lazy val listTypeJsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ListType] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike
+  implicit lazy val aDTWithoutDiscriminatorCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ADTWithoutDiscriminator] = new com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ADTWithoutDiscriminator] {
+    def decodeValue(in: com.github.plokhotnyuk.jsoniter_scala.core.JsonReader, default: ADTWithoutDiscriminator): ADTWithoutDiscriminator = {
+      List(
+        subtypeWithoutD1JsonCodec,
+        subtypeWithoutD2JsonCodec,
+        subtypeWithoutD3JsonCodec)
+        .foldLeft(Option.empty[ADTWithoutDiscriminator]) {
+          case (Some(v), _) => Some(v)
+          case (None, next) =>
+            in.setMark()
+            scala.util.Try(next.asInstanceOf[com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ADTWithoutDiscriminator]].decodeValue(in, default))
+              .fold(_ => { in.rollbackToMark(); None }, Some(_))
+        }.getOrElse(throw new RuntimeException("Unable to decode json to untagged ADT type ADTWithoutDiscriminator"))
+    }
+    def encodeValue(x: ADTWithoutDiscriminator, out: com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter): Unit = x match {
+      case x: SubtypeWithoutD1 => subtypeWithoutD1JsonCodec.encodeValue(x, out)
+      case x: SubtypeWithoutD2 => subtypeWithoutD2JsonCodec.encodeValue(x, out)
+      case x: SubtypeWithoutD3 => subtypeWithoutD3JsonCodec.encodeValue(x, out)
+    }
+
+    def nullValue: ADTWithoutDiscriminator = subtypeWithoutD1JsonCodec.nullValue
+  }
+  implicit lazy val postInlineSimpleObjectResponseJsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[PostInlineSimpleObjectResponse] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike
+  implicit lazy val postInlineSimpleObjectRequestJsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[PostInlineSimpleObjectRequest] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.makeOpenapiLike
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file("."))
     openapiJsonSerdeLib := "jsoniter",
     openapiStreamingImplementation := "pekko",
     openapiGenerateEndpointTypes := true,
-    useCustomJsoniterSerdesOpt := true
+    openapiUseCustomJsoniterSerdes := true
   )
 
 val catsXmlVersion = "0.0.20"

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/build.sbt
@@ -5,11 +5,12 @@ lazy val root = (project in file("."))
     version := "0.1",
     openapiJsonSerdeLib := "jsoniter",
     openapiStreamingImplementation := "pekko",
-    openapiGenerateEndpointTypes := true
+    openapiGenerateEndpointTypes := true,
+    useCustomJsoniterSerdesOpt := true
   )
 
 val catsXmlVersion = "0.0.20"
-val jsoniterScalaVersion = "2.35.3"
+val jsoniterScalaVersion = "2.36.0"
 val tapirVersion = "1.11.18"
 libraryDependencies ++= Seq(
   "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % tapirVersion,
@@ -53,5 +54,6 @@ TaskKey[Unit]("check") := {
     "target/scala-2.13/src_managed/main/sbt-openapi-codegen/TapirGeneratedEndpointsXmlSerdes.scala",
     "ExpectedXmlSerdes.scala.txt"
   )
+  compare("json", "target/scala-2.13/src_managed/main/sbt-openapi-codegen/TapirGeneratedEndpointsJsonSerdes.scala", "ExpectedJsonSerdes.scala.txt")
   ()
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/ExpectedJsonSerdes.scala.txt
@@ -1,0 +1,51 @@
+package sttp.tapir.generated
+
+object TapirGeneratedEndpointsJsonSerdes {
+  import sttp.tapir.generated.TapirGeneratedEndpoints._
+  import sttp.tapir.generic.auto._
+  implicit val byteStringJsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ByteString] = new com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ByteString] {
+    def nullValue: ByteString = Array.empty[Byte]
+    def decodeValue(in: com.github.plokhotnyuk.jsoniter_scala.core.JsonReader, default: ByteString): ByteString =
+      toByteString(java.util.Base64.getDecoder.decode(in.readString("")))
+    def encodeValue(x: ByteString, out: com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter): _root_.scala.Unit =
+      out.writeVal(java.util.Base64.getEncoder.encodeToString(x))
+  }
+
+  implicit def seqCodec[T: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec]: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[List[T]] =
+    com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[List[T]]
+  implicit def optionCodec[T: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec]: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[Option[T]] =
+    com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make[Option[T]]
+
+  implicit lazy val aDTWithDiscriminatorCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ADTWithDiscriminator] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true).withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("type")).withAdtLeafClassNameMapper(x => com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.simpleClassName(x) match {
+    case "SubtypeWithD1" => "SubA"
+    case "SubtypeWithD2" => "SubB"}))
+
+  implicit lazy val subtypeWithoutD1JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[SubtypeWithoutD1] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true))
+  implicit lazy val aDTWithDiscriminatorNoMappingCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ADTWithDiscriminatorNoMapping] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true).withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("type")))
+  implicit lazy val subtypeWithoutD3JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[SubtypeWithoutD3] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true))
+  implicit lazy val subtypeWithoutD2JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[SubtypeWithoutD2] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true))
+
+  implicit lazy val anEnumJsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[AnEnum] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true).withDiscriminatorFieldName(scala.None))
+  implicit lazy val aDTWithoutDiscriminatorCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ADTWithoutDiscriminator] = new com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ADTWithoutDiscriminator] {
+    def decodeValue(in: com.github.plokhotnyuk.jsoniter_scala.core.JsonReader, default: ADTWithoutDiscriminator): ADTWithoutDiscriminator = {
+      List(
+        subtypeWithoutD1JsonCodec,
+        subtypeWithoutD2JsonCodec,
+        subtypeWithoutD3JsonCodec)
+        .foldLeft(Option.empty[ADTWithoutDiscriminator]) {
+          case (Some(v), _) => Some(v)
+          case (None, next) =>
+            in.setMark()
+            scala.util.Try(next.asInstanceOf[com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ADTWithoutDiscriminator]].decodeValue(in, default))
+              .fold(_ => { in.rollbackToMark(); None }, Some(_))
+        }.getOrElse(throw new RuntimeException("Unable to decode json to untagged ADT type ADTWithoutDiscriminator"))
+    }
+    def encodeValue(x: ADTWithoutDiscriminator, out: com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter): Unit = x match {
+      case x: SubtypeWithoutD1 => subtypeWithoutD1JsonCodec.encodeValue(x, out)
+      case x: SubtypeWithoutD2 => subtypeWithoutD2JsonCodec.encodeValue(x, out)
+      case x: SubtypeWithoutD3 => subtypeWithoutD3JsonCodec.encodeValue(x, out)
+    }
+  
+    def nullValue: ADTWithoutDiscriminator = subtypeWithoutD1JsonCodec.nullValue
+  }
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/build.sbt
@@ -6,7 +6,7 @@ lazy val root = (project in file("."))
     openapiJsonSerdeLib := "jsoniter",
     openapiXmlSerdeLib := "none",
     openapiStreamingImplementation := "pekko",
-    useCustomJsoniterSerdesOpt := false
+    openapiUseCustomJsoniterSerdes := false
   )
 
 val tapirVersion = "1.11.16"


### PR DESCRIPTION
Mitigates flakiness in macro expansion during compilation (cf [this issue](https://github.com/plokhotnyuk/jsoniter-scala/issues/1279))

Enabling the newer codegen with an option (default can be changed at some point sufficiently-far-in-the-future) because I don't want to break things for those as don't need this.