### PR TITLE
codegen: support singleton allOf for default on refs

### DIFF
--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -96,10 +96,10 @@ object TapirGeneratedEndpoints {
   sealed trait ADTWithoutDiscriminator
   case class ValidatedObj (
     oneOf: Option[ValidatedOneOf] = None,
-    bar: ValidatedSubObj,
     foo: String,
     map: Option[Map[String, Int]] = None,
     set: Option[Set[String]] = None,
+    bar: ValidatedSubObj = ValidatedSubObj(i = "i..."),
     rec: Option[ValidatedRecursive] = None,
     arr: Option[Seq[Int]] = None,
     quux: Option[String] = None,
@@ -155,7 +155,7 @@ object TapirGeneratedEndpoints {
   case class SubtypeWithoutD3 (
     s: String,
     i: Option[Int] = None,
-    e: Option[AnEnum] = None,
+    e: Option[AnEnum] = Some(AnEnum.Foo),
     absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
   case class NullableThingy2 (
@@ -175,7 +175,7 @@ object TapirGeneratedEndpoints {
     case object foo4 extends ObjectWithInlineEnumInlineEnum
   }
   case class ValidatedRecursive (
-    self: Option[Seq[ValidatedRecursive]] = None
+    self: Option[Seq[ValidatedRecursive]] = Some(Vector(ValidatedRecursive(self = Some(Vector()))))
   )
   case class SubtypeWithoutD2 (
     a: Seq[String],

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/ValidationSpec.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/ValidationSpec.scala
@@ -87,7 +87,7 @@ class ValidationSpec extends AnyFreeSpec with Matchers {
       resp.code.code shouldEqual 400
       resp.body shouldEqual Left(())
     }
-    checkFailure(Some(ValidatedObj(None, ValidatedSubObj(""), "", None, None, None, None)))
+    checkFailure(Some(minimalValidObj.copy(bar = ValidatedSubObj(""))))
     checkFailure(Some(minimalValidObj.copy(oneOf = Some(ValidatedOneOfA("i")))))
     checkFailure(Some(minimalValidObj.copy(oneOf = Some(ValidatedOneOfB(Some(-1))))))
     checkFailure(Some(minimalValidObj.copy(map = Some(Map("a" -> 1, "b" -> 2, "c" -> -1)))))

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -654,7 +654,9 @@ components:
         i:
           type: integer
         e:
-          $ref: '#/components/schemas/AnEnum'
+          allOf:
+            - $ref: '#/components/schemas/AnEnum'
+          default: Foo
         absent:
           type: string
     AnEnum:
@@ -824,10 +826,13 @@ components:
       type: object
       properties:
         self:
-          type: array
-          maxItems: 3
-          items:
-            $ref: '#/components/schemas/ValidatedRecursive'
+          allOf:
+            - type: array
+              maxItems: 3
+              items:
+                $ref: '#/components/schemas/ValidatedRecursive'
+          default:
+            - self: [ ]
     ValidatedSubObj:
       title: ValidatedSubObj
       type: object
@@ -848,7 +853,10 @@ components:
           type: string
           maxLength: 128
         bar:
-          $ref: '#/components/schemas/ValidatedSubObj'
+          allOf:
+            - $ref: '#/components/schemas/ValidatedSubObj'
+          default:
+            i: "i..."
         baz:
           $ref: '#/components/schemas/ValidatedSubObj'
         quux:


### PR DESCRIPTION
A use-case for allOf that I'd missed is supporting default values on fields whose type are declared by 'ref's. In fact, there are really the only two ways to do that that works with openapi 3.0:
```yaml
allOf:
 - $ref: ...someRef
 - default: defaultValue
```
and

```yaml
allOf:
 - $ref: ...someRef
default: defaultValue
```
since sibling fields to $ref are ignored.

I'm only supporting the latter form here, and _not_ attempting to support other usages of allOf outside of top-level usage in components/schemas definitions (which are already largely handled). This is really a very specific case, and more general handling would be _far_ more involved

(github's default diff on this looks really weird, it makes more sense with 'hide whitespace' enabled)