### PR TITLE
codegen: make generated class field & endpoint decl orders consistent with api declarations

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
@@ -176,8 +176,8 @@ object JsonSerdeGenerator {
       case (k, OpenapiSchemaField(OpenapiSchemaMap(`type`: OpenapiSchemaObject, _, _), _, _)) =>
         genCirceObjectSerde(s"$name${k.capitalize}Item", `type`)
     } match {
-      case Nil => ""
-      case s   => s.mkString("", "\n", "\n")
+      case s if s.isEmpty => ""
+      case s              => s.mkString("", "\n", "\n")
     }
     val uncapitalisedName = RootGenerator.uncapitalise(name)
     s"""${subs}implicit lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] = io.circe.generic.semiauto.deriveDecoder[$name]
@@ -515,8 +515,8 @@ object JsonSerdeGenerator {
       case (k, OpenapiSchemaField(OpenapiSchemaMap(`type`: OpenapiSchemaObject, _, _), _, _)) =>
         genZioObjectSerde(s"$name${k.capitalize}Item", `type`)
     } match {
-      case Nil => ""
-      case s   => s.mkString("", "\n", "\n")
+      case s if s.isEmpty => ""
+      case s              => s.mkString("", "\n", "\n")
     }
     val uncapitalisedName = RootGenerator.uncapitalise(name)
     s"""${subs}implicit lazy val ${uncapitalisedName}JsonDecoder: zio.json.JsonDecoder[$name] = zio.json.DeriveJsonDecoder.gen[$name]

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
@@ -197,8 +197,8 @@ object SchemaGenerator {
       case (k, OpenapiSchemaField(OpenapiSchemaMap(_: OpenapiSchemaEnum, _, _), _, _)) =>
         schemaForEnum(s"$name${k.capitalize}Item")
     } match {
-      case Nil => ""
-      case s   => s.mkString("", "\n", "\n")
+      case s if s.isEmpty => ""
+      case s              => s.mkString("", "\n", "\n")
     }
     s"${subs}implicit lazy val ${RootGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -364,7 +364,7 @@ object OpenapiModels {
     for {
       paths <- c
         .withFocusM[Decoder.Result](j => Right(j.mapObject(_.filterKeys(!specificationExtensionKeys.contains(_)))))
-        .flatMap(_.as[Map[String, OpenapiPath]])
+        .flatMap(_.as[mutable.LinkedHashMap[String, OpenapiPath]])
       extensions = extensionsFrom(c, specificationExtensionKeys)
     } yield paths.map { case (url, path) => path.copy(url = url) }.toSeq -> extensions
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -13,6 +13,8 @@ import OpenapiSchemaType.{
 import io.circe.Json
 import sttp.tapir.codegen.RootGenerator.strippedToCamelCase
 import sttp.tapir.codegen.util.MapUtils
+
+import scala.collection.mutable
 // https://swagger.io/specification/
 object OpenapiModels {
 
@@ -59,7 +61,7 @@ object OpenapiModels {
                     s"Only objects and object refs are currently supported in allOf schemas.For $n found ${s.map(_.getClass.getSimpleName)}"
                   )
               }
-              val merged = resolved.foldLeft((Set.empty[String], Map.empty[String, OpenapiSchemaField])) {
+              val merged = resolved.foldLeft((Set.empty[String], mutable.LinkedHashMap.empty[String, OpenapiSchemaField])) {
                 case ((_, accProp), next) if accProp.isEmpty => next
                 case ((accReq, accProp), (nextReq, nextProp)) =>
                   val dupDecls = accProp.keySet.intersect(nextProp.keySet)

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -6,6 +6,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
 import sttp.tapir.codegen.testutils.CompileCheckTestBase
 import sttp.tapir.codegen.util.DocUtils
 
+import scala.collection.mutable
 import scala.util.Try
 
 class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
@@ -24,7 +25,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       Some(
         OpenapiComponent(
           Map(
-            "Test" -> OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(false))), Seq("text"), false)
+            "Test" -> OpenapiSchemaObject(mutable.LinkedHashMap("text" -> noDefault(OpenapiSchemaString(false))), Seq("text"), false)
           )
         )
       ),
@@ -66,7 +67,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       Some(
         OpenapiComponent(
           Map(
-            "Test" -> OpenapiSchemaObject(Map("type" -> noDefault(OpenapiSchemaString(false))), Seq("type"), false)
+            "Test" -> OpenapiSchemaObject(mutable.LinkedHashMap("type" -> noDefault(OpenapiSchemaString(false))), Seq("type"), false)
           )
         )
       ),
@@ -86,7 +87,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
         OpenapiComponent(
           Map(
             "Test" -> OpenapiSchemaObject(
-              Map("texts" -> noDefault(OpenapiSchemaArray(OpenapiSchemaString(false), false))),
+              mutable.LinkedHashMap("texts" -> noDefault(OpenapiSchemaArray(OpenapiSchemaString(false), false))),
               Seq("texts"),
               false
             )
@@ -109,7 +110,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
         OpenapiComponent(
           Map(
             "Test" -> OpenapiSchemaObject(
-              Map("texts" -> noDefault(OpenapiSchemaMap(OpenapiSchemaString(false), false))),
+              mutable.LinkedHashMap("texts" -> noDefault(OpenapiSchemaMap(OpenapiSchemaString(false), false))),
               Seq("texts"),
               false
             )
@@ -131,7 +132,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       Some(
         OpenapiComponent(
           Map(
-            "Test" -> OpenapiSchemaObject(Map("anyType" -> noDefault(OpenapiSchemaAny(false))), Seq("anyType"), false)
+            "Test" -> OpenapiSchemaObject(mutable.LinkedHashMap("anyType" -> noDefault(OpenapiSchemaAny(false))), Seq("anyType"), false)
           )
         )
       ),
@@ -151,8 +152,8 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
         OpenapiComponent(
           Map(
             "Test" -> OpenapiSchemaObject(
-              Map(
-                "inner" -> noDefault(OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(false))), Seq("text"), false))
+              mutable.LinkedHashMap(
+                "inner" -> noDefault(OpenapiSchemaObject(mutable.LinkedHashMap("text" -> noDefault(OpenapiSchemaString(false))), Seq("text"), false))
               ),
               Seq("inner"),
               false
@@ -177,10 +178,10 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
           Map(
             "Test" ->
               OpenapiSchemaObject(
-                Map(
+                mutable.LinkedHashMap(
                   "objects" -> noDefault(
                     OpenapiSchemaArray(
-                      OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(false))), Seq("text"), false),
+                      OpenapiSchemaObject(mutable.LinkedHashMap("text" -> noDefault(OpenapiSchemaString(false))), Seq("text"), false),
                       false
                     )
                   )
@@ -208,10 +209,10 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
           Map(
             "Test" ->
               OpenapiSchemaObject(
-                Map(
+                mutable.LinkedHashMap(
                   "objects" -> noDefault(
                     OpenapiSchemaMap(
-                      OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(false))), Seq("text"), false),
+                      OpenapiSchemaObject(mutable.LinkedHashMap("text" -> noDefault(OpenapiSchemaString(false))), Seq("text"), false),
                       false
                     )
                   )
@@ -237,7 +238,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       Some(
         OpenapiComponent(
           Map(
-            "Test" -> OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(false))), Seq.empty, false)
+            "Test" -> OpenapiSchemaObject(mutable.LinkedHashMap("text" -> noDefault(OpenapiSchemaString(false))), Seq.empty, false)
           )
         )
       ),
@@ -251,7 +252,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       Some(
         OpenapiComponent(
           Map(
-            "Test" -> OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(false))), Seq("text"), false)
+            "Test" -> OpenapiSchemaObject(mutable.LinkedHashMap("text" -> noDefault(OpenapiSchemaString(false))), Seq("text"), false)
           )
         )
       ),
@@ -273,7 +274,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       Some(
         OpenapiComponent(
           Map(
-            "Test" -> OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(false))), Seq.empty, false)
+            "Test" -> OpenapiSchemaObject(mutable.LinkedHashMap("text" -> noDefault(OpenapiSchemaString(false))), Seq.empty, false)
           )
         )
       ),
@@ -287,7 +288,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       Some(
         OpenapiComponent(
           Map(
-            "Test" -> OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(true))), Seq("text"), false)
+            "Test" -> OpenapiSchemaObject(mutable.LinkedHashMap("text" -> noDefault(OpenapiSchemaString(true))), Seq("text"), false)
           )
         )
       ),
@@ -370,7 +371,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       Some(
         OpenapiComponent(
           Map(
-            "MyObject" -> OpenapiSchemaObject(Map("text" -> noDefault(OpenapiSchemaString(true))), Seq("text"), false),
+            "MyObject" -> OpenapiSchemaObject(mutable.LinkedHashMap("text" -> noDefault(OpenapiSchemaString(true))), Seq("text"), false),
             "MyEnum" -> OpenapiSchemaEnum("string", Seq(OpenapiSchemaConstantString("enum1"), OpenapiSchemaConstantString("enum2")), false),
             "MyMapPrimitive" -> OpenapiSchemaMap(OpenapiSchemaString(false), false),
             "MyMapObject" -> OpenapiSchemaMap(OpenapiSchemaRef("#/components/schemas/MyObject"), false),
@@ -466,7 +467,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
       ),
       "OneOfValue" -> OpenapiSchemaArray(OpenapiSchemaBinary(false), false),
       "TopObject" -> OpenapiSchemaObject(
-        Map(
+        mutable.LinkedHashMap(
           "innerMap" -> OpenapiSchemaField(OpenapiSchemaRef("#/components/schemas/TopMap"), None),
           "innerArray" -> OpenapiSchemaField(OpenapiSchemaRef("#/components/schemas/TopArray"), None),
           "innerOneOf" -> OpenapiSchemaField(OpenapiSchemaRef("#/components/schemas/TopOneOf"), None),

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -1,33 +1,12 @@
 package sttp.tapir.codegen
 
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
-import sttp.tapir.codegen.openapi.models.OpenapiModels.{
-  OpenapiDocument,
-  OpenapiParameter,
-  OpenapiPath,
-  OpenapiPathMethod,
-  OpenapiRequestBody,
-  OpenapiRequestBodyContent,
-  OpenapiRequestBodyDefn,
-  OpenapiResponse,
-  OpenapiResponseContent,
-  OpenapiResponseDef,
-  Resolved
-}
-import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType.{
-  OpenapiSecuritySchemeApiKeyType,
-  OpenapiSecuritySchemeBasicType,
-  OpenapiSecuritySchemeBearerType
-}
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  OpenapiSchemaArray,
-  OpenapiSchemaBinary,
-  OpenapiSchemaField,
-  OpenapiSchemaObject,
-  OpenapiSchemaRef,
-  OpenapiSchemaString
-}
+import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiDocument, OpenapiParameter, OpenapiPath, OpenapiPathMethod, OpenapiRequestBody, OpenapiRequestBodyContent, OpenapiRequestBodyDefn, OpenapiResponse, OpenapiResponseContent, OpenapiResponseDef, Resolved}
+import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType.{OpenapiSecuritySchemeApiKeyType, OpenapiSecuritySchemeBasicType, OpenapiSecuritySchemeBearerType}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{OpenapiSchemaArray, OpenapiSchemaBinary, OpenapiSchemaField, OpenapiSchemaObject, OpenapiSchemaRef, OpenapiSchemaString}
 import sttp.tapir.codegen.testutils.CompileCheckTestBase
+
+import scala.collection.mutable
 
 class EndpointGeneratorSpec extends CompileCheckTestBase {
 
@@ -274,7 +253,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
         OpenapiComponent(
           schemas = Map(
             "FileUpload" -> OpenapiSchemaObject(
-              properties = Map(
+              properties = mutable.LinkedHashMap(
                 "file" -> OpenapiSchemaField(OpenapiSchemaBinary(false), None)
               ),
               required = Seq("file"),

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -19,6 +19,8 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaUUID
 }
 
+import scala.collection.mutable
+
 object TestHelpers {
 
   val myBookshopYaml =
@@ -269,7 +271,11 @@ object TestHelpers {
     Some(
       OpenapiComponent(
         schemas = Map(
-          "Book" -> OpenapiSchemaObject(Map("title" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), Seq("title"), false)
+          "Book" -> OpenapiSchemaObject(
+            mutable.LinkedHashMap("title" -> OpenapiSchemaField(OpenapiSchemaString(false), None)),
+            Seq("title"),
+            false
+          )
         ),
         securitySchemes = Map.empty,
         parameters = Map(
@@ -417,9 +423,9 @@ object TestHelpers {
     Some(
       OpenapiComponent(
         Map(
-          "Author" -> OpenapiSchemaObject(Map("name" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), List("name"), false),
+          "Author" -> OpenapiSchemaObject(mutable.LinkedHashMap("name" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), List("name"), false),
           "Book" -> OpenapiSchemaObject(
-            properties = Map(
+            properties = mutable.LinkedHashMap(
               "title" -> OpenapiSchemaField(OpenapiSchemaString(false), None),
               "year" -> OpenapiSchemaField(OpenapiSchemaInt(false, NumericRestrictions()), None),
               "author" -> OpenapiSchemaField(OpenapiSchemaRef("#/components/schemas/Author"), None)
@@ -810,7 +816,7 @@ object TestHelpers {
       OpenapiComponent(
         Map(
           "ReqWithDefaults" -> OpenapiSchemaObject(
-            Map(
+            mutable.LinkedHashMap(
               "f1" -> OpenapiSchemaField(OpenapiSchemaString(false), Some(Json.fromString("default string"))),
               "f2" -> OpenapiSchemaField(OpenapiSchemaInt(false, NumericRestrictions()), Some(Json.fromLong(1977)))
             ),
@@ -818,7 +824,7 @@ object TestHelpers {
             false
           ),
           "RespWithDefaults" -> OpenapiSchemaObject(
-            Map(
+            mutable.LinkedHashMap(
               "g1" -> OpenapiSchemaField(OpenapiSchemaUUID(false), Some(Json.fromString("default string"))),
               "g2" -> OpenapiSchemaField(OpenapiSchemaFloat(false, NumericRestrictions()), Some(Json.fromLong(1977))),
               "g3" -> OpenapiSchemaField(OpenapiSchemaRef("#/components/schemas/AnEnum"), Some(Json.fromString("v1"))),
@@ -851,12 +857,12 @@ object TestHelpers {
             false
           ),
           "SubObject" -> OpenapiSchemaObject(
-            Map("subsub" -> OpenapiSchemaField(OpenapiSchemaRef("#/components/schemas/SubSubObject"), None)),
+            mutable.LinkedHashMap("subsub" -> OpenapiSchemaField(OpenapiSchemaRef("#/components/schemas/SubSubObject"), None)),
             List("subsub"),
             false
           ),
           "SubSubObject" -> OpenapiSchemaObject(
-            Map(
+            mutable.LinkedHashMap(
               "value" -> OpenapiSchemaField(OpenapiSchemaString(false), None),
               "value2" -> OpenapiSchemaField(OpenapiSchemaUUID(false), None)
             ),
@@ -1142,13 +1148,13 @@ object TestHelpers {
             false
           ),
           "ReqSubtype1" -> OpenapiSchemaObject(
-            Map("foo" -> OpenapiSchemaField(OpenapiSchemaInt(false, NumericRestrictions()), None)),
+            mutable.LinkedHashMap("foo" -> OpenapiSchemaField(OpenapiSchemaInt(false, NumericRestrictions()), None)),
             List("foo"),
             false
           ),
-          "ReqSubtype2" -> OpenapiSchemaObject(Map("foo" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), List("foo"), false),
-          "ReqSubtype3" -> OpenapiSchemaObject(Map("foo" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), List("foo"), false),
-          "ReqSubtype4" -> OpenapiSchemaObject(Map("bar" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), List("bar"), false)
+          "ReqSubtype2" -> OpenapiSchemaObject(mutable.LinkedHashMap("foo" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), List("foo"), false),
+          "ReqSubtype3" -> OpenapiSchemaObject(mutable.LinkedHashMap("foo" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), List("foo"), false),
+          "ReqSubtype4" -> OpenapiSchemaObject(mutable.LinkedHashMap("bar" -> OpenapiSchemaField(OpenapiSchemaString(false), None)), List("bar"), false)
         ),
         Map(),
         Map()

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/SchemaParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/SchemaParserSpec.scala
@@ -1,24 +1,13 @@
 package sttp.tapir.codegen.openapi.models
 
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiResponseContent
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  NumericRestrictions,
-  OpenapiSchemaAny,
-  OpenapiSchemaArray,
-  OpenapiSchemaField,
-  OpenapiSchemaInt,
-  OpenapiSchemaMap,
-  OpenapiSchemaObject,
-  OpenapiSchemaString
-}
-import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType.{
-  OpenapiSecuritySchemeApiKeyType,
-  OpenapiSecuritySchemeBasicType,
-  OpenapiSecuritySchemeBearerType
-}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{NumericRestrictions, OpenapiSchemaAny, OpenapiSchemaArray, OpenapiSchemaField, OpenapiSchemaInt, OpenapiSchemaMap, OpenapiSchemaObject, OpenapiSchemaString}
+import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType.{OpenapiSecuritySchemeApiKeyType, OpenapiSecuritySchemeBasicType, OpenapiSecuritySchemeBearerType}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
+
+import scala.collection.mutable
 
 class SchemaParserSpec extends AnyFlatSpec with Matchers with Checkers {
   import io.circe.yaml.parser
@@ -51,7 +40,7 @@ class SchemaParserSpec extends AnyFlatSpec with Matchers with Checkers {
         OpenapiComponent(
           Map(
             "User" -> OpenapiSchemaObject(
-              Map(
+              mutable.LinkedHashMap(
                 "id" -> OpenapiSchemaField(OpenapiSchemaInt(false, NumericRestrictions()), None),
                 "name" -> OpenapiSchemaField(OpenapiSchemaString(false), None)
               ),
@@ -86,7 +75,7 @@ class SchemaParserSpec extends AnyFlatSpec with Matchers with Checkers {
       OpenapiComponent(
         Map(
           "User" -> OpenapiSchemaObject(
-            Map("attributes" -> OpenapiSchemaField(OpenapiSchemaMap(OpenapiSchemaString(false), false), None)),
+            mutable.LinkedHashMap("attributes" -> OpenapiSchemaField(OpenapiSchemaMap(OpenapiSchemaString(false), false), None)),
             Seq("attributes"),
             false
           )
@@ -114,7 +103,7 @@ class SchemaParserSpec extends AnyFlatSpec with Matchers with Checkers {
       OpenapiComponent(
         Map(
           "User" -> OpenapiSchemaObject(
-            Map("anyValue" -> OpenapiSchemaField(OpenapiSchemaAny(false), None)),
+            mutable.LinkedHashMap("anyValue" -> OpenapiSchemaField(OpenapiSchemaAny(false), None)),
             Seq("anyValue"),
             false
           )
@@ -198,7 +187,7 @@ class SchemaParserSpec extends AnyFlatSpec with Matchers with Checkers {
       .flatMap(_.as[Seq[OpenapiResponseContent]])
 
     res shouldBe Right(
-      Seq(OpenapiResponseContent("application/json", OpenapiSchemaArray(OpenapiSchemaObject(Map.empty, Seq.empty, false), false)))
+      Seq(OpenapiResponseContent("application/json", OpenapiSchemaArray(OpenapiSchemaObject(mutable.LinkedHashMap.empty, Seq.empty, false), false)))
     )
   }
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -95,15 +95,15 @@ object TapirGeneratedEndpoints {
   sealed trait ADTWithDiscriminatorNoMapping
   sealed trait ADTWithoutDiscriminator
   case class ValidatedObj (
-    oneOf: Option[ValidatedOneOf] = None,
     foo: String,
-    map: Option[Map[String, Int]] = None,
-    set: Option[Set[String]] = None,
     bar: ValidatedSubObj = ValidatedSubObj(i = "i..."),
-    rec: Option[ValidatedRecursive] = None,
-    arr: Option[Seq[Int]] = None,
+    baz: Option[ValidatedSubObj] = None,
     quux: Option[String] = None,
-    baz: Option[ValidatedSubObj] = None
+    map: Option[Map[String, Int]] = None,
+    arr: Option[Seq[Int]] = None,
+    set: Option[Set[String]] = None,
+    oneOf: Option[ValidatedOneOf] = None,
+    rec: Option[ValidatedRecursive] = None
   )
   case class ValidatedOneOfA (
     s: String

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -252,6 +252,23 @@ object TapirGeneratedEndpoints {
   type TapirCodegenDirectivesExtension = Seq[String]
   val tapirCodegenDirectivesExtensionKey = new sttp.tapir.AttributeKey[TapirCodegenDirectivesExtension]("sttp.tapir.generated.TapirGeneratedEndpoints.TapirCodegenDirectivesExtension")
 
+  type GetSecurityGroupSecurityGroupNameEndpoint = Endpoint[(String, String), Unit, Unit, Unit, Any]
+  lazy val getSecurityGroupSecurityGroupName: GetSecurityGroupSecurityGroupNameEndpoint =
+    endpoint
+      .get
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .prependSecurityIn("security-group" / path[String]("securityGroupName").description("used by security logic"))
+      .out(statusCode(sttp.model.StatusCode(204)).description("OK"))
+
+  type GetSecurityGroupSecurityGroupNameMorePathEndpoint = Endpoint[(String, String), Unit, Unit, Unit, Any]
+  lazy val getSecurityGroupSecurityGroupNameMorePath: GetSecurityGroupSecurityGroupNameMorePathEndpoint =
+    endpoint
+      .get
+      .in(("more-path"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .prependSecurityIn("security-group" / path[String]("securityGroupName").description("used by security logic"))
+      .out(statusCode(sttp.model.StatusCode(204)).description("OK"))
+
   type GetBinaryTestEndpoint = Endpoint[String, Unit, Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
   lazy val getBinaryTest: GetBinaryTestEndpoint =
     endpoint
@@ -303,51 +320,6 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[Option[NullableThingy2]].description("an optional request body (nullable)"))
       .out(jsonBody[Option[NullableThingy]].description("an optional response body"))
 
-  type PostJsonStringJsonBodyEndpoint = Endpoint[Option[String], PostJsonStringJsonBodyBodyIn, Unit, Option[PostJsonStringJsonBodyBodyOut], Any]
-  lazy val postJsonStringJsonBody: PostJsonStringJsonBodyEndpoint =
-    endpoint
-      .post
-      .in(("json" / "stringJsonBody"))
-      .securityIn(auth.bearer[Option[String]]())
-      .in(oneOfBody[PostJsonStringJsonBodyBodyIn](
-        stringJsonBody.map(Option(_))(_.orNull).map(PostJsonStringJsonBodyBodyOption_String_In(_))(_.value).widenBody[PostJsonStringJsonBodyBodyIn],
-        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/zipCodecFormat`](`application/zipCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(PostJsonStringJsonBodyBody1In(_))(_.value).widenBody[PostJsonStringJsonBodyBodyIn]))
-      .out(oneOf[Option[PostJsonStringJsonBodyBodyOut]](
-        oneOfVariantValueMatcher(sttp.model.StatusCode(200), oneOfBody[PostJsonStringJsonBodyBodyOut](
-        stringJsonBody.map(Option(_))(_.orNull).map(PostJsonStringJsonBodyBodyOption_String_Out(_))(_.`application/json`())
-        .map(_.asInstanceOf[PostJsonStringJsonBodyBodyOut])(p => PostJsonStringJsonBodyBodyOption_String_Out(p.`application/json`())).description("Possibly-invalid json"),
-        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/zipCodecFormat`](`application/zipCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(PostJsonStringJsonBodyBody1Out(_))(_.`application/zip`())
-        .map(_.asInstanceOf[PostJsonStringJsonBodyBodyOut])(p => PostJsonStringJsonBodyBody1Out(p.`application/zip`())).description("Possibly-invalid json")).map(Some(_))(_.orNull)){ case Some(_: PostJsonStringJsonBodyBodyOut) => true },
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None)))
-      .attribute[TapirCodegenDirectivesExtension](tapirCodegenDirectivesExtensionKey, Vector("json-body-as-string"))
-
-  type PostJsonStringJsonBodySimpleEndpoint = Endpoint[String, String, Unit, String, Any]
-  lazy val postJsonStringJsonBodySimple: PostJsonStringJsonBodySimpleEndpoint =
-    endpoint
-      .post
-      .in(("json" / "stringJsonBody" / "simple"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
-      .in(stringJsonBody)
-      .out(stringJsonBody.description("Possibly-invalid json"))
-      .attribute[TapirCodegenDirectivesExtension](tapirCodegenDirectivesExtensionKey, Vector("json-body-as-string"))
-
-  type GetSecurityGroupSecurityGroupNameEndpoint = Endpoint[(String, String), Unit, Unit, Unit, Any]
-  lazy val getSecurityGroupSecurityGroupName: GetSecurityGroupSecurityGroupNameEndpoint =
-    endpoint
-      .get
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
-      .prependSecurityIn("security-group" / path[String]("securityGroupName").description("used by security logic"))
-      .out(statusCode(sttp.model.StatusCode(204)).description("OK"))
-
-  type PostValidationTestEndpoint = Endpoint[String, Option[ValidatedObj], Unit, Unit, Any]
-  lazy val postValidationTest: PostValidationTestEndpoint =
-    endpoint
-      .post
-      .in(("validation" / "test"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
-      .in(jsonBody[Option[ValidatedObj]].validateOption(ValidatedObjValidator))
-      .out(statusCode(sttp.model.StatusCode(204)).description("ok"))
-
   type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
   lazy val putAdtTest: PutAdtTestEndpoint =
     endpoint
@@ -364,90 +336,6 @@ object TapirGeneratedEndpoints {
       .securityIn(auth.apiKey(header[String]("api_key")))
       .in(jsonBody[ADTWithDiscriminatorNoMapping].description("Update an existent user in the store"))
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
-
-  type GetHeadersTestsEndpoint = Endpoint[String, Unit, Unit, Option[String], Any]
-  lazy val getHeadersTests: GetHeadersTestsEndpoint =
-    endpoint
-      .get
-      .in(("headers" / "tests"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
-      .out(statusCode(sttp.model.StatusCode(302)).description("response").and(header[Option[String]]("foo").description("a description")))
-
-  type GetOneofErrorSecParamTestEndpoint = Endpoint[(String, Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn), Unit, Error, Unit, Any]
-  lazy val getOneofErrorSecParamTest: GetOneofErrorSecParamTestEndpoint =
-    endpoint
-      .get
-      .in(("test"))
-      .securityIn(auth.apiKey(header[Option[String]]("api_key")))
-      .securityIn(auth.apiKey(header[Option[String]]("api_key"))
-        .and(auth.bearer[Option[String]]()).map(Api_key_and_BearerSecurityInMapping))
-      .securityIn(auth.bearer[Option[String]]())
-      .mapSecurityInDecode[Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn]{
-        case (Some(x), None, None) => DecodeResult.Value(Api_keySecurityIn(x))
-        case (_, Some(x), _) => DecodeResult.Value(Api_key_and_BearerSecurityIn(x))
-        case (None, None, Some(x)) => DecodeResult.Value(BearerSecurityIn(x))
-        case (None, None, None) => DecodeResult.Value(EmptySecurityIn)
-        case other =>
-          val count = other.productIterator.count(_.isInstanceOf[Some[?]])
-          DecodeResult.Error(s"$count security inputs", new RuntimeException(s"Expected a single security input, found $count"))
-      }{
-        case Api_keySecurityIn(x) => (Some(x), None, None)
-        case Api_key_and_BearerSecurityIn(x) => (None, Some(x), None)
-        case BearerSecurityIn(x) => (None, None, Some(x))
-        case EmptySecurityIn => (None, None, None)
-      }
-      .prependSecurityIn("oneof" / "error" / path[String]("secParam"))
-      .errorOut(oneOf[Error](
-        oneOfVariant[NotFoundError](sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")),
-        oneOfVariant[SimpleError](sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
-      .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
-
-  type PostAllOfEndpoint = Endpoint[String, Option[HasFooBarBazQuux], Unit, Unit, Any]
-  lazy val postAllOf: PostAllOfEndpoint =
-    endpoint
-      .post
-      .in(("allOf"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
-      .in(jsonBody[Option[HasFooBarBazQuux]].description("list type in"))
-      .out(statusCode(sttp.model.StatusCode(204)).description("fine"))
-
-  type GetSecurityGroupSecurityGroupNameMorePathEndpoint = Endpoint[(String, String), Unit, Unit, Unit, Any]
-  lazy val getSecurityGroupSecurityGroupNameMorePath: GetSecurityGroupSecurityGroupNameMorePathEndpoint =
-    endpoint
-      .get
-      .in(("more-path"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
-      .prependSecurityIn("security-group" / path[String]("securityGroupName").description("used by security logic"))
-      .out(statusCode(sttp.model.StatusCode(204)).description("OK"))
-
-  type GetOneofOptionTestEndpoint = Endpoint[String, Unit, Unit, (Option[AnyObjectWithInlineEnum], Option[String]), Any]
-  lazy val getOneofOptionTest: GetOneofOptionTestEndpoint =
-    endpoint
-      .get
-      .in(("oneof" / "option" / "test"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
-      .out(oneOf[(Option[AnyObjectWithInlineEnum], Option[String])](
-        oneOfVariantValueMatcher(sttp.model.StatusCode(204), emptyOutputAs(None).description("No response").and(header[Option[String]]("common-response-header"))){ case (None, _) => true},
-        oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object").and(header[Option[String]]("common-response-header"))){ case (Some(_: ObjectWithInlineEnum), _) => true },
-        oneOfVariantValueMatcher(sttp.model.StatusCode(201), jsonBody[Option[ObjectWithInlineEnum2]].description("Another object").and(header[Option[String]]("common-response-header"))){ case (Some(_: ObjectWithInlineEnum2), _) => true }))
-
-  type GetPatternRestrictedObjectEndpoint = Endpoint[String, (String, Option[String], String, Option[String], String), Unit, String, Any]
-  lazy val getPatternRestrictedObject: GetPatternRestrictedObjectEndpoint =
-    endpoint
-      .get
-      .in(("pattern" / path[String]("restricted").validate(Validator.all(Validator.maxLength(10), Validator.minLength(3), Validator.pattern("[a-z]+"))).description("used by security logic") / "object"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
-      .in(query[Option[String]]("q1").validate(Validator.custom[Option[String]](ot => ot.map(Validator.pattern("[a-z_].+")(_)).map{
-        case Nil => ValidationResult.Valid
-        case l   => ValidationResult.Invalid(l.flatMap(_.customMessage).toList)
-      }.getOrElse(ValidationResult.Valid))))
-      .in(query[String]("q2").validate(Validator.minLength(3)))
-      .in(header[Option[String]]("h1").validate(Validator.custom[Option[String]](ot => ot.map(Validator.all(Validator.minLength(3), Validator.pattern("[a-z_].+"))(_)).map{
-        case Nil => ValidationResult.Valid
-        case l   => ValidationResult.Invalid(l.flatMap(_.customMessage).toList)
-      }.getOrElse(ValidationResult.Valid))))
-      .in(header[String]("h2").validate(Validator.minLength(3)))
-      .out(jsonBody[String].description("ok"))
 
   type PostInlineEnumTestEndpoint = Endpoint[Unit, (PostInlineEnumTestQueryEnum, Option[PostInlineEnumTestQueryOptEnum], List[PostInlineEnumTestQuerySeqEnum], Option[List[PostInlineEnumTestQueryOptSeqEnum]], ObjectWithInlineEnum), Unit, Unit, Any]
   lazy val postInlineEnumTest: PostInlineEnumTestEndpoint =
@@ -501,6 +389,100 @@ object TapirGeneratedEndpoints {
       extraCodecSupport[PostInlineEnumTestQueryOptSeqEnum]("PostInlineEnumTestQueryOptSeqEnum", PostInlineEnumTestQueryOptSeqEnum)
   }
 
+  type GetOneofErrorSecParamTestEndpoint = Endpoint[(String, Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn), Unit, Error, Unit, Any]
+  lazy val getOneofErrorSecParamTest: GetOneofErrorSecParamTestEndpoint =
+    endpoint
+      .get
+      .in(("test"))
+      .securityIn(auth.apiKey(header[Option[String]]("api_key")))
+      .securityIn(auth.apiKey(header[Option[String]]("api_key"))
+        .and(auth.bearer[Option[String]]()).map(Api_key_and_BearerSecurityInMapping))
+      .securityIn(auth.bearer[Option[String]]())
+      .mapSecurityInDecode[Bearer_or_Empty_or_api_key_or_api_key_and_Bearer_SecurityIn]{
+        case (Some(x), None, None) => DecodeResult.Value(Api_keySecurityIn(x))
+        case (_, Some(x), _) => DecodeResult.Value(Api_key_and_BearerSecurityIn(x))
+        case (None, None, Some(x)) => DecodeResult.Value(BearerSecurityIn(x))
+        case (None, None, None) => DecodeResult.Value(EmptySecurityIn)
+        case other =>
+          val count = other.productIterator.count(_.isInstanceOf[Some[?]])
+          DecodeResult.Error(s"$count security inputs", new RuntimeException(s"Expected a single security input, found $count"))
+      }{
+        case Api_keySecurityIn(x) => (Some(x), None, None)
+        case Api_key_and_BearerSecurityIn(x) => (None, Some(x), None)
+        case BearerSecurityIn(x) => (None, None, Some(x))
+        case EmptySecurityIn => (None, None, None)
+      }
+      .prependSecurityIn("oneof" / "error" / path[String]("secParam"))
+      .errorOut(oneOf[Error](
+        oneOfVariant[NotFoundError](sttp.model.StatusCode(404), jsonBody[NotFoundError].description("Not found")),
+        oneOfVariant[SimpleError](sttp.model.StatusCode(400), jsonBody[SimpleError].description("Not found"))))
+      .out(statusCode(sttp.model.StatusCode(204)).description("No response"))
+
+  type PostJsonStringJsonBodyEndpoint = Endpoint[Option[String], PostJsonStringJsonBodyBodyIn, Unit, Option[PostJsonStringJsonBodyBodyOut], Any]
+  lazy val postJsonStringJsonBody: PostJsonStringJsonBodyEndpoint =
+    endpoint
+      .post
+      .in(("json" / "stringJsonBody"))
+      .securityIn(auth.bearer[Option[String]]())
+      .in(oneOfBody[PostJsonStringJsonBodyBodyIn](
+        stringJsonBody.map(Option(_))(_.orNull).map(PostJsonStringJsonBodyBodyOption_String_In(_))(_.value).widenBody[PostJsonStringJsonBodyBodyIn],
+        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/zipCodecFormat`](`application/zipCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(PostJsonStringJsonBodyBody1In(_))(_.value).widenBody[PostJsonStringJsonBodyBodyIn]))
+      .out(oneOf[Option[PostJsonStringJsonBodyBodyOut]](
+        oneOfVariantValueMatcher(sttp.model.StatusCode(200), oneOfBody[PostJsonStringJsonBodyBodyOut](
+        stringJsonBody.map(Option(_))(_.orNull).map(PostJsonStringJsonBodyBodyOption_String_Out(_))(_.`application/json`())
+        .map(_.asInstanceOf[PostJsonStringJsonBodyBodyOut])(p => PostJsonStringJsonBodyBodyOption_String_Out(p.`application/json`())).description("Possibly-invalid json"),
+        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/zipCodecFormat`](`application/zipCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(PostJsonStringJsonBodyBody1Out(_))(_.`application/zip`())
+        .map(_.asInstanceOf[PostJsonStringJsonBodyBodyOut])(p => PostJsonStringJsonBodyBody1Out(p.`application/zip`())).description("Possibly-invalid json")).map(Some(_))(_.orNull)){ case Some(_: PostJsonStringJsonBodyBodyOut) => true },
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None)))
+      .attribute[TapirCodegenDirectivesExtension](tapirCodegenDirectivesExtensionKey, Vector("json-body-as-string"))
+
+  type PostJsonStringJsonBodySimpleEndpoint = Endpoint[String, String, Unit, String, Any]
+  lazy val postJsonStringJsonBodySimple: PostJsonStringJsonBodySimpleEndpoint =
+    endpoint
+      .post
+      .in(("json" / "stringJsonBody" / "simple"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .in(stringJsonBody)
+      .out(stringJsonBody.description("Possibly-invalid json"))
+      .attribute[TapirCodegenDirectivesExtension](tapirCodegenDirectivesExtensionKey, Vector("json-body-as-string"))
+
+  type GetOneofOptionTestEndpoint = Endpoint[String, Unit, Unit, (Option[AnyObjectWithInlineEnum], Option[String]), Any]
+  lazy val getOneofOptionTest: GetOneofOptionTestEndpoint =
+    endpoint
+      .get
+      .in(("oneof" / "option" / "test"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .out(oneOf[(Option[AnyObjectWithInlineEnum], Option[String])](
+        oneOfVariantValueMatcher(sttp.model.StatusCode(204), emptyOutputAs(None).description("No response").and(header[Option[String]]("common-response-header"))){ case (None, _) => true},
+        oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[ObjectWithInlineEnum]].description("An object").and(header[Option[String]]("common-response-header"))){ case (Some(_: ObjectWithInlineEnum), _) => true },
+        oneOfVariantValueMatcher(sttp.model.StatusCode(201), jsonBody[Option[ObjectWithInlineEnum2]].description("Another object").and(header[Option[String]]("common-response-header"))){ case (Some(_: ObjectWithInlineEnum2), _) => true }))
+
+  type GetHeadersTestsEndpoint = Endpoint[String, Unit, Unit, Option[String], Any]
+  lazy val getHeadersTests: GetHeadersTestsEndpoint =
+    endpoint
+      .get
+      .in(("headers" / "tests"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .out(statusCode(sttp.model.StatusCode(302)).description("response").and(header[Option[String]]("foo").description("a description")))
+
+  type GetPatternRestrictedObjectEndpoint = Endpoint[String, (String, Option[String], String, Option[String], String), Unit, String, Any]
+  lazy val getPatternRestrictedObject: GetPatternRestrictedObjectEndpoint =
+    endpoint
+      .get
+      .in(("pattern" / path[String]("restricted").validate(Validator.all(Validator.maxLength(10), Validator.minLength(3), Validator.pattern("[a-z]+"))).description("used by security logic") / "object"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .in(query[Option[String]]("q1").validate(Validator.custom[Option[String]](ot => ot.map(Validator.pattern("[a-z_].+")(_)).map{
+        case Nil => ValidationResult.Valid
+        case l   => ValidationResult.Invalid(l.flatMap(_.customMessage).toList)
+      }.getOrElse(ValidationResult.Valid))))
+      .in(query[String]("q2").validate(Validator.minLength(3)))
+      .in(header[Option[String]]("h1").validate(Validator.custom[Option[String]](ot => ot.map(Validator.all(Validator.minLength(3), Validator.pattern("[a-z_].+"))(_)).map{
+        case Nil => ValidationResult.Valid
+        case l   => ValidationResult.Invalid(l.flatMap(_.customMessage).toList)
+      }.getOrElse(ValidationResult.Valid))))
+      .in(header[String]("h2").validate(Validator.minLength(3)))
+      .out(jsonBody[String].description("ok"))
+
   type PutInlineSimpleObjectEndpoint = Endpoint[String, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
   lazy val putInlineSimpleObject: PutInlineSimpleObjectEndpoint =
     endpoint
@@ -545,8 +527,26 @@ object TapirGeneratedEndpoints {
       .errorOut(jsonBody[ListType].description("list type error").and(statusCode(sttp.model.StatusCode(400))))
       .out(jsonBody[ListType].description("list type out"))
 
+  type PostAllOfEndpoint = Endpoint[String, Option[HasFooBarBazQuux], Unit, Unit, Any]
+  lazy val postAllOf: PostAllOfEndpoint =
+    endpoint
+      .post
+      .in(("allOf"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .in(jsonBody[Option[HasFooBarBazQuux]].description("list type in"))
+      .out(statusCode(sttp.model.StatusCode(204)).description("fine"))
 
-  lazy val generatedEndpoints = List(getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, getSecurityGroupSecurityGroupName, postValidationTest, putAdtTest, postAdtTest, getHeadersTests, getOneofErrorSecParamTest, postAllOf, getSecurityGroupSecurityGroupNameMorePath, getOneofOptionTest, getPatternRestrictedObject, postInlineEnumTest, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+  type PostValidationTestEndpoint = Endpoint[String, Option[ValidatedObj], Unit, Unit, Any]
+  lazy val postValidationTest: PostValidationTestEndpoint =
+    endpoint
+      .post
+      .in(("validation" / "test"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .in(jsonBody[Option[ValidatedObj]].validateOption(ValidatedObjValidator))
+      .out(statusCode(sttp.model.StatusCode(204)).description("ok"))
+
+
+  lazy val generatedEndpoints = List(getSecurityGroupSecurityGroupName, getSecurityGroupSecurityGroupNameMorePath, getBinaryTest, postBinaryTest, putOptionalTest, postOptionalTest, putAdtTest, postAdtTest, postInlineEnumTest, getOneofErrorSecParamTest, postJsonStringJsonBody, postJsonStringJsonBodySimple, getOneofOptionTest, getHeadersTests, getPatternRestrictedObject, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject, postAllOf, postValidationTest)
 
 
   object Servers {

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -91,13 +91,13 @@ object TapirGeneratedEndpoints {
     case object sold extends PetStatus
   }
   case class Pet (
-    status: Option[PetStatus] = None,
-    tags: Option[Seq[Tag]] = None,
     id: Option[Long] = None,
-    tags2: Option[Seq[Tag2]] = None,
-    photoUrls: Seq[String],
     name: String,
-    category: Option[Category] = None
+    category: Option[Category] = None,
+    photoUrls: Seq[String],
+    tags: Option[Seq[Tag]] = None,
+    tags2: Option[Seq[Tag2]] = None,
+    status: Option[PetStatus] = None
   )
   case class Category (
     id: Option[Long] = None,
@@ -122,11 +122,11 @@ object TapirGeneratedEndpoints {
     d: Option[Double] = None
   ) extends ADTWithDiscriminator with ADTWithDiscriminatorNoMapping
   case class SubtypeWithoutD3 (
-    absent: Option[String] = None,
     s: String,
     i: Option[Int] = None,
+    e: Option[AnEnum] = None,
     e2: Option[SubtypeWithoutD3E2] = None,
-    e: Option[AnEnum] = None
+    absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
 
   sealed trait SubtypeWithoutD3E2 extends enumeratum.EnumEntry

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -21,6 +21,8 @@ object TapirGeneratedEndpoints {
     override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "text", subType = "csv")
   }
 
+
+
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
   trait ExtraParamSupport[T] {
@@ -166,41 +168,6 @@ object TapirGeneratedEndpoints {
   case class SomeBinaryType (
 
   )
-
-  sealed trait PostCustomContentNegotiationBodyIn extends Product with java.io.Serializable
-  case class PostCustomContentNegotiationBody0In(value: sttp.capabilities.pekko.PekkoStreams.BinaryStream) extends PostCustomContentNegotiationBodyIn
-  case class PostCustomContentNegotiationBody1In(value: sttp.capabilities.pekko.PekkoStreams.BinaryStream) extends PostCustomContentNegotiationBodyIn
-
-  sealed trait PostCustomContentNegotiationBodyOut extends Product with java.io.Serializable {
-    def `text/csv`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream = () => throw new RuntimeException("Body for content type text/csv not provided")
-    def `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream = () => throw new RuntimeException("Body for content type application/vnd.openxmlformats-officedocument.spreadsheetml.sheet not provided")
-  }
-  case class PostCustomContentNegotiationBodyOutFull (
-    override val `text/csv`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream,
-    override val `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream,
-  ) extends PostCustomContentNegotiationBodyOut
-  case class PostCustomContentNegotiationBody0Out(value: sttp.capabilities.pekko.PekkoStreams.BinaryStream) extends PostCustomContentNegotiationBodyOut{
-    override def `text/csv`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream = () => value
-  }
-  case class PostCustomContentNegotiationBody1Out(value: sttp.capabilities.pekko.PekkoStreams.BinaryStream) extends PostCustomContentNegotiationBodyOut{
-    override def `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream = () => value
-  }
-
-  sealed trait PostCustomContentNegotiationBodyErr extends Product with java.io.Serializable {
-    def `text/csv`: () => String = () => throw new RuntimeException("Body for content type text/csv not provided")
-    def `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => Array[Byte] = () => throw new RuntimeException("Body for content type application/vnd.openxmlformats-officedocument.spreadsheetml.sheet not provided")
-  }
-  case class PostCustomContentNegotiationBodyErrFull (
-    override val `text/csv`: () => String,
-    override val `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => Array[Byte],
-  ) extends PostCustomContentNegotiationBodyErr
-  case class PostCustomContentNegotiationBodyStringErr(value: String) extends PostCustomContentNegotiationBodyErr{
-    override def `text/csv`: () => String = () => value
-  }
-  case class PostCustomContentNegotiationBody1Err(value: Array[Byte]) extends PostCustomContentNegotiationBodyErr{
-    override def `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => Array[Byte] = () => value
-  }
-
   case class PutInlineSimpleObjectRequest (
     foo: String,
     bar: Option[java.util.UUID] = None
@@ -218,15 +185,43 @@ object TapirGeneratedEndpoints {
     bar: Option[java.util.UUID] = None
   )
 
+  sealed trait PostCustomContentNegotiationBodyIn extends Product with java.io.Serializable
+  case class PostCustomContentNegotiationBody0In(value: sttp.capabilities.pekko.PekkoStreams.BinaryStream) extends PostCustomContentNegotiationBodyIn
+  case class PostCustomContentNegotiationBody1In(value: sttp.capabilities.pekko.PekkoStreams.BinaryStream) extends PostCustomContentNegotiationBodyIn
 
 
-  type PostXmlEndpointEndpoint = Endpoint[Unit, Pet, Unit, Pet, Any]
-  lazy val postXmlEndpoint: PostXmlEndpointEndpoint =
-    endpoint
-      .post
-      .in(("xml" / "endpoint"))
-      .in(xmlBody[Pet])
-      .out(xmlBody[Pet].description("An object"))
+  sealed trait PostCustomContentNegotiationBodyOut extends Product with java.io.Serializable {
+    def `text/csv`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream = () => throw new RuntimeException("Body for content type text/csv not provided")
+    def `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream = () => throw new RuntimeException("Body for content type application/vnd.openxmlformats-officedocument.spreadsheetml.sheet not provided")
+  }
+  case class PostCustomContentNegotiationBodyOutFull (
+    override val `text/csv`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream,
+    override val `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream,
+  ) extends PostCustomContentNegotiationBodyOut
+  case class PostCustomContentNegotiationBody0Out(value: sttp.capabilities.pekko.PekkoStreams.BinaryStream) extends PostCustomContentNegotiationBodyOut{
+    override def `text/csv`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream = () => value
+  }
+  case class PostCustomContentNegotiationBody1Out(value: sttp.capabilities.pekko.PekkoStreams.BinaryStream) extends PostCustomContentNegotiationBodyOut{
+    override def `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => sttp.capabilities.pekko.PekkoStreams.BinaryStream = () => value
+  }
+
+
+  sealed trait PostCustomContentNegotiationBodyErr extends Product with java.io.Serializable {
+    def `text/csv`: () => String = () => throw new RuntimeException("Body for content type text/csv not provided")
+    def `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => Array[Byte] = () => throw new RuntimeException("Body for content type application/vnd.openxmlformats-officedocument.spreadsheetml.sheet not provided")
+  }
+  case class PostCustomContentNegotiationBodyErrFull (
+    override val `text/csv`: () => String,
+    override val `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => Array[Byte],
+  ) extends PostCustomContentNegotiationBodyErr
+  case class PostCustomContentNegotiationBodyStringErr(value: String) extends PostCustomContentNegotiationBodyErr{
+    override def `text/csv`: () => String = () => value
+  }
+  case class PostCustomContentNegotiationBody1Err(value: Array[Byte]) extends PostCustomContentNegotiationBodyErr{
+    override def `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: () => Array[Byte] = () => value
+  }
+
+
 
   type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
   lazy val putAdtTest: PutAdtTestEndpoint =
@@ -244,36 +239,6 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[ADTWithDiscriminatorNoMapping].description("Update an existent user in the store"))
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 
-  type PostGenericJsonEndpoint = Endpoint[Unit, (Option[List[AnEnum]], Option[io.circe.Json]), Unit, io.circe.Json, Any]
-  lazy val postGenericJson: PostGenericJsonEndpoint =
-    endpoint
-      .post
-      .in(("generic" / "json"))
-      .in(query[Option[CommaSeparatedValues[AnEnum]]]("aTrickyParam").map(_.map(_.values))(_.map(CommaSeparatedValues(_))).description("A very thorough description"))
-      .in(jsonBody[Option[io.circe.Json]].description("anything"))
-      .out(jsonBody[io.circe.Json].description("anything back"))
-
-  type PostCustomContentNegotiationEndpoint = Endpoint[Unit, PostCustomContentNegotiationBodyIn, PostCustomContentNegotiationBodyErr, Option[PostCustomContentNegotiationBodyOut], sttp.capabilities.pekko.PekkoStreams]
-  lazy val postCustomContentNegotiation: PostCustomContentNegotiationEndpoint =
-    endpoint
-      .post
-      .in(("custom" / "content-negotiation"))
-      .in(oneOfBody[PostCustomContentNegotiationBodyIn](
-        sttp.tapir.EndpointIO.StreamBodyWrapper(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `text/csvCodecFormat`()).map(PostCustomContentNegotiationBody0In(_))(_.value).widenBody[PostCustomContentNegotiationBodyIn]),
-        sttp.tapir.EndpointIO.StreamBodyWrapper(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()).map(PostCustomContentNegotiationBody1In(_))(_.value).widenBody[PostCustomContentNegotiationBodyIn])))
-      .errorOut(oneOfBody[PostCustomContentNegotiationBodyErr](
-        stringBodyUtf8AnyFormat(Codec.id[String, `text/csvCodecFormat`](`text/csvCodecFormat`(), Schema.schemaForString)).map(PostCustomContentNegotiationBodyStringErr(_))(_.`text/csv`())
-        .map(_.asInstanceOf[PostCustomContentNegotiationBodyErr])(p => PostCustomContentNegotiationBodyStringErr(p.`text/csv`())).description("binary error"),
-        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`](`application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(PostCustomContentNegotiationBody1Err(_))(_.`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`())
-        .map(_.asInstanceOf[PostCustomContentNegotiationBodyErr])(p => PostCustomContentNegotiationBody1Err(p.`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`())).description("binary error")).and(statusCode(sttp.model.StatusCode(400))))
-      .out(oneOf[Option[PostCustomContentNegotiationBodyOut]](
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("no content"))(None),
-        oneOfVariantValueMatcher(sttp.model.StatusCode(200), oneOfBody[PostCustomContentNegotiationBodyOut](
-        sttp.tapir.EndpointIO.StreamBodyWrapper(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `text/csvCodecFormat`()).map(PostCustomContentNegotiationBody0Out(_))(_.`text/csv`())
-        .map(_.asInstanceOf[PostCustomContentNegotiationBodyOut])(p => PostCustomContentNegotiationBody0Out(p.`text/csv`())).description("text success")),
-        sttp.tapir.EndpointIO.StreamBodyWrapper(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()).map(PostCustomContentNegotiationBody1Out(_))(_.`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`())
-        .map(_.asInstanceOf[PostCustomContentNegotiationBodyOut])(p => PostCustomContentNegotiationBody1Out(p.`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`())).description("text success"))).map(Some(_))(_.orNull)){ case Some(_: PostCustomContentNegotiationBodyOut) => true }))
-
   type GetOneofOptionTestEndpoint = Endpoint[Unit, Unit, Unit, Option[AnEnum], Any]
   lazy val getOneofOptionTest: GetOneofOptionTestEndpoint =
     endpoint
@@ -283,31 +248,22 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("No response"))(None),
         oneOfVariantValueMatcher(sttp.model.StatusCode(200), jsonBody[Option[AnEnum]].description("An enum")){ case Some(_: AnEnum) => true }))
 
-  type PostUniqueItemsEndpoint = Endpoint[Unit, Option[HasASet], Unit, HasASet, Any]
-  lazy val postUniqueItems: PostUniqueItemsEndpoint =
+  type PostGenericJsonEndpoint = Endpoint[Unit, (Option[List[AnEnum]], Option[io.circe.Json]), Unit, io.circe.Json, Any]
+  lazy val postGenericJson: PostGenericJsonEndpoint =
     endpoint
       .post
-      .in(("unique-items"))
-      .in(jsonBody[Option[HasASet]])
-      .out(jsonBody[HasASet].description("OK"))
+      .in(("generic" / "json"))
+      .in(query[Option[CommaSeparatedValues[AnEnum]]]("aTrickyParam").map(_.map(_.values))(_.map(CommaSeparatedValues(_))).description("A very thorough description"))
+      .in(jsonBody[Option[io.circe.Json]].description("anything"))
+      .out(jsonBody[io.circe.Json].description("anything back"))
 
-  type PutCustomContentTypesEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, String, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
-  lazy val putCustomContentTypes: PutCustomContentTypesEndpoint =
-    endpoint
-      .put
-      .in(("custom" / "content-types"))
-      .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `text/csvCodecFormat`()))
-      .errorOut(stringBodyUtf8AnyFormat(Codec.id[String, `text/csvCodecFormat`](`text/csvCodecFormat`(), Schema.schemaForString)).description("text error").and(statusCode(sttp.model.StatusCode(400))))
-      .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()).description("binary success"))
-
-  type PostCustomContentTypesEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, Array[Byte], sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
-  lazy val postCustomContentTypes: PostCustomContentTypesEndpoint =
+  type PostXmlEndpointEndpoint = Endpoint[Unit, Pet, Unit, Pet, Any]
+  lazy val postXmlEndpoint: PostXmlEndpointEndpoint =
     endpoint
       .post
-      .in(("custom" / "content-types"))
-      .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()))
-      .errorOut(EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`](`application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).description("binary error").and(statusCode(sttp.model.StatusCode(400))))
-      .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `text/csvCodecFormat`()).description("text success"))
+      .in(("xml" / "endpoint"))
+      .in(xmlBody[Pet])
+      .out(xmlBody[Pet].description("An object"))
 
   type PutInlineSimpleObjectEndpoint = Endpoint[Unit, PutInlineSimpleObjectRequest, Array[Byte], PutInlineSimpleObjectResponse, Any]
   lazy val putInlineSimpleObject: PutInlineSimpleObjectEndpoint =
@@ -349,11 +305,59 @@ object TapirGeneratedEndpoints {
       .errorOut(jsonBody[ListType].description("list type error").and(statusCode(sttp.model.StatusCode(400))))
       .out(jsonBody[ListType].description("list type out"))
 
-  lazy val generatedEndpoints = List(postXmlEndpoint, putAdtTest, postAdtTest, postGenericJson, postCustomContentNegotiation, getOneofOptionTest, postUniqueItems, putCustomContentTypes, postCustomContentTypes, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject)
+  type PostCustomContentNegotiationEndpoint = Endpoint[Unit, PostCustomContentNegotiationBodyIn, PostCustomContentNegotiationBodyErr, Option[PostCustomContentNegotiationBodyOut], sttp.capabilities.pekko.PekkoStreams]
+  lazy val postCustomContentNegotiation: PostCustomContentNegotiationEndpoint =
+    endpoint
+      .post
+      .in(("custom" / "content-negotiation"))
+      .in(oneOfBody[PostCustomContentNegotiationBodyIn](
+        sttp.tapir.EndpointIO.StreamBodyWrapper(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `text/csvCodecFormat`()).map(PostCustomContentNegotiationBody0In(_))(_.value).widenBody[PostCustomContentNegotiationBodyIn]),
+        sttp.tapir.EndpointIO.StreamBodyWrapper(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()).map(PostCustomContentNegotiationBody1In(_))(_.value).widenBody[PostCustomContentNegotiationBodyIn])))
+      .errorOut(oneOfBody[PostCustomContentNegotiationBodyErr](
+        stringBodyUtf8AnyFormat(Codec.id[String, `text/csvCodecFormat`](`text/csvCodecFormat`(), Schema.schemaForString)).map(PostCustomContentNegotiationBodyStringErr(_))(_.`text/csv`())
+        .map(_.asInstanceOf[PostCustomContentNegotiationBodyErr])(p => PostCustomContentNegotiationBodyStringErr(p.`text/csv`())).description("binary error"),
+        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`](`application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(PostCustomContentNegotiationBody1Err(_))(_.`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`())
+        .map(_.asInstanceOf[PostCustomContentNegotiationBodyErr])(p => PostCustomContentNegotiationBody1Err(p.`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`())).description("binary error")).and(statusCode(sttp.model.StatusCode(400))))
+      .out(oneOf[Option[PostCustomContentNegotiationBodyOut]](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(204), emptyOutput.description("no content"))(None),
+        oneOfVariantValueMatcher(sttp.model.StatusCode(200), oneOfBody[PostCustomContentNegotiationBodyOut](
+        sttp.tapir.EndpointIO.StreamBodyWrapper(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `text/csvCodecFormat`()).map(PostCustomContentNegotiationBody0Out(_))(_.`text/csv`())
+        .map(_.asInstanceOf[PostCustomContentNegotiationBodyOut])(p => PostCustomContentNegotiationBody0Out(p.`text/csv`())).description("text success")),
+        sttp.tapir.EndpointIO.StreamBodyWrapper(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()).map(PostCustomContentNegotiationBody1Out(_))(_.`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`())
+        .map(_.asInstanceOf[PostCustomContentNegotiationBodyOut])(p => PostCustomContentNegotiationBody1Out(p.`application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`())).description("text success"))).map(Some(_))(_.orNull)){ case Some(_: PostCustomContentNegotiationBodyOut) => true }))
+
+  type PutCustomContentTypesEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, String, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
+  lazy val putCustomContentTypes: PutCustomContentTypesEndpoint =
+    endpoint
+      .put
+      .in(("custom" / "content-types"))
+      .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `text/csvCodecFormat`()))
+      .errorOut(stringBodyUtf8AnyFormat(Codec.id[String, `text/csvCodecFormat`](`text/csvCodecFormat`(), Schema.schemaForString)).description("text error").and(statusCode(sttp.model.StatusCode(400))))
+      .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()).description("binary success"))
+
+  type PostCustomContentTypesEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, Array[Byte], sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
+  lazy val postCustomContentTypes: PostCustomContentTypesEndpoint =
+    endpoint
+      .post
+      .in(("custom" / "content-types"))
+      .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`()))
+      .errorOut(EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`](`application/vnd.openxmlformats-officedocument.spreadsheetml.sheetCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).description("binary error").and(statusCode(sttp.model.StatusCode(400))))
+      .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[SomeBinaryType], `text/csvCodecFormat`()).description("text success"))
+
+  type PostUniqueItemsEndpoint = Endpoint[Unit, Option[HasASet], Unit, HasASet, Any]
+  lazy val postUniqueItems: PostUniqueItemsEndpoint =
+    endpoint
+      .post
+      .in(("unique-items"))
+      .in(jsonBody[Option[HasASet]])
+      .out(jsonBody[HasASet].description("OK"))
+
+  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, getOneofOptionTest, postGenericJson, postXmlEndpoint, putInlineSimpleObject, postInlineSimpleObject, deleteInlineSimpleObject, patchInlineSimpleObject, postCustomContentNegotiation, putCustomContentTypes, postCustomContentTypes, postUniqueItems)
 
   object Servers {
     import sttp.model.Uri.UriContext
 
     val `/v3`: sttp.model.Uri = uri"/v3"
+
   }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/ExpectedXmlSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/ExpectedXmlSerdes.scala.txt
@@ -124,35 +124,35 @@ object TapirGeneratedEndpointsXmlSerdes {
   implicit lazy val Tag2XmlDecoder: Decoder[Tag2] = deriveConfiguredDecoder[Tag2]
   implicit lazy val Tag2XmlEncoder: Encoder[Tag2] = deriveConfiguredEncoder[Tag2]
 
+  implicit lazy val PetStatusXmlTypeInterpreter: XmlTypeInterpreter[PetStatus] = XmlTypeInterpreter.auto[PetStatus]((_, _) => false, (_, _) => false)
+  implicit lazy val PetStatusXmlDecoder: Decoder[PetStatus] = deriveConfiguredDecoder[PetStatus]
+  implicit lazy val PetStatusXmlEncoder: Encoder[PetStatus] = deriveConfiguredEncoder[PetStatus]
+
   implicit lazy val PetXmlTypeInterpreter: XmlTypeInterpreter[Pet] = XmlTypeInterpreter.fullOf[Pet]{
       case (cats.xml.utils.generic.ParamName("tags2"), _) =>
         (XmlElemType.Child, { case "tags2" => "extra-tags"; case "extra-tags" => "tags2"; case x => x})
       case (_, _) => (XmlElemType.Child, identity)
     }
   implicit lazy val PetXmlDecoder: Decoder[Pet] = {
-    implicit val PetTagsSeqDecoder: Decoder[Seq[Tag]] = seqDecoder[Tag]("tags", isWrapped = true)
+    // implicit val PetCategoryDecoder: Decoder[Option[Category]] = deriveConfiguredDecoder[Option[Category]]
     implicit val PetPhotoUrlsSeqDecoder: Decoder[Seq[String]] = seqDecoder[String]("photoUrls", isWrapped = true)
+    implicit val PetTagsSeqDecoder: Decoder[Seq[Tag]] = seqDecoder[Tag]("tags", isWrapped = true)
     implicit val PetTags2SeqDecoder: Decoder[Seq[Tag2]] = seqDecoder[Tag2]("extra-tags", isWrapped = false)
     implicit val PetStatusOptionDecoder: Decoder[Option[PetStatus]] = optionDecoder[PetStatus](enumDecoder[PetStatus](PetStatus))
-    // implicit val PetCategoryDecoder: Decoder[Option[Category]] = deriveConfiguredDecoder[Option[Category]]
     deriveConfiguredDecoder[Pet]
   }
   implicit lazy val PetXmlEncoder: Encoder[Pet] = {
-    implicit val PetTagsSeqEncoder: Encoder[Seq[Tag]] =
-      seqEncoder[Tag]("tags", isWrapped = true, itemName = "tag")
+    implicit val PetCategoryEncoder: Encoder[Option[Category]] = deriveConfiguredEncoder[Option[Category]]
     implicit val PetPhotoUrlsSeqEncoder: Encoder[Seq[String]] =
       seqEncoder[String]("photoUrls", isWrapped = true, itemName = "photoUrl")
+    implicit val PetTagsSeqEncoder: Encoder[Seq[Tag]] =
+      seqEncoder[Tag]("tags", isWrapped = true, itemName = "tag")
     implicit val PetTags2SeqEncoder: Encoder[Seq[Tag2]] =
       seqEncoder[Tag2]("extra-tags", isWrapped = false, itemName = "tags2")
     implicit val PetStatusEncoder: Encoder[PetStatus] = enumEncoder[PetStatus]("status")
     implicit val PetStatusOptionEncoder: Encoder[Option[PetStatus]] = optionEncoder[PetStatus](PetStatusEncoder)
-    implicit val PetCategoryEncoder: Encoder[Option[Category]] = deriveConfiguredEncoder[Option[Category]]
     deriveConfiguredEncoder[Pet]
   }
-
-  implicit lazy val PetStatusXmlTypeInterpreter: XmlTypeInterpreter[PetStatus] = XmlTypeInterpreter.auto[PetStatus]((_, _) => false, (_, _) => false)
-  implicit lazy val PetStatusXmlDecoder: Decoder[PetStatus] = deriveConfiguredDecoder[PetStatus]
-  implicit lazy val PetStatusXmlEncoder: Encoder[PetStatus] = deriveConfiguredEncoder[PetStatus]
 
   implicit lazy val CategoryXmlTypeInterpreter: XmlTypeInterpreter[Category] = XmlTypeInterpreter.auto[Category]((_, _) => false, (_, _) => false)
   implicit lazy val CategoryXmlDecoder: Decoder[Category] = deriveConfiguredDecoder[Category]

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/JsonRoundtrip.scala
@@ -78,8 +78,8 @@ class JsonRoundtrip extends AnyFreeSpec with Matchers {
       val reqJsonBody = writeToString(reqBody)
       val respBody = SubtypeWithoutD3(s = "a string+SubtypeWithoutD3", i = Some(123), e = Some(AnEnum.Foo), e2 = Some(SubtypeWithoutD3E2.A))
       val respJsonBody = writeToString(respBody)
-      reqJsonBody shouldEqual """{"s":"a string","i":123,"e2":"A","e":"Foo"}"""
-      respJsonBody shouldEqual """{"s":"a string+SubtypeWithoutD3","i":123,"e2":"A","e":"Foo"}"""
+      reqJsonBody shouldEqual """{"s":"a string","i":123,"e":"Foo","e2":"A"}"""
+      respJsonBody shouldEqual """{"s":"a string+SubtypeWithoutD3","i":123,"e":"Foo","e2":"A"}"""
       Await.result(
         sttp.client3.basicRequest
           .put(uri"http://test.com/adt/test")

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/XmlRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/XmlRoundtrip.scala
@@ -25,20 +25,29 @@ class XmlRoundtrip extends AnyFreeSpec with Matchers {
 
     locally {
       val reqBody = Pet(
-        Some(PetStatus.pending),
-        Some(Seq(Tag(Some(1), Some("foo")), Tag(Some(2), None))),
         Some(2L),
-        Some(Seq(Tag2(Some(3), Some("bar")), Tag2(Some(4), None))),
-        Seq("uri1", "uri2"),
         "a name",
-        Some(Category(Some(3L), Some("a category")))
+        Some(Category(Some(3L), Some("a category"))),
+        Seq("uri1", "uri2"),
+        Some(Seq(Tag(Some(1), Some("foo")), Tag(Some(2), None))),
+        Some(Seq(Tag2(Some(3), Some("bar")), Tag2(Some(4), None))),
+        Some(PetStatus.pending)
       )
       val reqXmlBody = TapirGeneratedEndpointsXmlSerdes.PetXmlEncoder.encode(reqBody)
       val decodedXmlBody = TapirGeneratedEndpointsXmlSerdes.PetXmlDecoder.decode(reqXmlBody)
       decodedXmlBody shouldEqual cats.data.Validated.Valid(reqBody)
       reqXmlBody.toString() shouldEqual
         """<Pet>
-          | <status>pending</status>
+          | <id>2</id>
+          | <name>a name</name>
+          | <category>
+          |  <id>3</id>
+          |  <name>a category</name>
+          | </category>
+          | <photoUrls>
+          |  <photoUrl>uri1</photoUrl>
+          |  <photoUrl>uri2</photoUrl>
+          | </photoUrls>
           | <tags>
           |  <tag>
           |   <id>1</id>
@@ -48,7 +57,6 @@ class XmlRoundtrip extends AnyFreeSpec with Matchers {
           |   <id>2</id>
           |  </tag>
           | </tags>
-          | <id>2</id>
           | <extra-tags>
           |  <id>3</id>
           |  <name>bar</name>
@@ -56,15 +64,7 @@ class XmlRoundtrip extends AnyFreeSpec with Matchers {
           | <extra-tags>
           |  <id>4</id>
           | </extra-tags>
-          | <photoUrls>
-          |  <photoUrl>uri1</photoUrl>
-          |  <photoUrl>uri2</photoUrl>
-          | </photoUrls>
-          | <name>a name</name>
-          | <category>
-          |  <id>3</id>
-          |  <name>a category</name>
-          | </category>
+          | <status>pending</status>
           |</Pet>""".stripMargin
       Await.result(
         sttp.client3.basicRequest

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
@@ -63,13 +63,13 @@ object TapirGeneratedEndpoints {
     case available, pending, sold
   }
   case class Pet (
-    status: Option[PetStatus] = None,
-    tags: Option[Seq[Tag]] = None,
     id: Option[Long] = None,
-    tags2: Option[Seq[Tag2]] = None,
-    photoUrls: Seq[String],
     name: String,
-    category: Option[Category] = None
+    category: Option[Category] = None,
+    photoUrls: Seq[String],
+    tags: Option[Seq[Tag]] = None,
+    tags2: Option[Seq[Tag2]] = None,
+    status: Option[PetStatus] = None
   )
   case class Category (
     id: Option[Long] = None,
@@ -140,9 +140,11 @@ object TapirGeneratedEndpoints {
 
   lazy val generatedEndpoints = List(putAdtTest, postAdtTest, postXmlEndpoint)
 
-   object Servers {
+
+  object Servers {
     import sttp.model.Uri.UriContext
 
-     val `/v3`: sttp.model.Uri = uri"/v3"
-   }
+    val `/v3`: sttp.model.Uri = uri"/v3"
+
+  }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
@@ -134,17 +134,6 @@ object TapirGeneratedEndpoints {
     message: Option[String] = None
   )
 
-  sealed trait PlaceOrderBodyIn extends Product with java.io.Serializable
-  case class PlaceOrderBodyOption_Order_In(value: Option[Order]) extends PlaceOrderBodyIn
-  case class PlaceOrderBody2In(value: Array[Byte]) extends PlaceOrderBodyIn
-
-  type FindPetsByTagsResponse <: Seq[Pet]
-  implicit val FindPetsByTagsResponseSeqDecoder: cats.xml.codec.Decoder[FindPetsByTagsResponse] = seqDecoder[Pet]("Pet", isWrapped = false).map(_.asInstanceOf[FindPetsByTagsResponse])
-  implicit val FindPetsByTagsResponseSeqEncoder: cats.xml.codec.Encoder[FindPetsByTagsResponse] =
-    seqEncoder[Pet]("Pet", isWrapped = false, itemName = "Pet").contramap(_.asInstanceOf[Seq[Pet]])
-  implicit val FindPetsByTagsResponseSeqSchema: sttp.tapir.Schema[FindPetsByTagsResponse] =
-    implicitly[Schema[Seq[Pet]]].map(x => Some(x.asInstanceOf[FindPetsByTagsResponse]))(_.asInstanceOf[Seq[Pet]])
-
   sealed trait UpdatePetBodyIn extends Product with java.io.Serializable
   case class UpdatePetBodyPetIn(value: Pet) extends UpdatePetBodyIn
   case class UpdatePetBody2In(value: Array[Byte]) extends UpdatePetBodyIn
@@ -154,59 +143,34 @@ object TapirGeneratedEndpoints {
   case class AddPetBodyPetIn(value: Pet) extends AddPetBodyIn
   case class AddPetBody2In(value: Array[Byte]) extends AddPetBodyIn
 
-
-  sealed trait UpdateUserBodyIn extends Product with java.io.Serializable
-  case class UpdateUserBodyOption_User_In(value: Option[User]) extends UpdateUserBodyIn
-  case class UpdateUserBody2In(value: Array[Byte]) extends UpdateUserBodyIn
-
-
-  sealed trait CreateUserBodyIn extends Product with java.io.Serializable
-  case class CreateUserBodyOption_User_In(value: Option[User]) extends CreateUserBodyIn
-  case class CreateUserBody2In(value: Array[Byte]) extends CreateUserBodyIn
-
   type FindPetsByStatusResponse <: Seq[Pet]
   implicit val FindPetsByStatusResponseSeqDecoder: cats.xml.codec.Decoder[FindPetsByStatusResponse] = seqDecoder[Pet]("Pet", isWrapped = false).map(_.asInstanceOf[FindPetsByStatusResponse])
   implicit val FindPetsByStatusResponseSeqEncoder: cats.xml.codec.Encoder[FindPetsByStatusResponse] =
     seqEncoder[Pet]("Pet", isWrapped = false, itemName = "Pet").contramap(_.asInstanceOf[Seq[Pet]])
   implicit val FindPetsByStatusResponseSeqSchema: sttp.tapir.Schema[FindPetsByStatusResponse] =
     implicitly[Schema[Seq[Pet]]].map(x => Some(x.asInstanceOf[FindPetsByStatusResponse]))(_.asInstanceOf[Seq[Pet]])
+  type FindPetsByTagsResponse <: Seq[Pet]
+  implicit val FindPetsByTagsResponseSeqDecoder: cats.xml.codec.Decoder[FindPetsByTagsResponse] = seqDecoder[Pet]("Pet", isWrapped = false).map(_.asInstanceOf[FindPetsByTagsResponse])
+  implicit val FindPetsByTagsResponseSeqEncoder: cats.xml.codec.Encoder[FindPetsByTagsResponse] =
+    seqEncoder[Pet]("Pet", isWrapped = false, itemName = "Pet").contramap(_.asInstanceOf[Seq[Pet]])
+  implicit val FindPetsByTagsResponseSeqSchema: sttp.tapir.Schema[FindPetsByTagsResponse] =
+    implicitly[Schema[Seq[Pet]]].map(x => Some(x.asInstanceOf[FindPetsByTagsResponse]))(_.asInstanceOf[Seq[Pet]])
+
+  sealed trait PlaceOrderBodyIn extends Product with java.io.Serializable
+  case class PlaceOrderBodyOption_Order_In(value: Option[Order]) extends PlaceOrderBodyIn
+  case class PlaceOrderBody2In(value: Array[Byte]) extends PlaceOrderBodyIn
+
+
+  sealed trait CreateUserBodyIn extends Product with java.io.Serializable
+  case class CreateUserBodyOption_User_In(value: Option[User]) extends CreateUserBodyIn
+  case class CreateUserBody2In(value: Array[Byte]) extends CreateUserBodyIn
+
+  sealed trait UpdateUserBodyIn extends Product with java.io.Serializable
+  case class UpdateUserBodyOption_User_In(value: Option[User]) extends UpdateUserBodyIn
+  case class UpdateUserBody2In(value: Array[Byte]) extends UpdateUserBodyIn
 
   type SwaggerRouterControllerExtension = String
   val swaggerRouterControllerExtensionKey = new sttp.tapir.AttributeKey[SwaggerRouterControllerExtension]("sttp.tapir.generated.TapirGeneratedEndpoints.SwaggerRouterControllerExtension")
-
-  type PlaceOrderEndpoint = Endpoint[Unit, PlaceOrderBodyIn, Unit, Order, Any]
-  lazy val placeOrder: PlaceOrderEndpoint =
-    endpoint
-      .name("placeOrder")
-      .post
-      .in(("store" / "order"))
-      .in(oneOfBody[PlaceOrderBodyIn](
-        jsonBody[Option[Order]].map(PlaceOrderBodyOption_Order_In(_))(_.value).widenBody[PlaceOrderBodyIn],
-        xmlBody[Option[Order]].map(PlaceOrderBodyOption_Order_In(_))(_.value).widenBody[PlaceOrderBodyIn],
-        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/x-www-form-urlencodedCodecFormat`](`application/x-www-form-urlencodedCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(PlaceOrderBody2In(_))(_.value).widenBody[PlaceOrderBodyIn]))
-      .errorOut(oneOf[Unit](
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid input"))(()),
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(422), emptyOutput.description("Validation exception"))(()),
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
-      .out(jsonBody[Order].description("successful operation"))
-      .tags(List("store"))
-      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "OrderController")
-
-  type FindPetsByTagsEndpoint = Endpoint[String, List[String], Unit, List[Pet], Any]
-  lazy val findPetsByTags: FindPetsByTagsEndpoint =
-    endpoint
-      .name("findPetsByTags")
-      .get
-      .in(("pet" / "findByTags"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
-      .in(query[ExplodedValues[String]]("tags").map(_.values)(ExplodedValues(_)).description("Tags to filter by"))
-      .errorOut(oneOf[Unit](
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid tag value"))(()),
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
-      .out(oneOfBody[List[Pet]](
-        jsonBody[List[Pet]].description("successful operation"),
-        xmlBody[FindPetsByTagsResponse].map(_.asInstanceOf[List[Pet]].toList)(_.asInstanceOf[FindPetsByTagsResponse]).description("successful operation")))
-      .tags(List("pet"))
 
   type UpdatePetEndpoint = Endpoint[String, UpdatePetBodyIn, Unit, Pet, Any]
   lazy val updatePet: UpdatePetEndpoint =
@@ -249,142 +213,47 @@ object TapirGeneratedEndpoints {
         xmlBody[Pet].description("Successful operation")))
       .tags(List("pet"))
 
-  type GetOrderByIdEndpoint = Endpoint[Unit, Long, Unit, Order, Any]
-  lazy val getOrderById: GetOrderByIdEndpoint =
+  type FindPetsByStatusEndpoint = Endpoint[String, Option[FindPetsByStatusStatus], Unit, List[Pet], Any]
+  lazy val findPetsByStatus: FindPetsByStatusEndpoint =
     endpoint
-      .name("getOrderById")
+      .name("findPetsByStatus")
       .get
-      .in(("store" / "order" / path[Long]("orderId").description("ID of order that needs to be fetched")))
+      .in(("pet" / "findByStatus"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .in(query[Option[FindPetsByStatusStatus]]("status").description("Status values that need to be considered for filter"))
       .errorOut(oneOf[Unit](
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid ID supplied"))(()),
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(404), emptyOutput.description("Order not found"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid status value"))(()),
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
-      .out(oneOfBody[Order](
-        jsonBody[Order].description("successful operation"),
-        xmlBody[Order].description("successful operation")))
-      .tags(List("store"))
-      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "OrderController")
+      .out(oneOfBody[List[Pet]](
+        jsonBody[List[Pet]].description("successful operation"),
+        xmlBody[FindPetsByStatusResponse].map(_.asInstanceOf[List[Pet]].toList)(_.asInstanceOf[FindPetsByStatusResponse]).description("successful operation")))
+      .tags(List("pet"))
 
-  type DeleteOrderEndpoint = Endpoint[Unit, Long, Unit, Unit, Any]
-  lazy val deleteOrder: DeleteOrderEndpoint =
-    endpoint
-      .name("deleteOrder")
-      .delete
-      .in(("store" / "order" / path[Long]("orderId").description("ID of the order that needs to be deleted")))
-      .errorOut(oneOf[Unit](
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid ID supplied"))(()),
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(404), emptyOutput.description("Order not found"))(()),
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
-      .tags(List("store"))
-      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "OrderController")
+  sealed trait FindPetsByStatusStatus extends enumeratum.EnumEntry
+  object FindPetsByStatusStatus extends enumeratum.Enum[FindPetsByStatusStatus] with enumeratum.CirceEnum[FindPetsByStatusStatus] {
+    val values = findValues
+    case object available extends FindPetsByStatusStatus
+    case object pending extends FindPetsByStatusStatus
+    case object sold extends FindPetsByStatusStatus
+    implicit val enumCodecSupportFindPetsByStatusStatus: ExtraParamSupport[FindPetsByStatusStatus] =
+      extraCodecSupport[FindPetsByStatusStatus]("FindPetsByStatusStatus", FindPetsByStatusStatus)
+  }
 
-  type LogoutUserEndpoint = Endpoint[Unit, Unit, Unit, Unit, Any]
-  lazy val logoutUser: LogoutUserEndpoint =
+  type FindPetsByTagsEndpoint = Endpoint[String, List[String], Unit, List[Pet], Any]
+  lazy val findPetsByTags: FindPetsByTagsEndpoint =
     endpoint
-      .name("logoutUser")
+      .name("findPetsByTags")
       .get
-      .in(("user" / "logout"))
-      .tags(List("user"))
-
-  type GetInventoryEndpoint = Endpoint[String, Unit, Unit, Map[String, Int], Any]
-  lazy val getInventory: GetInventoryEndpoint =
-    endpoint
-      .name("getInventory")
-      .get
-      .in(("store" / "inventory"))
-      .securityIn(auth.apiKey(header[String]("api_key")))
-      .out(jsonBody[Map[String, Int]].description("successful operation"))
-      .tags(List("store"))
-      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "OrderController")
-
-  type CreateUsersWithListInputEndpoint = Endpoint[Unit, Option[List[User]], Unit, User, Any]
-  lazy val createUsersWithListInput: CreateUsersWithListInputEndpoint =
-    endpoint
-      .name("createUsersWithListInput")
-      .post
-      .in(("user" / "createWithList"))
-      .in(jsonBody[Option[List[User]]])
-      .out(oneOfBody[User](
-        jsonBody[User].description("Successful operation"),
-        xmlBody[User].description("Successful operation")))
-      .tags(List("user"))
-      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "UserController")
-
-  type GetUserByNameEndpoint = Endpoint[Unit, String, Unit, User, Any]
-  lazy val getUserByName: GetUserByNameEndpoint =
-    endpoint
-      .name("getUserByName")
-      .get
-      .in(("user" / path[String]("username").description("The name that needs to be fetched. Use user1 for testing")))
+      .in(("pet" / "findByTags"))
+      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
+      .in(query[ExplodedValues[String]]("tags").map(_.values)(ExplodedValues(_)).description("Tags to filter by"))
       .errorOut(oneOf[Unit](
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid username supplied"))(()),
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(404), emptyOutput.description("User not found"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid tag value"))(()),
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
-      .out(oneOfBody[User](
-        jsonBody[User].description("successful operation"),
-        xmlBody[User].description("successful operation")))
-      .tags(List("user"))
-
-  type UpdateUserEndpoint = Endpoint[Unit, (String, UpdateUserBodyIn), Unit, Unit, Any]
-  lazy val updateUser: UpdateUserEndpoint =
-    endpoint
-      .name("updateUser")
-      .put
-      .in(("user" / path[String]("username").description("name that need to be deleted")))
-      .in(oneOfBody[UpdateUserBodyIn](
-        jsonBody[Option[User]].map(UpdateUserBodyOption_User_In(_))(_.value).widenBody[UpdateUserBodyIn].description("Update an existent user in the store"),
-        xmlBody[Option[User]].map(UpdateUserBodyOption_User_In(_))(_.value).widenBody[UpdateUserBodyIn].description("Update an existent user in the store"),
-        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/x-www-form-urlencodedCodecFormat`](`application/x-www-form-urlencodedCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(UpdateUserBody2In(_))(_.value).widenBody[UpdateUserBodyIn].description("Update an existent user in the store")))
-      .errorOut(oneOf[Unit](
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("bad request"))(()),
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(404), emptyOutput.description("user not found"))(()),
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
-      .tags(List("user"))
-      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "UserController")
-
-  type DeleteUserEndpoint = Endpoint[Unit, String, Unit, Unit, Any]
-  lazy val deleteUser: DeleteUserEndpoint =
-    endpoint
-      .name("deleteUser")
-      .delete
-      .in(("user" / path[String]("username").description("The name that needs to be deleted")))
-      .errorOut(oneOf[Unit](
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid username supplied"))(()),
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(404), emptyOutput.description("User not found"))(()),
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
-      .tags(List("user"))
-
-  type LoginUserEndpoint = Endpoint[Unit, (Option[String], Option[String]), Unit, (String, Option[Int], Option[java.time.Instant]), Any]
-  lazy val loginUser: LoginUserEndpoint =
-    endpoint
-      .name("loginUser")
-      .get
-      .in(("user" / "login"))
-      .in(query[Option[String]]("username").description("The user name for login"))
-      .in(query[Option[String]]("password").description("The password for login in clear text"))
-      .errorOut(oneOf[Unit](
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid username/password supplied"))(()),
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
-      .out(oneOfBody[String](
-        xmlBody[String].description("successful operation"),
-        jsonBody[String].description("successful operation")).and(header[Option[Int]]("X-Rate-Limit").description("calls per hour allowed by the user")).and(header[Option[java.time.Instant]]("X-Expires-After").description("date in UTC when token expires")))
-      .tags(List("user"))
-
-  type CreateUserEndpoint = Endpoint[Unit, CreateUserBodyIn, Unit, User, Any]
-  lazy val createUser: CreateUserEndpoint =
-    endpoint
-      .name("createUser")
-      .post
-      .in(("user"))
-      .in(oneOfBody[CreateUserBodyIn](
-        jsonBody[Option[User]].map(CreateUserBodyOption_User_In(_))(_.value).widenBody[CreateUserBodyIn].description("Created user object"),
-        xmlBody[Option[User]].map(CreateUserBodyOption_User_In(_))(_.value).widenBody[CreateUserBodyIn].description("Created user object"),
-        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/x-www-form-urlencodedCodecFormat`](`application/x-www-form-urlencodedCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(CreateUserBody2In(_))(_.value).widenBody[CreateUserBodyIn].description("Created user object")))
-      .out(oneOfBody[User](
-        jsonBody[User].description("successful operation"),
-        xmlBody[User].description("successful operation")))
-      .tags(List("user"))
-      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "UserController")
+      .out(oneOfBody[List[Pet]](
+        jsonBody[List[Pet]].description("successful operation"),
+        xmlBody[FindPetsByTagsResponse].map(_.asInstanceOf[List[Pet]].toList)(_.asInstanceOf[FindPetsByTagsResponse]).description("successful operation")))
+      .tags(List("pet"))
 
   type GetPetByIdEndpoint = Endpoint[Bearer_or_api_key_SecurityIn, Long, Unit, Pet, Any]
   lazy val getPetById: GetPetByIdEndpoint =
@@ -459,34 +328,162 @@ object TapirGeneratedEndpoints {
       .out(jsonBody[ApiResponse].description("successful operation"))
       .tags(List("pet"))
 
-  type FindPetsByStatusEndpoint = Endpoint[String, Option[FindPetsByStatusStatus], Unit, List[Pet], Any]
-  lazy val findPetsByStatus: FindPetsByStatusEndpoint =
+  type GetInventoryEndpoint = Endpoint[String, Unit, Unit, Map[String, Int], Any]
+  lazy val getInventory: GetInventoryEndpoint =
     endpoint
-      .name("findPetsByStatus")
+      .name("getInventory")
       .get
-      .in(("pet" / "findByStatus"))
-      .securityIn(auth.oauth2.implicitFlow("https://petstore3.swagger.io/oauth/authorize", None))
-      .in(query[Option[FindPetsByStatusStatus]]("status").description("Status values that need to be considered for filter"))
+      .in(("store" / "inventory"))
+      .securityIn(auth.apiKey(header[String]("api_key")))
+      .out(jsonBody[Map[String, Int]].description("successful operation"))
+      .tags(List("store"))
+      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "OrderController")
+
+  type PlaceOrderEndpoint = Endpoint[Unit, PlaceOrderBodyIn, Unit, Order, Any]
+  lazy val placeOrder: PlaceOrderEndpoint =
+    endpoint
+      .name("placeOrder")
+      .post
+      .in(("store" / "order"))
+      .in(oneOfBody[PlaceOrderBodyIn](
+        jsonBody[Option[Order]].map(PlaceOrderBodyOption_Order_In(_))(_.value).widenBody[PlaceOrderBodyIn],
+        xmlBody[Option[Order]].map(PlaceOrderBodyOption_Order_In(_))(_.value).widenBody[PlaceOrderBodyIn],
+        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/x-www-form-urlencodedCodecFormat`](`application/x-www-form-urlencodedCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(PlaceOrderBody2In(_))(_.value).widenBody[PlaceOrderBodyIn]))
       .errorOut(oneOf[Unit](
-        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid status value"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid input"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(422), emptyOutput.description("Validation exception"))(()),
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
-      .out(oneOfBody[List[Pet]](
-        jsonBody[List[Pet]].description("successful operation"),
-        xmlBody[FindPetsByStatusResponse].map(_.asInstanceOf[List[Pet]].toList)(_.asInstanceOf[FindPetsByStatusResponse]).description("successful operation")))
-      .tags(List("pet"))
+      .out(jsonBody[Order].description("successful operation"))
+      .tags(List("store"))
+      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "OrderController")
 
-  sealed trait FindPetsByStatusStatus extends enumeratum.EnumEntry
-  object FindPetsByStatusStatus extends enumeratum.Enum[FindPetsByStatusStatus] with enumeratum.CirceEnum[FindPetsByStatusStatus] {
-    val values = findValues
-    case object available extends FindPetsByStatusStatus
-    case object pending extends FindPetsByStatusStatus
-    case object sold extends FindPetsByStatusStatus
-    implicit val enumCodecSupportFindPetsByStatusStatus: ExtraParamSupport[FindPetsByStatusStatus] =
-      extraCodecSupport[FindPetsByStatusStatus]("FindPetsByStatusStatus", FindPetsByStatusStatus)
-  }
+  type GetOrderByIdEndpoint = Endpoint[Unit, Long, Unit, Order, Any]
+  lazy val getOrderById: GetOrderByIdEndpoint =
+    endpoint
+      .name("getOrderById")
+      .get
+      .in(("store" / "order" / path[Long]("orderId").description("ID of order that needs to be fetched")))
+      .errorOut(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid ID supplied"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(404), emptyOutput.description("Order not found"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
+      .out(oneOfBody[Order](
+        jsonBody[Order].description("successful operation"),
+        xmlBody[Order].description("successful operation")))
+      .tags(List("store"))
+      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "OrderController")
 
+  type DeleteOrderEndpoint = Endpoint[Unit, Long, Unit, Unit, Any]
+  lazy val deleteOrder: DeleteOrderEndpoint =
+    endpoint
+      .name("deleteOrder")
+      .delete
+      .in(("store" / "order" / path[Long]("orderId").description("ID of the order that needs to be deleted")))
+      .errorOut(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid ID supplied"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(404), emptyOutput.description("Order not found"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
+      .tags(List("store"))
+      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "OrderController")
 
-  lazy val generatedEndpoints = List(placeOrder, findPetsByTags, updatePet, addPet, getOrderById, deleteOrder, logoutUser, getInventory, createUsersWithListInput, getUserByName, updateUser, deleteUser, loginUser, createUser, getPetById, updatePetWithForm, deletePet, uploadFile, findPetsByStatus)
+  type CreateUserEndpoint = Endpoint[Unit, CreateUserBodyIn, Unit, User, Any]
+  lazy val createUser: CreateUserEndpoint =
+    endpoint
+      .name("createUser")
+      .post
+      .in(("user"))
+      .in(oneOfBody[CreateUserBodyIn](
+        jsonBody[Option[User]].map(CreateUserBodyOption_User_In(_))(_.value).widenBody[CreateUserBodyIn].description("Created user object"),
+        xmlBody[Option[User]].map(CreateUserBodyOption_User_In(_))(_.value).widenBody[CreateUserBodyIn].description("Created user object"),
+        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/x-www-form-urlencodedCodecFormat`](`application/x-www-form-urlencodedCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(CreateUserBody2In(_))(_.value).widenBody[CreateUserBodyIn].description("Created user object")))
+      .out(oneOfBody[User](
+        jsonBody[User].description("successful operation"),
+        xmlBody[User].description("successful operation")))
+      .tags(List("user"))
+      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "UserController")
+
+  type CreateUsersWithListInputEndpoint = Endpoint[Unit, Option[List[User]], Unit, User, Any]
+  lazy val createUsersWithListInput: CreateUsersWithListInputEndpoint =
+    endpoint
+      .name("createUsersWithListInput")
+      .post
+      .in(("user" / "createWithList"))
+      .in(jsonBody[Option[List[User]]])
+      .out(oneOfBody[User](
+        jsonBody[User].description("Successful operation"),
+        xmlBody[User].description("Successful operation")))
+      .tags(List("user"))
+      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "UserController")
+
+  type LoginUserEndpoint = Endpoint[Unit, (Option[String], Option[String]), Unit, (String, Option[Int], Option[java.time.Instant]), Any]
+  lazy val loginUser: LoginUserEndpoint =
+    endpoint
+      .name("loginUser")
+      .get
+      .in(("user" / "login"))
+      .in(query[Option[String]]("username").description("The user name for login"))
+      .in(query[Option[String]]("password").description("The password for login in clear text"))
+      .errorOut(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid username/password supplied"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
+      .out(oneOfBody[String](
+        xmlBody[String].description("successful operation"),
+        jsonBody[String].description("successful operation")).and(header[Option[Int]]("X-Rate-Limit").description("calls per hour allowed by the user")).and(header[Option[java.time.Instant]]("X-Expires-After").description("date in UTC when token expires")))
+      .tags(List("user"))
+
+  type LogoutUserEndpoint = Endpoint[Unit, Unit, Unit, Unit, Any]
+  lazy val logoutUser: LogoutUserEndpoint =
+    endpoint
+      .name("logoutUser")
+      .get
+      .in(("user" / "logout"))
+      .tags(List("user"))
+
+  type GetUserByNameEndpoint = Endpoint[Unit, String, Unit, User, Any]
+  lazy val getUserByName: GetUserByNameEndpoint =
+    endpoint
+      .name("getUserByName")
+      .get
+      .in(("user" / path[String]("username").description("The name that needs to be fetched. Use user1 for testing")))
+      .errorOut(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid username supplied"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(404), emptyOutput.description("User not found"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
+      .out(oneOfBody[User](
+        jsonBody[User].description("successful operation"),
+        xmlBody[User].description("successful operation")))
+      .tags(List("user"))
+
+  type UpdateUserEndpoint = Endpoint[Unit, (String, UpdateUserBodyIn), Unit, Unit, Any]
+  lazy val updateUser: UpdateUserEndpoint =
+    endpoint
+      .name("updateUser")
+      .put
+      .in(("user" / path[String]("username").description("name that need to be deleted")))
+      .in(oneOfBody[UpdateUserBodyIn](
+        jsonBody[Option[User]].map(UpdateUserBodyOption_User_In(_))(_.value).widenBody[UpdateUserBodyIn].description("Update an existent user in the store"),
+        xmlBody[Option[User]].map(UpdateUserBodyOption_User_In(_))(_.value).widenBody[UpdateUserBodyIn].description("Update an existent user in the store"),
+        EndpointIO.Body(RawBodyType.ByteArrayBody, Codec.id[Array[Byte], `application/x-www-form-urlencodedCodecFormat`](`application/x-www-form-urlencodedCodecFormat`(), Schema.schemaForByteArray), EndpointIO.Info.empty).map(UpdateUserBody2In(_))(_.value).widenBody[UpdateUserBodyIn].description("Update an existent user in the store")))
+      .errorOut(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("bad request"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(404), emptyOutput.description("user not found"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
+      .tags(List("user"))
+      .attribute[SwaggerRouterControllerExtension](swaggerRouterControllerExtensionKey, "UserController")
+
+  type DeleteUserEndpoint = Endpoint[Unit, String, Unit, Unit, Any]
+  lazy val deleteUser: DeleteUserEndpoint =
+    endpoint
+      .name("deleteUser")
+      .delete
+      .in(("user" / path[String]("username").description("The name that needs to be deleted")))
+      .errorOut(oneOf[Unit](
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Invalid username supplied"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(404), emptyOutput.description("User not found"))(()),
+        oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
+      .tags(List("user"))
+
+  lazy val generatedEndpoints = List(updatePet, addPet, findPetsByStatus, findPetsByTags, getPetById, updatePetWithForm, deletePet, uploadFile, getInventory, placeOrder, getOrderById, deleteOrder, createUser, createUsersWithListInput, loginUser, logoutUser, getUserByName, updateUser, deleteUser)
 
   object Servers {
     import sttp.model.Uri.UriContext

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
@@ -79,12 +79,12 @@ object TapirGeneratedEndpoints {
   def extraCodecSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): ExtraParamSupport[T] =
     EnumExtraParamSupport(enumName, T)
   case class Pet (
-    status: Option[PetStatus] = None,
-    tags: Option[Seq[Tag]] = None,
     id: Option[Long] = None,
-    photoUrls: Seq[String],
     name: String,
-    category: Option[Category] = None
+    category: Option[Category] = None,
+    photoUrls: Seq[String],
+    tags: Option[Seq[Tag]] = None,
+    status: Option[PetStatus] = None
   )
 
   sealed trait PetStatus extends enumeratum.EnumEntry
@@ -103,22 +103,22 @@ object TapirGeneratedEndpoints {
     name: Option[String] = None
   )
   case class User (
-    userStatus: Option[Int] = None,
-    phone: Option[String] = None,
-    lastName: Option[String] = None,
     id: Option[Long] = None,
     username: Option[String] = None,
-    password: Option[String] = None,
+    firstName: Option[String] = None,
+    lastName: Option[String] = None,
     email: Option[String] = None,
-    firstName: Option[String] = None
+    password: Option[String] = None,
+    phone: Option[String] = None,
+    userStatus: Option[Int] = None
   )
   case class Order (
     id: Option[Long] = None,
-    status: Option[OrderStatus] = None,
-    shipDate: Option[java.time.Instant] = None,
+    petId: Option[Long] = None,
     quantity: Option[Int] = None,
-    complete: Option[Boolean] = None,
-    petId: Option[Long] = None
+    shipDate: Option[java.time.Instant] = None,
+    status: Option[OrderStatus] = None,
+    complete: Option[Boolean] = None
   )
 
   sealed trait OrderStatus extends enumeratum.EnumEntry

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/ExpectedXmlSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/ExpectedXmlSerdes.scala.txt
@@ -122,20 +122,20 @@ object TapirGeneratedEndpointsXmlSerdes {
 
   implicit lazy val PetXmlTypeInterpreter: XmlTypeInterpreter[Pet] = XmlTypeInterpreter.auto[Pet]((_, _) => false, (_, _) => false)
   implicit lazy val PetXmlDecoder: Decoder[Pet] = {
-    implicit val PetTagsSeqDecoder: Decoder[Seq[Tag]] = seqDecoder[Tag]("tags", isWrapped = true)
-    implicit val PetPhotoUrlsSeqDecoder: Decoder[Seq[String]] = seqDecoder[String]("photoUrls", isWrapped = true)
-    implicit val PetStatusOptionDecoder: Decoder[Option[PetStatus]] = optionDecoder[PetStatus](enumDecoder[PetStatus](PetStatus))
     // implicit val PetCategoryDecoder: Decoder[Option[Category]] = deriveConfiguredDecoder[Option[Category]]
+    implicit val PetPhotoUrlsSeqDecoder: Decoder[Seq[String]] = seqDecoder[String]("photoUrls", isWrapped = true)
+    implicit val PetTagsSeqDecoder: Decoder[Seq[Tag]] = seqDecoder[Tag]("tags", isWrapped = true)
+    implicit val PetStatusOptionDecoder: Decoder[Option[PetStatus]] = optionDecoder[PetStatus](enumDecoder[PetStatus](PetStatus))
     deriveConfiguredDecoder[Pet]
   }
   implicit lazy val PetXmlEncoder: Encoder[Pet] = {
-    implicit val PetTagsSeqEncoder: Encoder[Seq[Tag]] =
-      seqEncoder[Tag]("tags", isWrapped = true, itemName = "tags")
+    implicit val PetCategoryEncoder: Encoder[Option[Category]] = deriveConfiguredEncoder[Option[Category]]
     implicit val PetPhotoUrlsSeqEncoder: Encoder[Seq[String]] =
       seqEncoder[String]("photoUrls", isWrapped = true, itemName = "photoUrl")
+    implicit val PetTagsSeqEncoder: Encoder[Seq[Tag]] =
+      seqEncoder[Tag]("tags", isWrapped = true, itemName = "tags")
     implicit val PetStatusEncoder: Encoder[PetStatus] = enumEncoder[PetStatus]("status")
     implicit val PetStatusOptionEncoder: Encoder[Option[PetStatus]] = optionEncoder[PetStatus](PetStatusEncoder)
-    implicit val PetCategoryEncoder: Encoder[Option[Category]] = deriveConfiguredEncoder[Option[Category]]
     deriveConfiguredEncoder[Pet]
   }
 


### PR DESCRIPTION
The non-deterministic ordering of the field declarations in object schemas is annoying, and can randomly break code that depends on it being consistent (e.g. case-class pattern matching, or positional case class construction). The sanest consistent field ordering is the one declared in the openapi yaml. This pr replaces usage of Map with LinkedHashMap, which retains the initial ordering of fields as declared in the schema.

Where 'allOf' is involved, fields will be declared in the order in which they first appear in the flattened property list of all component schemas.

Endpoint ordering has also been non-deterministic, which can also be problematic (although it's probably less of an issue for most). That has a similar resolution - to read the paths into a LinkedHashMap rather than a Map, so as to preserve declaration ordering.

Honestly, this should've been done ages ago, since 'fixing' the ordering does have the potential to break code on plugin bump -- although changing the type of a field (or whether it has a default) can already randomly break stuff, the plugin version can be updated entirely independently of other updates, and better to do this late than never I guess... 