### PR TITLE
Fix admonition syntax in documentation

### DIFF
--- a/doc/server/netty.md
+++ b/doc/server/netty.md
@@ -79,7 +79,7 @@ NettyFutureServer(NettyFutureServerOptions.customiseInterceptors.serverLog(None)
 NettyFutureServer(NettyConfig.default.socketBacklog(256))
 ```
 
-```note
+```{note}
 Unlike other server interpreters, the Netty-based servers are by default configured to return a 404, in case none of
 the given endpoints match a request. This can be changed by using a different `RejectHandler`.
 

--- a/doc/tutorials/06_error_variants.md
+++ b/doc/tutorials/06_error_variants.md
@@ -159,7 +159,7 @@ val successOutput: EndpointOutput[AvatarSuccess] = oneOf(
 The `oneOf` output can be typed using the common parent of both variants, which is `AvatarSuccess`. The server logic
 will then have to return an instance of `AvatarSuccess`, in case of successful completion.
 
-```{warn}
+```{warning}
 Unfortunately, Tapir is not able to verify at compile-time that the variants are exhaustive, that is that every variant
 of the high-level type has a corresponding output-variant.
 ```


### PR DESCRIPTION
Building the documentation with Sphinx produces the following errors:

    target/tapir-doc/tutorials/06_error_variants.md:162: WARNING:
    Unknown directive type: 'warn' [myst.directive_unknown]

    target/tapir-doc/server/netty.md:82: WARNING: Pygments lexer name
    'note' is not known

Use the right syntax to use note and warning admonitions.

## Changes

For https://tapir.softwaremill.com/en/latest/server/netty.html#configuration

Before:
![image](https://github.com/user-attachments/assets/2a63dd6c-7c70-4ca1-b234-3003dababb2c)

After:
![image](https://github.com/user-attachments/assets/29e16ae3-6cf5-4d5e-b45b-6712cdf9e23a)

For https://tapir.softwaremill.com/en/latest/tutorials/06_error_variants.html#picking-the-right-variant

Before:
![image](https://github.com/user-attachments/assets/7a288155-19e0-4cf8-a42b-f6e1e9ba8145)

After:
![image](https://github.com/user-attachments/assets/6e8dccb7-50c5-4702-9782-5a4f63f5efbd)
