### PR TITLE
codegen: handle recursive schema defns in scala 3

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -58,7 +58,8 @@ class ClassDefinitionGenerator {
       throw new NotImplementedError(
         s"any not implemented for json libs other than circe and jsoniter (problematic models: ${schemasWithAny.keys})"
       )
-    val schemas = SchemaGenerator.generateSchemas(doc, allSchemas, fullModelPath, jsonSerdeLib, maxSchemasPerFile, schemasContainAny)
+    val schemas = SchemaGenerator
+      .generateSchemas(doc, allSchemas, fullModelPath, jsonSerdeLib, maxSchemasPerFile, schemasContainAny, targetScala3)
     val jsonSerdes = JsonSerdeGenerator.serdeDefs(
       doc,
       jsonSerdeLib,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
@@ -25,6 +25,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
 import scala.collection.mutable
 
 object SchemaGenerator {
+  def decl(isRecursive: Boolean): String = if (isRecursive) "def" else "lazy val"
 
   def generateSchemas(
       doc: OpenapiDocument,
@@ -32,57 +33,80 @@ object SchemaGenerator {
       fullModelPath: String,
       jsonSerdeLib: JsonSerdeLib,
       maxSchemasPerFile: Int,
-      schemasContainAny: Boolean
+      schemasContainAny: Boolean,
+      targetScala3: Boolean
   ): Seq[String] = {
-    val maybeAnySchema: Option[(String, String)] =
+    val maybeAnySchema: Option[(String, Boolean => String)] =
       if (!schemasContainAny) None
       else if (jsonSerdeLib == JsonSerdeLib.Circe || jsonSerdeLib == JsonSerdeLib.Jsoniter)
         Some(
-          "anyTapirSchema" -> "implicit lazy val anyTapirSchema: sttp.tapir.Schema[io.circe.Json] = sttp.tapir.Schema.any[io.circe.Json]"
+          "anyTapirSchema" -> (_ =>
+            "implicit lazy val anyTapirSchema: sttp.tapir.Schema[io.circe.Json] = sttp.tapir.Schema.any[io.circe.Json]"
+          )
         )
       else throw new NotImplementedError("any not implemented for json libs other than circe and jsoniter")
     val extraSchemaRefs: Seq[Seq[(String, OpenapiSchemaType)]] = Seq(
       Seq("byteStringSchema" -> OpenapiSchemaByte(false)),
       maybeAnySchema.map { case (_, _) => "anyTapirSchema" -> OpenapiSchemaAny(false) }.toSeq
     )
-    val openApiSchemasWithTapirSchemas = doc.components
-      .map(_.schemas.flatMap {
-        case (name, _: OpenapiSchemaEnum) =>
-          Some(
-            name -> s"implicit lazy val ${RootGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
-          )
-        case (name, obj: OpenapiSchemaObject)   => Some(name -> schemaForObject(name, obj))
-        case (name, schema: OpenapiSchemaMap)   => Some(name -> schemaForMapOrArray(name, schema.items))
-        case (name, schema: OpenapiSchemaArray) => Some(name -> schemaForMapOrArray(name, schema.items))
-        case (_, _: OpenapiSchemaAny)           => None
-        case (name, schema: OpenapiSchemaOneOf) =>
-          Some(name -> genADTSchema(name, schema, if (fullModelPath.isEmpty) None else Some(fullModelPath)))
-        case (n, x) => throw new NotImplementedError(s"Only objects, enums, maps, arrays and oneOf supported! (for $n found ${x})")
-      })
-      .toSeq
-      .flatMap(maybeAnySchema.toSeq ++ _)
-      .toMap + ("byteStringSchema" -> "implicit lazy val byteStringSchema: sttp.tapir.Schema[ByteString] = sttp.tapir.Schema.schemaForByteArray.map(ba => Some(toByteString(ba)))(bs => bs)")
+    val openApiSchemasWithTapirSchemas: Map[String, Boolean => String] =
+      doc.components
+        .map(_.schemas.toSeq.flatMap {
+          case (name, _: OpenapiSchemaEnum) =>
+            Some(
+              name -> ((_: Boolean) =>
+                s"implicit lazy val ${RootGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
+              )
+            )
+          case (name, obj: OpenapiSchemaObject)   => Some(name -> (schemaForObject(name, _, obj)))
+          case (name, schema: OpenapiSchemaMap)   => Some(name -> (schemaForMapOrArray(name, _, schema.items)))
+          case (name, schema: OpenapiSchemaArray) => Some(name -> (schemaForMapOrArray(name, _, schema.items)))
+          case (_, _: OpenapiSchemaAny)           => None
+          case (name, schema: OpenapiSchemaOneOf) =>
+            Some(name -> (genADTSchema(name, schema, _, if (fullModelPath.isEmpty) None else Some(fullModelPath))))
+          case (n, x) => throw new NotImplementedError(s"Only objects, enums, maps, arrays and oneOf supported! (for $n found ${x})")
+        })
+        .toSeq
+        .flatMap(maybeAnySchema.toSeq ++ _)
+        .toMap + ("byteStringSchema" -> (_ =>
+        "implicit lazy val byteStringSchema: sttp.tapir.Schema[ByteString] = sttp.tapir.Schema.schemaForByteArray.map(ba => Some(toByteString(ba)))(bs => bs)"
+      ))
 
-    // The algorithm here is to aviod mutually references between objects. It goes like this:
+    // The algorithm here is to avoid mutually references between objects. It goes like this:
     // 1) Find all 'rings' -- that is, sets of mutually-recursive object references that will need to be defined in the same object
     // (e.g. the schemas for `case class A(maybeB: Option[B])` and `case class B(maybeA: Option[A])` would need to be defined together)
     val groupedByRing = constructRings(allSchemas)
     // 2) Order the definitions, such that objects appear before any places they're referenced
     val orderedLayers = orderLayers(groupedByRing)
     // 3) Group the definitions into at most `maxSchemasPerFile`, whilst avoiding splitting groups across files
-    val foldedLayers = foldLayers(maxSchemasPerFile)(extraSchemaRefs ++ orderedLayers)
-    // Our output will now only need to imports the 'earlier' files into the 'later' files, and _not_ vice verse
-    foldedLayers.map(ring => ring.map(openApiSchemasWithTapirSchemas apply _._1).mkString("\n"))
+    // We also return an `isRecursive` boolean here, so that we can appropriately use 'def' instead of 'lazy val' for
+    // defns that would otherwise break in scala 3. Since this will _not_ break in scala 2, we return true _only_ when
+    // the target is scala 3
+    val foldedLayers = foldLayers(maxSchemasPerFile, targetScala3)(extraSchemaRefs ++ orderedLayers)
+    // Our output will now only need to import the 'earlier' files into the 'later' files, and _not_ vice verse
+    foldedLayers.map(ring => ring.map(r => openApiSchemasWithTapirSchemas(r._1)(r._2)).mkString("\n"))
   }
   // Group files into chunks of size < maxLayerSize
-  private def foldLayers(maxSchemasPerFile: Int)(layers: Seq[Seq[(String, OpenapiSchemaType)]]): Seq[Seq[(String, OpenapiSchemaType)]] = {
-    val maxLayerSize = maxSchemasPerFile
-    layers.foldLeft(Seq.empty[Seq[(String, OpenapiSchemaType)]]) { (acc, next) =>
-      if (acc.isEmpty) Seq(next)
-      else if (acc.last.size + next.size >= maxLayerSize) acc :+ next
+  // The boolean in the return signature indicates whether the schema is part of a recursive definition or not.
+  // This is required since for scala 3, these schemas must be declared with `def` rather than `lazy val`
+  private def foldLayers(
+      maxLayerSize: Int,
+      isScala3: Boolean
+  )(layers: Seq[Seq[(String, OpenapiSchemaType)]]): Seq[Seq[(String, Boolean, OpenapiSchemaType)]] = {
+    def withRecursiveBoolean(s: Seq[(String, OpenapiSchemaType)]): Seq[(String, Boolean, OpenapiSchemaType)] = {
+      if (!isScala3) s.map { case (n, t) => (n, false, t) }
+      else if (s.size != 1) s.map { case (n, t) => (n, true, t) }
+      else if (isSimpleRecursive(s.head._1, s.head._2)) s.map { case (n, t) => (n, true, t) }
+      else s.map { case (n, t) => (n, false, t) }
+    }
+
+    layers.foldLeft(Seq.empty[Seq[(String, Boolean, OpenapiSchemaType)]]) { (acc, next) =>
+      val mappedNext = withRecursiveBoolean(next)
+      if (acc.isEmpty) Seq(mappedNext)
+      else if (acc.last.size + next.size >= maxLayerSize) acc :+ mappedNext
       else {
         val first :+ last = acc
-        first :+ (last ++ next)
+        first :+ (last ++ mappedNext)
       }
     }
   }
@@ -148,6 +172,21 @@ object SchemaGenerator {
     }
     res.toSeq
   }
+
+  private def isSimpleRecursive(schemaName: String, schema: OpenapiSchemaType): Boolean = schema match {
+    case r: OpenapiSchemaRef => r.stripped == schemaName
+    // these types cannot contain a reference
+    case _: OpenapiSchemaSimpleType | _: OpenapiSchemaEnum | _: OpenapiSchemaConstantString => false
+    // descend into the sole child type
+    case OpenapiSchemaArray(items, _, _, _) => isSimpleRecursive(schemaName, items)
+    case OpenapiSchemaNot(items)            => isSimpleRecursive(schemaName, items)
+    case OpenapiSchemaMap(items, _, _)      => isSimpleRecursive(schemaName, items)
+    // descend into all child types
+    case OpenapiSchemaOneOf(items, _)      => items.exists(isSimpleRecursive(schemaName, _))
+    case OpenapiSchemaAllOf(items)         => items.exists(isSimpleRecursive(schemaName, _))
+    case OpenapiSchemaAnyOf(items)         => items.exists(isSimpleRecursive(schemaName, _))
+    case OpenapiSchemaObject(kvs, _, _, _) => kvs.values.exists(v => isSimpleRecursive(schemaName, v.`type`))
+  }
   // find all simple reference loops starting at a single schema (e.g. A -> B -> C -> A)
   private def getReferencesToXInY(
       allSchemas: Map[String, OpenapiSchemaType],
@@ -184,13 +223,13 @@ object SchemaGenerator {
       kvs.values.flatMap(v => getReferencesToXInY(allSchemas, referent, v.`type`, checked, maybeRefs)).toSet
   }
 
-  private def schemaForObject(name: String, schema: OpenapiSchemaObject): String = {
+  private def schemaForObject(name: String, isRecursive: Boolean, schema: OpenapiSchemaObject): String = {
     val subs = schema.properties.collect {
-      case (k, OpenapiSchemaField(`type`: OpenapiSchemaObject, _, _)) => schemaForObject(s"$name${k.capitalize}", `type`)
+      case (k, OpenapiSchemaField(`type`: OpenapiSchemaObject, _, _)) => schemaForObject(s"$name${k.capitalize}", isRecursive, `type`)
       case (k, OpenapiSchemaField(OpenapiSchemaArray(`type`: OpenapiSchemaObject, _, _, _), _, _)) =>
-        schemaForObject(s"$name${k.capitalize}Item", `type`)
+        schemaForObject(s"$name${k.capitalize}Item", isRecursive, `type`)
       case (k, OpenapiSchemaField(OpenapiSchemaMap(`type`: OpenapiSchemaObject, _, _), _, _)) =>
-        schemaForObject(s"$name${k.capitalize}Item", `type`)
+        schemaForObject(s"$name${k.capitalize}Item", isRecursive, `type`)
       case (k, OpenapiSchemaField(_: OpenapiSchemaEnum, _, _)) => schemaForEnum(s"$name${k.capitalize}")
       case (k, OpenapiSchemaField(OpenapiSchemaArray(_: OpenapiSchemaEnum, _, _, _), _, _)) =>
         schemaForEnum(s"$name${k.capitalize}Item")
@@ -200,11 +239,11 @@ object SchemaGenerator {
       case s if s.isEmpty => ""
       case s              => s.mkString("", "\n", "\n")
     }
-    s"${subs}implicit lazy val ${RootGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
+    s"${subs}implicit ${decl(isRecursive)} ${RootGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"
   }
-  private def schemaForMapOrArray(name: String, schema: OpenapiSchemaType): String = {
+  private def schemaForMapOrArray(name: String, isRecursive: Boolean, schema: OpenapiSchemaType): String = {
     val subs = schema match {
-      case `type`: OpenapiSchemaObject => Some(schemaForObject(s"${name}ObjectsItem", `type`))
+      case `type`: OpenapiSchemaObject => Some(schemaForObject(s"${name}ObjectsItem", isRecursive, `type`))
       case _                           => None
     }
     subs.fold("")("\n" + _)
@@ -212,7 +251,7 @@ object SchemaGenerator {
   private def schemaForEnum(name: String): String =
     s"""implicit lazy val ${RootGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = sttp.tapir.Schema.derived"""
 
-  private def genADTSchema(name: String, schema: OpenapiSchemaOneOf, fullModelPath: Option[String]): String = {
+  private def genADTSchema(name: String, schema: OpenapiSchemaOneOf, isRecursive: Boolean, fullModelPath: Option[String]): String = {
     val schemaImpl = schema match {
       case OpenapiSchemaOneOf(_, None) => "sttp.tapir.Schema.derived"
       case OpenapiSchemaOneOf(_, Some(Discriminator(propertyName, maybeMapping))) =>
@@ -246,6 +285,6 @@ object SchemaGenerator {
            |}""".stripMargin
     }
 
-    s"implicit lazy val ${RootGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = ${schemaImpl}"
+    s"implicit ${decl(isRecursive)} ${RootGenerator.uncapitalise(name)}TapirSchema: sttp.tapir.Schema[$name] = ${schemaImpl}"
   }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
@@ -81,6 +81,10 @@ object TapirGeneratedEndpoints {
     a: Seq[String],
     absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
+  case class Node (
+    value: String,
+    children: Option[Seq[Node]] = None
+  )
   case class SubtypeWithD1 (
     s: String,
     i: Option[Int] = None,
@@ -116,29 +120,39 @@ object TapirGeneratedEndpoints {
 
 
 
-  lazy val putAdtTest =
+  type PutAdtTestEndpoint = Endpoint[Unit, ADTWithoutDiscriminator, Unit, ADTWithoutDiscriminator, Any]
+  lazy val putAdtTest: PutAdtTestEndpoint =
     endpoint
       .put
       .in(("adt" / "test"))
       .in(jsonBody[ADTWithoutDiscriminator].description("Update an existent user in the store"))
       .out(jsonBody[ADTWithoutDiscriminator].description("successful operation"))
 
-  lazy val postAdtTest =
+  type PostAdtTestEndpoint = Endpoint[Unit, ADTWithDiscriminatorNoMapping, Unit, ADTWithDiscriminator, Any]
+  lazy val postAdtTest: PostAdtTestEndpoint =
     endpoint
       .post
       .in(("adt" / "test"))
       .in(jsonBody[ADTWithDiscriminatorNoMapping].description("Update an existent user in the store"))
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 
-  lazy val postXmlEndpoint =
+  type PostXmlEndpointEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
+  lazy val postXmlEndpoint: PostXmlEndpointEndpoint =
     endpoint
       .post
       .in(("xml" / "endpoint"))
       .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Pet], CodecFormat.Xml()))
       .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Pet], CodecFormat.Xml()).description("An object"))
 
+  type PostRecursiveSchemaEndpointEndpoint = Endpoint[Unit, Node, Unit, Node, Any]
+  lazy val postRecursiveSchemaEndpoint: PostRecursiveSchemaEndpointEndpoint =
+    endpoint
+      .post
+      .in(("recursive" / "schema" / "endpoint"))
+      .in(jsonBody[Node])
+      .out(jsonBody[Node].description("An object"))
 
-  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, postXmlEndpoint)
+  lazy val generatedEndpoints = List(putAdtTest, postAdtTest, postXmlEndpoint, postRecursiveSchemaEndpoint)
 
 
   object Servers {

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/ExpectedJsonSerdes.scala.txt
@@ -21,6 +21,7 @@ object TapirGeneratedEndpointsJsonSerdes {
     case "SubtypeWithD2" => "SubB"}))
 
   implicit lazy val subtypeWithoutD1JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[SubtypeWithoutD1] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true))
+  implicit lazy val nodeJsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[Node] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true))
   implicit lazy val aDTWithDiscriminatorNoMappingCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[ADTWithDiscriminatorNoMapping] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true).withRequireDiscriminatorFirst(false).withDiscriminatorFieldName(Some("type")))
   implicit lazy val subtypeWithoutD3JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[SubtypeWithoutD3] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true))
   implicit lazy val subtypeWithoutD2JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[SubtypeWithoutD2] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make(com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig.withAllowRecursiveTypes(true).withTransientEmpty(false).withTransientDefault(false).withRequireCollectionFields(true))
@@ -45,7 +46,7 @@ object TapirGeneratedEndpointsJsonSerdes {
       case x: SubtypeWithoutD2 => subtypeWithoutD2JsonCodec.encodeValue(x, out)
       case x: SubtypeWithoutD3 => subtypeWithoutD3JsonCodec.encodeValue(x, out)
     }
-  
+
     def nullValue: ADTWithoutDiscriminator = subtypeWithoutD1JsonCodec.nullValue
   }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/ExpectedSchemas.scala.txt
@@ -1,0 +1,48 @@
+package sttp.tapir.generated
+
+object TapirGeneratedEndpointsSchemas {
+  import sttp.tapir.generated.TapirGeneratedEndpoints._
+  import sttp.tapir.generic.auto._
+  implicit lazy val byteStringSchema: sttp.tapir.Schema[ByteString] = sttp.tapir.Schema.schemaForByteArray.map(ba => Some(toByteString(ba)))(bs => bs)
+  implicit lazy val anEnumTapirSchema: sttp.tapir.Schema[AnEnum] = sttp.tapir.Schema.derived
+  implicit lazy val categoryTapirSchema: sttp.tapir.Schema[Category] = sttp.tapir.Schema.derived
+  implicit def nodeTapirSchema: sttp.tapir.Schema[Node] = sttp.tapir.Schema.derived
+  implicit lazy val petStatusTapirSchema: sttp.tapir.Schema[PetStatus] = sttp.tapir.Schema.derived
+  implicit lazy val subtypeWithD1TapirSchema: sttp.tapir.Schema[SubtypeWithD1] = sttp.tapir.Schema.derived
+  implicit lazy val subtypeWithD2TapirSchema: sttp.tapir.Schema[SubtypeWithD2] = sttp.tapir.Schema.derived
+  implicit lazy val subtypeWithoutD1TapirSchema: sttp.tapir.Schema[SubtypeWithoutD1] = sttp.tapir.Schema.derived
+  implicit lazy val subtypeWithoutD2TapirSchema: sttp.tapir.Schema[SubtypeWithoutD2] = sttp.tapir.Schema.derived
+  implicit lazy val tagTapirSchema: sttp.tapir.Schema[Tag] = sttp.tapir.Schema.derived
+  implicit lazy val tag2TapirSchema: sttp.tapir.Schema[Tag2] = sttp.tapir.Schema.derived
+  implicit lazy val aDTWithDiscriminatorTapirSchema: sttp.tapir.Schema[ADTWithDiscriminator] = {
+    val derived = implicitly[sttp.tapir.generic.Derived[sttp.tapir.Schema[ADTWithDiscriminator]]].value
+    derived.schemaType match {
+      case s: sttp.tapir.SchemaType.SCoproduct[_] => derived.copy(schemaType = s.addDiscriminatorField(
+        sttp.tapir.FieldName("type"),
+        sttp.tapir.Schema.string,
+        Map(
+          "SubA" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithD1")),
+          "SubB" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithD2"))
+        )
+      ))
+      case _ => throw new IllegalStateException("Derived schema for ADTWithDiscriminator should be a coproduct")
+    }
+  }
+  implicit lazy val aDTWithDiscriminatorNoMappingTapirSchema: sttp.tapir.Schema[ADTWithDiscriminatorNoMapping] = {
+    val derived = implicitly[sttp.tapir.generic.Derived[sttp.tapir.Schema[ADTWithDiscriminatorNoMapping]]].value
+    derived.schemaType match {
+      case s: sttp.tapir.SchemaType.SCoproduct[_] => derived.copy(schemaType = s.addDiscriminatorField(
+        sttp.tapir.FieldName("type"),
+        sttp.tapir.Schema.string,
+        Map(
+          "SubtypeWithD1" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithD1")),
+          "SubtypeWithD2" -> sttp.tapir.SchemaType.SRef(sttp.tapir.Schema.SName("sttp.tapir.generated.TapirGeneratedEndpoints.SubtypeWithD2"))
+        )
+      ))
+      case _ => throw new IllegalStateException("Derived schema for ADTWithDiscriminatorNoMapping should be a coproduct")
+    }
+  }
+  implicit lazy val petTapirSchema: sttp.tapir.Schema[Pet] = sttp.tapir.Schema.derived
+  implicit lazy val subtypeWithoutD3TapirSchema: sttp.tapir.Schema[SubtypeWithoutD3] = sttp.tapir.Schema.derived
+  implicit lazy val aDTWithoutDiscriminatorTapirSchema: sttp.tapir.Schema[ADTWithoutDiscriminator] = sttp.tapir.Schema.derived
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/build.sbt
@@ -6,7 +6,8 @@ lazy val root = (project in file("."))
     openapiJsonSerdeLib := "jsoniter",
     openapiXmlSerdeLib := "none",
     openapiStreamingImplementation := "pekko",
-    openapiUseCustomJsoniterSerdes := false
+    openapiUseCustomJsoniterSerdes := false,
+    openapiGenerateEndpointTypes := true
   )
 
 val tapirVersion = "1.11.16"
@@ -19,7 +20,8 @@ libraryDependencies ++= Seq(
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.36.5",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.36.5" % "compile-internal",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,
-  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.10.0" % Test
+  "com.softwaremill.sttp.tapir" %% "tapir-sttp-stub-server" % "1.10.0" % Test,
+  "com.softwaremill.sttp.client3" %% "http4s-backend" % "3.11.0" % Test
 )
 
 import sttp.tapir.sbt.OpenapiCodegenPlugin.autoImport.{openapiJsonSerdeLib, openapiUseHeadTagForObjectName}
@@ -48,6 +50,11 @@ TaskKey[Unit]("check") := {
     "json",
     "target/scala-3.3.3/src_managed/main/sbt-openapi-codegen/TapirGeneratedEndpointsJsonSerdes.scala",
     "ExpectedJsonSerdes.scala.txt"
+  )
+  compare(
+    "schemas",
+    "target/scala-3.3.3/src_managed/main/sbt-openapi-codegen/TapirGeneratedEndpointsSchemas.scala",
+    "ExpectedSchemas.scala.txt"
   )
   ()
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/swagger.yaml
@@ -53,6 +53,21 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/Pet'
+  '/recursive/schema/endpoint':
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Node'
+      responses:
+        "200":
+          description: An object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
 
 components:
   schemas:
@@ -236,3 +251,15 @@ components:
       xml:
         name: category
       type: object
+    Node:
+      title: Node
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Node'


### PR DESCRIPTION
Supports deriving schemas for recursive schema definitions in scala 3.

Without this change, the code will hang eternally at runtime. This appears to be because, when declared as a `lazy val`, the tapir schema for a recursive struct enters some infinite loop. `def` declarations have no such issues; however `lazy val` is, probably, preferable for most cases becase the schema only needs to be evaluated once, even if used in multiple locations - so there's a little extra complexity in the generation now, so that we only declare the schemas as `def`s when they're recursive (or part of a mutually-recursive set of defns, which had the same issue).

I guess it'd be nicer to fix the 'root issue' with lazy val schema declarations, but that's probably some magnolia issue that I have not the wit to fix, and this approach does well enough.