### PR TITLE
Properly return a 404 when trying to get a non-existent single file

### DIFF
--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerFilesTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerFilesTests.scala
@@ -507,6 +507,13 @@ class ServerFilesTests[F[_], OPTIONS, ROUTE](
             .unsafeToFuture()
         }
       },
+      Test("should return a 404 when the single file from the given system path does not exist") {
+        withTestFilesDirectory { testDir =>
+          serveRoute(staticFileGetServerEndpoint[F]("test")(testDir.toPath.resolve("f_not_there").toFile.getAbsolutePath))
+            .use { port => get(port, List("test")).map(_.code shouldBe StatusCode.NotFound) }
+            .unsafeToFuture()
+        }
+      },
       Test("if an etag is present, should only return the resource if it doesn't match the etag") {
         serveRoute(staticResourcesGetServerEndpoint[F](emptyInput)(classLoader, "test"))
           .use { port =>


### PR DESCRIPTION
Closes #4715

It seems that the call to `.getRealPath()` was unnecessary, as later in `resolveSystemPathUrl` there's also a `resolved.toRealPath(LinkOption.NOFOLLOW_LINKS)` call. This is done after checking, if the file exists. That way, we can simplify the logic and remove one `MonadError.blocking` call.