### PR TITLE
Fixed telemetry request duration unit

### DIFF
--- a/metrics/opentelemetry-metrics/src/main/scala/sttp/tapir/server/metrics/opentelemetry/OpenTelemetryMetrics.scala
+++ b/metrics/opentelemetry-metrics/src/main/scala/sttp/tapir/server/metrics/opentelemetry/OpenTelemetryMetrics.scala
@@ -157,7 +157,7 @@ object OpenTelemetryMetrics {
       meter
         .histogramBuilder("http.server.request.duration")
         .setDescription("Duration of HTTP requests")
-        .setUnit("s")
+        .setUnit("ms")
         .build(),
       onRequest = (req, recorder, m) =>
         m.eval {


### PR DESCRIPTION
Hi!

I've noticed, that the `http.server.request.duration` OpenTelemetry metric is calculated in milliseconds, but the declared histogram unit is `s`, which results in some crazy response times reported.