### PR TITLE
Fix filename decoding in http4s multipart handling

### DIFF
--- a/server/armeria-server/cats/src/test/scala/sttp/tapir/server/armeria/cats/ArmeriaCatsServerTest.scala
+++ b/server/armeria-server/cats/src/test/scala/sttp/tapir/server/armeria/cats/ArmeriaCatsServerTest.scala
@@ -16,8 +16,10 @@ class ArmeriaCatsServerTest extends TestSuite {
     def drainFs2(stream: Fs2Streams[IO]#BinaryStream): IO[Unit] =
       stream.compile.drain.void
 
-    new AllServerTests(createServerTest, interpreter, backend, basic = false, options = false, maxContentLength = false).tests() ++
+    new AllServerTests(createServerTest, interpreter, backend, basic = false, options = false, maxContentLength = false, multipart = false)
+      .tests() ++
       new ServerBasicTests(createServerTest, interpreter, supportsUrlEncodedPathSegments = false, maxContentLength = false).tests() ++
-      new ServerStreamingTests(createServerTest).tests(Fs2Streams[IO])(drainFs2)
+      new ServerStreamingTests(createServerTest).tests(Fs2Streams[IO])(drainFs2) ++
+      new ServerMultipartTests(createServerTest, utf8FileNameSupport = false, maxContentLengthSupport = false).tests()
   }
 }

--- a/server/armeria-server/src/main/scala/sttp/tapir/server/armeria/ArmeriaRequestBody.scala
+++ b/server/armeria-server/src/main/scala/sttp/tapir/server/armeria/ArmeriaRequestBody.scala
@@ -14,6 +14,7 @@ import java.io.ByteArrayInputStream
 import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ExecutionContext, Future}
+import java.nio.charset.StandardCharsets
 
 private[armeria] final class ArmeriaRequestBody[F[_], S <: Streams[S]](
     serverOptions: ArmeriaServerOptions[F],

--- a/server/armeria-server/src/test/scala/sttp/tapir/server/armeria/ArmeriaFutureServerTest.scala
+++ b/server/armeria-server/src/test/scala/sttp/tapir/server/armeria/ArmeriaFutureServerTest.scala
@@ -15,8 +15,10 @@ class ArmeriaFutureServerTest extends TestSuite {
     val interpreter = new ArmeriaTestFutureServerInterpreter()
     val createServerTest = new DefaultCreateServerTest(backend, interpreter)
 
-    new AllServerTests(createServerTest, interpreter, backend, basic = false, options = false, maxContentLength = false).tests() ++
+    new AllServerTests(createServerTest, interpreter, backend, basic = false, options = false, maxContentLength = false, multipart = false)
+      .tests() ++
       new ServerBasicTests(createServerTest, interpreter, supportsUrlEncodedPathSegments = false, maxContentLength = false).tests() ++
-      new ServerStreamingTests(createServerTest, maxLengthSupported = false).tests(ArmeriaStreams)(_ => Future.unit)
+      new ServerStreamingTests(createServerTest, maxLengthSupported = false).tests(ArmeriaStreams)(_ => Future.unit) ++
+      new ServerMultipartTests(createServerTest, utf8FileNameSupport = false, maxContentLengthSupport = false).tests()
   }
 }

--- a/server/armeria-server/zio/src/test/scala/sttp/tapir/server/armeria/zio/ArmeriaZioServerTest.scala
+++ b/server/armeria-server/zio/src/test/scala/sttp/tapir/server/armeria/zio/ArmeriaZioServerTest.scala
@@ -19,8 +19,10 @@ class ArmeriaZioServerTest extends TestSuite {
     def drainZStream(zStream: ZioStreams.BinaryStream): Task[Unit] =
       zStream.run(ZSink.drain)
 
-    new AllServerTests(createServerTest, interpreter, backend, basic = false, options = false, maxContentLength = false).tests() ++
+    new AllServerTests(createServerTest, interpreter, backend, basic = false, options = false, maxContentLength = false, multipart = false)
+      .tests() ++
       new ServerBasicTests(createServerTest, interpreter, supportsUrlEncodedPathSegments = false, maxContentLength = false).tests() ++
-      new ServerStreamingTests(createServerTest).tests(ZioStreams)(drainZStream)
+      new ServerStreamingTests(createServerTest).tests(ZioStreams)(drainZStream) ++
+      new ServerMultipartTests(createServerTest, utf8FileNameSupport = false, maxContentLengthSupport = false).tests()
   }
 }

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestBody.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/Http4sRequestBody.scala
@@ -85,13 +85,18 @@ private[http4s] class Http4sRequestBody[F[_]: Async](
 
   private def toRawPart[R](serverRequest: ServerRequest, part: multipart.Part[F], partType: RawBodyType[R]): F[Part[R]] = {
     val dispositionParams = part.headers.get[`Content-Disposition`].map(_.parameters).getOrElse(Map.empty)
+
+    // #4730: filenames need to be treated separately, as part.filename decodes the name using UTF-8, otherwise an incorrect encoding is used
+    var otherDispositionParams = dispositionParams.map { case (k, v) => k.toString -> v } - Part.NameDispositionParam
+    part.filename.foreach(f => otherDispositionParams += Part.FileNameDispositionParam -> f)
+
     val charset = part.headers.get[`Content-Type`].flatMap(_.charset)
     toRawFromStream(serverRequest, part.body, partType, charset, maxBytes = None)
       .map(r =>
         Part(
           part.name.getOrElse(""),
           r.value,
-          otherDispositionParams = dispositionParams.map { case (k, v) => k.toString -> v } - Part.NameDispositionParam,
+          otherDispositionParams = otherDispositionParams,
           headers = part.headers.headers.map(h => Header(h.name.toString, h.value))
         )
       )

--- a/server/jdkhttp-server/src/test/scala/sttp/tapir/server/jdkhttp/JdkHttpServerTest.scala
+++ b/server/jdkhttp-server/src/test/scala/sttp/tapir/server/jdkhttp/JdkHttpServerTest.scala
@@ -36,7 +36,8 @@ class JdkHttpServerTest extends TestSuite with EitherValues {
           val createServerTest = new DefaultCreateServerTest(backend, interpreter)
 
           new ServerBasicTests(createServerTest, interpreter, invulnerableToUnsanitizedHeaders = false).tests() ++
-            new AllServerTests(createServerTest, interpreter, backend, basic = false).tests()
+            new AllServerTests(createServerTest, interpreter, backend, basic = false, multipart = false).tests() ++
+            new ServerMultipartTests(createServerTest, utf8FileNameSupport = false).tests()
         })
     }
 }

--- a/tests/src/main/scalajs/sttp/tapir/tests/TestUtilExtensions.scala
+++ b/tests/src/main/scalajs/sttp/tapir/tests/TestUtilExtensions.scala
@@ -14,10 +14,12 @@ trait Blob extends js.Object {
 }
 
 trait TestUtilExtensions {
-  def writeToFile(s: String): File = {
+  def writeToFile(s: String): File = writeToFile("test", "tapir", s)
+
+  def writeToFile(fileName: String, suffix: String, s: String): File = {
     new File(
       Iterable(s.getBytes.toTypedArray.asInstanceOf[BlobPart]).toJSIterable,
-      "test.tapir"
+      s"$fileName.$suffix"
     )
   }
 

--- a/tests/src/main/scalajvm/sttp/tapir/tests/TestUtilExtensions.scala
+++ b/tests/src/main/scalajvm/sttp/tapir/tests/TestUtilExtensions.scala
@@ -6,8 +6,10 @@ import scala.concurrent.Future
 import scala.io.Source
 
 trait TestUtilExtensions {
-  def writeToFile(s: String): File = {
-    val f = File.createTempFile("test", "tapir")
+  def writeToFile(s: String): File = writeToFile("test", "tapir", s)
+
+  def writeToFile(fileName: String, suffix: String, s: String): File = {
+    val f = File.createTempFile(fileName, suffix)
     new PrintWriter(f) { write(s); close() }
     f.deleteOnExit()
     f

--- a/tests/src/main/scalanative/sttp/tapir/tests/TestUtilExtensions.scala
+++ b/tests/src/main/scalanative/sttp/tapir/tests/TestUtilExtensions.scala
@@ -6,8 +6,10 @@ import scala.concurrent.Future
 import scala.io.Source
 
 trait TestUtilExtensions {
-  def writeToFile(s: String): File = {
-    val f = File.createTempFile("test", "tapir")
+  def writeToFile(s: String): File = writeToFile("test", "tapir", s)
+
+  def writeToFile(fileName: String, suffix: String, s: String): File = {
+    val f = File.createTempFile(fileName, suffix)
     new PrintWriter(f) { write(s); close() }
     f.deleteOnExit()
     f


### PR DESCRIPTION
Closes #4730 

Not supported in Armeria & JDK-builtin server interpreters