### PR TITLE
Use the current Ox scope when running a Netty sync-server to create threads (forks)

### DIFF
--- a/perf-tests/README.md
+++ b/perf-tests/README.md
@@ -12,9 +12,9 @@ perfTests/runMain sttp.tapir.perf.apis.ServerRunner http4s.TapirMulti
 Run it without server name to see a list of all available names. 
 Exception: If you're testing `NettySyncServer` (tapir-server-netty-sync), its server runner is located elsewhere:
 ```
-nettyServerSync3/Test/runMain sttp.tapir.netty.sync.perf.NettySyncServerRunner
+nettyServerSync3/Test/runMain sttp.tapir.server.netty.sync.perf.NettySyncServerRunner
 ```
-This is caused by `perf-tests` using Scala 2.13 forced by Gatling, while `NettySyncServer` is written excluisively for Scala 3.
+This is caused by `perf-tests` using Scala 2.13 forced by Gatling, while `NettySyncServer` is written exclusively for Scala 3.
 
 ## Configuring and running simulations
 
@@ -37,7 +37,7 @@ If not set, default values will be used (see `sttp.tapir.perf.CommonSimulations`
 
 ## Profiling 
 
-To atach the profiler to a running server, it is recommended to use [async-profiler](https://github.com/async-profiler/async-profiler).
+To attach the profiler to a running server, it is recommended to use [async-profiler](https://github.com/async-profiler/async-profiler).
 Start the profiler by calling:
 ```
 asprof -e cpu,alloc,lock -f profile.jfr <PID>

--- a/server/netty-server/sync/src/test/scala/sttp/tapir/server/netty/sync/NettySyncTestServerInterpreter.scala
+++ b/server/netty-server/sync/src/test/scala/sttp/tapir/server/netty/sync/NettySyncTestServerInterpreter.scala
@@ -32,15 +32,7 @@ class NettySyncTestServerInterpreter(eventLoopGroup: NioEventLoopGroup)
   override def server(
       routes: NonEmptyList[IdRoute],
       gracefulShutdownTimeout: Option[FiniteDuration] = None
-  ): Resource[IO, Port] = {
-    val config =
-      NettyConfig.default.eventLoopGroup(eventLoopGroup).randomPort.withDontShutdownEventLoopGroupOnClose.noGracefulShutdown
-    val customizedConfig = gracefulShutdownTimeout.map(config.withGracefulShutdownTimeout).getOrElse(config)
-    val options = NettySyncServerOptions.default
-    val bind = IO.blocking(NettySyncServer(options, customizedConfig).start(Route.combine(routes.toList)))
-
-    Resource.make(bind)(server => IO.blocking(server.stop())).map(_.port)
-  }
+  ): Resource[IO, Port] = throw new UnsupportedOperationException // instead, scoped* variants are used by NettySyncCreateServerTest
 
   def scopedServerWithRoutesStop(
       routes: NonEmptyList[IdRoute],
@@ -50,7 +42,7 @@ class NettySyncTestServerInterpreter(eventLoopGroup: NioEventLoopGroup)
       NettyConfig.default.eventLoopGroup(eventLoopGroup).randomPort.withDontShutdownEventLoopGroupOnClose.noGracefulShutdown
     val customizedConfig = gracefulShutdownTimeout.map(config.withGracefulShutdownTimeout).getOrElse(config)
     val options = NettySyncServerOptions.default
-    useInScope(NettySyncServer(options, customizedConfig).start(Route.combine(routes.toList)))(_.stop())
+    useInScope(NettySyncServer(options, customizedConfig).addRoute(Route.combine(routes.toList)).start())(_.stop())
 
   def scopedServerWithInterceptorsStop(
       endpoint: ServerEndpoint[OxStreams with WebSockets, Identity],

--- a/server/netty-server/sync/src/test/scala/sttp/tapir/server/netty/sync/perf/NettySyncServerRunner.scala
+++ b/server/netty-server/sync/src/test/scala/sttp/tapir/server/netty/sync/perf/NettySyncServerRunner.scala
@@ -74,7 +74,7 @@ object NettySyncServerRunner {
     )
   val wsServerEndpoint = wsEndpoint.handleSuccess(_ => wsPipe)
 
-  val endpoints = genEndpointsId(1)
+  val endpoints = genEndpointsId(128)
 
   def main(args: Array[String]): Unit = {
     val declaredPort = 8080


### PR DESCRIPTION
Closes #4747