### PR TITLE
Adds support for otel4s metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1122,8 +1122,24 @@ lazy val otel4sTracing: ProjectMatrix = (projectMatrix in file("tracing/otel4s-t
   .settings(
     name := "tapir-otel4s-tracing",
     libraryDependencies ++= Seq(
-      "io.opentelemetry.semconv" % "opentelemetry-semconv" % Versions.openTelemetrySemconvVersion,
+      "org.typelevel" %% "otel4s-semconv" % Versions.otel4s,
       "org.typelevel" %% "otel4s-oteljava" % Versions.otel4s,
+      "io.opentelemetry.semconv" % "opentelemetry-semconv" % Versions.openTelemetrySemconvVersion % Test,
+      "org.typelevel" %% "otel4s-oteljava-testkit" % Versions.otel4s % Test,
+      scalaTest.value % Test
+    )
+  )
+  .jvmPlatform(scalaVersions = scala2_13And3Versions, settings = commonJvmSettings)
+  .dependsOn(serverCore % CompileAndTest, catsEffect % Test)
+
+lazy val otel4sMetrics: ProjectMatrix = (projectMatrix in file("metrics/otel4s-metrics"))
+  .settings(commonSettings)
+  .settings(
+    name := "tapir-otel4s-metrics",
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "otel4s-semconv" % Versions.otel4s,
+      "org.typelevel" %% "otel4s-oteljava" % Versions.otel4s,
+      "io.opentelemetry.semconv" % "opentelemetry-semconv" % Versions.openTelemetrySemconvVersion % Test,
       "org.typelevel" %% "otel4s-oteljava-testkit" % Versions.otel4s % Test,
       scalaTest.value % Test
     )
@@ -2237,6 +2253,7 @@ lazy val examples: ProjectMatrix = (projectMatrix in file("examples"))
     opentelemetryMetrics,
     opentelemetryTracing,
     otel4sTracing,
+    otel4sMetrics,
     pekkoHttpServer,
     picklerJson,
     prometheusMetrics,
@@ -2306,6 +2323,7 @@ lazy val documentation: ProjectMatrix = (projectMatrix in file("generated-doc"))
     opentelemetryMetrics,
     opentelemetryTracing,
     otel4sTracing,
+    otel4sMetrics,
     pekkoHttpServer,
     picklerJson,
     playClient,

--- a/examples/src/main/scala/sttp/tapir/examples/observability/Otel4sMetricsExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/Otel4sMetricsExample.scala
@@ -1,0 +1,117 @@
+// {cat=Observability; effects=cats-effect; server=Netty; json=circe}: Otel4s collecting metrics
+
+//> using dep com.softwaremill.sttp.tapir::tapir-core:1.11.43
+//> using dep com.softwaremill.sttp.tapir::tapir-netty-server-cats:1.11.43
+//> using dep com.softwaremill.sttp.tapir::tapir-json-circe:1.11.43
+//> using dep com.softwaremill.sttp.tapir::tapir-otel4s-metrics:1.11.43
+//> using dep "org.typelevel::otel4s-oteljava:0.13.1"
+//> using deps io.opentelemetry:opentelemetry-exporter-otlp:1.53.0
+//> using dep "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.53.0"
+//> using dep ch.qos.logback:logback-classic:1.5.18
+
+package sttp.tapir.examples.observability
+
+import cats.effect
+import cats.effect.std.Dispatcher
+import cats.effect.{IO, IOApp}
+import io.circe.generic.auto.*
+import sttp.tapir.*
+import sttp.tapir.generic.auto.*
+import sttp.tapir.json.circe.jsonBody
+import sttp.tapir.server.netty.cats.{NettyCatsServer, NettyCatsServerOptions}
+import sttp.tapir.server.metrics.otel4s.Otel4sMetrics
+import org.slf4j.{Logger, LoggerFactory}
+import org.typelevel.otel4s.metrics.Meter
+import org.typelevel.otel4s.oteljava.OtelJava
+
+import scala.concurrent.duration.*
+import sttp.tapir.server.ServerEndpoint
+
+import scala.io.StdIn
+
+/** This example application demonstrates how to implement metrics in a Scala application using the <a
+  * href="https://github.com/typelevel/otel4s"> otel4s library </a>. More info about oltel4s you may find <a
+  * href="https://typelevel.org/otel4s/">here</a>
+  *
+  * In order to run otel collector and collect metrics in Prometheus format, you can run it using Docker with the following command:
+  * {{{
+  *   cat > otel-config.yaml << 'EOF'
+  *   receivers:
+  *     otlp:
+  *       protocols:
+  *         grpc:
+  *           endpoint: 0.0.0.0:4317
+  *   exporters:
+  *     prometheus:
+  *       endpoint: 0.0.0.0:8889
+  *   service:
+  *     pipelines:
+  *       metrics:
+  *         receivers: [otlp]
+  *         exporters: [prometheus]
+  *   EOF
+  *
+  *   docker run -p 4317:4317 -p 8889:8889 -v $(pwd)/otel-config.yaml:/etc/otelcol-contrib/config.yaml otel/opentelemetry-collector-contrib:latest
+  * }}}
+  * You can find the collected metrics in prometheus format at http://localhost:8889/metrics
+  */
+object Otel4sMetricsExample extends IOApp.Simple:
+  private val logger: Logger = LoggerFactory.getLogger(this.getClass.getName)
+
+  override def run: IO[Unit] = otel
+    .use { otel4s =>
+      otel4s.meterProvider
+        .get("sttp.tapir.examples.observability")
+        .flatMap { case given Meter[IO] => server() }
+    }
+
+  private def server()(using meter: Meter[IO]): IO[Unit] =
+    Dispatcher
+      .parallel[IO]
+      .map(dispatcher =>
+        NettyCatsServer(
+          NettyCatsServerOptions
+            .customiseInterceptors(dispatcher)
+            .metricsInterceptor(Otel4sMetrics.default(meter).metricsInterceptor())
+            .options
+        )
+      )
+      .use { server =>
+        for {
+          bind <- server
+            .port(8080)
+            .host("localhost")
+            .addEndpoint(personEndpoint)
+            .start()
+          _ <- IO
+            .blocking {
+              logger.info(s"""Server started. Try it with: curl -X POST ${bind.hostName}:${bind.port}/person -d '{"name": "Jacob"}'""")
+              logger.info("Press ENTER key to exit.")
+              StdIn.readLine()
+
+            }
+            .guarantee(bind.stop())
+        } yield ()
+      }
+
+  private def otel: effect.Resource[IO, OtelJava[IO]] = {
+    // Please notice in your, production cases could be better to use env variable instead.
+    // Under following link you may find more details about configuration https://typelevel.org/otel4s/sdk/configuration.html
+    System.setProperty("otel.java.global-autoconfigure.enabled", "true")
+    System.setProperty("otel.service.name", "Otel4s-Metrics-Example")
+    OtelJava.autoConfigured[IO]()
+  }
+
+  case class Person(name: String)
+
+  // Simple endpoint returning 200 or 400 response with string body
+  val personEndpoint: ServerEndpoint[Any, IO] =
+    endpoint.post
+      .in("person")
+      .in(jsonBody[Person])
+      .out(stringBody)
+      .errorOut(stringBody)
+      .serverLogic { p =>
+        IO.sleep(3.seconds) *>
+          IO.pure(Either.cond(p.name == "Jacob", "Welcome", "Unauthorized"))
+      }

--- a/metrics/otel4s-metrics/src/main/scala/sttp/tapir/server/metrics/otel4s/Otel4sMetrics.scala
+++ b/metrics/otel4s-metrics/src/main/scala/sttp/tapir/server/metrics/otel4s/Otel4sMetrics.scala
@@ -1,0 +1,162 @@
+package sttp.tapir.server.metrics.otel4s
+
+import org.typelevel.otel4s.{Attribute, Attributes}
+import org.typelevel.otel4s.metrics.{Counter, Histogram, Meter}
+import org.typelevel.otel4s.semconv.attributes.{ErrorAttributes, HttpAttributes, UrlAttributes}
+import sttp.tapir.server.interceptor.metrics.MetricsRequestInterceptor
+import sttp.tapir.server.metrics.{EndpointMetric, Metric, MetricLabelsTyped}
+import sttp.tapir.AnyEndpoint
+import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.model.ServerResponse
+
+import java.time.{Duration, Instant}
+
+case class Otel4sMetrics[F[_]](metrics: List[Metric[F, _]]) {
+
+  import Otel4sMetrics.*
+
+  /** Registers a `http.server.active_requests` up-down-counter (assuming default labels). */
+  def addRequestsActive(meter: Meter[F], labels: MetricLabels = DefaultMetricLabels): Otel4sMetrics[F] =
+    copy(metrics = metrics :+ requestActive(meter, labels))
+
+  /** Registers a `http.server.requests.total` counter (assuming default labels). */
+  def addRequestsTotal(meter: Meter[F], labels: MetricLabels = DefaultMetricLabels): Otel4sMetrics[F] =
+    copy(metrics = metrics :+ requestTotal(meter, labels))
+
+  /** Registers a `http.server.request.duration` histogram (assuming default labels). */
+  def addRequestsDuration(meter: Meter[F], labels: MetricLabels = DefaultMetricLabels): Otel4sMetrics[F] =
+    copy(metrics = metrics :+ requestDuration(meter, labels))
+
+  /** Registers a custom metric. */
+  def addCustom(m: Metric[F, _]): Otel4sMetrics[F] = copy(metrics = metrics :+ m)
+
+  /** The interceptor which can be added to a server's options, to enable metrics collection. */
+  def metricsInterceptor(ignoreEndpoints: Seq[AnyEndpoint] = Seq.empty): MetricsRequestInterceptor[F] =
+    new MetricsRequestInterceptor[F](metrics, ignoreEndpoints)
+}
+
+object Otel4sMetrics {
+  private type MetricLabels = MetricLabelsTyped[Attribute[_]]
+
+  /** Using the default labels, registers the following metrics:
+    *
+    *   - `http.server.active_requests` (up-down-counter)
+    *   - `http.server.requests.total` (counter)
+    *   - `http.server.request.duration` (histogram)
+    */
+  def default[F[_]](meter: Meter[F], labels: MetricLabels = DefaultMetricLabels): Otel4sMetrics[F] =
+    Otel4sMetrics(
+      List[Metric[F, _]](
+        requestActive(meter, labels),
+        requestTotal(meter, labels),
+        requestDuration(meter, labels)
+      )
+    )
+
+  /** Default labels for OpenTelemetry-compliant metrics, as recommended here:
+    * https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#http-server
+    *
+    *   - `http.request.method` - HTTP request method (e.g., GET, POST).
+    *   - `url.scheme` - the scheme of the request URL (e.g., http, https).
+    *   - `http.route` - the request path or route template.
+    *   - `http.response.status_code` - HTTP response status code (200, 404, etc.).
+    */
+  private val DefaultMetricLabels: MetricLabels = MetricLabelsTyped[Attribute[_]](
+    forRequest = List(
+      { case (ep, req) => HttpAttributes.HttpRequestMethod(req.method.method) },
+      { case (_, req) => UrlAttributes.UrlScheme(req.uri.scheme.getOrElse("unknown")) },
+      { case (ep, _) => HttpAttributes.HttpRoute(ep.showPathTemplate(showQueryParam = None)) }
+    ),
+    forResponse = List(
+      {
+        case Right(r) => Some(HttpAttributes.HttpResponseStatusCode(r.code.code.toLong))
+        case Left(ex) => Some(HttpAttributes.HttpResponseStatusCode(500))
+      },
+      {
+        case Right(_) => None
+        case Left(ex) => Some(ErrorAttributes.ErrorType(ex.getClass.getName))
+      }
+    )
+  )
+
+  private def requestActive[F[_]](meter: Meter[F], labels: MetricLabels): Metric[F, ?] =
+    Metric(
+      metric = meter
+        .upDownCounter[Long]("http.server.active_requests")
+        .withDescription("Active HTTP requests")
+        .withUnit("1")
+        .create,
+      onRequest = (req, counterM, m) =>
+        m.map(counterM) { counter =>
+          EndpointMetric()
+            .onEndpointRequest(ep => counter.inc(requestAttrs(labels, ep, req)))
+            .onResponseBody((ep, _) => counter.dec(requestAttrs(labels, ep, req)))
+            .onException((ep, _) => counter.dec(requestAttrs(labels, ep, req)))
+        }
+    )
+
+  private def requestTotal[F[_]](meter: Meter[F], labels: MetricLabels): Metric[F, F[Counter[F, Long]]] =
+    Metric(
+      metric = meter
+        .counter[Long]("http.server.requests.total")
+        .withDescription("Total HTTP requests")
+        .withUnit("1")
+        .create,
+      onRequest = (req, counterM, m) =>
+        m.map(counterM) { counter =>
+          EndpointMetric()
+            .onResponseBody { (ep, res) =>
+              counter.inc(requestAttrs(labels, ep, req) ++ responseAttrs(labels, Right(res), None))
+            }
+            .onException { (ep, ex) =>
+              counter.inc(requestAttrs(labels, ep, req) ++ responseAttrs(labels, Left(ex), None))
+            }
+        }
+    )
+
+  private def requestDuration[F[_]](meter: Meter[F], labels: MetricLabels): Metric[F, F[Histogram[F, Double]]] =
+    Metric(
+      metric = meter
+        .histogram[Double]("http.server.request.duration")
+        .withDescription("Duration of HTTP requests")
+        .withUnit("ms")
+        .create,
+      onRequest = (req, recorderM, m) =>
+        m.map(recorderM) { recorder =>
+          val requestStart = Instant.now()
+
+          def duration = Duration.between(requestStart, Instant.now()).toMillis.toDouble
+
+          EndpointMetric()
+            .onResponseHeaders { (ep, res) =>
+              recorder.record(
+                duration,
+                requestAttrs(labels, ep, req) ++ responseAttrs(labels, Right(res), Some(labels.forResponsePhase.headersValue))
+              )
+            }
+            .onResponseBody { (ep, res) =>
+              recorder.record(
+                duration,
+                requestAttrs(labels, ep, req) ++ responseAttrs(labels, Right(res), Some(labels.forResponsePhase.bodyValue))
+              )
+            }
+            .onException { (ep, ex) =>
+              recorder.record(
+                duration,
+                requestAttrs(labels, ep, req) ++ responseAttrs(labels, Left(ex), None)
+              )
+            }
+        }
+    )
+
+  private[otel4s] def requestAttrs(l: MetricLabels, ep: AnyEndpoint, req: ServerRequest): Attributes =
+    Attributes.newBuilder
+      .addAll(l.forRequest.map(label => label(ep, req)))
+      .result()
+
+  private[otel4s] def responseAttrs(l: MetricLabels, res: Either[Throwable, ServerResponse[_]], phase: Option[String]): Attributes =
+    Attributes.newBuilder
+      .addAll(l.forResponse.flatMap(label => label(res)))
+      .addAll(phase.map(v => Attribute.from(l.forResponsePhase.name, v)))
+      .result()
+}

--- a/metrics/otel4s-metrics/src/test/scala/sttp/tapir/server/metrics/otel4s/Otel4sMetricsTest.scala
+++ b/metrics/otel4s-metrics/src/test/scala/sttp/tapir/server/metrics/otel4s/Otel4sMetricsTest.scala
@@ -1,0 +1,340 @@
+package sttp.tapir.server.metrics.otel4s
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.traverse.*
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator
+import io.opentelemetry.api.common.{AttributeKey, Attributes}
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.sdk.metrics.data.{HistogramPointData, LongPointData, MetricData, MetricDataType}
+import io.opentelemetry.semconv.{ErrorAttributes, HttpAttributes, UrlAttributes}
+import org.scalatest.compatible.Assertion
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.typelevel.otel4s.oteljava.testkit.OtelJavaTestkit
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.metrics.Meter
+import sttp.capabilities.Streams
+import sttp.model.*
+import sttp.model.Uri.*
+import sttp.monad.MonadError
+import sttp.tapir.{AttributeKey => _, *}
+import sttp.tapir.TestUtil.serverRequestFromUri
+import sttp.tapir.capabilities.NoStreams
+import sttp.tapir.integ.cats.effect.CatsMonadError
+import sttp.tapir.model.ServerRequest
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.server.TestUtil.StringToResponseBody
+import sttp.tapir.server.interceptor.exception.{DefaultExceptionHandler, ExceptionInterceptor}
+import sttp.tapir.server.interpreter.*
+import sttp.tapir.server.metrics.{EndpointMetric, Metric, MetricLabelsTyped}
+import sttp.tapir.server.metrics.otel4s.Otel4sMetrics.{requestAttrs, responseAttrs}
+
+import scala.jdk.CollectionConverters.*
+import scala.util.{Success, Try}
+
+class Otel4sMetricsTest extends AsyncFlatSpec with Matchers {
+  implicit val bodyListener: BodyListener[IO, String] = new BodyListener[IO, String] {
+    override def onComplete(body: String)(cb: Try[Unit] => IO[Unit]): IO[String] = cb(Success(())).map(_ => body)
+  }
+  implicit val ioErr: MonadError[IO] = new CatsMonadError[IO]()
+
+  private val ioTestRequestBody = new RequestBody[IO, NoStreams] {
+    override def toRaw[R](serverRequest: ServerRequest, bodyType: RawBodyType[R], maxBytes: Option[Long]): IO[RawValue[R]] =
+      IO.pure(RawValue(null.asInstanceOf[R], Seq.empty))
+    override val streams: Streams[NoStreams] = NoStreams
+    override def toStream(serverRequest: ServerRequest, maxBytes: Option[Long]): streams.BinaryStream = ???
+  }
+
+  it should "collect metrics from all successful requests" in {
+    testEndpointWithMetrics(
+      endpoint
+        .in("person")
+        .in(query[String]("name"))
+        .out(stringBody)
+        .errorOut(stringBody)
+        .serverLogic[IO](_ => IO(Right("hello"))),
+      serverRequestFromUri(uri"http://example.com/person?name=Adam"), // collect metrics, counter increments
+      serverRequestFromUri(uri"http://example.com/person?name=Eva"), // collect metrics, counter increments
+      serverRequestFromUri(uri"http://example.com/human?name=Adam") // doesn't collect metrics
+    )(
+      expectedCount = 2,
+      expectedStatusCode = 200,
+      isFailure = false
+    ).unsafeToFuture()
+  }
+
+  it should "collect metrics from successfully error requests" in {
+    testEndpointWithMetrics(
+      endpoint
+        .in("person")
+        .in(query[String]("name"))
+        .out(stringBody)
+        .errorOut(stringBody)
+        .serverLogic[IO](_ => IO(Left("Bad request"))),
+      serverRequestFromUri(uri"http://example.com/person?name=Adam"), // collect metrics, counter increments
+      serverRequestFromUri(uri"http://example.com/human?name=Adam") // doesn't collect metrics
+    )(
+      expectedCount = 1,
+      expectedStatusCode = 400,
+      isFailure = false
+    ).unsafeToFuture()
+  }
+
+  it should "collect metrics from failed requests" in {
+    testEndpointWithMetrics(
+      endpoint
+        .in("person")
+        .in(query[String]("name"))
+        .in(stringBody)
+        .out(stringBody)
+        .errorOut(stringBody)
+        .serverLogic[IO](_ => IO.raiseError(new RuntimeException("boom!"))),
+      serverRequestFromUri(uri"http://example.com/person?name=Adam"),
+      serverRequestFromUri(uri"http://example.com/person?name=Eva")
+    )(
+      expectedCount = 2,
+      expectedStatusCode = 500,
+      isFailure = true
+    ).unsafeToFuture()
+  }
+
+  it should "collect custom metrics from all successful requests" in {
+    testEndpointWithCustomMetrics(
+      endpoint
+        .in("person")
+        .in(query[String]("name"))
+        .out(stringBody)
+        .errorOut(stringBody)
+        .serverLogic[IO](_ => IO(Right("hello"))),
+      serverRequestFromUri(uri"http://example.com/person?name=Adam"), // collect metrics, counter increments
+      serverRequestFromUri(uri"http://example.com/person?name=Eva"), // collect metrics, counter increments
+      serverRequestFromUri(uri"http://example.com/human?name=Adam") // doesn't collect metrics
+    )(
+      isFailure = false
+    ).unsafeToFuture()
+  }
+
+  it should "collect custom metrics from successfully error requests" in {
+    testEndpointWithCustomMetrics(
+      endpoint
+        .in("person")
+        .in(query[String]("name"))
+        .out(stringBody)
+        .errorOut(stringBody)
+        .serverLogic[IO](_ => IO(Left("Bad request"))),
+      serverRequestFromUri(uri"http://example.com/person?name=Adam"), // collect metrics, counter increments
+      serverRequestFromUri(uri"http://example.com/human?name=Adam") // doesn't collect metrics
+    )(
+      isFailure = false
+    ).unsafeToFuture()
+  }
+
+  it should "collect custom metrics from failed requests" in {
+    testEndpointWithCustomMetrics(
+      endpoint
+        .in("person")
+        .in(query[String]("name"))
+        .in(stringBody)
+        .out(stringBody)
+        .errorOut(stringBody)
+        .serverLogic[IO](_ => IO.raiseError(new RuntimeException("boom!"))),
+      serverRequestFromUri(uri"http://example.com/person?name=Adam"),
+      serverRequestFromUri(uri"http://example.com/person?name=Eva")
+    )(
+      isFailure = true
+    ).unsafeToFuture()
+  }
+
+  private def testEndpointWithMetrics(endpoint: ServerEndpoint[Any, IO], requests: ServerRequest*)(
+      expectedCount: Int,
+      expectedStatusCode: Long,
+      isFailure: Boolean
+  ): IO[Assertion] =
+    OtelJavaTestkit
+      .inMemory[IO](textMapPropagators = List(W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance()))
+      .use(testkit =>
+        for {
+          meter <- testkit.meterProvider.get("Test Meter")
+          interpreter = new ServerInterpreter[Any, IO, String, NoStreams](
+            serverEndpoints = _ => List(endpoint),
+            requestBody = ioTestRequestBody,
+            toResponseBody = StringToResponseBody,
+            interceptors = List(
+              new ExceptionInterceptor(DefaultExceptionHandler[IO]),
+              Otel4sMetrics.default(meter).metricsInterceptor()
+            ),
+            deleteFile = _ => IO.pure(())
+          )
+          _ <- requests.traverse(interpreter.apply)
+          metrics <- testkit.collectMetrics[MetricData]
+        } yield {
+          metrics should have size 3
+
+          // asserts for metric "http.server.requests.total"
+          val requestsTotal = metrics.find(_.getName == "http.server.requests.total").head
+          requestsTotal.getType shouldBe MetricDataType.LONG_SUM
+          requestsTotal.getUnit shouldBe "1"
+          requestsTotal.getDescription shouldBe "Total HTTP requests"
+
+          val requestsTotalData = requestsTotal.getData.getPoints.asScala.toList.asInstanceOf[List[LongPointData]].head
+          requestsTotalData.getValue shouldBe expectedCount
+          if (isFailure) {
+            requestsTotalData.getAttributes shouldBe
+              Attributes
+                .builder()
+                .put(HttpAttributes.HTTP_REQUEST_METHOD, "GET")
+                .put(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, expectedStatusCode)
+                .put(HttpAttributes.HTTP_ROUTE, "/person")
+                .put(UrlAttributes.URL_SCHEME, "http")
+                .put(ErrorAttributes.ERROR_TYPE, "java.lang.RuntimeException")
+                .build()
+          } else {
+            requestsTotalData.getAttributes shouldBe
+              Attributes
+                .builder()
+                .put(HttpAttributes.HTTP_REQUEST_METHOD, "GET")
+                .put(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, expectedStatusCode)
+                .put(HttpAttributes.HTTP_ROUTE, "/person")
+                .put(UrlAttributes.URL_SCHEME, "http")
+                .build()
+          }
+
+          // asserts for metric "http.server.active_requests"
+          val activeRequests = metrics.find(_.getName == "http.server.active_requests").head
+          activeRequests.getType shouldBe MetricDataType.LONG_SUM
+          activeRequests.getUnit shouldBe "1"
+          activeRequests.getDescription shouldBe "Active HTTP requests"
+
+          val activeRequestsData = activeRequests.getData.getPoints.asScala.toList.asInstanceOf[List[LongPointData]].head
+          activeRequestsData.getValue shouldBe 0
+          activeRequestsData.getAttributes.size() shouldBe 3
+          activeRequestsData.getAttributes shouldBe
+            Attributes
+              .builder()
+              .put(HttpAttributes.HTTP_REQUEST_METHOD, "GET")
+              .put(HttpAttributes.HTTP_ROUTE, "/person")
+              .put(UrlAttributes.URL_SCHEME, "http")
+              .build()
+
+          // asserts for metric "http.server.request.duration"
+          val requestDuration = metrics.find(_.getName == "http.server.request.duration").head
+          requestDuration.getType shouldBe MetricDataType.HISTOGRAM
+          requestDuration.getUnit shouldBe "ms"
+          requestDuration.getDescription shouldBe "Duration of HTTP requests"
+
+          val requestDurationData = requestDuration.getData.getPoints.asScala.toList.asInstanceOf[List[HistogramPointData]]
+          if (isFailure) {
+            requestDurationData.map(_.getCount) shouldBe List(expectedCount)
+            requestDurationData.map(_.getAttributes) shouldBe List(
+              Attributes
+                .builder()
+                .put(HttpAttributes.HTTP_REQUEST_METHOD, "GET")
+                .put(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, expectedStatusCode)
+                .put(HttpAttributes.HTTP_ROUTE, "/person")
+                .put(UrlAttributes.URL_SCHEME, "http")
+                .put(ErrorAttributes.ERROR_TYPE, "java.lang.RuntimeException")
+                .build()
+            )
+          } else {
+            requestDurationData.map(_.getCount) shouldBe List(expectedCount, expectedCount)
+            requestDurationData.map(_.getAttributes) should contain theSameElementsAs List(
+              Attributes
+                .builder()
+                .put(HttpAttributes.HTTP_REQUEST_METHOD, "GET")
+                .put(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, expectedStatusCode)
+                .put(HttpAttributes.HTTP_ROUTE, "/person")
+                .put(UrlAttributes.URL_SCHEME, "http")
+                .put(AttributeKey.stringKey("phase"), "headers")
+                .build(),
+              Attributes
+                .builder()
+                .put(HttpAttributes.HTTP_REQUEST_METHOD, "GET")
+                .put(HttpAttributes.HTTP_RESPONSE_STATUS_CODE, expectedStatusCode)
+                .put(HttpAttributes.HTTP_ROUTE, "/person")
+                .put(UrlAttributes.URL_SCHEME, "http")
+                .put(AttributeKey.stringKey("phase"), "body")
+                .build()
+            )
+          }
+        }
+      )
+
+  private def testEndpointWithCustomMetrics(endpoint: ServerEndpoint[Any, IO], requests: ServerRequest*)(
+      isFailure: Boolean
+  ): IO[Assertion] = {
+    val labels = MetricLabelsTyped[Attribute[_]](
+      forRequest = List(
+        { (_, _) => Attribute.apply("custom.request.key", "value") }
+      ),
+      forResponse = List(
+        {
+          case Right(r) => Some(Attribute.apply("custom.response.key", "value"))
+          case Left(ex) => Some(Attribute.apply("custom.error.key", "value"))
+        }
+      )
+    )
+    val customGauge: Meter[IO] => Metric[IO, _] = meter =>
+      Metric(
+        metric = meter
+          .gauge[Long]("my.custom.gauge")
+          .withUnit("ms")
+          .withDescription("My custom Gauge")
+          .create,
+        onRequest = (req, gaugeM, m) =>
+          m.map(gaugeM) { gauge =>
+            EndpointMetric()
+              .onResponseBody((ep, res) => gauge.record(10, requestAttrs(labels, ep, req) ++ responseAttrs(labels, Right(res), None)))
+              .onException((ep, ex) => gauge.record(11, requestAttrs(labels, ep, req) ++ responseAttrs(labels, Left(ex), None)))
+          }
+      )
+
+    OtelJavaTestkit
+      .inMemory[IO](textMapPropagators = List(W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance()))
+      .use(testkit =>
+        for {
+          meter <- testkit.meterProvider.get("Test Meter Custom")
+          interpreter = new ServerInterpreter[Any, IO, String, NoStreams](
+            serverEndpoints = _ => List(endpoint),
+            requestBody = ioTestRequestBody,
+            toResponseBody = StringToResponseBody,
+            interceptors = List(
+              new ExceptionInterceptor(DefaultExceptionHandler[IO]),
+              Otel4sMetrics(List(customGauge(meter))).metricsInterceptor()
+            ),
+            deleteFile = _ => IO.pure(())
+          )
+          _ <- requests.traverse(interpreter.apply)
+          metrics <- testkit.collectMetrics[MetricData]
+        } yield {
+          metrics should have size 1
+
+          // asserts for metric "my.custom.gauge"
+          val requestsTotal = metrics.find(_.getName == "my.custom.gauge").head
+          requestsTotal.getType shouldBe MetricDataType.LONG_GAUGE
+          requestsTotal.getUnit shouldBe "ms"
+          requestsTotal.getDescription shouldBe "My custom Gauge"
+
+          val requestsTotalData = requestsTotal.getData.getPoints.asScala.toList.asInstanceOf[List[LongPointData]].head
+
+          if (isFailure) {
+            requestsTotalData.getValue shouldBe 11
+            requestsTotalData.getAttributes shouldBe
+              Attributes
+                .builder()
+                .put("custom.request.key", "value")
+                .put("custom.error.key", "value")
+                .build()
+          } else {
+            requestsTotalData.getValue shouldBe 10
+            requestsTotalData.getAttributes shouldBe
+              Attributes
+                .builder()
+                .put("custom.request.key", "value")
+                .put("custom.response.key", "value")
+                .build()
+          }
+        }
+      )
+  }
+}

--- a/server/core/src/main/scala/sttp/tapir/server/metrics/Metric.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/metrics/Metric.scala
@@ -40,6 +40,12 @@ case class MetricLabels(
   def valuesForResponse(ex: Throwable): List[String] = forResponse.flatMap { case (_, f) => f(Left(ex)).toList }
 }
 
+case class MetricLabelsTyped[A](
+    forRequest: List[(AnyEndpoint, ServerRequest) => A],
+    forResponse: List[Either[Throwable, ServerResponse[_]] => Option[A]],
+    forResponsePhase: ResponsePhaseLabel = ResponsePhaseLabel("phase", "headers", "body")
+)
+
 object MetricLabels {
 
   /** Labels request by path and method, response by status code */


### PR DESCRIPTION
# Adding otel4s OpenTelemetry metrics integration for Tapir

This PR adds support for OpenTelemetry **metrics** integration with Tapir using the [otel4s](https://typelevel.org/otel4s/) library.

It adds a new module `tapir-otel4s-metrics` which is inspired by the existing `tapir-opentelemetry-metrics` module and highly inspired by the `tapir-otel4s-tracing` module, especially the PR https://github.com/softwaremill/tapir/pull/4428 by @yannick-cw.

## Implementation Details

* `Otel4sMetrics` - Main _metrics interceptor_ class that handles default metrics creation and management
* Proper error handling and status code reporting

Small refactoring of `tapir-otel4s-tracing`:
* Replaces dependency to `"io.opentelemetry.semconv" % "opentelemetry-semconv"` by `"org.typelevel" %% "otel4s-semconv"` for `tapir-otel4s-tracing`, so that there are only dependencis to `otel4s` libraries in both modules now
