### PR TITLE
test: adding nested native zio route with tapir routes test

### DIFF
--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
@@ -38,7 +38,7 @@ class ZioHttpCompositionTest(
       basicRequest.get(uri"$baseUri/p1").send(backend).map(_.code shouldBe StatusCode.Ok) >>
         basicRequest.get(uri"$baseUri/p2").send(backend).map(_.code shouldBe StatusCode.Ok) >>
         basicRequest.get(uri"$baseUri/p3").send(backend).map(_.code shouldBe StatusCode.BadRequest) >>
-        basicRequest.get(uri"$baseUri/p4/p3").send(backend).map(_.code shouldBe StatusCode.Ok)
+        basicRequest.get(uri"$baseUri/p4/p1").send(backend).map(_.code shouldBe StatusCode.Ok)
     }
   )
 }


### PR DESCRIPTION
Test to show nesting Tapir ZIO routes with native zio paths fail