### PR TITLE
netty interpreter: Return 400 when the request URI is malformed

### DIFF
--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyServerRequest.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyServerRequest.scala
@@ -10,6 +10,9 @@ import sttp.tapir.server.netty.internal.RichNettyHttpHeaders
 import io.netty.handler.codec.http.FullHttpRequest
 
 case class NettyServerRequest(req: HttpRequest, attributes: AttributeMap = AttributeMap.Empty) extends ServerRequest {
+  // non-lazy, so that we can validate that the URI parses upfront
+  override val uri: Uri = Uri.unsafeParse(req.uri())
+
   override lazy val protocol: String = req.protocolVersion().text()
   override lazy val connectionInfo: ConnectionInfo = ConnectionInfo.NoInfo
   override lazy val underlying: Any = req
@@ -25,7 +28,7 @@ case class NettyServerRequest(req: HttpRequest, attributes: AttributeMap = Attri
   }
   override lazy val method: Method = Method.unsafeApply(req.method().name())
   override lazy val showShort: String = s"$method ${req.uri()}"
-  override lazy val uri: Uri = Uri.unsafeParse(req.uri())
+
   override lazy val pathSegments: List[String] = uri.pathSegments.segments.map(_.v).filter(_.nonEmpty).toList
   override lazy val headers: Seq[Header] = req.headers().toHeaderSeq ::: (req match {
     case full: FullHttpRequest => full.trailingHeaders().toHeaderSeq

--- a/server/netty-server/sync/src/test/scala/sttp/tapir/server/netty/sync/NettySyncServerTest.scala
+++ b/server/netty-server/sync/src/test/scala/sttp/tapir/server/netty/sync/NettySyncServerTest.scala
@@ -86,6 +86,16 @@ class NettySyncServerTest extends AsyncFunSuite with BeforeAndAfterAll {
               parseBytesToSSE(Flow.fromValues(Chunk.fromArray(bytes))).runToList() shouldBe List(sse1, sse2)
             }
         }
+      },
+      createServerTest.testServerLogic(
+        endpoint.get.in("hello").out(stringBody).handleSuccess(_ => "ok"),
+        testNameSuffix = "properly log invalid requests when the URL is malformed"
+      ) { (backend, baseUri) =>
+        IO.blocking:
+          val conn = new java.net.URL(s"$baseUri/hello?param=%%2G").openConnection().asInstanceOf[java.net.HttpURLConnection]
+          try
+            conn.getResponseCode() shouldBe 400
+          finally conn.disconnect
       }
     )
 }


### PR DESCRIPTION
Closes #4828