### PR TITLE
codegen: support alternative effect types for fs2 streaming

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -47,7 +47,8 @@ openapiXmlSerdeLib                    cats-xml                             The x
 openapiValidateNonDiscriminatedOneOfs true                                 Whether to fail if variants of a oneOf without a discriminator cannot be disambiguated.
 openapiMaxSchemasPerFile              400                                  Maximum number of schemas to generate in a single file (tweak if hitting javac class size limits).
 openapiAdditionalPackages             Nil                                  Additional packageName/swaggerFile pairs for generating from multiple schemas 
-openapiStreamingImplementation        fs2                                  Implementation for streamTextBody. Supports: akka, fs2, pekko, zio
+openapiStreamingImplementation        fs2                                  Implementation for streamTextBody. Supports: akka, fs2, pekko, zio.
+                                                                           fs2 defaults to using the IO effect -- an alternative effect type can be specified with fs2-my.fully.qualified.Effect
 openapiGenerateEndpointTypes          false                                Whether to emit explicit types for endpoint defns
 openapiDisableValidatorGeneration     false                                If true, we will not generate validation for constraints (min, max, pattern etc)
 openapiUseCustomJsoniterSerdes        false                                If true and openapiJsonSerdeLib = jsoniter, serdes will be generated to use custom 'openapi' make defns. May help with flaky compilation, but requires jsoniter-scala >= 2.36.0+

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -2,7 +2,6 @@ package sttp.tapir.codegen
 import io.circe.Json
 import sttp.tapir.codegen.RootGenerator.{indent, mapSchemaSimpleTypeToType, strippedToCamelCase}
 import sttp.tapir.codegen.JsonSerdeLib.JsonSerdeLib
-import sttp.tapir.codegen.StreamingImplementation.StreamingImplementation
 import sttp.tapir.codegen.XmlSerdeLib.XmlSerdeLib
 import sttp.tapir.codegen.openapi.models.OpenapiModels.{
   OpenapiDocument,
@@ -111,14 +110,14 @@ class EndpointGenerator {
   private[codegen] def allEndpoints: String = "generatedEndpoints"
 
   private def capabilityImpl(streamingImplementation: StreamingImplementation): String = streamingImplementation match {
-    case StreamingImplementation.Akka  => "sttp.capabilities.akka.AkkaStreams"
-    case StreamingImplementation.FS2   => "sttp.capabilities.fs2.Fs2Streams[cats.effect.IO]"
-    case StreamingImplementation.Pekko => "sttp.capabilities.pekko.PekkoStreams"
-    case StreamingImplementation.Zio   => "sttp.capabilities.zio.ZioStreams"
+    case Akka            => "sttp.capabilities.akka.AkkaStreams"
+    case FS2(effectType) => s"sttp.capabilities.fs2.Fs2Streams[$effectType]"
+    case Pekko           => "sttp.capabilities.pekko.PekkoStreams"
+    case Zio             => "sttp.capabilities.zio.ZioStreams"
   }
   private def capabilityType(streamingImplementation: StreamingImplementation): String = streamingImplementation match {
-    case StreamingImplementation.FS2 => "fs2.Stream[cats.effect.IO, Byte]"
-    case x                           => s"${capabilityImpl(x)}.BinaryStream"
+    case FS2(effectType) => s"fs2.Stream[$effectType, Byte]"
+    case x               => s"${capabilityImpl(x)}.BinaryStream"
   }
 
   def endpointDefs(

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -74,16 +74,19 @@ object RootGenerator {
     }
     val fs2WithEffect = """fs2-(.+)""".r
     val normalisedStreamingImplementation: StreamingImplementation = streamingImplementation.toLowerCase match {
-      case "akka"                    => Akka
-      case "fs2"                     => FS2()
-      case "pekko"                   => Pekko
-      case "zio"                     => Zio
-      case fs2WithEffect(effectType) => FS2(effectType)
+      case "akka"  => Akka
+      case "fs2"   => FS2()
+      case "pekko" => Pekko
+      case "zio"   => Zio
       case _ =>
-        System.err.println(
-          s"!!! Unrecognised value $streamingImplementation for streaming impl -- should be one of akka, fs2, pekko or zio. Defaulting to fs2 !!!"
-        )
-        FS2()
+        streamingImplementation match {
+          case fs2WithEffect(effectType) =>
+            FS2(effectType)
+            System.err.println(
+              s"!!! Unrecognised value $streamingImplementation for streaming impl -- should be one of akka, fs2, pekko or zio. Defaulting to fs2 !!!"
+            )
+            FS2()
+        }
     }
 
     val validators = if (generateValidators) ValidationGenerator.mkValidators(doc) else ValidationDefns.empty

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -26,10 +26,11 @@ object XmlSerdeLib extends Enumeration {
   val CatsXml, NoSupport = Value
   type XmlSerdeLib = Value
 }
-object StreamingImplementation extends Enumeration {
-  val Akka, FS2, Pekko, Zio = Value
-  type StreamingImplementation = Value
-}
+sealed trait StreamingImplementation
+object Akka extends StreamingImplementation
+case class FS2(effectType: String = "cats.effect.IO") extends StreamingImplementation
+object Pekko extends StreamingImplementation
+object Zio extends StreamingImplementation
 
 object RootGenerator {
 
@@ -71,16 +72,18 @@ object RootGenerator {
         )
         XmlSerdeLib.NoSupport
     }
-    val normalisedStreamingImplementation = streamingImplementation.toLowerCase match {
-      case "akka"  => StreamingImplementation.Akka
-      case "fs2"   => StreamingImplementation.FS2
-      case "pekko" => StreamingImplementation.Pekko
-      case "zio"   => StreamingImplementation.Zio
+    val fs2WithEffect = """fs2-(.+)""".r
+    val normalisedStreamingImplementation: StreamingImplementation = streamingImplementation.toLowerCase match {
+      case "akka"                    => Akka
+      case "fs2"                     => FS2()
+      case "pekko"                   => Pekko
+      case "zio"                     => Zio
+      case fs2WithEffect(effectType) => FS2(effectType)
       case _ =>
         System.err.println(
           s"!!! Unrecognised value $streamingImplementation for streaming impl -- should be one of akka, fs2, pekko or zio. Defaulting to fs2 !!!"
         )
-        StreamingImplementation.FS2
+        FS2()
     }
 
     val validators = if (generateValidators) ValidationGenerator.mkValidators(doc) else ValidationDefns.empty

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -82,6 +82,7 @@ object RootGenerator {
         streamingImplementation match {
           case fs2WithEffect(effectType) =>
             FS2(effectType)
+          case _ =>
             System.err.println(
               s"!!! Unrecognised value $streamingImplementation for streaming impl -- should be one of akka, fs2, pekko or zio. Defaulting to fs2 !!!"
             )

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -431,7 +431,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             targetScala3 = false,
             jsonSerdeLib = JsonSerdeLib.Circe,
             xmlSerdeLib = XmlSerdeLib.CatsXml,
-            streamingImplementation = StreamingImplementation.FS2,
+            streamingImplementation = FS2(),
             generateEndpointTypes = false,
             validators = ValidationDefns.empty,
             generateValidators = true

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -75,7 +75,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           targetScala3 = false,
           jsonSerdeLib = JsonSerdeLib.Circe,
           xmlSerdeLib = XmlSerdeLib.CatsXml,
-          streamingImplementation = StreamingImplementation.FS2,
+          streamingImplementation = FS2(),
           generateEndpointTypes = false,
           validators = ValidationDefns.empty,
           generateValidators = true
@@ -166,7 +166,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           targetScala3 = false,
           jsonSerdeLib = JsonSerdeLib.Circe,
           xmlSerdeLib = XmlSerdeLib.CatsXml,
-          streamingImplementation = StreamingImplementation.FS2,
+          streamingImplementation = FS2(),
           generateEndpointTypes = false,
           validators = ValidationDefns.empty,
           generateValidators = true
@@ -224,7 +224,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           targetScala3 = false,
           jsonSerdeLib = JsonSerdeLib.Circe,
           xmlSerdeLib = XmlSerdeLib.CatsXml,
-          streamingImplementation = StreamingImplementation.FS2,
+          streamingImplementation = FS2(),
           generateEndpointTypes = false,
           validators = ValidationDefns.empty,
           generateValidators = true

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -31,7 +31,7 @@ trait OpenapiCodegenKeys {
     settingKey[Boolean]("Whether to fail if variants of a oneOf without a discriminator cannot be disambiguated..")
   lazy val openapiMaxSchemasPerFile = settingKey[Int]("Maximum number of schemas to generate for a single file")
   lazy val openapiAdditionalPackages = settingKey[List[(String, File)]]("Addition package -> spec mappings to generate.")
-  lazy val openapiStreamingImplementation = settingKey[String]("Implementation for streamTextBody. Supports: akka, fs2, pekko, zio.")
+  lazy val openapiStreamingImplementation = settingKey[String]("Implementation for streamTextBody. Supports: akka, fs2(-EffectType)?, pekko, zio.")
   lazy val openapiGenerateEndpointTypes = settingKey[Boolean]("Whether to emit explicit types for endpoint defns")
   lazy val openapiDisableValidatorGeneration = settingKey[Boolean]("Set to true to disable validator generation")
   lazy val openapiUseCustomJsoniterSerdes = settingKey[Boolean](

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
@@ -136,13 +136,13 @@ object TapirGeneratedEndpoints {
       .in(jsonBody[ADTWithDiscriminatorNoMapping].description("Update an existent user in the store"))
       .out(jsonBody[ADTWithDiscriminator].description("successful operation"))
 
-  type PostXmlEndpointEndpoint = Endpoint[Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, Unit, sttp.capabilities.pekko.PekkoStreams.BinaryStream, sttp.capabilities.pekko.PekkoStreams]
+  type PostXmlEndpointEndpoint = Endpoint[Unit, fs2.Stream[injections.Types.A, Byte], Unit, fs2.Stream[injections.Types.A, Byte], sttp.capabilities.fs2.Fs2Streams[injections.Types.A]]
   lazy val postXmlEndpoint: PostXmlEndpointEndpoint =
     endpoint
       .post
       .in(("xml" / "endpoint"))
-      .in(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Pet], CodecFormat.Xml()))
-      .out(streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[Pet], CodecFormat.Xml()).description("An object"))
+      .in(streamBody(sttp.capabilities.fs2.Fs2Streams[injections.Types.A])(Schema.binary[Pet], CodecFormat.Xml()))
+      .out(streamBody(sttp.capabilities.fs2.Fs2Streams[injections.Types.A])(Schema.binary[Pet], CodecFormat.Xml()).description("An object"))
 
   type PostRecursiveSchemaEndpointEndpoint = Endpoint[Unit, Node, Unit, Node, Any]
   lazy val postRecursiveSchemaEndpoint: PostRecursiveSchemaEndpointEndpoint =

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file("."))
     version := "0.1",
     openapiJsonSerdeLib := "jsoniter",
     openapiXmlSerdeLib := "none",
-    openapiStreamingImplementation := "pekko",
+    openapiStreamingImplementation := "fs2-injections.Types.A",
     openapiUseCustomJsoniterSerdes := false,
     openapiGenerateEndpointTypes := true
   )
@@ -14,9 +14,10 @@ val tapirVersion = "1.11.16"
 libraryDependencies ++= Seq(
   "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % tapirVersion,
   "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % tapirVersion,
-  "com.softwaremill.sttp.tapir" %% "tapir-pekko-http-server" % tapirVersion,
+  "com.softwaremill.sttp.tapir" %% "tapir-http4s-server" % tapirVersion,
   "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.11.10",
   "com.beachape" %% "enumeratum" % "1.9.0",
+  "co.fs2" %% "fs2-core" % "3.12.2",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.38.2",
   "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.38.2" % "compile-internal",
   "org.scalatest" %% "scalatest" % "3.2.19" % Test,

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/src/main/scala/injections/Types.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/src/main/scala/injections/Types.scala
@@ -1,0 +1,6 @@
+package injections
+
+object Types {
+  type A[T] = cats.effect.IO[T]
+
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/src/test/scala/JsonRoundtrip.scala
@@ -8,9 +8,6 @@ import sttp.tapir.generated.{TapirGeneratedEndpoints, TapirGeneratedEndpointsJso
 import sttp.tapir.generated.TapirGeneratedEndpoints.*
 import sttp.tapir.generated.TapirGeneratedEndpointsSchemas.*
 import TapirGeneratedEndpointsJsonSerdes.*
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.util.ByteString
-import sttp.capabilities.pekko.PekkoStreams
 import sttp.monad.FutureMonad
 import sttp.tapir.DecodeResult
 import sttp.tapir.client.sttp.{SttpClientInterpreter, SttpClientOptions, WebSocketToPipe}


### PR DESCRIPTION
Permits overriding the default effect type when generating fs2-capable apis.

This is useful if using trace4cats and streaming endpoints are defined.