### PR TITLE
use StandardCharsets.UTF_8

### DIFF
--- a/client/sttp-client/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientStreamingTests.scala
+++ b/client/sttp-client/src/test/scalajvm/sttp/tapir/client/sttp/SttpClientStreamingTests.scala
@@ -1,5 +1,7 @@
 package sttp.tapir.client.sttp
 
+import java.nio.charset.StandardCharsets
+
 import cats.effect.IO
 import cats.effect.unsafe._
 import cats.implicits._
@@ -12,7 +14,7 @@ class SttpClientStreamingTests extends SttpClientTests[Fs2Streams[IO]] with Clie
   override def wsToPipe: WebSocketToPipe[Fs2Streams[IO]] = implicitly
   override val streams: Fs2Streams[IO] = Fs2Streams[IO]
 
-  override def mkStream(s: String): fs2.Stream[IO, Byte] = fs2.Stream.emits(s.getBytes("utf-8"))
+  override def mkStream(s: String): fs2.Stream[IO, Byte] = fs2.Stream.emits(s.getBytes(StandardCharsets.UTF_8))
   override def rmStream(s: fs2.Stream[IO, Byte]): String =
     s.through(fs2.text.utf8.decode)
       .compile

--- a/core/src/main/scala/sttp/tapir/Codec.scala
+++ b/core/src/main/scala/sttp/tapir/Codec.scala
@@ -383,7 +383,7 @@ object Codec extends CodecExtensions with CodecExtensions2 with FormCodecMacros 
       }
 
     def encode(up: UsernamePassword): String =
-      Base64.getEncoder.encodeToString(s"${up.username}:${up.password.getOrElse("")}".getBytes("UTF-8"))
+      Base64.getEncoder.encodeToString(s"${up.username}:${up.password.getOrElse("")}".getBytes(StandardCharsets.UTF_8))
 
     Codec.string.mapDecode(decode)(encode)
   }

--- a/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/package.scala
+++ b/docs/apispec-docs/src/main/scala/sttp/tapir/docs/apispec/package.scala
@@ -4,7 +4,7 @@ import sttp.apispec.{ExampleMultipleValue, ExampleSingleValue, ExampleValue, Sec
 import sttp.tapir.{AnyEndpoint, Codec, EndpointInput, Schema, SchemaType}
 
 import java.nio.ByteBuffer
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 package object apispec {
   private[docs] type SchemeName = String
@@ -21,8 +21,8 @@ package object apispec {
   }
 
   private def rawToString(v: Any): String = v match {
-    case a: Array[Byte] => new String(a, "UTF-8")
-    case b: ByteBuffer  => Charset.forName("UTF-8").decode(b).toString
+    case a: Array[Byte] => new String(a, StandardCharsets.UTF_8)
+    case b: ByteBuffer  => StandardCharsets.UTF_8.decode(b).toString
     case _              => v.toString
   }
 

--- a/integrations/zio/src/main/scala/sttp/tapir/ztapir/ZioServerSentEvents.scala
+++ b/integrations/zio/src/main/scala/sttp/tapir/ztapir/ZioServerSentEvents.scala
@@ -1,5 +1,7 @@
 package sttp.tapir.ztapir
 
+import java.nio.charset.StandardCharsets
+
 import zio.stream.{Stream, ZPipeline}
 import sttp.model.sse.ServerSentEvent
 import zio.Chunk
@@ -10,7 +12,7 @@ object ZioServerSentEvents {
       .map(sse => {
         s"${sse.toString()}\n\n"
       })
-      .mapConcatChunk(s => Chunk.fromArray(s.getBytes("UTF-8")))
+      .mapConcatChunk(s => Chunk.fromArray(s.getBytes(StandardCharsets.UTF_8)))
   }
 
   def parseBytesToSSE: Stream[Throwable, Byte] => Stream[Throwable, ServerSentEvent] = stream => {

--- a/integrations/zio/src/test/scala/sttp/tapir/ztapir/ZioServerSentEventsTest.scala
+++ b/integrations/zio/src/test/scala/sttp/tapir/ztapir/ZioServerSentEventsTest.scala
@@ -6,7 +6,7 @@ import zio.test._
 import zio.test.Assertion._
 import zio.stream._
 
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 object ZioServerSentEventsTest extends ZIOSpecDefault {
   def spec: Spec[TestEnvironment, Any] =
@@ -20,7 +20,7 @@ object ZioServerSentEventsTest extends ZIOSpecDefault {
              |id: id1
              |retry: 10
              |
-             |""".stripMargin.getBytes(Charset.forName("UTF-8")).toList))
+             |""".stripMargin.getBytes(StandardCharsets.UTF_8).toList))
         }
       },
       test("serialiseSSEToBytes should omit fields that are not set") {
@@ -30,7 +30,7 @@ object ZioServerSentEventsTest extends ZIOSpecDefault {
           assert(sseEvents.toList)(equalTo(s"""data: data
              |id: id1
              |
-             |""".stripMargin.getBytes(Charset.forName("UTF-8")).toList))
+             |""".stripMargin.getBytes(StandardCharsets.UTF_8).toList))
         }
       },
       test("serialiseSSEToBytes should successfully serialise multiline data event") {
@@ -50,7 +50,7 @@ object ZioServerSentEventsTest extends ZIOSpecDefault {
              |data: some data info 2
              |data: some data info 3
              |
-             |""".stripMargin.getBytes(Charset.forName("UTF-8")).toList))
+             |""".stripMargin.getBytes(StandardCharsets.UTF_8).toList))
         }
       },
       test("parseBytesToSSE should successfully parse SSE bytes to SSE structure") {
@@ -67,7 +67,7 @@ object ZioServerSentEventsTest extends ZIOSpecDefault {
           |data: event2 data3
           |id: id2
           |
-          |""".stripMargin.getBytes(Charset.forName("UTF-8"))
+          |""".stripMargin.getBytes(StandardCharsets.UTF_8)
           )
         )
         val parsed = ZioServerSentEvents.parseBytesToSSE(sseBytes)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/BinaryEndpoints.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/src/test/scala/BinaryEndpoints.scala
@@ -11,6 +11,8 @@ import sttp.monad.FutureMonad
 import sttp.tapir.generated.TapirGeneratedEndpoints
 import sttp.tapir.server.stub.TapirStubInterpreter
 
+import java.nio.charset.StandardCharsets
+
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
@@ -28,7 +30,7 @@ class BinaryEndpoints extends AnyFreeSpec with Matchers {
       def next(): ByteString = {
         val nxt = Random.alphanumeric.take(40).mkString
         linesToGo -= 1
-        ByteString.fromString(nxt, "utf-8")
+        ByteString.fromString(nxt, StandardCharsets.UTF_8)
       }
     }
     val route1 =

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/BinaryEndpoints.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/src/test/scala/BinaryEndpoints.scala
@@ -23,6 +23,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 import scala.util.Random
+import java.nio.charset.StandardCharsets
 
 class BinaryEndpoints extends AnyFreeSpec with Matchers {
   private implicit val system: ActorSystem = ActorSystem()
@@ -35,7 +36,7 @@ class BinaryEndpoints extends AnyFreeSpec with Matchers {
       def next(): ByteString = {
         val nxt = Random.alphanumeric.take(140).mkString
         linesToGo -= 1
-        ByteString.fromString(nxt, "utf-8")
+        ByteString.fromString(nxt, StandardCharsets.UTF_8)
       }
     }
     def handleCsv(stream: ByteString): State = State(stream.utf8String.take(100).mkString)

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/package.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/package.scala
@@ -8,12 +8,12 @@ import sttp.capabilities.akka.AkkaStreams
 import sttp.model.sse.ServerSentEvent
 import sttp.tapir.{CodecFormat, StreamBodyIO, streamTextBody}
 
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 package object akkahttp {
   type AkkaResponseBody = Either[Flow[Message, Message, Any], ResponseEntity]
 
   val serverSentEventsBody: StreamBodyIO[Source[ByteString, Any], Source[ServerSentEvent, Any], AkkaStreams] =
-    streamTextBody(AkkaStreams)(CodecFormat.TextEventStream(), Some(Charset.forName("UTF-8")))
+    streamTextBody(AkkaStreams)(CodecFormat.TextEventStream(), Some(StandardCharsets.UTF_8))
       .map(AkkaServerSentEvents.parseBytesToSSE)(AkkaServerSentEvents.serialiseSSEToBytes)
 }

--- a/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/package.scala
+++ b/server/http4s-server/src/main/scala/sttp/tapir/server/http4s/package.scala
@@ -9,7 +9,7 @@ import sttp.tapir.model.ServerRequest
 import sttp.tapir.typelevel.ParamConcat
 import sttp.tapir.{AttributeKey, CodecFormat, Endpoint, StreamBodyIO, extractFromRequest, streamTextBody}
 
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import scala.reflect.ClassTag
 
 package object http4s {
@@ -18,7 +18,7 @@ package object http4s {
 
   def serverSentEventsBody[F[_]]: StreamBodyIO[fs2.Stream[F, Byte], fs2.Stream[F, ServerSentEvent], Fs2Streams[F]] = {
     val fs2Streams = Fs2Streams[F]
-    streamTextBody(fs2Streams)(CodecFormat.TextEventStream(), Some(Charset.forName("UTF-8")))
+    streamTextBody(fs2Streams)(CodecFormat.TextEventStream(), Some(StandardCharsets.UTF_8))
       .map(Http4sServerSentEvents.parseBytesToSSE[F])(Http4sServerSentEvents.serialiseSSEToBytes[F])
   }
 

--- a/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerSentEventsTest.scala
+++ b/server/http4s-server/src/test/scala/sttp/tapir/server/http4s/Http4sServerSentEventsTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 import sttp.model.sse.ServerSentEvent
 
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 class Http4sServerSentEventsTest extends AsyncFunSuite with Matchers {
 
@@ -22,7 +22,7 @@ class Http4sServerSentEventsTest extends AsyncFunSuite with Matchers {
              |id: id1
              |retry: 10
              |
-             |""".stripMargin.getBytes(Charset.forName("UTF-8")).toList
+             |""".stripMargin.getBytes(StandardCharsets.UTF_8).toList
       })
       .unsafeToFuture()
   }
@@ -37,7 +37,7 @@ class Http4sServerSentEventsTest extends AsyncFunSuite with Matchers {
           s"""data: data
              |id: id1
              |
-             |""".stripMargin.getBytes(Charset.forName("UTF-8")).toList
+             |""".stripMargin.getBytes(StandardCharsets.UTF_8).toList
       })
       .unsafeToFuture()
   }
@@ -62,7 +62,7 @@ class Http4sServerSentEventsTest extends AsyncFunSuite with Matchers {
              |data: some data info 2
              |data: some data info 3
              |
-             |""".stripMargin.getBytes(Charset.forName("UTF-8")).toList
+             |""".stripMargin.getBytes(StandardCharsets.UTF_8).toList
       })
       .unsafeToFuture()
   }
@@ -80,7 +80,7 @@ class Http4sServerSentEventsTest extends AsyncFunSuite with Matchers {
           |data: event2 data3
           |id: id2
           |
-          |""".stripMargin.getBytes(Charset.forName("UTF-8"))
+          |""".stripMargin.getBytes(StandardCharsets.UTF_8)
     )
     val parsed = Http4sServerSentEvents.parseBytesToSSE[IO](sseBytes)
     val futureEvents = parsed.compile.toList

--- a/server/http4s-server/zio/src/main/scala/sttp/tapir/server/http4s/ztapir/package.scala
+++ b/server/http4s-server/zio/src/main/scala/sttp/tapir/server/http4s/ztapir/package.scala
@@ -6,11 +6,11 @@ import sttp.tapir.ztapir.ZioServerSentEvents
 import sttp.tapir.{CodecFormat, StreamBodyIO, streamTextBody}
 import zio.stream._
 
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 package object ztapir {
   val serverSentEventsBody: StreamBodyIO[Stream[Throwable, Byte], Stream[Throwable, ServerSentEvent], ZioStreams] = {
-    streamTextBody(ZioStreams)(CodecFormat.TextEventStream(), Some(Charset.forName("UTF-8")))
+    streamTextBody(ZioStreams)(CodecFormat.TextEventStream(), Some(StandardCharsets.UTF_8))
       .map(ZioServerSentEvents.parseBytesToSSE)(ZioServerSentEvents.serialiseSSEToBytes)
   }
 }

--- a/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/OxServerSentEvents.scala
+++ b/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/OxServerSentEvents.scala
@@ -1,12 +1,14 @@
 package sttp.tapir.server.netty
 
+import java.nio.charset.StandardCharsets
+
 import sttp.model.sse.ServerSentEvent
 import ox.flow.Flow
 import ox.Chunk
 
 object OxServerSentEvents:
   def serializeSSEToBytes: Flow[ServerSentEvent] => Flow[Chunk[Byte]] = sseStream =>
-    sseStream.map(sse => Chunk.fromArray(s"${sse.toString()}\n\n".getBytes("UTF-8")))
+    sseStream.map(sse => Chunk.fromArray(s"${sse.toString()}\n\n".getBytes(StandardCharsets.UTF_8)))
 
   def parseBytesToSSE: Flow[Chunk[Byte]] => Flow[ServerSentEvent] = stream =>
     stream.linesUtf8

--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/package.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/package.scala
@@ -8,12 +8,12 @@ import sttp.capabilities.pekko.PekkoStreams
 import sttp.model.sse.ServerSentEvent
 import sttp.tapir.{CodecFormat, StreamBodyIO, streamTextBody}
 
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 package object pekkohttp {
   type PekkoResponseBody = Either[Flow[Message, Message, Any], ResponseEntity]
 
   val serverSentEventsBody: StreamBodyIO[Source[ByteString, Any], Source[ServerSentEvent, Any], PekkoStreams] =
-    streamTextBody(PekkoStreams)(CodecFormat.TextEventStream(), Some(Charset.forName("UTF-8")))
+    streamTextBody(PekkoStreams)(CodecFormat.TextEventStream(), Some(StandardCharsets.UTF_8))
       .map(PekkoServerSentEvents.parseBytesToSSE)(PekkoServerSentEvents.serialiseSSEToBytes)
 }

--- a/server/play-server/src/main/scala/sttp/tapir/server/play/PlayToResponseBody.scala
+++ b/server/play-server/src/main/scala/sttp/tapir/server/play/PlayToResponseBody.scala
@@ -12,7 +12,7 @@ import sttp.tapir.server.interpreter.ToResponseBody
 import sttp.tapir.{CodecFormat, FileRange, RawBodyType, RawPart, WebSocketBodyOutput}
 
 import java.nio.ByteBuffer
-import java.nio.charset.Charset
+import java.nio.charset.{Charset, StandardCharsets}
 
 class PlayToResponseBody extends ToResponseBody[PlayResponseBody, PekkoStreams] {
 
@@ -195,8 +195,8 @@ class PlayToResponseBody extends ToResponseBody[PlayResponseBody, PekkoStreams] 
         Source
           .single(filePartHeader(file))
           .concat(file.ref)
-          .concat(Source.single(ByteString("\r\n", Charset.forName("UTF-8"))))
-          .concat(Source.single(ByteString(s"--$boundary--", "UTF-8")))
+          .concat(Source.single(ByteString("\r\n", StandardCharsets.UTF_8)))
+          .concat(Source.single(ByteString(s"--$boundary--", StandardCharsets.UTF_8)))
       })
   }
 }

--- a/server/play29-server/src/main/scala/sttp/tapir/server/play/PlayToResponseBody.scala
+++ b/server/play29-server/src/main/scala/sttp/tapir/server/play/PlayToResponseBody.scala
@@ -12,7 +12,7 @@ import sttp.tapir.server.interpreter.ToResponseBody
 import sttp.tapir.{CodecFormat, FileRange, RawBodyType, RawPart, WebSocketBodyOutput}
 
 import java.nio.ByteBuffer
-import java.nio.charset.Charset
+import java.nio.charset.{Charset, StandardCharsets}
 
 class PlayToResponseBody extends ToResponseBody[PlayResponseBody, AkkaStreams] {
 
@@ -195,8 +195,8 @@ class PlayToResponseBody extends ToResponseBody[PlayResponseBody, AkkaStreams] {
         Source
           .single(filePartHeader(file))
           .concat(file.ref)
-          .concat(Source.single(ByteString("\r\n", Charset.forName("UTF-8"))))
-          .concat(Source.single(ByteString(s"--$boundary--", "UTF-8")))
+          .concat(Source.single(ByteString("\r\n", StandardCharsets.UTF_8)))
+          .concat(Source.single(ByteString(s"--$boundary--", StandardCharsets.UTF_8)))
       })
   }
 }

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpServerTest.scala
@@ -44,7 +44,7 @@ import zio.stream
 import zio.stream.ZPipeline
 import zio.stream.ZStream
 
-import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 import java.time
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
@@ -222,7 +222,7 @@ class ZioHttpServerTest extends TestSuite {
             val input: ZStream[Any, Nothing, Byte] =
               ZStream(inputStrings: _*)
                 .via(ZPipeline.intersperse(java.lang.System.lineSeparator()))
-                .mapConcat(_.getBytes(Charset.forName("UTF-8")))
+                .mapConcat(_.getBytes(StandardCharsets.UTF_8))
 
             val makeRequest = basicRequest
               .post(uri"/hello")


### PR DESCRIPTION
where possible - to avoid overhead of doing a search (eg Charset.forName)