### PR TITLE
Merge MediaTypes only on schema

### DIFF
--- a/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOperationResponse.scala
+++ b/docs/openapi-docs/src/main/scala/sttp/tapir/docs/openapi/EndpointToOperationResponse.scala
@@ -107,7 +107,7 @@ private[openapi] class EndpointToOperationResponse(
   }
 
   private def mergeMediaTypesToAnyOf(bodies: Vector[MediaType]): MediaType =
-    bodies.toSet.toList match {
+    bodies.distinctBy(_.schema).toList match {
       case List(body) => body
       case bodies     =>
         MediaType(

--- a/docs/openapi-docs/src/test/resources/oneOf/expected_status_codes.yml
+++ b/docs/openapi-docs/src/test/resources/oneOf/expected_status_codes.yml
@@ -21,6 +21,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NotFound'
+            example:
+              what: notfound
         default:
           description: unknown
           content:

--- a/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlOneOfTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm/sttp/tapir/docs/openapi/VerifyYamlOneOfTest.scala
@@ -32,7 +32,8 @@ class VerifyYamlOneOfTest extends AnyFunSuite with Matchers {
     val e = endpoint.errorOut(
       sttp.tapir.oneOf(
         oneOfVariant(StatusCode.Unauthorized, jsonBody[Unauthorized].description("unauthorized")),
-        oneOfVariant(StatusCode.NotFound, jsonBody[NotFound].description("not found")),
+        oneOfVariant(StatusCode.NotFound, jsonBody[NotFound].description("not found").example(NotFound("not found"))),
+        oneOfVariant(StatusCode.NotFound, jsonBody[NotFound].description("404").example(NotFound("404"))),
         oneOfDefaultVariant(jsonBody[Unknown].description("unknown"))
       )
     )
@@ -50,7 +51,8 @@ class VerifyYamlOneOfTest extends AnyFunSuite with Matchers {
       .errorOut(jsonBody[Unknown].description("unknown"))
       .errorOutVariants[ErrorInfo](
         oneOfVariant(StatusCode.Unauthorized, jsonBody[Unauthorized].description("unauthorized")),
-        oneOfVariant(StatusCode.NotFound, jsonBody[NotFound].description("not found"))
+        oneOfVariant(StatusCode.NotFound, jsonBody[NotFound].description("not found").example(NotFound("not found"))),
+        oneOfVariant(StatusCode.NotFound, jsonBody[NotFound].description("404").example(NotFound("404")))
       )
 
     val actualYaml = OpenAPIDocsInterpreter().toOpenAPI(e, Info("Fruits", "1.0")).toYaml


### PR DESCRIPTION
When defining more than one `oneOfVariant` on same error outputs type, we want to merge `MediaType`s to the more precise `schema` field and thus excluding examples and output types.

To illustrate the change I've modified test case:

```diff
  val e = endpoint.errorOut(
    sttp.tapir.oneOf(
      oneOfVariant(StatusCode.Unauthorized, jsonBody[Unauthorized].description("unauthorized")),
      oneOfVariant(StatusCode.NotFound, jsonBody[NotFound].description("not found").example(NotFound("not found"))),
+     oneOfVariant(StatusCode.NotFound, jsonBody[NotFound].description("404").example(NotFound("404"))),
      oneOfDefaultVariant(jsonBody[Unknown].description("unknown"))
    )
  )
```

The resulting yaml will produce this if we do not modify production code:

```diff
  paths:
    /:
      get:
        operationId: getRoot
        responses:
          '404':
            description: not found
            content:
              application/json:
                schema:
-                 $ref: '#/components/schemas/NotFound'
+                 anyOf:
+                   - $ref: '#/components/schemas/NotFound'
+                   - $ref: '#/components/schemas/NotFound'
              example:
                what: notfound
```

Please note the unwanted `anyOf` of the same `$ref` written twice.

It could looks weird here to have two variants with the same type `NotFound` but if you replace it with [Problem Details](https://datatracker.ietf.org/doc/html/rfc7807#section-3) then it makes sense.

The merge operation is coming from #3703.