### PR TITLE
codegen: fix validator generation for nullable fields

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ValidationGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ValidationGenerator.scala
@@ -55,7 +55,7 @@ object ValidationGenerator {
     val allSchemas = doc.components.map(_.schemas).getOrElse(Map.empty)
 
     // All schemas that have explicit validation _or_ refer to a ref, which _may_ have.
-    // We need to filter this, because we may have trivial
+    // We need to filter this, because we may have recursive references that don't contain any 'real' validation
     val unfiltered = {
       val mapped = allSchemas.flatMap { case (k, v) => genValidationDefn(allSchemas, ignoreRefs = false)(k, v).filterNot(_.refOnly) }
       if (mapped.isEmpty) ValidationDefns.empty
@@ -272,7 +272,8 @@ object ValidationGenerator {
               fn,
               (
                 defn,
-                f.`type`.nullable || !rs.contains(fn),
+                // exclude non-required 'nullable' here because the field validators will already treat the value as optional
+                !rs.contains(fn) && !f.`type`.nullable,
                 f.`type`
               )
             )

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedValidators.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/ExpectedValidators.scala.txt
@@ -13,6 +13,14 @@ object TapirGeneratedEndpointsValidators {
         ValidationResult.Invalid(msgs)
     }
   ), Validator.custom(
+    (obj: ValidatedObj) => ValidatedObjQuuxValidator.apply(obj.quux) match {
+      case Nil => ValidationResult.Valid
+      case errs =>
+        val msgs: List[String] = "Object element validation failed for ValidatedObj.quux" +:
+          errs.flatMap(_.customMessage).toList
+        ValidationResult.Invalid(msgs)
+    }
+  ), Validator.custom(
     (obj: ValidatedObj) => ValidatedSubObjValidator.apply(obj.bar) match {
       case Nil => ValidationResult.Valid
       case errs =>
@@ -49,14 +57,6 @@ object TapirGeneratedEndpointsValidators {
       case Nil => ValidationResult.Valid
       case errs =>
         val msgs: List[String] = "Object element validation failed for ValidatedObj.oneOf" +:
-          errs.flatMap(_.customMessage).toList
-        ValidationResult.Invalid(msgs)
-    }
-  ), Validator.custom(
-    (obj: ValidatedObj) => obj.quux.toSeq.flatMap(ValidatedObjQuuxValidator.apply) match {
-      case Nil => ValidationResult.Valid
-      case errs =>
-        val msgs: List[String] = "Object element validation failed for ValidatedObj.quux" +:
           errs.flatMap(_.customMessage).toList
         ValidationResult.Invalid(msgs)
     }
@@ -100,7 +100,10 @@ object TapirGeneratedEndpointsValidators {
     }
   ), Validator.maxSize(12), Validator.minSize(3))
   lazy val ValidatedObjMapItemValidator: Validator[Int] = Validator.all(Validator.max(900, exclusive = true), Validator.min(0, exclusive = false))
-  lazy val ValidatedObjQuuxValidator: Validator[String] = Validator.maxLength(128)
+  lazy val ValidatedObjQuuxValidator: Validator[Option[String]] = Validator.custom[Option[String]](ot => ot.map(Validator.maxLength(128)(_)).map{
+    case Nil => ValidationResult.Valid
+    case l   => ValidationResult.Invalid(l.flatMap(_.customMessage).toList)
+  }.getOrElse(ValidationResult.Valid))
   lazy val ValidatedObjSetValidator: Validator[Set[String]] = Validator.maxSize(9)
   lazy val ValidatedOneOfValidator: Validator[ValidatedOneOf] = Validator.custom(
     (obj: ValidatedOneOf) => (obj match {

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/swagger.yaml
@@ -1135,6 +1135,7 @@ components:
         quux:
           type: string
           maxLength: 128
+          nullable: true
         map:
           type: object
           additionalProperties:


### PR DESCRIPTION
Exclude 'nullable' fields when 'wrapping' them in generated validators (the validators on nullable types already assume the value is an Option, so treating them optionally twice generates non-compiling code)

Closes https://github.com/softwaremill/tapir/issues/4933