### PR TITLE
In Pekko/Akka, ServerRequest.uri should return the full path

### DIFF
--- a/server/pekko-http-server/src/test/scala/sttp/tapir/server/pekkohttp/PekkoHttpServerTest.scala
+++ b/server/pekko-http-server/src/test/scala/sttp/tapir/server/pekkohttp/PekkoHttpServerTest.scala
@@ -183,6 +183,33 @@ class PekkoHttpServerTest extends TestSuite with EitherValues {
                 .map(_.body.value should fullyMatch regex """Some\(/127\.0\.0\.1:\d+\) Some\(false\)""")
             }
             .unsafeToFuture()
+        },
+        Test("extractFromRequest(_.uri) returns full URI when nested in path directive") {
+          // Given: an endpoint that extracts the URI from the request
+          val e = endpoint.get
+            .in("test" / "path")
+            .in(extractFromRequest(_.uri))
+            .out(stringBody)
+            .serverLogic { requestUri =>
+              requestUri.toString.asRight[Unit].unit
+            }
+
+          // When: the route is nested inside a pathPrefix directive
+          val route = Directives.pathPrefix("api")(PekkoHttpServerInterpreter().toRoute(e))
+
+          interpreter
+            .server(route)
+            .use { port =>
+              // Then: the extracted URI should contain the full path including the prefix
+              basicRequest
+                .get(uri"http://localhost:$port/api/test/path?query=value")
+                .send(backend)
+                .map { response =>
+                  response.body.value should include("/api/test/path")
+                  response.body.value should include("query=value")
+                }
+            }
+            .unsafeToFuture()
         }
       )
       def drainPekko(stream: PekkoStreams.BinaryStream): Future[Unit] =


### PR DESCRIPTION
Closes #4972