### PR TITLE
CI: compile core and server-core with Scala 3.8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,15 @@ jobs:
       run: echo "ONLY_LOOM=1" >> $GITHUB_ENV
     - name: Compile
       run: sbt $SBT_JAVA_OPTS -v "compileScoped ${{ matrix.scala-version }} ${{ matrix.target-platform }}"
-    - name: Compile core & server-core with Scala 3.8.3
+    - name: Compile core & server-core with next Scala 3
       if: matrix.scala-version == '3' && matrix.target-platform == 'JVM' && matrix.java == '21'
-      run: sbt $SBT_JAVA_OPTS -v 'set LocalProject("core3") / scalaVersion := "3.8.3"' 'set LocalProject("serverCore3") / scalaVersion := "3.8.3"' core3/Test/compile serverCore3/Test/compile
+      env:
+        SCALA_3_NEXT: "3.8.3"
+      run: |
+        sbt $SBT_JAVA_OPTS -v \
+          "set LocalProject(\"core3\") / scalaVersion := \"$SCALA_3_NEXT\"" \
+          "set LocalProject(\"serverCore3\") / scalaVersion := \"$SCALA_3_NEXT\"" \
+          core3/Test/compile serverCore3/Test/compile
     - name: Compile documentation
       if: matrix.target-platform == 'JVM' && matrix.java == '21'
       run: sbt $SBT_JAVA_OPTS -v compileDocumentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
       run: echo "ONLY_LOOM=1" >> $GITHUB_ENV
     - name: Compile
       run: sbt $SBT_JAVA_OPTS -v "compileScoped ${{ matrix.scala-version }} ${{ matrix.target-platform }}"
+    - name: Compile core & server-core with Scala 3.8.3
+      if: matrix.scala-version == '3' && matrix.target-platform == 'JVM' && matrix.java == '21'
+      run: sbt $SBT_JAVA_OPTS -v 'set LocalProject("core3") / scalaVersion := "3.8.3"' 'set LocalProject("serverCore3") / scalaVersion := "3.8.3"' core3/Test/compile serverCore3/Test/compile
     - name: Compile documentation
       if: matrix.target-platform == 'JVM' && matrix.java == '21'
       run: sbt $SBT_JAVA_OPTS -v compileDocumentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,10 @@ jobs:
         sbt $SBT_JAVA_OPTS -v \
           "set LocalProject(\"core3\") / scalaVersion := \"$SCALA_3_NEXT\"" \
           "set LocalProject(\"serverCore3\") / scalaVersion := \"$SCALA_3_NEXT\"" \
-          core3/Test/compile serverCore3/Test/compile
+          "set LocalProject(\"coreJS3\") / scalaVersion := \"$SCALA_3_NEXT\"" \
+          "set LocalProject(\"serverCoreJS3\") / scalaVersion := \"$SCALA_3_NEXT\"" \
+          core3/Test/compile serverCore3/Test/compile \
+          coreJS3/Test/compile serverCoreJS3/Test/compile
     - name: Compile documentation
       if: matrix.target-platform == 'JVM' && matrix.java == '21'
       run: sbt $SBT_JAVA_OPTS -v compileDocumentation

--- a/core/src/main/scala-3/sttp/tapir/internal/AnnotationsMacros.scala
+++ b/core/src/main/scala-3/sttp/tapir/internal/AnnotationsMacros.scala
@@ -299,9 +299,11 @@ private[tapir] class AnnotationsMacros[T <: Product: Type](using q: Quotes) {
   ): Expr[EndpointInput.Single[f]] =
     setSecuritySchemeName(
       '{
-        TapirAuth.bearer(${ auth.asExprOf[EndpointIO.annotations.bearer] }.challenge)(${
-          summonCodec[List[String], f, CodecFormat.TextPlain](field)
-        })
+        TapirAuth.bearer(${ auth.asExprOf[EndpointIO.annotations.bearer] }.challenge)(using
+          ${
+            summonCodec[List[String], f, CodecFormat.TextPlain](field)
+          }
+        )
       },
       schemeName
     )
@@ -313,9 +315,11 @@ private[tapir] class AnnotationsMacros[T <: Product: Type](using q: Quotes) {
   ): Expr[EndpointInput.Single[f]] =
     setSecuritySchemeName(
       '{
-        TapirAuth.basic(${ auth.asExprOf[EndpointIO.annotations.basic] }.challenge)(${
-          summonCodec[List[String], f, CodecFormat.TextPlain](field)
-        })
+        TapirAuth.basic(${ auth.asExprOf[EndpointIO.annotations.basic] }.challenge)(using
+          ${
+            summonCodec[List[String], f, CodecFormat.TextPlain](field)
+          }
+        )
       },
       schemeName
     )

--- a/core/src/main/scala-3/sttp/tapir/macros/FormCodecMacros.scala
+++ b/core/src/main/scala-3/sttp/tapir/macros/FormCodecMacros.scala
@@ -45,7 +45,7 @@ private[tapir] object FormCodecMacros {
 
     val encodeDefSymbol = Symbol.newMethod(
       Symbol.spliceOwner,
-      "encode",
+      "$anonfun$encode",
       MethodType(List("t"))(_ => List(caseClass.tpe), _ => TypeRepr.of[Seq[(String, String)]])
     )
     val encodeDef = DefDef(
@@ -83,7 +83,7 @@ private[tapir] object FormCodecMacros {
 
     val decodeDefSymbol = Symbol.newMethod(
       Symbol.spliceOwner,
-      "decode",
+      "$anonfun$decode",
       MethodType(List("params"))(_ => List(TypeRepr.of[Seq[(String, String)]]), _ => TypeRepr.of[DecodeResult[T]])
     )
     val decodeDef = DefDef(

--- a/core/src/main/scala-3/sttp/tapir/macros/MultipartCodecMacros.scala
+++ b/core/src/main/scala-3/sttp/tapir/macros/MultipartCodecMacros.scala
@@ -85,7 +85,7 @@ private[tapir] object MultipartCodecMacros {
     val encodeDefSymbol =
       Symbol.newMethod(
         Symbol.spliceOwner,
-        "encode",
+        "$anonfun$encode",
         MethodType(List("t"))(_ => List(caseClass.tpe), _ => TypeRepr.of[ListMap[String, Any]])
       )
     val encodeDef = DefDef(
@@ -113,7 +113,7 @@ private[tapir] object MultipartCodecMacros {
     val decodeDefSymbol =
       Symbol.newMethod(
         Symbol.spliceOwner,
-        "decode",
+        "$anonfun$decode",
         MethodType(List("params"))(_ => List(TypeRepr.of[ListMap[String, Any]]), _ => TypeRepr.of[T])
       )
     val decodeDef = DefDef(

--- a/core/src/main/scala/sttp/tapir/TapirAuth.scala
+++ b/core/src/main/scala/sttp/tapir/TapirAuth.scala
@@ -51,7 +51,9 @@ object TapirAuth {
       .schema(codec.schema)
 
     EndpointInput.Auth(
-      header[T](HeaderNames.Authorization)(authCodec),
+      // this should be header[T](HeaderNames.Authorization)(authCodec), but since Scala 3.8 we would need an additional "using",
+      // which we can't add due to source compatibility
+      { implicit val c: Codec[List[String], T, TextPlain] = authCodec; header[T](HeaderNames.Authorization) },
       challenge,
       EndpointInput.AuthType.Http(authScheme),
       EndpointInput.AuthInfo.Empty

--- a/core/src/main/scala/sttp/tapir/TapirAuth.scala
+++ b/core/src/main/scala/sttp/tapir/TapirAuth.scala
@@ -53,7 +53,7 @@ object TapirAuth {
     EndpointInput.Auth(
       // this should be header[T](HeaderNames.Authorization)(authCodec), but since Scala 3.8 we would need an additional "using",
       // which we can't add due to source compatibility
-      { implicit val _: Codec[List[String], T, TextPlain] = authCodec; header[T](HeaderNames.Authorization) },
+      EndpointIO.Header(HeaderNames.Authorization, authCodec, EndpointIO.Info.empty),
       challenge,
       EndpointInput.AuthType.Http(authScheme),
       EndpointInput.AuthInfo.Empty

--- a/core/src/main/scala/sttp/tapir/TapirAuth.scala
+++ b/core/src/main/scala/sttp/tapir/TapirAuth.scala
@@ -53,7 +53,7 @@ object TapirAuth {
     EndpointInput.Auth(
       // this should be header[T](HeaderNames.Authorization)(authCodec), but since Scala 3.8 we would need an additional "using",
       // which we can't add due to source compatibility
-      { implicit val c: Codec[List[String], T, TextPlain] = authCodec; header[T](HeaderNames.Authorization) },
+      { implicit val _: Codec[List[String], T, TextPlain] = authCodec; header[T](HeaderNames.Authorization) },
       challenge,
       EndpointInput.AuthType.Http(authScheme),
       EndpointInput.AuthInfo.Empty

--- a/core/src/main/scalajvm/sttp/tapir/static/TapirStaticContentEndpoints.scala
+++ b/core/src/main/scalajvm/sttp/tapir/static/TapirStaticContentEndpoints.scala
@@ -225,7 +225,10 @@ trait TapirStaticContentEndpoints {
   ): ServerEndpoint[Any, F] =
     ServerEndpoint.public(
       resourcesGetEndpoint(prefix),
-      (m: MonadError[F]) => Resources(classLoader, resourcePrefix, options)(m)
+      (m: MonadError[F]) => {
+        implicit val _m: MonadError[F] = m // needed because of Scala 3.8 compatibility
+        Resources(classLoader, resourcePrefix, options)
+      }
     )
 
   /** A server endpoint, which exposes a single resource available from the given `classLoader` at `resourcePath`, using the given `path`.
@@ -242,7 +245,10 @@ trait TapirStaticContentEndpoints {
   ): ServerEndpoint[Any, F] =
     ServerEndpoint.public(
       removePath(resourcesGetEndpoint(prefix)),
-      (m: MonadError[F]) => Resources(classLoader, resourcePath, options)(m)
+      (m: MonadError[F]) => {
+        implicit val _m: MonadError[F] = m // needed because of Scala 3.8 compatibility
+        Resources(classLoader, resourcePath, options)
+      }
     )
 
   private def removePath[T](e: Endpoint[Unit, StaticInput, StaticErrorOutput, StaticOutput[T], Any]) =

--- a/server/core/src/test/scala/sttp/tapir/server/interpreter/ServerInterpreterTest.scala
+++ b/server/core/src/test/scala/sttp/tapir/server/interpreter/ServerInterpreterTest.scala
@@ -69,21 +69,11 @@ class ServerInterpreterTest extends AnyFlatSpec with Matchers {
         _ =>
           List(
             endpoint
-              .securityIn({
-                // needed due to Scala 3.8 compatibility
-                implicit val _: Codec[List[String], StringWrapper, TextPlain] = Codec.listHead(addToTrailCodec("x"))
-                query[StringWrapper]("x")
-              })
-              .in({
-                // needed due to Scala 3.8 compatibility
-                implicit val _: Codec[List[String], StringWrapper, TextPlain] = Codec.listHead(addToTrailCodec("y"))
-                query[StringWrapper]("y")
-              })
-              .in({
-                // needed due to Scala 3.8 compatibility
-                implicit val _: Codec[String, StringWrapper, TextPlain] = addToTrailCodec("z")
-                plainBody[StringWrapper]
-              })
+              // passing the codec explicitly via queryAnyFormat/Body instead of query[T]/plainBody[T],
+              // due to Scala 3.8 compatibility (the implicit can no longer be applied as a regular argument)
+              .securityIn(queryAnyFormat[StringWrapper, TextPlain]("x", Codec.listHead(addToTrailCodec("x"))))
+              .in(queryAnyFormat[StringWrapper, TextPlain]("y", Codec.listHead(addToTrailCodec("y"))))
+              .in(EndpointIO.Body(RawBodyType.StringBody(java.nio.charset.StandardCharsets.UTF_8), addToTrailCodec("z"), EndpointIO.Info.empty))
               .serverSecurityLogic[Unit, Identity](_ => Left(()))
               .serverLogic(_ => _ => Right(()))
           ),

--- a/server/core/src/test/scala/sttp/tapir/server/interpreter/ServerInterpreterTest.scala
+++ b/server/core/src/test/scala/sttp/tapir/server/interpreter/ServerInterpreterTest.scala
@@ -13,6 +13,7 @@ import sttp.tapir.server.interceptor.RequestResult.Response
 import sttp.tapir.server.interceptor._
 import sttp.tapir.server.interceptor.reject.{DefaultRejectHandler, RejectInterceptor}
 import sttp.tapir.server.model.{ServerResponse, ValuedEndpointOutput}
+import sttp.tapir.CodecFormat.TextPlain
 
 class ServerInterpreterTest extends AnyFlatSpec with Matchers {
   implicit val idMonad: MonadError[Identity] = sttp.monad.IdentityMonad
@@ -68,9 +69,21 @@ class ServerInterpreterTest extends AnyFlatSpec with Matchers {
         _ =>
           List(
             endpoint
-              .securityIn(query[StringWrapper]("x")(Codec.listHead(addToTrailCodec("x"))))
-              .in(query[StringWrapper]("y")(Codec.listHead(addToTrailCodec("y"))))
-              .in(plainBody[StringWrapper](addToTrailCodec("z")))
+              .securityIn({
+                // needed due to Scala 3.8 compatibility
+                implicit val _: Codec[List[String], StringWrapper, TextPlain] = Codec.listHead(addToTrailCodec("x"))
+                query[StringWrapper]("x")
+              })
+              .in({
+                // needed due to Scala 3.8 compatibility
+                implicit val _: Codec[List[String], StringWrapper, TextPlain] = Codec.listHead(addToTrailCodec("y"))
+                query[StringWrapper]("y")
+              })
+              .in({
+                // needed due to Scala 3.8 compatibility
+                implicit val _: Codec[String, StringWrapper, TextPlain] = addToTrailCodec("z")
+                plainBody[StringWrapper]
+              })
               .serverSecurityLogic[Unit, Identity](_ => Left(()))
               .serverLogic(_ => _ => Right(()))
           ),


### PR DESCRIPTION
## Summary
- Adds a CI step that compiles `core` and `server-core` (JVM + JS, main + test sources) using Scala 3.8.3
- Runs only in the Scala 3 / JVM / Java 21 matrix cell
- Uses `set LocalProject(...) / scalaVersion := "3.8.3"` to override the matrix-pinned Scala version without changing `build.sbt`
- Fixes #5039 by adding `$anonfun$` prefix to the string methods
- Fixes compilation errors by constructing input description directly, instead of passing an implicit codec as a parameter (which is not possible since 3.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)