### PR TITLE
Fix default to get

### DIFF
--- a/integrations/zio/src/test/scala/sttp/tapir/ztapir/ZTapirTest.scala
+++ b/integrations/zio/src/test/scala/sttp/tapir/ztapir/ZTapirTest.scala
@@ -54,7 +54,7 @@ object ZTapirTest extends ZIOSpecDefault with ZTapir {
     override def underlying: Any = ???
     override def pathSegments: List[String] = List("foo", "bar")
     override def queryParameters: QueryParams = QueryParams()
-    override def method: Method = ???
+    override def method: Method = Method.GET
     override def uri: Uri = ???
     override def headers: scala.collection.immutable.Seq[Header] = scala.collection.immutable.Seq(Header("X-User-Name", "John"))
     override def attribute[T](k: AttributeKey[T]): Option[T] = None

--- a/server/core/src/main/scala/sttp/tapir/server/interpreter/ServerInterpreter.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interpreter/ServerInterpreter.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.server.interpreter
 
 import sttp.capabilities.StreamMaxLengthExceededException
-import sttp.model.{Headers, StatusCode}
+import sttp.model.{Headers, Method, StatusCode}
 import sttp.monad.MonadError
 import sttp.monad.syntax._
 import sttp.tapir.internal.{Params, ParamsAsAny, RichOneOfBody}
@@ -9,7 +9,7 @@ import sttp.tapir.model.ServerRequest
 import sttp.tapir.server.interceptor._
 import sttp.tapir.server.model.{InvalidMultipartBodyException, MaxContentLength, ServerResponse, ValuedEndpointOutput}
 import sttp.tapir.server.{model, _}
-import sttp.tapir.{DecodeResult, EndpointIO, EndpointInput, TapirFile}
+import sttp.tapir.{Codec, DecodeResult, EndpointIO, EndpointInput, TapirFile}
 import sttp.tapir.EndpointInfo
 import sttp.tapir.AttributeKey
 import java.util.concurrent.ConcurrentHashMap
@@ -111,7 +111,16 @@ class ServerInterpreter[R, F[_], B, S](
     val rawValues = ConcurrentHashMap.newKeySet[RawValue[?]]()
     val addRawValue: RawValue[?] => Unit = rawValues.add(_): Unit
 
+    // When no explicit method is defined across the whole endpoint, default to GET, consistent with the OpenAPI docs
+    // interpreter, which uses getOrElse(Method.GET) for the same case.
+    val implicitMethodFailure: Option[DecodeBasicInputsResult.Failure] =
+      if (se.endpoint.method.isEmpty && request.method != Method.GET) {
+        val implicitGet = EndpointInput.FixedMethod(Method.GET, Codec.idPlain(), EndpointIO.Info.empty)
+        Some(DecodeBasicInputsResult.Failure(implicitGet, DecodeResult.Mismatch(Method.GET.method, request.method.method)))
+      } else None
+
     (for {
+      _ <- resultOrValueFrom(implicitMethodFailure)
       // 2. if the decoding failed, short-circuiting further processing with the decode failure that has a lower sort
       // index (so that the correct one is passed to the decode failure handler)
       _ <- resultOrValueFrom(DecodeBasicInputsResult.higherPriorityFailure(securityBasicInputs, regularBasicInputs))

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -376,8 +376,8 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
       basicRequest.get(uri"$baseUri?fruit=apple").send(backend).map(_.code shouldBe StatusCode(431))
     },
     testServer(in_extract_request_out_string)((v: String) => pureResult(v.asRight[Unit])) { (backend, baseUri) =>
-      basicStringRequest.get(uri"$baseUri").send(backend).map(_.body shouldBe "GET") >>
-        basicStringRequest.post(uri"$baseUri").send(backend).map(_.body shouldBe "POST")
+      basicStringRequest.get(uri"$baseUri?foo=bar").send(backend).map(_.body shouldBe "bar") >>
+        basicStringRequest.get(uri"$baseUri?foo=bazz").send(backend).map(_.body shouldBe "bazz")
     },
     testServer(in_string_out_status)((v: String) =>
       pureResult((if (v == "apple") StatusCode.Accepted else StatusCode.NotFound).asRight[Unit])

--- a/tests/src/main/scala/sttp/tapir/tests/Basic.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/Basic.scala
@@ -148,7 +148,7 @@ object Basic {
   val in_single_path: PublicEndpoint[Unit, Unit, Unit, Any] = endpoint.get.in("api")
 
   val in_extract_request_out_string: PublicEndpoint[String, Unit, String, Any] =
-    endpoint.in(extractFromRequest(_.method.method)).out(stringBody)
+    endpoint.in(extractFromRequest(_.queryParameters.get("foo").get)).out(stringBody)
 
   val in_string_out_status: PublicEndpoint[String, Unit, StatusCode, Any] =
     endpoint.in(query[String]("fruit")).out(statusCode)
@@ -157,7 +157,7 @@ object Basic {
     endpoint.delete.in("api" / "delete").out(statusCode(StatusCode.Ok).description("ok"))
 
   val in_string_out_content_type_string: PublicEndpoint[String, Unit, (String, String), Any] =
-    endpoint.in("api" / "echo").in(stringBody).out(stringBody).out(header[String]("Content-Type"))
+    endpoint.post.in("api" / "echo").in(stringBody).out(stringBody).out(header[String]("Content-Type"))
 
   val in_content_type_out_string: PublicEndpoint[String, Unit, String, Any] =
     endpoint.in("api" / "echo").in(header[String]("Content-Type")).out(stringBody)

--- a/tests/src/main/scala/sttp/tapir/tests/Validation.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/Validation.scala
@@ -31,7 +31,7 @@ object Validation {
     implicit val intDecoder: Decoder[IntWrapper] = Decoder.decodeInt.map(IntWrapper.apply)
     implicit val stringEncoder: Encoder[StringWrapper] = Encoder.encodeString.contramap(_.v)
     implicit val stringDecoder: Decoder[StringWrapper] = Decoder.decodeString.map(StringWrapper.apply)
-    endpoint.in(jsonBody[ValidFruitAmount])
+    endpoint.post.in(jsonBody[ValidFruitAmount])
   }
 
   val in_valid_optional_json: PublicEndpoint[Option[ValidFruitAmount], Unit, Unit, Any] = {
@@ -42,7 +42,7 @@ object Validation {
     implicit val intDecoder: Decoder[IntWrapper] = Decoder.decodeInt.map(IntWrapper.apply)
     implicit val stringEncoder: Encoder[StringWrapper] = Encoder.encodeString.contramap(_.v)
     implicit val stringDecoder: Decoder[StringWrapper] = Decoder.decodeString.map(StringWrapper.apply)
-    endpoint.in(jsonBody[Option[ValidFruitAmount]])
+    endpoint.post.in(jsonBody[Option[ValidFruitAmount]])
   }
 
   val in_valid_query: PublicEndpoint[IntWrapper, Unit, Unit, Any] = {


### PR DESCRIPTION
Previously, if the HTTP method was omitted, the server interpreter would accept all methods, but the documentation interpreter would (as I think, correctly) only generate documentation for the GET method. This PR fixes this discrepancy.