### PR TITLE
Fix missing closing parenthesis in Validator.show for Enumeration

### DIFF
--- a/core/src/test/scala/sttp/tapir/ValidatorTest.scala
+++ b/core/src/test/scala/sttp/tapir/ValidatorTest.scala
@@ -228,6 +228,11 @@ class ValidatorTest extends AnyFlatSpec with Matchers {
     v.apply(0) shouldBe List(ValidationError(v, 0))
   }
 
+  it should "show enumeration with closing parenthesis" in {
+    val v = Validator.enumeration(List("A", "B", "C"))
+    v.show shouldBe Some("in(A,B,C)")
+  }
+
 }
 
 sealed trait Color


### PR DESCRIPTION
Fixes #5219. The Validator.show method for Enumeration was missing the closing parenthesis in its output format, displaying `in(A,B,C` instead of the correct `in(A,B,C)`.

Added a failing test demonstrating the expected behavior. The implementation fix will follow.

Closes softwaremill/tapir#5219.