### PR TITLE
Add failing test: Fix Validator.show for Enumeration missing closing parenthesis

### DIFF
--- a/core/src/test/scala/sttp/tapir/ValidatorTest.scala
+++ b/core/src/test/scala/sttp/tapir/ValidatorTest.scala
@@ -228,6 +228,11 @@ class ValidatorTest extends AnyFlatSpec with Matchers {
     v.apply(0) shouldBe List(ValidationError(v, 0))
   }
 
+  it should "show enumeration with a closing parenthesis" in {
+    val v = Validator.enumeration(List("A", "B", "C"))
+    v.show shouldBe Some("in(A,B,C)")
+  }
+
 }
 
 sealed trait Color


### PR DESCRIPTION
Addresses softwaremill/tapir#5219.

Test for `Validator.show` with Enumeration validators. The implementation is currently missing the closing parenthesis — an enumeration with ["A", "B", "C"] should produce "in(A,B,C)".

Implementation fix pending.

Closes softwaremill/tapir#5219.