### PR TITLE
Add PATCH to CORSConfig.default allowed methods

### DIFF
--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/cors/CORSConfig.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/cors/CORSConfig.scala
@@ -126,7 +126,7 @@ object CORSConfig {
   val default: CORSConfig = CORSConfig(
     allowedOrigin = AllowedOrigin.All,
     allowedCredentials = AllowedCredentials.Deny,
-    allowedMethods = AllowedMethods.Some(Set(Method.GET, Method.HEAD, Method.POST, Method.PUT, Method.DELETE)),
+    allowedMethods = AllowedMethods.Some(Set(Method.GET, Method.HEAD, Method.POST, Method.PUT, Method.PATCH, Method.DELETE)),
     allowedHeaders = AllowedHeaders.Reflect,
     exposedHeaders = ExposedHeaders.None,
     maxAge = MaxAge.Default,

--- a/server/core/src/test/scala/sttp/tapir/server/interceptor/cors/CORSConfigTest.scala
+++ b/server/core/src/test/scala/sttp/tapir/server/interceptor/cors/CORSConfigTest.scala
@@ -2,6 +2,8 @@ package sttp.tapir.server.interceptor.cors
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.model.Method
+import sttp.tapir.server.interceptor.cors.CORSConfig.AllowedMethods
 
 class CORSConfigTest extends AnyFlatSpec with Matchers {
 
@@ -9,6 +11,11 @@ class CORSConfigTest extends AnyFlatSpec with Matchers {
 
   it should "provide a valid default config" in {
     CORSConfig.default.isValid shouldBe true
+  }
+
+  it should "allow PATCH by default" in {
+    val AllowedMethods.Some(methods) = CORSConfig.default.allowedMethods: @unchecked
+    methods should contain(Method.PATCH)
   }
 
   it should "detect an invalid config" in {


### PR DESCRIPTION
Fixes #5221: The default CORS configuration was missing PATCH from its list of allowed HTTP methods, preventing PATCH requests from being handled correctly by default.

Added PATCH to the allowed methods alongside the existing GET, HEAD, POST, PUT, and DELETE methods, aligning with standard REST API patterns where PATCH is used for partial updates.

Includes a test verifying that PATCH is now included in the default CORS configuration.

Closes softwaremill/tapir#5221.