### PR TITLE
Fix missing jsoniter codecs for inline enums nested in JSON models

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -349,7 +349,7 @@ class ClassDefinitionGenerator {
       (if (optional || !required) s"Option[$tpe]" else tpe, maybeEnum)
   }
 
-  private def addName(parentName: String, key: String) = parentName + key.replace('_', ' ').replace('-', ' ').capitalize.replace(" ", "")
+  private def addName(parentName: String, key: String) = RootGenerator.addName(parentName, key)
 
   private val reservedKeys = VersionedHelpers.reservedKeys
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/JsonSerdeGenerator.scala
@@ -4,6 +4,7 @@ import sttp.tapir.codegen.RootGenerator.indent
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
+  OpenapiSchemaAllOf,
   OpenapiSchemaAny,
   OpenapiSchemaArray,
   OpenapiSchemaBoolean,
@@ -314,11 +315,14 @@ object JsonSerdeGenerator {
     def getSerdeString(name: String, t: OpenapiSchemaType, isJson: Boolean): Seq[String] = (name, t, isJson) match {
       // For standard objects, generate the schema if it's a 'top level' json schema or if it's referenced as a subtype of an ADT without a discriminator
       case (name, o: OpenapiSchemaObject, isJson) =>
-        val inlinedEnumDefns = if (allTransitiveJsonParamRefs.contains(name)) {
-          o.properties.collect { case (en, OpenapiSchemaField(_: OpenapiSchemaEnum, _, _)) =>
-            genJsoniterEnumSerde(useCustomJsoniterSerdes, name + en.capitalize)
-          }
-        } else Nil
+        // Inline enums (defined on a property rather than via $ref) need an explicitly emitted codec: jsoniter would
+        // otherwise derive them as discriminated ADTs and reject their bare-string values. We descend through nested
+        // inline objects/arrays/maps to reach enums at any depth, naming each to match the class ClassDefinitionGenerator
+        // generates for it.
+        val inlinedEnumDefns =
+          if (allTransitiveJsonParamRefs.contains(name))
+            collectInlineEnumNames(RootGenerator.addName("", name), o).distinct.map(genJsoniterEnumSerde(useCustomJsoniterSerdes, _))
+          else Nil
         val supertypes =
           adtInheritanceMap.getOrElse(name, Nil).map(allSchemas.apply).collect { case oneOf: OpenapiSchemaOneOf => oneOf }
         val topLevelDefn =
@@ -349,6 +353,8 @@ object JsonSerdeGenerator {
     }
     (docSchemas.map { case (n, t) => (n, t, false) } ++ pathSchemas)
       .flatMap { (getSerdeString _).tupled }
+      // an inline enum can be reached by multiple paths (or also be emitted at top level); duplicate decls won't compile
+      .distinct
       .sorted
       .foldLeft(Option.empty[String]) {
         case (Some(a), b) => Some(a + "\n" + b)
@@ -380,6 +386,23 @@ object JsonSerdeGenerator {
         s"""implicit lazy val ${uncapitalisedName}JsonCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[${name}] = com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make($jsoniterBaseConfig)"""
     }
   }
+
+  // Collects the class names of all inline enums reachable from the given object, descending through nested inline
+  // objects and the element schemas of arrays/maps. Nested inline objects need no codec of their own (jsoniter derives
+  // them as part of the parent); only inline enums require an explicitly emitted codec, so we gather just their names.
+  // Naming mirrors ClassDefinitionGenerator (via the shared RootGenerator.addName) so codec types match the classes.
+  private def collectInlineEnumNames(objName: String, obj: OpenapiSchemaObject): Seq[String] =
+    obj.properties.toSeq.flatMap { case (key, OpenapiSchemaField(tpe, _, _)) => inlineEnumNamesForType(objName, key, tpe) }
+
+  private def inlineEnumNamesForType(parentName: String, key: String, schemaType: OpenapiSchemaType): Seq[String] =
+    schemaType match {
+      case OpenapiSchemaAllOf(Seq(single))    => inlineEnumNamesForType(parentName, key, single)
+      case _: OpenapiSchemaEnum               => Seq(RootGenerator.addName(parentName.capitalize, key))
+      case o: OpenapiSchemaObject             => collectInlineEnumNames(RootGenerator.addName(parentName, key), o)
+      case OpenapiSchemaArray(items, _, _, _) => inlineEnumNamesForType(RootGenerator.addName(parentName, key), "item", items)
+      case OpenapiSchemaMap(items, _, _)      => inlineEnumNamesForType(RootGenerator.addName(parentName, key), "item", items)
+      case _                                  => Nil
+    }
 
   private def genJsoniterEnumSerde(useCustomJsoniterSerdes: Boolean, name: String): String = {
     val uncapitalisedName = RootGenerator.uncapitalise(name)

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -383,4 +383,9 @@ object RootGenerator {
     .mkString
 
   def uncapitalise(name: String): String = name.head.toLower +: name.tail
+
+  // Derives the class name of a schema nested under `parentName` at property `key`. Shared by the class generator and
+  // the json serde generators so that emitted codec types cannot drift from the generated class names.
+  def addName(parentName: String, key: String): String =
+    parentName + key.replace('_', ' ').replace('-', ' ').capitalize.replace(" ", "")
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/build.sbt
@@ -1,0 +1,18 @@
+lazy val root = (project in file("."))
+  .enablePlugins(OpenapiCodegenPlugin)
+  .settings(
+    scalaVersion := "3.3.3",
+    version := "0.1",
+    openapiJsonSerdeLib := "jsoniter",
+    openapiXmlSerdeLib := "none",
+    openapiUseCustomJsoniterSerdes := false,
+    openapiGenerateEndpointTypes := true
+  )
+
+val tapirVersion = "1.11.16"
+libraryDependencies ++= Seq(
+  "com.softwaremill.sttp.tapir" %% "tapir-jsoniter-scala" % tapirVersion,
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "2.38.14",
+  "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % "2.38.14" % "compile-internal",
+  "org.scalatest" %% "scalatest" % "3.2.19" % Test
+)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/project/plugins.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/project/plugins.sbt
@@ -1,0 +1,11 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|
+                                  |
+                                  |The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.
+                                  |
+                                  |""".stripMargin)
+  else addSbtPlugin("com.softwaremill.sttp.tapir" % "sbt-openapi-codegen" % pluginVersion)
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/src/test/scala/JsonRoundtrip.scala
@@ -5,13 +5,22 @@ import sttp.tapir.generated.TapirGeneratedEndpoints.*
 import sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes.*
 
 class JsonRoundtrip extends AnyFreeSpec with Matchers {
-  "an inline enum nested in a json object can be round-tripped by generated jsoniter serdes" in {
-    val json = """{"message":{"role":"assistant","content":"hi"}}"""
-    val expected = ChatResponse(ChatResponseMessage(ChatResponseMessageRole.assistant, Some("hi")))
+  // Without a dedicated codec for an inline enum, jsoniter derives it as a discriminated ADT and throws
+  // "expected '{'" on the bare string value. We exercise inline enums reached as a direct property, an array
+  // element, a map value, and through a single-element allOf, asserting each round-trips its bare-string values.
+  "inline enums nested in a json object (direct, array, map, allOf) can be round-tripped by generated jsoniter serdes" in {
+    val json =
+      """{"message":{"role":"assistant","roles":["user","tool"],"labels":{"a":"system"},"priority":"user","content":"hi"}}"""
+    val expected = ChatResponse(
+      ChatResponseMessage(
+        role = ChatResponseMessageRole.assistant,
+        roles = Seq(ChatResponseMessageRolesItem.user, ChatResponseMessageRolesItem.tool),
+        labels = Map("a" -> ChatResponseMessageLabelsItem.system),
+        priority = ChatResponseMessagePriority.user,
+        content = Some("hi")
+      )
+    )
 
-    // Fails on the current code: the codegen does not emit a JsonValueCodec for the inline enum
-    // 'ChatResponseMessageRole', so jsoniter's derivation for ChatResponse treats the enum as a
-    // discriminated ADT and throws "expected '{'" when decoding the bare string "assistant".
     readFromString[ChatResponse](json) shouldEqual expected
     readFromString[ChatResponse](writeToString(expected)) shouldEqual expected
   }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/src/test/scala/JsonRoundtrip.scala
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/src/test/scala/JsonRoundtrip.scala
@@ -1,0 +1,18 @@
+import com.github.plokhotnyuk.jsoniter_scala.core.{readFromString, writeToString}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import sttp.tapir.generated.TapirGeneratedEndpoints.*
+import sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes.*
+
+class JsonRoundtrip extends AnyFreeSpec with Matchers {
+  "an inline enum nested in a json object can be round-tripped by generated jsoniter serdes" in {
+    val json = """{"message":{"role":"assistant","content":"hi"}}"""
+    val expected = ChatResponse(ChatResponseMessage(ChatResponseMessageRole.assistant, Some("hi")))
+
+    // Fails on the current code: the codegen does not emit a JsonValueCodec for the inline enum
+    // 'ChatResponseMessageRole', so jsoniter's derivation for ChatResponse treats the enum as a
+    // discriminated ADT and throws "expected '{'" when decoding the bare string "assistant".
+    readFromString[ChatResponse](json) shouldEqual expected
+    readFromString[ChatResponse](writeToString(expected)) shouldEqual expected
+  }
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/swagger.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: Inline enum json test for jsoniter-scala
+  version: 1.0.0
+paths:
+  '/chat':
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatResponse'
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatResponse'
+components:
+  schemas:
+    # 'message' is an inline object (not a $ref) carrying an inline string enum 'role'.
+    # The codegen names the inline enum '<object><field>' => ChatResponseMessageRole.
+    ChatResponse:
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: object
+          required:
+            - role
+          properties:
+            role:
+              type: string
+              enum:
+                - system
+                - user
+                - assistant
+                - tool
+            content:
+              type: string

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/swagger.yaml
@@ -20,8 +20,12 @@ paths:
                 $ref: '#/components/schemas/ChatResponse'
 components:
   schemas:
-    # 'message' is an inline object (not a $ref) carrying an inline string enum 'role'.
-    # The codegen names the inline enum '<object><field>' => ChatResponseMessageRole.
+    # 'message' is an inline object (not a $ref) carrying inline string enums at varying depths/shapes:
+    #  - 'role'     : a direct inline enum                    => ChatResponseMessageRole
+    #  - 'roles'    : an array of an inline enum              => ChatResponseMessageRolesItem
+    #  - 'labels'   : a map (additionalProperties) of an enum => ChatResponseMessageLabelsItem
+    #  - 'priority' : a single-element allOf wrapping an enum => ChatResponseMessagePriority
+    # Each requires its own jsoniter codec; the codegen names them '<object><field>[Item]'.
     ChatResponse:
       type: object
       required:
@@ -31,6 +35,9 @@ components:
           type: object
           required:
             - role
+            - roles
+            - labels
+            - priority
           properties:
             role:
               type: string
@@ -39,5 +46,31 @@ components:
                 - user
                 - assistant
                 - tool
+            roles:
+              type: array
+              items:
+                type: string
+                enum:
+                  - system
+                  - user
+                  - assistant
+                  - tool
+            labels:
+              type: object
+              additionalProperties:
+                type: string
+                enum:
+                  - system
+                  - user
+                  - assistant
+                  - tool
+            priority:
+              allOf:
+                - type: string
+                  enum:
+                    - system
+                    - user
+                    - assistant
+                    - tool
             content:
               type: string

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/test
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/inline-enum-json-roundtrip_jsoniter_scala3/test
@@ -1,0 +1,3 @@
+> clean
+> generateTapirDefinitions
+> test


### PR DESCRIPTION
Fixes #5276.

When jsoniter-scala serializes inline enums (enums defined directly in a schema rather than via $ref), it derives them as discriminated ADTs and rejects bare-string values unless an explicit codec is emitted. The openapi-codegen was only discovering inline enums at the top level of object properties, missing those nested deeper in the schema (inside arrays, maps, or allOf constructs).

This change:

- Extracts the class-naming logic to `RootGenerator.addName` so it's shared between the class generator and serde generators, ensuring codec types match the generated classes
- Replaces the shallow enum collection with recursive descent through nested inline objects, arrays, maps, and allOf to discover all inline enums
- Emits a distinct codec for each discovered inline enum, with deduplication to prevent duplicate declarations
- Adds integration test coverage for inline enums at all nesting depths: direct properties, array elements, map values, and single-element allOf wrappers

The test verifies that JSON round-tripping works correctly for each scenario without manual codec definitions.

Closes softwaremill/tapir#5276.