### PR TITLE
Fix remaining maxContentLength flake (connection reuse after reset)

### DIFF
--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerMultipartTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerMultipartTests.scala
@@ -52,7 +52,16 @@ class ServerMultipartTests[F[_], OPTIONS, ROUTE](
         .maxRequestBodyLength(15000),
       "multipart with maxContentLength"
     )((_: DoubleFruit) => pureResult(("ok").asRight[Unit])) { (backend, baseUri) =>
+      // The within-limit request is sent first, on a fresh connection: rejecting the over-limit body can reset
+      // the connection, and if that happened first a following request reusing the (keep-alive) connection from
+      // the pool would intermittently fail with a transport error.
       basicStringRequest
+        .post(uri"$baseUri/api/echo/multipart")
+        .multipartBody(multipart("fruitA", "pineapple".repeat(850)), multipart("fruitB", "maracuja".repeat(850)))
+        .send(backend)
+        .map { r =>
+          r.code shouldBe StatusCode.Ok
+        } >> basicStringRequest
         .post(uri"$baseUri/api/echo/multipart")
         .multipartBody(multipart("fruitA", "pineapple".repeat(1100)), multipart("fruitB", "maracuja".repeat(1200)))
         .send(backend)
@@ -63,13 +72,7 @@ class ServerMultipartTests[F[_], OPTIONS, ROUTE](
         // finished sending it (there is no Expect: 100-continue handshake), which surfaces on the
         // client as a transport error (connection reset / broken pipe / EOF) instead of a 413. Both
         // are valid rejections of the too-large body, so accept either to avoid a timing-dependent flake.
-        .recover { case _: SttpClientException => Succeeded } >> basicStringRequest
-        .post(uri"$baseUri/api/echo/multipart")
-        .multipartBody(multipart("fruitA", "pineapple".repeat(850)), multipart("fruitB", "maracuja".repeat(850)))
-        .send(backend)
-        .map { r =>
-          r.code shouldBe StatusCode.Ok
-        }
+        .recover { case _: SttpClientException => Succeeded }
     }
   )
 


### PR DESCRIPTION
Follow-up to #5289.

That fix tolerated a connection reset on the **over-limit** request, but `multipart with maxContentLength` still flakes intermittently (seen across unrelated dependency PRs, e.g. #5295) — this time on the **second, within-limit** request:

```
multipart with maxContentLength *** FAILED ***
  sttp.client4.SttpClientException$ReadException: POST .../api/echo/multipart
  Cause: java.io.IOException: HTTP/1.1 header parser received no bytes
```

**Root cause:** the over-limit request runs first; rejecting the body resets the keep-alive connection. The within-limit request that follows reuses that pooled connection (same host:port) and intermittently fails with a transport error before it can complete. The `.recover` from #5289 only wrapped the over-limit request, so this surfaced as a real failure.

**Fix:** reorder — send the within-limit request **first** (on a fresh connection, so its strict `200` assertion is preserved) and the over-limit request **last**, where its connection reset poisons nothing and is tolerated by the existing `recover`.

Verified locally on http4s (`multipart with maxContentLength` passes; `serverTests` compiles on Scala 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)