### PR TITLE
Fix flaky CI: stop client test server before sbt exits (revolver shutdown race)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,9 @@ jobs:
         # the netty server interpreter tests include some which run a large number of requests, to detect potential leaks
         # storing the output to verify it in the next step
         command: |
-          sbt $SBT_JAVA_OPTS -v "testScoped ${{ matrix.scala-version }} ${{ matrix.target-platform }}" 2>&1 | tee output.log
+          # reStop the forked client test server while the JVM is healthy; otherwise sbt-revolver's
+          # shutdown hook races on JVM exit (IllegalStateException: Shutdown in progress) and can flake the build
+          sbt $SBT_JAVA_OPTS -v "testScoped ${{ matrix.scala-version }} ${{ matrix.target-platform }}" "clientTestServer/reStop" 2>&1 | tee output.log
           exit ${PIPESTATUS[0]}
     - name: Check for reported leaks
       if: matrix.target-platform != 'JS'
@@ -129,13 +131,13 @@ jobs:
     # https://github.com/scala-js/scala-js/issues/4317 has a solution
     - name: Test
       if: matrix.target-platform == 'JS' && matrix.scala-version == '2.12'
-      run: sbt $SBT_JAVA_OPTS catsJS2_12/test circeJsonJS2_12/test clientCoreJS2_12/test clientTestsJS2_12/test coreJS2_12/test enumeratumJS2_12/test jsoniterScalaJS2_12/test newtypeJS2_12/test openapiDocsJS2_12/test playJsonJS2_12/test redocJS2_12/test serverCoreJS2_12/test sttpClientJS2_12/test testingJS2_12/test testsJS2_12/test uPickleJsonJS2_12/test zioJsonJS2_12/test
+      run: sbt $SBT_JAVA_OPTS catsJS2_12/test circeJsonJS2_12/test clientCoreJS2_12/test clientTestsJS2_12/test coreJS2_12/test enumeratumJS2_12/test jsoniterScalaJS2_12/test newtypeJS2_12/test openapiDocsJS2_12/test playJsonJS2_12/test redocJS2_12/test serverCoreJS2_12/test sttpClientJS2_12/test testingJS2_12/test testsJS2_12/test uPickleJsonJS2_12/test zioJsonJS2_12/test clientTestServer/reStop
     - name: Test
       if: matrix.target-platform == 'JS' && matrix.scala-version == '2.13'
-      run: sbt $SBT_JAVA_OPTS catsJS/test circeJsonJS/test clientCoreJS/test clientTestsJS/test coreJS/test enumeratumJS/test jsoniterScalaJS/test newtypeJS/test openapiDocsJS/test playJsonJS/test redocJS/test serverCoreJS/test sttpClientJS/test testingJS/test testsJS/test uPickleJsonJS/test zioJsonJS/test
+      run: sbt $SBT_JAVA_OPTS catsJS/test circeJsonJS/test clientCoreJS/test clientTestsJS/test coreJS/test enumeratumJS/test jsoniterScalaJS/test newtypeJS/test openapiDocsJS/test playJsonJS/test redocJS/test serverCoreJS/test sttpClientJS/test testingJS/test testsJS/test uPickleJsonJS/test zioJsonJS/test clientTestServer/reStop
     - name: Test
       if: matrix.target-platform == 'JS' && matrix.scala-version == '3'
-      run: sbt $SBT_JAVA_OPTS catsJS3/test circeJsonJS3/test clientCoreJS3/test clientTestsJS3/test coreJS3/test jsoniterScalaJS3/test openapiDocsJS3/test redocJS3/test serverCoreJS3/test sttpClientJS3/test testingJS3/test testsJS3/test uPickleJsonJS3/test zioJsonJS3/test
+      run: sbt $SBT_JAVA_OPTS catsJS3/test circeJsonJS3/test clientCoreJS3/test clientTestsJS3/test coreJS3/test jsoniterScalaJS3/test openapiDocsJS3/test redocJS3/test serverCoreJS3/test sttpClientJS3/test testingJS3/test testsJS3/test uPickleJsonJS3/test zioJsonJS3/test clientTestServer/reStop
     - uses: actions/upload-artifact@v7  # upload test results
       if: success() || failure()        # run this step even if previous step failed
       with:


### PR DESCRIPTION
## Problem

CI intermittently fails even when **all tests pass**, with:

```
clientTestServer ... finished with exit code 143
##[error]Exception in thread "Thread-18" java.lang.IllegalStateException: Shutdown in progress
	at java.base/java.lang.Runtime.removeShutdownHook(Runtime.java:244)
	at spray.revolver.AppProcess.unregisterShutdownHook(AppProcess.scala:70)
##[error]Final attempt failed. Child_process exited with error code 1
```

(Seen recently on #5053, #5260, #5148.)

## Root cause

The client interpreter tests start a forked HTTP server via sbt-revolver (`reStart`, wired through `clientTestServerSettings` → `startClientTestServer`), but it is **never stopped**. When the `sbt` batch finishes, the JVM exits and its shutdown hook kills the forked server (exit 143). spray-revolver's non-daemon `watchThread` — blocked on `process.exitValue()` — then unblocks and calls `Runtime.removeShutdownHook` **while shutdown is already in progress**, throwing `IllegalStateException: Shutdown in progress`. Depending on timing this corrupts sbt's exit code (1 instead of 0), so the step flakes.

It's a race: the same lines appear on green runs too — sometimes the bad exit code wins, sometimes not.

## Fix

Append `clientTestServer/reStop` to each test command. `reStop` calls `AppProcess.stop()`, which unregisters the shutdown hook **while the JVM is healthy** (a clean `removeShutdownHook`), so the later `watchThread` cleanup is a harmless no-op and the JVM exits without a registered revolver hook. `reStop` is a no-op (`Application clientTestServer not yet started`) when the server wasn't started, so it's safe on every matrix cell.

Applied to the JVM `testScoped` step and the three JS test steps (sttp-client/sttp-client4 cross-build to JS and also start the JVM server).

Notes:
- sbt-revolver 0.10.0 is the last release, so this can't be fixed by a version bump.
- `Global / onUnload` was considered but does **not** fire on `sbt` batch exit (verified), so an explicit `reStop` is required.
- Verified locally that `clientTestServer/reStop` is a valid command and no-ops cleanly when nothing is running. The race itself is timing-dependent and infra-specific; this PR's own CI is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)