### PR TITLE
Send Connection: close on maxContentLength (413) responses

### DIFF
--- a/server/core/src/main/scala/sttp/tapir/server/interceptor/decodefailure/DecodeFailureHandler.scala
+++ b/server/core/src/main/scala/sttp/tapir/server/interceptor/decodefailure/DecodeFailureHandler.scala
@@ -145,7 +145,11 @@ object DefaultDecodeFailureHandler {
   }
   private val respondBadRequest = Some(onlyStatus(StatusCode.BadRequest))
   private val respondUnsupportedMediaType = Some(onlyStatus(StatusCode.UnsupportedMediaType))
-  private val respondPayloadTooLarge = Some(onlyStatus(StatusCode.PayloadTooLarge))
+  // A too-large body is rejected before it has been fully read, so the connection cannot be safely reused for the
+  // next request (the unread body would corrupt it). Signal `Connection: close` so the client does not return the
+  // connection to its pool and reuse it (which otherwise races with the server closing it -> a transport error).
+  private val respondPayloadTooLarge =
+    Some((StatusCode.PayloadTooLarge, List(Header(HeaderNames.Connection, "close"))))
 
   def respondNotFoundIfHasAuth(
       ctx: DecodeFailureContext,


### PR DESCRIPTION
Root-cause companion to #5297 (which reorders the test).

## Why

When `maxRequestBodyLength` is exceeded, tapir returns 413 **before the request body has been fully read**. Per HTTP/1.1 the connection then can't be safely reused (the unread body would corrupt the next message). Today the 413 carries no `Connection: close`, so a keep-alive client (e.g. sttp's JDK HttpClient backend) returns the connection to its pool and reuses it for the next request — racing with the server closing it, and intermittently failing with a transport error (`Broken pipe` / `HTTP/1.1 header parser received no bytes`). Non-idempotent POSTs aren't auto-retried by the JDK client, so the error surfaces. This is the root cause of the `multipart with maxContentLength` flake.

## What

Set `Connection: close` on `DefaultDecodeFailureHandler`'s `PayloadTooLarge` response, so a compliant client does not pool/reuse the connection and the next request gets a fresh one.

## Verification (local, Scala 3)

- **http4s** — confirmed the 413 now carries the header: `headers=List(connection: close, content-length: 59, ...)`. This is the backend where the flake was observed; the header makes the client not reuse the connection. ✅
- **netty** — copies tapir response headers and only overrides `Connection` for non-keep-alive / HTTP/1.0 requests, so it preserves `Connection: close` for HTTP/1.1 keep-alive; its maxContentLength tests still pass. ✅
- **pekko-http** — maxContentLength tests still pass; pekko enforces the size limit at its own parser layer (its own 413), and doesn't error on the header. ✅

No backend errored on the header. Backends that model `Connection` specially may ignore the raw header, but none break.

## Relationship to #5297

This addresses the cause for real users (a client pipelining a request after an over-limit POST), not just the test. If preferred, it could replace the test-side reorder in #5297; I've kept them separate per discussion so you can choose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)