### PR TITLE
Fix flaky graceful-shutdown tests: synchronize on request arrival

### DIFF
--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerGracefulShutdownTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerGracefulShutdownTests.scala
@@ -11,6 +11,7 @@ import sttp.monad.syntax._
 import sttp.tapir._
 import sttp.tapir.tests._
 
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 import scala.concurrent.duration._
 
 class ServerGracefulShutdownTests[F[_], OPTIONS, ROUTE](createServerTest: CreateServerTest[F, Any, OPTIONS, ROUTE], sleeper: Sleeper[F])(
@@ -19,46 +20,60 @@ class ServerGracefulShutdownTests[F[_], OPTIONS, ROUTE](createServerTest: Create
   import createServerTest._
 
   def tests(): List[Test] = List(
-    testServerLogicWithStop(
-      endpoint
-        .out(plainBody[String])
-        .serverLogic { _ =>
-          sleeper.sleep(3.seconds).flatMap(_ => pureResult("processing finished".asRight[Unit]))
-        },
-      "Server waits for long-running request to complete within timeout",
-      gracefulShutdownTimeout = Some(4.seconds)
-    ) { (stopServer) => (backend, baseUri) =>
-      (for {
-        runningRequest <- basicRequest.get(uri"$baseUri").send(backend).start
-        _ <- IO.sleep(1.second)
-        runningStop <- stopServer.start
-        result <- runningRequest.join.attempt
-        _ <- runningStop.join
-      } yield {
-        result.value.isSuccess shouldBe true
-      })
-    },
-    testServerLogicWithStop(
-      endpoint
-        .out(plainBody[String])
-        .serverLogic { _ =>
-          sleeper.sleep(4.seconds).flatMap(_ => pureResult("processing finished".asRight[Unit]))
-        },
-      "Server rejects requests with 503 during shutdown",
-      gracefulShutdownTimeout = Some(6.seconds)
-    ) { (stopServer) => (backend, baseUri) =>
-      (for {
-        runningRequest <- basicRequest.get(uri"$baseUri").send(backend).start
-        _ <- IO.sleep(1.second)
-        runningStop <- stopServer.start
-        _ <- IO.sleep(1.seconds)
-        rejected <- basicRequest.get(uri"$baseUri").send(backend).attempt
-        firstResult <- runningRequest.join.attempt
-        _ <- runningStop.join
-      } yield {
-        (rejected.value.code shouldBe StatusCode.ServiceUnavailable): Unit
-        firstResult.value.isSuccess shouldBe true
-      })
+    {
+      // Released by the server logic once it starts handling the request, so the test triggers shutdown only after
+      // the request is genuinely in-flight. Relying on a fixed sleep instead races under load: the stop could begin
+      // before the request reaches the server, which then aborts it and fails the test.
+      val requestReceived = new CountDownLatch(1)
+      testServerLogicWithStop(
+        endpoint
+          .out(plainBody[String])
+          .serverLogic { _ =>
+            m.eval(requestReceived.countDown())
+              .flatMap(_ => sleeper.sleep(3.seconds))
+              .flatMap(_ => pureResult("processing finished".asRight[Unit]))
+          },
+        "Server waits for long-running request to complete within timeout",
+        gracefulShutdownTimeout = Some(4.seconds)
+      ) { (stopServer) => (backend, baseUri) =>
+        (for {
+          runningRequest <- basicRequest.get(uri"$baseUri").send(backend).start
+          requestArrived <- IO.blocking(requestReceived.await(10, TimeUnit.SECONDS))
+          runningStop <- stopServer.start
+          result <- runningRequest.join.attempt
+          _ <- runningStop.join
+        } yield {
+          (requestArrived shouldBe true): Unit
+          result.value.isSuccess shouldBe true
+        })
+      }
+    }, {
+      val requestReceived = new CountDownLatch(1)
+      testServerLogicWithStop(
+        endpoint
+          .out(plainBody[String])
+          .serverLogic { _ =>
+            m.eval(requestReceived.countDown())
+              .flatMap(_ => sleeper.sleep(4.seconds))
+              .flatMap(_ => pureResult("processing finished".asRight[Unit]))
+          },
+        "Server rejects requests with 503 during shutdown",
+        gracefulShutdownTimeout = Some(6.seconds)
+      ) { (stopServer) => (backend, baseUri) =>
+        (for {
+          runningRequest <- basicRequest.get(uri"$baseUri").send(backend).start
+          requestArrived <- IO.blocking(requestReceived.await(10, TimeUnit.SECONDS))
+          runningStop <- stopServer.start
+          _ <- IO.sleep(1.seconds) // give shutdown time to start rejecting new requests
+          rejected <- basicRequest.get(uri"$baseUri").send(backend).attempt
+          firstResult <- runningRequest.join.attempt
+          _ <- runningStop.join
+        } yield {
+          (requestArrived shouldBe true): Unit
+          (rejected.value.code shouldBe StatusCode.ServiceUnavailable): Unit
+          firstResult.value.isSuccess shouldBe true
+        })
+      }
     }
   )
 }

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerGracefulShutdownTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerGracefulShutdownTests.scala
@@ -24,17 +24,21 @@ class ServerGracefulShutdownTests[F[_], OPTIONS, ROUTE](createServerTest: Create
       // Released by the server logic once it starts handling the request, so the test triggers shutdown only after
       // the request is genuinely in-flight. Relying on a fixed sleep instead races under load: the stop could begin
       // before the request reaches the server, which then aborts it and fails the test.
+      // The graceful-shutdown timeout is kept well above the request duration: the server force-closes in-flight
+      // requests once the timeout elapses, and a tight margin (e.g. 3s of work vs a 4s timeout) flakes on a loaded
+      // CI runner where the sleep and response write drift past it. A larger timeout doesn't slow the happy path -
+      // the stop returns as soon as the request's connection closes, not when the timeout elapses.
       val requestReceived = new CountDownLatch(1)
       testServerLogicWithStop(
         endpoint
           .out(plainBody[String])
           .serverLogic { _ =>
             m.eval(requestReceived.countDown())
-              .flatMap(_ => sleeper.sleep(3.seconds))
+              .flatMap(_ => sleeper.sleep(2.seconds))
               .flatMap(_ => pureResult("processing finished".asRight[Unit]))
           },
         "Server waits for long-running request to complete within timeout",
-        gracefulShutdownTimeout = Some(4.seconds)
+        gracefulShutdownTimeout = Some(10.seconds)
       ) { (stopServer) => (backend, baseUri) =>
         (for {
           runningRequest <- basicRequest.get(uri"$baseUri").send(backend).start
@@ -58,7 +62,7 @@ class ServerGracefulShutdownTests[F[_], OPTIONS, ROUTE](createServerTest: Create
               .flatMap(_ => pureResult("processing finished".asRight[Unit]))
           },
         "Server rejects requests with 503 during shutdown",
-        gracefulShutdownTimeout = Some(6.seconds)
+        gracefulShutdownTimeout = Some(10.seconds)
       ) { (stopServer) => (backend, baseUri) =>
         (for {
           runningRequest <- basicRequest.get(uri"$baseUri").send(backend).start


### PR DESCRIPTION
## Problem

`ServerGracefulShutdownTests` flakes on netty:

```
Server waits for long-running request to complete within timeout *** FAILED ***
  false was not equal to true (ServerGracefulShutdownTests.scala:47)
```

The in-flight request, which should complete during graceful shutdown, instead fails.

## Root cause (two independent races)

1. **Request not yet in-flight when stop begins.** The test fired the request as a fiber, waited a fixed `IO.sleep(1.second)`, then triggered stop — assuming the request had reached the server. Under load it sometimes hadn't, so shutdown aborted it.

2. **Too-tight timeout margin.** netty's graceful shutdown (`waitForClosedChannels`) force-closes in-flight channels once `elapsed > gracefulShutdownTimeout`. With 3s of work against a 4s timeout, only 1s of slack remained for the `sleeper.sleep` (a pooled `Thread.sleep` for the Future backend) and response write to drift under CI load. Failing runs took ~4.2s (hit the 4s force-close); passing ones ~3.0s.

## Fix

- **Synchronize on request arrival:** a `CountDownLatch` the server logic releases (`m.eval`) as it starts handling the request; the test awaits it before stopping. Shutdown now always begins with the request genuinely in-flight. (Mirrors the existing pattern in `ServerCancellationTests`.)
- **Widen the timeout margin:** raise the graceful timeouts well above the request duration (10s vs 2s/4s of work). This is free on the happy path — `stop` returns as soon as the request's connection closes, not when the timeout elapses — so the test still finishes in ~request time.

Shared test, so the fix applies across all server backends that run it.

## Verification

`serverTests` compiles (2.13, 3). On netty-future (Scala 3): the previously-flaky "waits for long-running request" test passes 6/6 repeated runs; the "503 during shutdown" test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)