### PR TITLE
Fix flaky netty file body: don't close the channel while a write is in flight

### DIFF
--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/FileWriterSubscriber.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/FileWriterSubscriber.scala
@@ -5,13 +5,15 @@ import org.reactivestreams.{Publisher, Subscription}
 
 import java.nio.channels.AsynchronousFileChannel
 import java.nio.file.{Path, StandardOpenOption}
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future, Promise}
 
 /** A Reactive Streams subscriber which receives chunks of bytes and writes them to a file.
   */
 class FileWriterSubscriber(path: Path) extends PromisingSubscriber[Unit, HttpContent] {
+  import FileWriterSubscriber._
+
   private var subscription: Subscription = _
 
   /** JDK interface to write asynchronously to a file */
@@ -20,15 +22,14 @@ class FileWriterSubscriber(path: Path) extends PromisingSubscriber[Unit, HttpCon
   /** Current position in the file */
   @volatile private var position: Long = 0
 
-  // Coordinates the (serially-signalled) upstream with the asynchronous write-completion handler, which runs on the
-  // file channel's thread pool. `onComplete` does not require demand, so the publisher may signal it while the last
-  // `onNext`'s write is still in flight; closing the channel then would race that write and truncate the file. We
-  // therefore close the channel and complete the promise only once the final write has finished. At most one write is
-  // ever in flight, because the next chunk is requested only from a write's completion callback.
-  private val lock = new Object
-  private var writeInProgress = false
-  private var upstreamCompleted = false
-  private val finished = new AtomicBoolean(false)
+  // Lock-free coordination between the (serially-signalled) upstream and the asynchronous write-completion handler,
+  // which runs on the file channel's thread pool. `onComplete` does not require demand, so the publisher may signal it
+  // while the last `onNext`'s write is still in flight; closing the channel then would race that write and truncate the
+  // file. At most one write is ever in flight (the next chunk is requested only from a write's completion callback), so
+  // the only contention is between that callback and `onComplete`. A CAS on `state` decides which of them performs the
+  // finalization, and `terminate*` (a single atomic move to Finished) makes the channel close + promise completion
+  // happen exactly once.
+  private val state = new AtomicInteger(Idle)
 
   /** Used to signal completion, so that external code can represent writing to a file as Future[Unit] */
   private val resultPromise = Promise[Unit]()
@@ -43,7 +44,7 @@ class FileWriterSubscriber(path: Path) extends PromisingSubscriber[Unit, HttpCon
 
   override def onNext(httpContent: HttpContent): Unit = {
     val byteBuffer = httpContent.content().nioBuffer()
-    lock.synchronized { writeInProgress = true }
+    state.set(Writing)
     fileChannel.write(
       byteBuffer,
       position,
@@ -52,47 +53,46 @@ class FileWriterSubscriber(path: Path) extends PromisingSubscriber[Unit, HttpCon
         override def completed(result: Integer, attachment: Unit): Unit = {
           httpContent.release()
           position += result
-          val finalizeNow = lock.synchronized {
-            writeInProgress = false
-            upstreamCompleted
-          }
-          if (finalizeNow) succeed()
-          else subscription.request(1)
+          // If upstream completed during this write (state moved to Completing), finalize now; otherwise ask for more.
+          if (state.compareAndSet(Writing, Idle)) subscription.request(1)
+          else terminateSuccess()
         }
 
         override def failed(exc: Throwable, attachment: Unit): Unit = {
           httpContent.release()
           subscription.cancel()
-          fail(exc)
+          terminateFailure(exc)
         }
       }
     )
   }
 
-  override def onError(t: Throwable): Unit = fail(t)
+  override def onError(t: Throwable): Unit = terminateFailure(t)
 
-  override def onComplete(): Unit = {
-    val finalizeNow = lock.synchronized {
-      upstreamCompleted = true
-      !writeInProgress
-    }
-    if (finalizeNow) succeed()
-  }
+  override def onComplete(): Unit =
+    // If a write is still in flight, defer finalization to its completion callback; otherwise finalize now.
+    if (!state.compareAndSet(Writing, Completing)) terminateSuccess()
 
-  private def succeed(): Unit =
-    if (finished.compareAndSet(false, true)) {
+  private def terminateSuccess(): Unit =
+    if (state.getAndSet(Finished) != Finished) {
       fileChannel.close()
       resultPromise.success(())
     }
 
-  private def fail(t: Throwable): Unit =
-    if (finished.compareAndSet(false, true)) {
+  private def terminateFailure(t: Throwable): Unit =
+    if (state.getAndSet(Finished) != Finished) {
       if (fileChannel != null) fileChannel.close()
       resultPromise.failure(t)
     }
 }
 
 object FileWriterSubscriber {
+  // States for the lock-free finalization handshake between the write-completion callback and `onComplete`.
+  private final val Idle = 0 // no write in flight, upstream not completed
+  private final val Writing = 1 // a write is in flight, upstream not completed
+  private final val Completing = 2 // a write is in flight, upstream completed - the write callback will finalize
+  private final val Finished = 3 // channel closed and promise completed
+
   def processAll(publisher: Publisher[HttpContent], path: Path, maxBytes: Option[Long]): Future[Unit] = {
     val subscriber = new FileWriterSubscriber(path)
     publisher.subscribe(maxBytes.map(new LimitedLengthSubscriber(_, subscriber)).getOrElse(subscriber))

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/FileWriterSubscriber.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/FileWriterSubscriber.scala
@@ -5,7 +5,7 @@ import org.reactivestreams.{Publisher, Subscription}
 
 import java.nio.channels.AsynchronousFileChannel
 import java.nio.file.{Path, StandardOpenOption}
-import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future, Promise}
 
@@ -20,6 +20,16 @@ class FileWriterSubscriber(path: Path) extends PromisingSubscriber[Unit, HttpCon
   /** Current position in the file */
   @volatile private var position: Long = 0
 
+  // Coordinates the (serially-signalled) upstream with the asynchronous write-completion handler, which runs on the
+  // file channel's thread pool. `onComplete` does not require demand, so the publisher may signal it while the last
+  // `onNext`'s write is still in flight; closing the channel then would race that write and truncate the file. We
+  // therefore close the channel and complete the promise only once the final write has finished. At most one write is
+  // ever in flight, because the next chunk is requested only from a write's completion callback.
+  private val lock = new Object
+  private var writeInProgress = false
+  private var upstreamCompleted = false
+  private val finished = new AtomicBoolean(false)
+
   /** Used to signal completion, so that external code can represent writing to a file as Future[Unit] */
   private val resultPromise = Promise[Unit]()
 
@@ -33,6 +43,7 @@ class FileWriterSubscriber(path: Path) extends PromisingSubscriber[Unit, HttpCon
 
   override def onNext(httpContent: HttpContent): Unit = {
     val byteBuffer = httpContent.content().nioBuffer()
+    lock.synchronized { writeInProgress = true }
     fileChannel.write(
       byteBuffer,
       position,
@@ -41,27 +52,44 @@ class FileWriterSubscriber(path: Path) extends PromisingSubscriber[Unit, HttpCon
         override def completed(result: Integer, attachment: Unit): Unit = {
           httpContent.release()
           position += result
-          subscription.request(1)
+          val finalizeNow = lock.synchronized {
+            writeInProgress = false
+            upstreamCompleted
+          }
+          if (finalizeNow) succeed()
+          else subscription.request(1)
         }
 
         override def failed(exc: Throwable, attachment: Unit): Unit = {
           httpContent.release()
           subscription.cancel()
-          onError(exc)
+          fail(exc)
         }
       }
     )
   }
 
-  override def onError(t: Throwable): Unit = {
-    fileChannel.close()
-    resultPromise.failure(t)
-  }
+  override def onError(t: Throwable): Unit = fail(t)
 
   override def onComplete(): Unit = {
-    fileChannel.close()
-    resultPromise.success(())
+    val finalizeNow = lock.synchronized {
+      upstreamCompleted = true
+      !writeInProgress
+    }
+    if (finalizeNow) succeed()
   }
+
+  private def succeed(): Unit =
+    if (finished.compareAndSet(false, true)) {
+      fileChannel.close()
+      resultPromise.success(())
+    }
+
+  private def fail(t: Throwable): Unit =
+    if (finished.compareAndSet(false, true)) {
+      if (fileChannel != null) fileChannel.close()
+      resultPromise.failure(t)
+    }
 }
 
 object FileWriterSubscriber {

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/FileWriterSubscriber.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/FileWriterSubscriber.scala
@@ -42,30 +42,34 @@ class FileWriterSubscriber(path: Path) extends PromisingSubscriber[Unit, HttpCon
     s.request(1)
   }
 
-  override def onNext(httpContent: HttpContent): Unit = {
-    val byteBuffer = httpContent.content().nioBuffer()
-    state.set(Writing)
-    fileChannel.write(
-      byteBuffer,
-      position,
-      (),
-      new java.nio.channels.CompletionHandler[Integer, Unit] {
-        override def completed(result: Integer, attachment: Unit): Unit = {
-          httpContent.release()
-          position += result
-          // If upstream completed during this write (state moved to Completing), finalize now; otherwise ask for more.
-          if (state.compareAndSet(Writing, Idle)) subscription.request(1)
-          else terminateSuccess()
-        }
+  override def onNext(httpContent: HttpContent): Unit =
+    // Normally state is Idle here. If the CAS fails we've already terminated - a compliant publisher may still deliver
+    // an onNext after we cancelled (rule 2.8) - so drop the chunk rather than write to an already-closed channel.
+    if (state.compareAndSet(Idle, Writing)) {
+      val byteBuffer = httpContent.content().nioBuffer()
+      fileChannel.write(
+        byteBuffer,
+        position,
+        (),
+        new java.nio.channels.CompletionHandler[Integer, Unit] {
+          override def completed(result: Integer, attachment: Unit): Unit = {
+            httpContent.release()
+            position += result
+            // If upstream completed during this write (state moved to Completing), finalize now; otherwise ask for more.
+            if (state.compareAndSet(Writing, Idle)) subscription.request(1)
+            else terminateSuccess()
+          }
 
-        override def failed(exc: Throwable, attachment: Unit): Unit = {
-          httpContent.release()
-          subscription.cancel()
-          terminateFailure(exc)
+          override def failed(exc: Throwable, attachment: Unit): Unit = {
+            httpContent.release()
+            subscription.cancel()
+            terminateFailure(exc)
+          }
         }
-      }
-    )
-  }
+      )
+    } else {
+      val _ = httpContent.release()
+    }
 
   override def onError(t: Throwable): Unit = terminateFailure(t)
 


### PR DESCRIPTION
## Problem

`ServerFileTests` flakes on netty (seen on Scala 2.12):

```
Endpoint[echo file](... POST /api/echo {body as application/octet-stream} ...) *** FAILED ***
  Right("") was not equal to Right("pen pineapple apple pen") (ServerFileTests.scala:29)
```

The echoed file body comes back **empty**.

## Root cause

`FileWriterSubscriber` (used by the netty-future and netty-sync backends to persist a request body to a file):

- `onNext` starts an **asynchronous** `fileChannel.write(...)` and returns immediately, requesting the next chunk only from the write's `completed` callback (so at most one write is ever in flight).
- Per the Reactive Streams spec, `onComplete` does **not** require demand — the publisher may signal it right after the last `onNext`, while that chunk's async write is still in flight.
- The old `onComplete` called `fileChannel.close()` immediately, racing the pending write. The write is dropped/truncated, the file ends up 0 bytes, and the response side (`FileRangePublisher`) reads EOF at position 0 → empty body.

Intermittent because the write usually wins; under load the close wins.

## Fix

Defer the channel close + promise completion until the final write has actually finished. Because at most one write is ever outstanding, the only contention is between that write's completion callback and `onComplete` — arbitrated with a single `AtomicInteger` state machine (lock-free):

```
Idle -> Writing            (onNext starts a write)
Writing -> Idle            (write completed, upstream still open -> request next)
Writing -> Completing      (onComplete arrived mid-write -> defer)
Completing -> Finished     (that write completes -> finalize)
Idle -> Finished           (onComplete with no write in flight -> finalize)
```

A CAS picks which of the two finalizes; a single atomic move to `Finished` makes the channel close + promise completion happen exactly once (error paths included). No behavioural change on the happy path; it only closes the truncation window.

## Verification

`netty-server` compiles. Ran the echo-file tests on netty-future (Scala 2.13) across repeated runs — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)