### PR TITLE
Fix two Netty ByteBuf leaks (flaky CI "LEAK" failures)

### DIFF
--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/LimitedLengthSubscriber.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/reactivestreams/LimitedLengthSubscriber.scala
@@ -19,6 +19,8 @@ private[netty] class LimitedLengthSubscriber[R](maxBytes: Long, delegate: Subscr
   override def onNext(content: HttpContent): Unit = {
     bytesReadSoFar = bytesReadSoFar + content.content.readableBytes()
     if (bytesReadSoFar > maxBytes) {
+      // this chunk is not forwarded to the delegate, so we must release it ourselves to avoid a ByteBuf leak
+      val _ = content.release()
       subscription.cancel()
       onError(StreamMaxLengthExceededException(maxBytes))
       subscription = null

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/ws/WebSocketPingPongFrameHandler.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/ws/WebSocketPingPongFrameHandler.scala
@@ -12,7 +12,9 @@ class WebSocketPingPongFrameHandler(ignorePong: Boolean, autoPongOnPing: Boolean
     msg match {
       case ping: PingWebSocketFrame =>
         if (autoPongOnPing) {
+          // retain the ping's content for the pong, then release the ping frame itself to avoid a ByteBuf leak
           val _ = ctx.writeAndFlush(new PongWebSocketFrame(ping.content().retain()))
+          val _ = ping.release()
         } else {
           val _ = ctx.fireChannelRead(ping)
         }

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/ws/WebSocketPingPongFrameHandler.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/ws/WebSocketPingPongFrameHandler.scala
@@ -14,7 +14,7 @@ class WebSocketPingPongFrameHandler(ignorePong: Boolean, autoPongOnPing: Boolean
         if (autoPongOnPing) {
           // retain the ping's content for the pong, then release the ping frame itself to avoid a ByteBuf leak
           val _ = ctx.writeAndFlush(new PongWebSocketFrame(ping.content().retain()))
-          val _ = ping.release()
+          ping.release(): Unit
         } else {
           val _ = ctx.fireChannelRead(ping)
         }

--- a/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/internal/NettySyncRequestBody.scala
+++ b/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/internal/NettySyncRequestBody.scala
@@ -98,9 +98,13 @@ private[sync] class NettySyncRequestBody(
       case _ => Flow.empty // Empty request, return an empty stream
 
 extension (decoder: HttpPostMultipartRequestDecoder)
-  private def decodeChunk(httpContent: HttpContent): Seq[InterfaceHttpData] = {
-    decoder.offer(httpContent)
-    Iterator.continually(maybeNext()).takeWhile(_.nonEmpty).flatten.toSeq
-  }
+  private def decodeChunk(httpContent: HttpContent): Seq[InterfaceHttpData] =
+    try
+      // offer() copies the readable bytes into the decoder's own buffer (released later via decoder.destroy()),
+      // and does not retain the passed content - so we must release the incoming chunk here to avoid a ByteBuf leak
+      decoder.offer(httpContent)
+      Iterator.continually(maybeNext()).takeWhile(_.nonEmpty).flatten.toSeq
+    finally
+      val _ = httpContent.release()
 
   private def maybeNext(): Option[InterfaceHttpData] = Option.when(decoder.hasNext)(decoder.next())


### PR DESCRIPTION
## Problem

CI intermittently fails the netty **"Check for reported leaks"** step (e.g. #5317, an unrelated sbt bump) with:

```
LEAK: ByteBuf.release() was not called before it's garbage-collected.
```

The step just `grep`s test output for `LEAK`; Netty's default detector samples buffers and reports on GC, so it's flaky and the log line's position does not identify the source.

## Investigation

Reproduced locally by running the full sync suite under `-Dio.netty.leakDetection.level=paranoid` (netty tests aren't forked, so passed via `SBT_OPTS`). PARANOID's access records pointed at two real leaks in tapir's own code:

1. **Multipart request body** (`NettySyncRequestBody.decodeChunk`) — the dominant cause (dozens of leaks per suite run). Each inbound `HttpContent` is offered to `HttpPostMultipartRequestDecoder` but never released. Verified in the netty 4.2.15 bytecode that `offer` **copies** the readable bytes into the decoder's own `undecodedChunk` and does **not** retain the passed content, so the caller must release each chunk; `decoder.destroy()` only frees the decoder's internal buffer, not the offered chunks.

2. **WebSocket ping/pong** (`WebSocketPingPongFrameHandler`, shared netty-server core) — rarer; surfaced once the multipart noise was gone. On `autoPongOnPing` we retain the ping's content for the pong but never release the original `ping` frame, leaking its buffer.

## Fix

- Release each multipart chunk after offering it (in a `finally`).
- Release the ping frame after building the pong.

## Verification

Under PARANOID, full sync suite ×3 (256 tests each):

| State | LEAK count |
|---|---|
| Before | dozens |
| After multipart fix | 4 (the WS leak) |
| After both fixes | **0** |

Regression check — future / cats / zio netty server suites under PARANOID: all pass (266 / 289 / 224 tests).

## Note (separate, pre-existing — not fixed here)

The regression run surfaced **one** rare, unrelated leak in the `FileWriterSubscriber` / `writeToFile` path (recently-churned concurrency code, see #5311). It's independent of these changes and very unlikely to flake CI at the default sampling level; worth a separate follow-up rather than guessing a concurrency fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)