### PR TITLE
Enable the ZIO OpenTelemetry example now that tapir-zio-opentelemetry is released

### DIFF
--- a/examples/src/main/scala/sttp/tapir/examples/observability/ZIOpenTelemetryExample.scala
+++ b/examples/src/main/scala/sttp/tapir/examples/observability/ZIOpenTelemetryExample.scala
@@ -1,13 +1,13 @@
 // {cat=Observability; effects=ZIO; server=ZIO HTTP}: Tracing requests with ZIO OpenTelemetry (customised config)
 
-//> using dep com.softwaremill.sttp.tapir::tapir-core:1.13.21
-//> using dep com.softwaremill.sttp.tapir::tapir-zio:1.13.21
-//> using dep com.softwaremill.sttp.tapir::tapir-zio-http-server:1.13.21
-//> using dep com.softwaremill.sttp.tapir::tapir-zio-opentelemetry:1.13.21
-//> using dep dev.zio::zio-opentelemetry:3.1.16
-//> using dep io.opentelemetry:opentelemetry-sdk:1.51.0
-//> using dep io.opentelemetry:opentelemetry-exporter-otlp:1.51.0
-//> using dep io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.51.0
+//> using dep com.softwaremill.sttp.tapir::tapir-core:1.13.22
+//> using dep com.softwaremill.sttp.tapir::tapir-zio:1.13.22
+//> using dep com.softwaremill.sttp.tapir::tapir-zio-http-server:1.13.22
+//> using dep com.softwaremill.sttp.tapir::tapir-zio-opentelemetry:1.13.22
+//> using dep dev.zio::zio-opentelemetry:3.1.17
+//> using dep io.opentelemetry:opentelemetry-sdk:1.63.0
+//> using dep io.opentelemetry:opentelemetry-exporter-otlp:1.63.0
+//> using dep io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.63.0
 
 package sttp.tapir.examples.observability
 


### PR DESCRIPTION
Follow-up to #5256: now that `tapir-zio-opentelemetry` is published (1.13.22), the example can be compiled.

- Renamed `ZIOpenTelemetryExample` from `.skip` to `.scala` so it's part of the build and the scala-cli verification.
- Bumped its `//> using` deps to the released versions: tapir `1.13.22`, zio-opentelemetry `3.1.17`, opentelemetry `1.63.0`.

Verified locally with `scala-cli compile` (the same command the `verifyExamplesCompileUsingScalaCli` CI step runs) — it resolves the 1.13.22 artifacts from Maven Central and compiles cleanly (Scala 3.8.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)