### PR TITLE
Fix flaky ServerCancellationTests (acquire/onCancel race)

### DIFF
--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerCancellationTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerCancellationTests.scala
@@ -21,13 +21,15 @@ class ServerCancellationTests[F[_], OPTIONS, ROUTE](createServerTest: CreateServ
   import createServerTest._
 
   def tests(): List[Test] = List({
-    val canceledSemaphore = new Semaphore(1)
+    // The semaphore starts with no permits; the only `release` happens in the server logic's cancellation finalizer,
+    // so the test's `tryAcquire` below blocks until cancellation has been handled.
+    val canceledSemaphore = new Semaphore(0)
     val canceled: AtomicBoolean = new AtomicBoolean(false)
     testServerLogic(
       endpoint
         .out(plainBody[String])
         .serverLogic { _ =>
-          (m.eval(canceledSemaphore.acquire())) >> (async.sleep(15.seconds) >> pureResult("processing finished".asRight[Unit]))
+          (async.sleep(15.seconds) >> pureResult("processing finished".asRight[Unit]))
             .onCancel(m.eval(canceled.set(true)) >> m.eval(canceledSemaphore.release()))
         },
       "Client cancelling request triggers cancellation on the server"


### PR DESCRIPTION
## Problem

The "Client cancelling request triggers cancellation on the server" test (run by `NettyCatsServerTest` and `NettyZioServerTest`) intermittently fails on CI with:

```
canceledSemaphore.tryAcquire(30L, java.util.concurrent.TimeUnit.SECONDS) was false
Timeout when waiting for cancellation to be handled as expected (ServerCancellationTests.scala:42)
```

Seen most recently on the v1.13.23 release CI (`ci (3, JVM, 11)`).

## Root cause

The semaphore was held by acquiring a permit **inside the server logic**, but `.onCancel` binds tighter than `>>`, so it wrapped only the `sleep >> result` block — **not** the preceding `acquire`:

```scala
m.eval(canceledSemaphore.acquire()) >> (async.sleep(15.seconds) >> pureResult(...))
  .onCancel(... canceledSemaphore.release())
```

Under CI load the handler fiber can start late, after the client's `readTimeout(300ms)` has already fired and the connection has been closed. The fiber then runs `acquire()` (permit 1 → 0) and, at the `>>` boundary, observes the already-pending cancellation and finalizes **before entering the `onCancel`-guarded block**. The finalizer is never registered, so `release()` never runs — the permit is stuck at 0 and the test's `tryAcquire` waits out the full 30s. The 30s timeout (added earlier for "slow CI") can't help, because the finalizer was never going to run.

## Fix

Start the semaphore with **0 permits** and release only from the cancellation finalizer, removing the server-side `acquire` entirely. The test still blocks in `tryAcquire` until cancellation is handled, but there's no longer a window where the permit is taken without the finalizer being registered. Genuine "cancellation didn't happen" failures are still caught (the sleep completes, nothing releases, `tryAcquire` times out).

## Verification

Focused test run repeatedly, green and fast (~0.4s) on both backends:
- `NettyCatsServerTest` — 3/3 runs passed
- `NettyZioServerTest` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)