### PR TITLE
clean resources (sockets/files)

### DIFF
--- a/core/src/main/scalajvm/sttp/tapir/Defaults.scala
+++ b/core/src/main/scalajvm/sttp/tapir/Defaults.scala
@@ -3,7 +3,8 @@ package sttp.tapir
 import java.io.File
 
 object Defaults {
-  def createTempFile: () => TapirFile = () => File.createTempFile("tapir", "tmp")
+  val Prefix: String = "tapir"
+  def createTempFile: () => TapirFile = () => File.createTempFile(Prefix, "tmp")
   def deleteFile(): TapirFile => Unit = file => {
     val _ = file.delete()
   }

--- a/core/src/main/scalajvm/sttp/tapir/Defaults.scala
+++ b/core/src/main/scalajvm/sttp/tapir/Defaults.scala
@@ -3,7 +3,7 @@ package sttp.tapir
 import java.io.File
 
 object Defaults {
-  val Prefix: String = "tapir"
+  private[tapir] val Prefix: String = "tapir"
   def createTempFile: () => TapirFile = () => File.createTempFile(Prefix, "tmp")
   def deleteFile(): TapirFile => Unit = file => {
     val _ = file.delete()

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaRequestBody.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaRequestBody.scala
@@ -49,12 +49,13 @@ private[akkahttp] class AkkaRequestBody(serverOptions: AkkaHttpServerOptions)(im
           .flatMap(file =>
             body.dataBytes
               .runWith(FileIO.toPath(file.toPath))
-              .recoverWith {
-                // We need to dig out EntityStreamSizeException from an external wrapper applied by FileIO sink
-                case e: Exception if e.getCause.isInstanceOf[EntityStreamSizeException] =>
-                  serverOptions.deleteFile(file).flatMap { _ =>
-                    Future.failed(e.getCause)
-                  }
+              .recoverWith { case e: Exception =>
+                // Any mid-stream failure leaves a partially-written temp file behind, so always delete it
+                serverOptions.deleteFile(file).flatMap { _ =>
+                  // We need to dig out EntityStreamSizeException from an external wrapper applied by FileIO sink
+                  if (e.getCause.isInstanceOf[EntityStreamSizeException]) Future.failed(e.getCause)
+                  else Future.failed(e)
+                }
               }
               .map(_ => FileRange(file))
               .map(f => RawValue(f, Seq(f)))

--- a/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaRequestBody.scala
+++ b/server/akka-http-server/src/main/scala/sttp/tapir/server/akkahttp/AkkaRequestBody.scala
@@ -51,8 +51,10 @@ private[akkahttp] class AkkaRequestBody(serverOptions: AkkaHttpServerOptions)(im
               .runWith(FileIO.toPath(file.toPath))
               .recoverWith {
                 // We need to dig out EntityStreamSizeException from an external wrapper applied by FileIO sink
-                case e: Exception if e.getCause().isInstanceOf[EntityStreamSizeException] =>
-                  Future.failed(e.getCause())
+                case e: Exception if e.getCause.isInstanceOf[EntityStreamSizeException] =>
+                  serverOptions.deleteFile(file).flatMap { _ =>
+                    Future.failed(e.getCause)
+                  }
               }
               .map(_ => FileRange(file))
               .map(f => RawValue(f, Seq(f)))

--- a/server/jdkhttp-server/src/main/scala/sttp/tapir/server/jdkhttp/JdkHttpServerInterpreter.scala
+++ b/server/jdkhttp-server/src/main/scala/sttp/tapir/server/jdkhttp/JdkHttpServerInterpreter.scala
@@ -16,7 +16,11 @@ trait JdkHttpServerInterpreter {
 
   def toHandler(ses: List[ServerEndpoint[Any, Identity]]): HttpHandler = {
     val filteredEndpoints = FilterServerEndpoints[Any, Identity](ses)
-    val requestBody = new JdkHttpRequestBody(jdkHttpServerOptions.createFile, jdkHttpServerOptions.multipartFileThresholdBytes)
+    val requestBody = new JdkHttpRequestBody(
+      jdkHttpServerOptions.createFile,
+      jdkHttpServerOptions.deleteFile,
+      jdkHttpServerOptions.multipartFileThresholdBytes
+    )
     val responseBody = new JdkHttpToResponseBody
     val interceptors = jdkHttpServerOptions.interceptors
 

--- a/server/jdkhttp-server/src/main/scala/sttp/tapir/server/jdkhttp/internal/JdkHttpRequestBody.scala
+++ b/server/jdkhttp-server/src/main/scala/sttp/tapir/server/jdkhttp/internal/JdkHttpRequestBody.scala
@@ -3,6 +3,7 @@ package internal
 
 import com.sun.net.httpserver.HttpExchange
 import sttp.capabilities
+import sttp.capabilities.StreamMaxLengthExceededException
 import sttp.model.Part
 import sttp.shared.Identity
 import sttp.tapir.capabilities.NoStreams
@@ -16,8 +17,11 @@ import java.io._
 import java.nio.ByteBuffer
 import java.nio.file.{Files, StandardCopyOption}
 
-private[jdkhttp] class JdkHttpRequestBody(createFile: ServerRequest => TapirFile, multipartFileThresholdBytes: Long)
-    extends RequestBody[Identity, NoStreams] {
+private[jdkhttp] class JdkHttpRequestBody(
+    createFile: ServerRequest => TapirFile,
+    deleteFile: TapirFile => Unit,
+    multipartFileThresholdBytes: Long
+) extends RequestBody[Identity, NoStreams] {
   override val streams: capabilities.Streams[NoStreams] = NoStreams
 
   override def toRaw[RAW](serverRequest: ServerRequest, bodyType: RawBodyType[RAW], maxBytes: Option[Long]): RawValue[RAW] = {
@@ -42,8 +46,14 @@ private[jdkhttp] class JdkHttpRequestBody(createFile: ServerRequest => TapirFile
       case RawBodyType.InputStreamBody      => RawValue(asInputStream)
       case RawBodyType.FileBody             =>
         val file = createFile(serverRequest)
-        Files.copy(asInputStream, file.toPath, StandardCopyOption.REPLACE_EXISTING)
-        RawValue(FileRange(file), Seq(FileRange(file)))
+        try {
+          Files.copy(asInputStream, file.toPath, StandardCopyOption.REPLACE_EXISTING)
+          RawValue(FileRange(file), Seq(FileRange(file)))
+        } catch {
+          case e: Exception =>
+            deleteFile(file)
+            throw e
+        }
       case m: RawBodyType.MultipartBody => RawValue.fromParts(multiPartRequestToRawBody(serverRequest, asInputStream, m))
     }
   }
@@ -84,7 +94,7 @@ private[jdkhttp] class JdkHttpRequestBody(createFile: ServerRequest => TapirFile
         )
       )
     } catch {
-      case e: Exception if e.getMessage().contains("Parsing multipart failed") => throw InvalidMultipartBodyException(e)
+      case e: Exception if e.getMessage.contains("Parsing multipart failed") => throw InvalidMultipartBodyException(e)
     }
   }
 

--- a/server/jdkhttp-server/src/main/scala/sttp/tapir/server/jdkhttp/internal/LimitedInputStream.scala
+++ b/server/jdkhttp-server/src/main/scala/sttp/tapir/server/jdkhttp/internal/LimitedInputStream.scala
@@ -7,7 +7,7 @@ import java.io.IOException
 
 class FailingLimitedInputStream(in: InputStream, limit: Long) extends LimitedInputStream(in, limit) {
   override def onLimit: Int = {
-    throw new StreamMaxLengthExceededException(limit)
+    throw StreamMaxLengthExceededException(limit)
   }
 }
 

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/NettyCatsServerInterpreter.scala
@@ -35,6 +35,7 @@ trait NettyCatsServerInterpreter[F[_]] {
       FilterServerEndpoints(ses),
       new NettyCatsRequestBody(
         createFile,
+        deleteFile,
         Fs2StreamCompatible[F](nettyServerOptions.dispatcher),
         nettyServerOptions.multipartTempDirectory,
         nettyServerOptions.multipartMinSizeForDisk

--- a/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/internal/NettyCatsRequestBody.scala
+++ b/server/netty-server/cats/src/main/scala/sttp/tapir/server/netty/cats/internal/NettyCatsRequestBody.scala
@@ -16,6 +16,7 @@ import scala.concurrent.Future
 
 private[cats] class NettyCatsRequestBody[F[_]: Async](
     val createFile: ServerRequest => F[TapirFile],
+    val deleteFile: TapirFile => F[Unit],
     val streamCompatible: StreamCompatible[Fs2Streams[F]],
     val multipartTempDirectory: Option[TapirFile],
     val multipartMinSizeForDisk: Option[Long]
@@ -32,9 +33,9 @@ private[cats] class NettyCatsRequestBody[F[_]: Async](
   override def publisherToBytes(publisher: Publisher[HttpContent], contentLength: Option[Long], maxBytes: Option[Long]): F[Array[Byte]] =
     streamCompatible.fromPublisher(publisher, maxBytes).compile.to(Chunk).map(_.toArray[Byte])
 
-  override def writeToFile(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): F[Unit] =
-    (toStream(serverRequest, maxBytes)
-      .asInstanceOf[streamCompatible.streams.BinaryStream])
+  override protected def writeToFileUnsafe(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): F[Unit] =
+    toStream(serverRequest, maxBytes)
+      .asInstanceOf[streamCompatible.streams.BinaryStream]
       .through(
         Files[F](Files.forAsync[F]).writeAll(Path.fromNioPath(file.toPath))
       )

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServerInterpreter.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/NettyFutureServerInterpreter.scala
@@ -22,6 +22,7 @@ trait NettyFutureServerInterpreter {
       nettyServerOptions.interceptors,
       new NettyFutureRequestBody(
         nettyServerOptions.createFile,
+        nettyServerOptions.deleteFile,
         nettyServerOptions.multipartTempDirectory,
         nettyServerOptions.multipartMinSizeForDisk
       ),

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyFutureRequestBody.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyFutureRequestBody.scala
@@ -14,6 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 private[netty] class NettyFutureRequestBody(
     val createFile: ServerRequest => Future[TapirFile],
+    val deleteFile: TapirFile => Future[Unit],
     val multipartTempDirectory: Option[TapirFile],
     val multipartMinSizeForDisk: Option[Long]
 )(implicit ec: ExecutionContext)
@@ -33,7 +34,7 @@ private[netty] class NettyFutureRequestBody(
   ): Future[Array[Byte]] =
     SimpleSubscriber.processAll(publisher, contentLength, maxBytes)
 
-  override def writeToFile(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): Future[Unit] =
+  override protected def writeToFileUnsafe(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): Future[Unit] =
     serverRequest.underlying match {
       case r: StreamedHttpRequest => FileWriterSubscriber.processAll(r, file.toPath, maxBytes)
       case _                      => monad.unit(()) // Empty request

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyMonadRequestBody.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyMonadRequestBody.scala
@@ -40,6 +40,14 @@ private[netty] trait NettyMonadRequestBody[F[_], S <: Streams[S]] extends NettyR
 
   }
 
+  override final def writeToFile(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): F[Unit] =
+    writeToFileUnsafe(serverRequest, file, maxBytes)
+      .handleError { case e =>
+        deleteFile(file).flatMap(_ => monad.error(e))
+      }
+
+  protected def writeToFileUnsafe(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): F[Unit]
+
   private class MonadSubscriber(
       decoder: HttpPostMultipartRequestDecoder,
       serverRequest: ServerRequest,

--- a/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyRequestBody.scala
+++ b/server/netty-server/src/main/scala/sttp/tapir/server/netty/internal/NettyRequestBody.scala
@@ -27,6 +27,9 @@ private[netty] trait NettyRequestBody[F[_], S <: Streams[S]] extends RequestBody
   /** Backend-specific implementation for creating a file. */
   def createFile: ServerRequest => F[TapirFile]
 
+  /** Backend-specific implementation for deleting a file. */
+  def deleteFile: TapirFile => F[Unit]
+
   /** Directory in which multipart parts that don't fit in memory are buffered as temporary files. */
   val multipartTempDirectory: Option[TapirFile]
 

--- a/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/NettySyncServerInterpreter.scala
+++ b/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/NettySyncServerInterpreter.scala
@@ -23,6 +23,7 @@ trait NettySyncServerInterpreter:
       FilterServerEndpoints(ses),
       new NettySyncRequestBody(
         nettyServerOptions.createFile,
+        nettyServerOptions.deleteFile,
         nettyServerOptions.multipartTempDirectory,
         nettyServerOptions.multipartMinSizeForDisk
       ),

--- a/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/internal/NettySyncRequestBody.scala
+++ b/server/netty-server/sync/src/main/scala/sttp/tapir/server/netty/sync/internal/NettySyncRequestBody.scala
@@ -22,6 +22,7 @@ import java.nio.file.Files
 
 private[sync] class NettySyncRequestBody(
     val createFile: ServerRequest => TapirFile,
+    val deleteFile: TapirFile => Unit,
     val multipartTempDirectory: Option[TapirFile],
     val multipartMinSizeForDisk: Option[Long]
 ) extends NettyRequestBody[Identity, OxStreams]:
@@ -62,9 +63,14 @@ private[sync] class NettySyncRequestBody(
   }
 
   override def writeToFile(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): Unit =
-    serverRequest.underlying match
-      case r: StreamedHttpRequest => FileWriterSubscriber.processAllBlocking(r, file.toPath, maxBytes)
-      case _                      => () // Empty request
+    try
+      serverRequest.underlying match
+        case r: StreamedHttpRequest => FileWriterSubscriber.processAllBlocking(r, file.toPath, maxBytes)
+        case _                      => ()     // Empty request
+    catch
+      case e =>
+        deleteFile(file)
+        throw e
 
   override def writeBytesToFile(bytes: Array[Byte], file: TapirFile): Unit = Files.write(file.toPath, bytes): Unit
 

--- a/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/NettyZioServerInterpreter.scala
+++ b/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/NettyZioServerInterpreter.scala
@@ -27,6 +27,7 @@ trait NettyZioServerInterpreter[R] {
         FilterServerEndpoints(widenedSes),
         new NettyZioRequestBody(
           widenedServerOptions.createFile,
+          widenedServerOptions.deleteFile,
           ZioStreamCompatible(runtime),
           widenedServerOptions.multipartTempDirectory,
           widenedServerOptions.multipartMinSizeForDisk

--- a/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/internal/NettyZioRequestBody.scala
+++ b/server/netty-server/zio/src/main/scala/sttp/tapir/server/netty/zio/internal/NettyZioRequestBody.scala
@@ -15,6 +15,7 @@ import scala.concurrent.Future
 
 private[zio] class NettyZioRequestBody[Env](
     val createFile: ServerRequest => RIO[Env, TapirFile],
+    val deleteFile: TapirFile => RIO[Env, Unit],
     val streamCompatible: StreamCompatible[ZioStreams],
     val multipartTempDirectory: Option[TapirFile],
     val multipartMinSizeForDisk: Option[Long]
@@ -34,7 +35,7 @@ private[zio] class NettyZioRequestBody[Env](
   ): RIO[Env, Array[Byte]] =
     streamCompatible.fromPublisher(publisher, maxBytes).run(ZSink.collectAll[Byte]).map(_.toArray)
 
-  override def writeToFile(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): RIO[Env, Unit] =
+  override protected def writeToFileUnsafe(serverRequest: ServerRequest, file: TapirFile, maxBytes: Option[Long]): RIO[Env, Unit] =
     toStream(serverRequest, maxBytes).run(ZSink.fromFile(file)).map(_ => ())
 
 }

--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoRequestBody.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoRequestBody.scala
@@ -49,12 +49,13 @@ private[pekkohttp] class PekkoRequestBody(serverOptions: PekkoHttpServerOptions)
           .flatMap(file =>
             body.dataBytes
               .runWith(FileIO.toPath(file.toPath))
-              .recoverWith {
-                // We need to dig out EntityStreamSizeException from an external wrapper applied by FileIO sink
-                case e: Exception if e.getCause.isInstanceOf[EntityStreamSizeException] =>
-                  serverOptions.deleteFile(file).flatMap { _ =>
-                    Future.failed(e.getCause)
-                  }
+              .recoverWith { case e: Exception =>
+                // Any mid-stream failure leaves a partially-written temp file behind, so always delete it
+                serverOptions.deleteFile(file).flatMap { _ =>
+                  // We need to dig out EntityStreamSizeException from an external wrapper applied by FileIO sink
+                  if (e.getCause.isInstanceOf[EntityStreamSizeException]) Future.failed(e.getCause)
+                  else Future.failed(e)
+                }
               }
               .map(_ => FileRange(file))
               .map(f => RawValue(f, Seq(f)))

--- a/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoRequestBody.scala
+++ b/server/pekko-http-server/src/main/scala/sttp/tapir/server/pekkohttp/PekkoRequestBody.scala
@@ -51,8 +51,10 @@ private[pekkohttp] class PekkoRequestBody(serverOptions: PekkoHttpServerOptions)
               .runWith(FileIO.toPath(file.toPath))
               .recoverWith {
                 // We need to dig out EntityStreamSizeException from an external wrapper applied by FileIO sink
-                case e: Exception if e.getCause().isInstanceOf[EntityStreamSizeException] =>
-                  Future.failed(e.getCause())
+                case e: Exception if e.getCause.isInstanceOf[EntityStreamSizeException] =>
+                  serverOptions.deleteFile(file).flatMap { _ =>
+                    Future.failed(e.getCause)
+                  }
               }
               .map(_ => FileRange(file))
               .map(f => RawValue(f, Seq(f)))

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -6,6 +6,7 @@ import enumeratum._
 import io.circe.generic.auto._
 import org.scalatest.Succeeded
 import org.scalatest.matchers.should.Matchers._
+import scala.util.Properties
 import sttp.client4._
 import sttp.model._
 import sttp.model.headers.{CookieValueWithMeta, CookieWithMeta}
@@ -886,21 +887,41 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
 
   def testPayloadTooLarge[I](
       testedEndpoint: PublicEndpoint[I, Unit, I, Any],
-      maxLength: Int
+      maxLength: Int,
+      fileBased: Boolean = false
   ) = testServer(
     testedEndpoint.maxRequestBodyLength(maxLength.toLong),
     "checks payload limit and returns 413 on exceeded max content length (request)"
   )(i => pureResult(i.asRight[Unit])) { (backend, baseUri) =>
-    val tooLargeBody: String = List.fill(maxLength + 1)('x').mkString
+    val tooLargeMarker = "tooLargeMarker"
+    val tooLargeBody: String = tooLargeMarker + List.fill(maxLength - tooLargeMarker.length + 1)('x').mkString
     basicRequest
       .post(uri"$baseUri/api/echo")
       .body(tooLargeBody)
       .send(backend)
       .map(_.code shouldBe StatusCode.PayloadTooLarge)
+      .map { r =>
+        if (fileBased) {
+          val tmpDir = new TapirFile(Properties.tmpDir)
+          val optFiles = Option(tmpDir.listFiles((_, name) => name.startsWith(Defaults.Prefix)))
+          for {
+            files <- optFiles
+            file <- files.filter(_.isFile)
+          } {
+            val txt = java.nio.file.Files.readString(file.toPath)
+            if (txt.startsWith(tooLargeMarker)) {
+              fail(s"File has not be deleted after ${StatusCode.PayloadTooLarge} error: ${file.getAbsolutePath}")
+            }
+          }
+        }
+        r
+      }
       // The server may reject the over-limit body by closing the connection before the client has
       // finished sending it, surfacing as a transport error instead of a 413. Both are valid
       // rejections of the too-large body, so accept either to avoid a timing-dependent flake.
-      .recover { case _: SttpClientException => Succeeded }
+      .recover { case _: SttpClientException =>
+        Succeeded
+      }
   }
   def testPayloadWithinLimit[I](
       testedEndpoint: PublicEndpoint[I, Unit, I, Any],
@@ -918,7 +939,7 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
     List(
       testPayloadTooLarge(in_string_out_string, maxLength),
       testPayloadTooLarge(in_byte_array_out_byte_array, maxLength),
-      testPayloadTooLarge(in_file_out_file, maxLength),
+      testPayloadTooLarge(in_file_out_file, maxLength, true),
       testServer(
         in_input_stream_out_input_stream.maxRequestBodyLength(maxLength.toLong),
         "checks payload limit and returns 413 on exceeded max content length (request)"

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -7,6 +7,7 @@ import io.circe.generic.auto._
 import org.scalatest.Succeeded
 import org.scalatest.matchers.should.Matchers._
 import scala.util.Properties
+import scala.util.control.NonFatal
 import sttp.client4._
 import sttp.model._
 import sttp.model.headers.{CookieValueWithMeta, CookieWithMeta}
@@ -908,7 +909,11 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
             files <- optFiles
             file <- files.filter(_.isFile)
           } {
-            val txt = java.nio.file.Files.readString(file.toPath)
+            // The file may be deleted concurrently by another test/backend between listing and reading; treat a
+            // missing/unreadable file as already cleaned up rather than failing the test.
+            val txt =
+              try java.nio.file.Files.readString(file.toPath)
+              catch { case NonFatal(_) => "" }
             if (txt.startsWith(tooLargeMarker)) {
               fail(s"File has not be deleted after ${StatusCode.PayloadTooLarge} error: ${file.getAbsolutePath}")
             }

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpRequestBody.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpRequestBody.scala
@@ -42,11 +42,17 @@ class ZioHttpRequestBody[R](serverOptions: ZioHttpServerOptions[R]) extends Requ
       case RawBodyType.InputStreamRangeBody       =>
         asByteArray.map(bytes => InputStreamRange(() => new ByteArrayInputStream(bytes))).map(RawValue(_))
       case RawBodyType.FileBody =>
-        for {
+        (for {
           file <- serverOptions.createFile(serverRequest)
-          _ <- limitedStream.run(ZSink.fromFile(file)).unit
-        } yield RawValue(FileRange(file), Seq(FileRange(file)))
-      case m: RawBodyType.MultipartBody => handleMultipartBody(serverRequest, m, limitedStream)
+          value <- limitedStream
+            .run(ZSink.fromFile(file))
+            .catchAll { e =>
+              serverOptions.deleteFile(file).flatMap(_ => ZIO.fail(e))
+            }
+            .map(_ => RawValue(FileRange(file), Seq(FileRange(file))))
+        } yield value).asInstanceOf[ZIO[Any, Throwable, RawValue[RAW]]]
+      case m: RawBodyType.MultipartBody =>
+        handleMultipartBody(serverRequest, m, limitedStream)
     }
   }
 


### PR DESCRIPTION
As a result of investigating the unstable tests, the following issues were discovered:

* After tests on linux the some sockets are waiting for close(even 10 minutes after run):

netstat -nap | grep tcp | grep `ps ax | grep sbt | grep java | awk '{print $1}' `
tcp6      32      0 127.0.0.1:36046         127.0.0.1:39005         CLOSE_WAIT  28290/java
tcp6       0      0 127.0.0.1:52832         127.0.0.1:41039         CLOSE_WAIT  28290/java
tcp6       0      0 127.0.0.1:37852         127.0.0.1:33087         CLOSE_WAIT  28290/java

Tested on ubuntu 25 and slackware 15.

But it failed unpredictably - so solution was removed from this PR

<del>After adding [ServerWebSocketTests.scala](https://github.com/softwaremill/tapir/compare/master...ajozwik:clean-resources?expand=1#diff-475ef454ba3da170a3ae427f5954ebd18dabeeb2bc757dbee59d0131cf6b1bb9) waitForMessage the problem disappeared. </del>

 * For other if StreamMaxLengthExceededException/EntityStreamSizeException (or related) is thrown the created file was not deleted. It is risky - this poses a risk of a DDOS attack (disk full). 