### PR TITLE
Apply class-level annotations in Pickler schema derivation

### DIFF
--- a/json/pickler/src/main/scala/sttp/tapir/json/pickler/SchemaDerivation.scala
+++ b/json/pickler/src/main/scala/sttp/tapir/json/pickler/SchemaDerivation.scala
@@ -35,7 +35,10 @@ private class SchemaDerivation(genericDerivationConfig: Expr[Configuration])(usi
     val tpe = TypeRepr.of[T]
     val typeInfo = TypeInfo.forType(tpe)
     val annotations = Annotations.onType(tpe)
-    '{ Schema[T](schemaType = ${ productSchemaType(childSchemas) }, name = Some(${ typeNameToSchemaName(typeInfo, annotations) })) }
+    val schema = '{
+      Schema[T](schemaType = ${ productSchemaType(childSchemas) }, name = Some(${ typeNameToSchemaName(typeInfo, annotations) }))
+    }
+    enrichSchema(schema, annotations)
 
   private def productSchemaType[T: Type, TFields <: Tuple](
       childSchemas: Expr[Tuple.Map[TFields, Schema]]

--- a/json/pickler/src/test/scala/sttp/tapir/json/pickler/SchemaDerivationTest.scala
+++ b/json/pickler/src/test/scala/sttp/tapir/json/pickler/SchemaDerivationTest.scala
@@ -158,7 +158,7 @@ class SchemaDerivationTest extends AsyncFlatSpec with Matchers with Inside {
     }
   }
 
-  ignore should "add meta-data to schema from annotations" in { // TODO https://github.com/softwaremill/tapir/issues/3167
+  it should "add meta-data to schema from annotations" in {
     val schema = implicitlySchema[I]
     schema shouldBe Schema[I](
       SProduct(
@@ -187,9 +187,7 @@ class SchemaDerivationTest extends AsyncFlatSpec with Matchers with Inside {
         )
       ),
       Some(SName("sttp.tapir.json.pickler.I"))
-    ).description(
-      "class I"
-    ) // TODO this causes test to fail, because SchemaDerivation doesn't support @description annotation on case classes
+    ).description("class I")
   }
 
   it should "find the right schema for a case class with simple types" in {
@@ -263,7 +261,7 @@ class SchemaDerivationTest extends AsyncFlatSpec with Matchers with Inside {
     )
   }
 
-  ignore should "customise the schema using the given function" in { // TODO https://github.com/softwaremill/tapir/issues/3166
+  it should "customise the schema using the given function" in {
     val schema = implicitlySchema[M]
     schema.attribute(M.testAttributeKey) shouldBe Some("test")
   }


### PR DESCRIPTION
The macro-based Pickler schema derivation (`json/pickler`) read a case class's class-level annotations only to derive its schema name, but never applied them to the product schema itself. So `@description`, `@customise`, and the other already-supported annotations had no effect when placed on a class, even though they worked fine on fields.

This wires the class-level annotations through the existing `enrichSchema` step on the top-level schema, mirroring what `SchemaMagnoliaDerivation` already does for the magnolia-based path. No new annotation handling is added; it just applies the annotations that derivation already understands at the class level too.

The two tests that were pinned to these issues in `SchemaDerivationTest` (previously `ignore`d, with TODOs referencing them) are now enabled and pass; the rest of the suite is unchanged.

Closes #3166
Closes #3167
