### PR TITLE
Fix flaky maxContentLength temp-file deletion test

### DIFF
--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerBasicTests.scala
@@ -886,6 +886,28 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
     }
   )
 
+  // The request-body temp file is deleted once the response body has been fully written
+  // (ServerInterpreter, #4886), which can complete slightly after the client observes the response.
+  // Poll for a bounded time, failing only if the file holding *our* request body survives the window.
+  private def assertRequestBodyTempFileDeleted(marker: String): Unit = {
+    val tmpDir = new TapirFile(Properties.tmpDir)
+    def leakedFile: Option[TapirFile] =
+      Option(tmpDir.listFiles((_, name) => name.startsWith(Defaults.Prefix))).toList.flatten
+        .filter(_.isFile)
+        .find { file =>
+          // The file may be deleted concurrently between listing and reading; treat a missing/unreadable
+          // file as already cleaned up rather than as a match.
+          val txt =
+            try java.nio.file.Files.readString(file.toPath)
+            catch { case NonFatal(_) => "" }
+          txt.startsWith(marker)
+        }
+
+    val deadline = System.currentTimeMillis() + 5000
+    while (leakedFile.isDefined && System.currentTimeMillis() < deadline) Thread.sleep(50)
+    leakedFile.foreach(file => fail(s"File has not been deleted after ${StatusCode.PayloadTooLarge} error: ${file.getAbsolutePath}"))
+  }
+
   def testPayloadTooLarge[I](
       testedEndpoint: PublicEndpoint[I, Unit, I, Any],
       maxLength: Int,
@@ -894,7 +916,10 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
     testedEndpoint.maxRequestBodyLength(maxLength.toLong),
     "checks payload limit and returns 413 on exceeded max content length (request)"
   )(i => pureResult(i.asRight[Unit])) { (backend, baseUri) =>
-    val tooLargeMarker = "tooLargeMarker"
+    // The marker is unique per test run so this assertion only inspects the temp file created for *this*
+    // request. Many server backends run this same test concurrently against the shared system temp
+    // directory; with a constant marker a backend could trip over another backend's in-flight file.
+    val tooLargeMarker = "tooLargeMarker-" + java.util.UUID.randomUUID().toString
     val tooLargeBody: String = tooLargeMarker + List.fill(maxLength - tooLargeMarker.length + 1)('x').mkString
     basicRequest
       .post(uri"$baseUri/api/echo")
@@ -902,23 +927,7 @@ class ServerBasicTests[F[_], OPTIONS, ROUTE](
       .send(backend)
       .map(_.code shouldBe StatusCode.PayloadTooLarge)
       .map { r =>
-        if (fileBased) {
-          val tmpDir = new TapirFile(Properties.tmpDir)
-          val optFiles = Option(tmpDir.listFiles((_, name) => name.startsWith(Defaults.Prefix)))
-          for {
-            files <- optFiles
-            file <- files.filter(_.isFile)
-          } {
-            // The file may be deleted concurrently by another test/backend between listing and reading; treat a
-            // missing/unreadable file as already cleaned up rather than failing the test.
-            val txt =
-              try java.nio.file.Files.readString(file.toPath)
-              catch { case NonFatal(_) => "" }
-            if (txt.startsWith(tooLargeMarker)) {
-              fail(s"File has not be deleted after ${StatusCode.PayloadTooLarge} error: ${file.getAbsolutePath}")
-            }
-          }
-        }
+        if (fileBased) assertRequestBodyTempFileDeleted(tooLargeMarker)
         r
       }
       // The server may reject the over-limit body by closing the connection before the client has


### PR DESCRIPTION
## Problem

The server test *"checks payload limit and returns 413 on exceeded max content length (request)"* (file-based variant) is intermittently failing in CI with:

```
File has not be deleted after 413 error: /tmp/tapir...tmp (ServerBasicTests.scala)
```

This is the failure that has been blocking dependency-bump PRs (e.g. #5356, a pure sttp version bump otherwise unrelated to the test).

## Root cause

Two genuine causes, both confirmed against the code:

1. **Cross-test contamination (dominant).** The assertion scanned the *shared* system temp dir (`Properties.tmpDir`) for any file starting with `Defaults.Prefix` whose content started with the **constant** marker `"tooLargeMarker"`. Every server backend (netty, vertx, http4s, …) runs this identical test concurrently in the same JVM, so one backend's scan could pick up another backend's still-in-flight temp file and fail — which is why the failure surfaced in e.g. `CatsVertxServerTest` for a file it didn't create.

2. **Async deletion race.** For a 413 (which carries an error body) the request-body temp file is deleted in `bodyListener.onComplete(body)(_ => cleanupRawValues(...))` (`ServerInterpreter`, #4886) — i.e. *after* the response body finishes being written, which can complete slightly after the client observes the response and runs the check.

Prior hardening (#5289, #5335) only tolerated read errors / connection resets; neither addressed the shared-state assertion.

## Fix

- **Unique marker per invocation** (`"tooLargeMarker-" + UUID`) so the scan matches only *this* request's file — concurrent backends can no longer trip over each other.
- **Bounded poll** for the file to be deleted (up to 5s), tolerating the post-response deletion window while still failing on a genuine leak. The happy path never sleeps.

This is a fix in the shared `serverTests` module, so it hardens the test for all backends.

## Verification

- `serverTests/compile` ✓
- `jdkhttpServer/testOnly *JdkHttpServerTest -- -z "413 on exceeded"` → 5/5 passed (incl. file-based)
- `serverTests/scalafmtCheck` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)