### PR TITLE
codegen: create a file per model

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -56,6 +56,7 @@ openapiPackageDependencies            Map.empty[String, String]            Allow
                                                                            repeated schema declarations between the openapis, with the generated code for the 'key' package defining type (and sometimes val)
                                                                            aliases to the duplicates in the 'value' package. This is still experimental - significantly, the type is likely to change
                                                                            to a Map[String, Seq[String]] in the near future to permit multiple 'inheritance', and there may be bugs in the implementation.
+openapiSeperateFilesForModels         false                                When true, models will be written to individual files under $pkg.models, with type aliases and helpers living under `package.scala` in a package object
 ===================================== ==================================== ==================================================================================================
 ```
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -1,11 +1,13 @@
 package sttp.tapir.codegen
 
-import sttp.tapir.codegen.RootGenerator.{indent, mapSchemaSimpleTypeToType}
+import sttp.tapir.codegen.RootGenerator.mapSchemaSimpleTypeToType
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.json.{JsonHelpers, JsonSerdeLib, JsonSerdeGenerator, SerdeGenResponse}
 import sttp.tapir.codegen.json.JsonSerdeLib.{Circe, Jsoniter}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.{DefaultValueRenderer, OpenapiSchemaType, RenderConfig}
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
+import sttp.tapir.codegen.util.NameHelpers.indent
 import sttp.tapir.codegen.util.{DocUtils, VersionedHelpers}
 
 case class GeneratedClassDefinitions(

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -114,7 +114,8 @@ class ClassDefinitionGenerator {
           case r: OpenapiSchemaRef                           => s"case class $tt${r.stripped}(v: ${r.stripped}) extends $tt"
         }
         .mkString("\n")
-      s"""sealed trait $tt
+      s"""
+         |sealed trait $tt
          |$variants""".stripMargin
     }
     val nonClassyOneOfReprs = resolvableNonClassyOneOfSchemas.map { case (name, st) => nonClassyOneOfRepr(name, st) }.mkString("\n")
@@ -200,25 +201,25 @@ class ClassDefinitionGenerator {
       child -> fileName
     }
 
-    val schemaDefns: Map[String, Seq[String]] = doc.components
+    val schemaDefns: Map[String, (Int, Seq[String])] = doc.components
       .map(
         _.schemas.map {
           case (name, _: OpenapiSchemaEnum) if PackageReuseContext.isReusedSchema(name, packageReuse) =>
-            name -> Seq(PackageReuseContext.enumAliasType(name, packageReuse, seperateFilesForModels))
+            (name, (0, Seq(PackageReuseContext.enumAliasType(name, packageReuse, seperateFilesForModels))))
           case (name, s) if PackageReuseContext.isReusedSchema(name, packageReuse) =>
-            name -> Seq(PackageReuseContext.aliasType(name, packageReuse, seperateFilesForModels))
+            (name, (0, Seq(PackageReuseContext.aliasType(name, packageReuse, seperateFilesForModels))))
           case (name, obj: OpenapiSchemaObject) =>
-            name -> generateClass(allSchemas, name, obj, allTransitiveJsonParamRefs, adtInheritanceMap, jsonSerdeLib, targetScala3)
+            (name, (2, generateClass(allSchemas, name, obj, allTransitiveJsonParamRefs, adtInheritanceMap, jsonSerdeLib, targetScala3)))
           case (name, obj: OpenapiSchemaEnum) =>
-            name -> EnumGenerator.generateEnum(name, obj, targetScala3, queryOrPathParamRefs, jsonSerdeLib, allTransitiveJsonParamRefs)
+            (name, (1, EnumGenerator.generateEnum(name, obj, targetScala3, queryOrPathParamRefs, jsonSerdeLib, allTransitiveJsonParamRefs)))
           case (name, OpenapiSchemaMap(valueSchema, _, _)) =>
-            name -> generateMap(name, valueSchema)
+            (name, (0, generateMap(name, valueSchema)))
           case (name, OpenapiSchemaArray(valueSchema, _, _, rs)) =>
-            name -> generateArray(name, valueSchema, rs)
+            (name, (0, generateArray(name, valueSchema, rs)))
           case (name, _: OpenapiSchemaOneOf) =>
-            name -> Nil
+            (name, (-1, Nil))
           case (name, r: OpenapiSchemaSimpleType) =>
-            name -> generateAlias(name, r)
+            (name, (0, generateAlias(name, r)))
           case (n, x) => throw new NotImplementedError(s"Only objects, enums and maps supported! (for $n found ${x})")
         }
       )
@@ -232,19 +233,23 @@ class ClassDefinitionGenerator {
     }
 
     val classReprs: Map[String, String] = if (!seperateFilesForModels) {
-      val defStr = schemaDefns.toSeq.sortBy(_._1).flatMap(_._2).mkString("\n") + nonClassyOneOfReprs
-      val helpers = (enumSerdeHelper + adtTypes).linesIterator.filterNot(_.forall(_.isWhitespace)).mkString("\n")
+      val defStr = adtTypes + "\n" +
+        schemaDefns.toSeq.sortBy(d => (d._2._1, d._1)).flatMap(_._2._2).mkString("\n") + "\n" +
+        nonClassyOneOfReprs
+      val helpers = enumSerdeHelper.linesIterator.filterNot(_.forall(_.isWhitespace)).mkString("\n")
       Map("" -> (helpers + "\n" + defStr))
     } else {
-      val mainOnly = scala.collection.mutable.ArrayBuffer[String]()
+      val (typeAliases, explicitDefns) = schemaDefns.toSeq.partition(_._2._1 == 0)
+      val mainContent =
+        enumSerdeHelper + "\n" + typeAliases.sortBy(_._1).flatMap(_._2._2).filterNot(_.forall(_.isWhitespace)).mkString("\n")
+
       val modelFiles = scala.collection.mutable.Map.empty[String, Vector[String]]
 
       def addModel(file: String, content: String): Unit =
         if (content.nonEmpty) modelFiles.update(file, modelFiles.getOrElse(file, Vector.empty) :+ content)
 
-      schemaDefns.foreach { case (name, defns) =>
-        if (isTypeAlias(name)) mainOnly ++= defns
-        else if (childToAdtFile.contains(name)) ()
+      explicitDefns.foreach { case (name, (_, defns)) =>
+        if (childToAdtFile.contains(name)) ()
         else if (allSchemas.get(name).exists(_.isInstanceOf[OpenapiSchemaEnum]))
           addModel(name, defns.mkString("\n"))
         else if (allSchemas.get(name).exists(_.isInstanceOf[OpenapiSchemaObject]))
@@ -257,9 +262,8 @@ class ClassDefinitionGenerator {
         val childContent = children
           .flatMap { child =>
             allSchemas.get(child).collect { case obj: OpenapiSchemaObject =>
-              generateClass(allSchemas, child, obj, allTransitiveJsonParamRefs, adtInheritanceMap, jsonSerdeLib, targetScala3).mkString(
-                "\n"
-              )
+              generateClass(allSchemas, child, obj, allTransitiveJsonParamRefs, adtInheritanceMap, jsonSerdeLib, targetScala3)
+                .mkString("\n")
             }
           }
           .mkString("\n")
@@ -270,7 +274,6 @@ class ClassDefinitionGenerator {
         addModel(name.capitalize, nonClassyOneOfRepr(name, st))
       }
 
-      val mainContent = (enumSerdeHelper.linesIterator ++ mainOnly).filterNot(_.forall(_.isWhitespace)).mkString("\n")
       Map("" -> mainContent) ++ modelFiles.map { case (k, v) => k -> v.mkString("\n") }.filter(_._2.nonEmpty)
     }
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -11,14 +11,16 @@ import sttp.tapir.codegen.util.NameHelpers.indent
 import sttp.tapir.codegen.util.{DocUtils, VersionedHelpers}
 
 case class GeneratedClassDefinitions(
-    classRepr: String,
+    classReprs: Map[String, String],
     jsonSerdeRepr: Option[String],
     schemaRepr: Seq[(Option[String], String)],
     xmlSerdeRepr: Option[String],
     schemasContainAny: Boolean,
     explicitNonObjTypes: Seq[String],
     allTransitiveJsonParamRefs: Set[String]
-)
+) {
+  def classRepr: String = classReprs.toSeq.sortBy(_._1).map(_._2).filter(_.nonEmpty).mkString("\n")
+}
 
 case class InlineEnumDefn(enumName: String, impl: String)
 
@@ -79,7 +81,8 @@ class ClassDefinitionGenerator {
       enumsDefinedOnEndpointParams: Boolean = false,
       xmlParamRefs: Set[String] = Set.empty,
       useCustomJsoniterSerdes: Boolean = true,
-      packageReuse: PackageReuseContext = PackageReuseContext.none
+      packageReuse: PackageReuseContext = PackageReuseContext.none,
+      seperateFilesForModels: Boolean = false
   ): Option[GeneratedClassDefinitions] = {
     val allSchemas: Map[String, OpenapiSchemaType] = doc.components.toSeq.flatMap(_.schemas).toMap
     val allOneOfSchemas = allSchemas.collect { case (name, oneOf: OpenapiSchemaOneOf) => name -> oneOf }.toSeq
@@ -95,28 +98,26 @@ class ClassDefinitionGenerator {
         s"Unable to constructing internal representation for oneOf(s) '${unresolvableNCOOS.map(_._1)}': discriminator provided, but not all variants are objects!"
       )
 
-    val nonClassyOneOfReprs = resolvableNonClassyOneOfSchemas
-      .map { case (name, st) =>
-        val tt = name.capitalize
-        val variants = st.types
-          .map {
-            case _: OpenapiSchemaBinary | _: OpenapiSchemaByte => s"case class ${tt}Bin(v: Array[Byte]) extends $tt"
-            case _: OpenapiSchemaDate                          => s"case class ${tt}Date(v: java.time.LocalDate) extends $tt"
-            case _: OpenapiSchemaDateTime                      => s"case class ${tt}DateTime(v: java.time.Instant) extends $tt"
-            case _: OpenapiSchemaDuration                      => s"case class ${tt}Duration(v: java.time.Duration) extends $tt"
-            case _: OpenapiSchemaUUID                          => s"case class ${tt}UUID(v: java.util.UUID) extends $tt"
-            case _: OpenapiSchemaBoolean                       => s"case class ${tt}Boolean(v: Boolean) extends $tt"
-            case t: OpenapiSchemaNumericType                   => s"case class $tt${t.scalaType}(v: ${t.scalaType}) extends $tt"
-            case _: OpenapiSchemaStringType                    => s"case class ${tt}String(v: String) extends $tt"
-            case _: OpenapiSchemaAny                           => s"case class ${tt}Json(v: io.circe.Json) extends $tt"
-            case r: OpenapiSchemaRef                           => s"case class $tt${r.stripped}(v: ${r.stripped}) extends $tt"
-          }
-          .mkString("\n")
-        s"""
-         |sealed trait $tt
+    def nonClassyOneOfRepr(name: String, st: OpenapiSchemaOneOf): String = {
+      val tt = name.capitalize
+      val variants = st.types
+        .map {
+          case _: OpenapiSchemaBinary | _: OpenapiSchemaByte => s"case class ${tt}Bin(v: Array[Byte]) extends $tt"
+          case _: OpenapiSchemaDate                          => s"case class ${tt}Date(v: java.time.LocalDate) extends $tt"
+          case _: OpenapiSchemaDateTime                      => s"case class ${tt}DateTime(v: java.time.Instant) extends $tt"
+          case _: OpenapiSchemaDuration                      => s"case class ${tt}Duration(v: java.time.Duration) extends $tt"
+          case _: OpenapiSchemaUUID                          => s"case class ${tt}UUID(v: java.util.UUID) extends $tt"
+          case _: OpenapiSchemaBoolean                       => s"case class ${tt}Boolean(v: Boolean) extends $tt"
+          case t: OpenapiSchemaNumericType                   => s"case class $tt${t.scalaType}(v: ${t.scalaType}) extends $tt"
+          case _: OpenapiSchemaStringType                    => s"case class ${tt}String(v: String) extends $tt"
+          case _: OpenapiSchemaAny                           => s"case class ${tt}Json(v: io.circe.Json) extends $tt"
+          case r: OpenapiSchemaRef                           => s"case class $tt${r.stripped}(v: ${r.stripped}) extends $tt"
+        }
+        .mkString("\n")
+      s"""sealed trait $tt
          |$variants""".stripMargin
-      }
-      .mkString("\n")
+    }
+    val nonClassyOneOfReprs = resolvableNonClassyOneOfSchemas.map { case (name, st) => nonClassyOneOfRepr(name, st) }.mkString("\n")
     val adtInheritanceMap: Map[String, Seq[(String, OpenapiSchemaOneOf)]] = mkMapParentsByChild(allClassyOneOfSchemas)
     val generatesQueryOrPathParamEnums = enumsDefinedOnEndpointParams ||
       allSchemas
@@ -179,40 +180,121 @@ class ClassDefinitionGenerator {
       xmlParamRefs.toSeq.flatMap(ref => allSchemas.get(ref.stripPrefix("#/components/schemas/")))
     )
     val xmlSerdes = XmlSerdeGenerator.generateSerdes(xmlSerdeLib, doc, allTransitiveXmlParamRefs, targetScala3, packageReuse)
-    val defns = doc.components
-      .map(_.schemas.flatMap {
-        case (name, _: OpenapiSchemaEnum) if PackageReuseContext.isReusedSchema(name, packageReuse) =>
-          Seq(PackageReuseContext.enumAliasType(name, packageReuse))
-        case (name, _) if PackageReuseContext.isReusedSchema(name, packageReuse) =>
-          Seq(PackageReuseContext.aliasType(name, packageReuse))
-        case (name, obj: OpenapiSchemaObject) =>
-          generateClass(allSchemas, name, obj, allTransitiveJsonParamRefs, adtInheritanceMap, jsonSerdeLib, targetScala3)
-        case (name, obj: OpenapiSchemaEnum) =>
-          EnumGenerator.generateEnum(name, obj, targetScala3, queryOrPathParamRefs, jsonSerdeLib, allTransitiveJsonParamRefs)
-        case (name, OpenapiSchemaMap(valueSchema, _, _))       => generateMap(name, valueSchema)
-        case (name, OpenapiSchemaArray(valueSchema, _, _, rs)) => generateArray(name, valueSchema, rs)
-        case (_, _: OpenapiSchemaOneOf)                        => Nil
-        case (name, r: OpenapiSchemaSimpleType)                => generateAlias(name, r)
-        case (n, x) => throw new NotImplementedError(s"Only objects, enums and maps supported! (for $n found ${x})")
-      })
-      .map(_.toSeq.sorted.mkString("\n") + nonClassyOneOfReprs)
-    val helpers = (enumSerdeHelper + adtTypes).linesIterator
-      .filterNot(_.forall(_.isWhitespace))
-      .mkString("\n")
-    // Json serdes & schemas live in separate files from the class defns
-    defns
-      .map(helpers + "\n" + _)
-      .map(defStr =>
-        GeneratedClassDefinitions(
-          defStr,
-          jsonSerdes,
-          shimsAndSchemas,
-          xmlSerdes,
-          schemasContainAny,
-          explicitNonObjTypes,
-          allTransitiveJsonParamRefs
-        )
+
+    def variantRefNames(oneOf: OpenapiSchemaOneOf): Set[String] =
+      oneOf.types.collect { case r: OpenapiSchemaRef => r.stripped }.toSet
+
+    val adtGroups: Map[String, Seq[String]] = allClassyOneOfSchemas
+      .groupBy { case (_, st) => variantRefNames(st) }
+      .map { case (_, group) =>
+        val parents = group.map(_._1).sorted.distinct
+        parents.head -> parents
+      }
+
+    val childToAdtFile: Map[String, String] = adtInheritanceMap.map { case (child, parents) =>
+      val parentNames = parents.map(_._1)
+      val fileName = adtGroups
+        .find { case (_, ps) => parentNames.forall(ps.contains) }
+        .map(_._1)
+        .getOrElse(parentNames.sorted.head)
+      child -> fileName
+    }
+
+    val schemaDefns: Map[String, Seq[String]] = doc.components
+      .map(
+        _.schemas.map {
+          case (name, _: OpenapiSchemaEnum) if PackageReuseContext.isReusedSchema(name, packageReuse) =>
+            def parentIsAlias = packageReuse.dependencyMeta.aliasedNames.contains(name)
+            name -> Seq(PackageReuseContext.enumAliasType(name, packageReuse, seperateFilesForModels && !parentIsAlias))
+          case (name, s) if PackageReuseContext.isReusedSchema(name, packageReuse) =>
+            val resolvedType = s match {
+              case s: OpenapiSchemaRef => s.maybeResolved(doc).getOrElse(s)
+              case s => s
+            }
+            def parentIsAlias = packageReuse.dependencyMeta.aliasedNames.contains(name) ||
+              resolvedType.isInstanceOf[OpenapiSchemaMap] ||
+              resolvedType.isInstanceOf[OpenapiSchemaArray] ||
+              resolvedType.isInstanceOf[OpenapiSchemaSimpleType]
+            name -> Seq(PackageReuseContext.aliasType(name, packageReuse, seperateFilesForModels && !parentIsAlias))
+          case (name, obj: OpenapiSchemaObject) =>
+            name -> generateClass(allSchemas, name, obj, allTransitiveJsonParamRefs, adtInheritanceMap, jsonSerdeLib, targetScala3)
+          case (name, obj: OpenapiSchemaEnum) =>
+            name -> EnumGenerator.generateEnum(name, obj, targetScala3, queryOrPathParamRefs, jsonSerdeLib, allTransitiveJsonParamRefs)
+          case (name, OpenapiSchemaMap(valueSchema, _, _)) =>
+            name -> generateMap(name, valueSchema)
+          case (name, OpenapiSchemaArray(valueSchema, _, _, rs)) =>
+            name -> generateArray(name, valueSchema, rs)
+          case (name, _: OpenapiSchemaOneOf) =>
+            name -> Nil
+          case (name, r: OpenapiSchemaSimpleType) =>
+            name -> generateAlias(name, r)
+          case (n, x) => throw new NotImplementedError(s"Only objects, enums and maps supported! (for $n found ${x})")
+        }
       )
+      .getOrElse(Map.empty)
+
+    def isTypeAlias(name: String): Boolean = allSchemas.get(name) match {
+      case Some(_: OpenapiSchemaMap) | Some(_: OpenapiSchemaArray) | Some(_: OpenapiSchemaSimpleType) => true
+      case Some(_: OpenapiSchemaEnum) if PackageReuseContext.isReusedSchema(name, packageReuse)       => true
+      case _ if PackageReuseContext.isReusedSchema(name, packageReuse)                                => true
+      case _                                                                                          => false
+    }
+
+    val classReprs: Map[String, String] = if (!seperateFilesForModels) {
+      val defStr = schemaDefns.toSeq.sortBy(_._1).flatMap(_._2).mkString("\n") + nonClassyOneOfReprs
+      val helpers = (enumSerdeHelper + adtTypes).linesIterator.filterNot(_.forall(_.isWhitespace)).mkString("\n")
+      Map("" -> (helpers + "\n" + defStr))
+    } else {
+      val mainOnly = scala.collection.mutable.ArrayBuffer[String]()
+      val modelFiles = scala.collection.mutable.Map.empty[String, Vector[String]]
+
+      def addModel(file: String, content: String): Unit =
+        if (content.nonEmpty) modelFiles.update(file, modelFiles.getOrElse(file, Vector.empty) :+ content)
+
+      schemaDefns.foreach { case (name, defns) =>
+        if (isTypeAlias(name)) mainOnly ++= defns
+        else if (childToAdtFile.contains(name)) ()
+        else if (allSchemas.get(name).exists(_.isInstanceOf[OpenapiSchemaEnum]))
+          addModel(name, defns.mkString("\n"))
+        else if (allSchemas.get(name).exists(_.isInstanceOf[OpenapiSchemaObject]))
+          addModel(name, defns.mkString("\n"))
+      }
+
+      adtGroups.toSeq.filterNot(p => isTypeAlias(p._1)).foreach { case (fileName, parentTraits) =>
+        val traits = parentTraits.map(p => s"sealed trait $p").mkString("\n")
+        val children = childToAdtFile.filter(_._2 == fileName).keys.toSeq.sorted
+        val childContent = children
+          .flatMap { child =>
+            allSchemas.get(child).collect { case obj: OpenapiSchemaObject =>
+              generateClass(allSchemas, child, obj, allTransitiveJsonParamRefs, adtInheritanceMap, jsonSerdeLib, targetScala3).mkString(
+                "\n"
+              )
+            }
+          }
+          .mkString("\n")
+        addModel(fileName, Seq(traits, childContent).filter(_.nonEmpty).mkString("\n"))
+      }
+
+      resolvableNonClassyOneOfSchemas.filterNot(p => isTypeAlias(p._1)).foreach { case (name, st) =>
+        addModel(name.capitalize, nonClassyOneOfRepr(name, st))
+      }
+
+      val mainContent = (enumSerdeHelper.linesIterator ++ mainOnly).filterNot(_.forall(_.isWhitespace)).mkString("\n")
+      Map("" -> mainContent) ++ modelFiles.map { case (k, v) => k -> v.mkString("\n") }.filter(_._2.nonEmpty)
+    }
+
+    // Json serdes & schemas live in separate files from the class defns
+    Some(
+      GeneratedClassDefinitions(
+        classReprs,
+        jsonSerdes,
+        shimsAndSchemas,
+        xmlSerdes,
+        schemasContainAny,
+        explicitNonObjTypes,
+        allTransitiveJsonParamRefs
+      )
+    )
   }
 
   private def mkMapParentsByChild(allOneOfSchemas: Seq[(String, OpenapiSchemaOneOf)]): Map[String, Seq[(String, OpenapiSchemaOneOf)]] =

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -123,6 +123,7 @@ class ClassDefinitionGenerator {
       allSchemas
         .collect { case (name, _: OpenapiSchemaEnum) => name }
         .exists(queryOrPathParamRefs.contains)
+    val enumSerdeHelper = if (!generatesQueryOrPathParamEnums) "" else EnumGenerator.enumSerdeHelperDefn(targetScala3)
 
     def fetchTransitiveParamRefs(initialSet: Set[String], toCheck: Seq[OpenapiSchemaType]): Set[String] = toCheck match {
       case Nil          => initialSet
@@ -144,7 +145,6 @@ class ClassDefinitionGenerator {
         .map(name => s"sealed trait $name")
         .sorted
         .mkString("", "\n", "\n")
-    val enumSerdeHelper = if (!generatesQueryOrPathParamEnums) "" else enumSerdeHelperDefn(targetScala3)
     val schemasWithAny = allSchemas.filter { case (_, schema) => schemaContainsAny(schema) }
     val schemasContainAny = schemasWithAny.nonEmpty || allTransitiveJsonParamRefs.contains("io.circe.Json")
     if (schemasContainAny && !Set(Circe, Jsoniter).contains(jsonSerdeLib))
@@ -204,18 +204,9 @@ class ClassDefinitionGenerator {
       .map(
         _.schemas.map {
           case (name, _: OpenapiSchemaEnum) if PackageReuseContext.isReusedSchema(name, packageReuse) =>
-            def parentIsAlias = packageReuse.dependencyMeta.aliasedNames.contains(name)
-            name -> Seq(PackageReuseContext.enumAliasType(name, packageReuse, seperateFilesForModels && !parentIsAlias))
+            name -> Seq(PackageReuseContext.enumAliasType(name, packageReuse, seperateFilesForModels))
           case (name, s) if PackageReuseContext.isReusedSchema(name, packageReuse) =>
-            val resolvedType = s match {
-              case s: OpenapiSchemaRef => s.maybeResolved(doc).getOrElse(s)
-              case s => s
-            }
-            def parentIsAlias = packageReuse.dependencyMeta.aliasedNames.contains(name) ||
-              resolvedType.isInstanceOf[OpenapiSchemaMap] ||
-              resolvedType.isInstanceOf[OpenapiSchemaArray] ||
-              resolvedType.isInstanceOf[OpenapiSchemaSimpleType]
-            name -> Seq(PackageReuseContext.aliasType(name, packageReuse, seperateFilesForModels && !parentIsAlias))
+            name -> Seq(PackageReuseContext.aliasType(name, packageReuse, seperateFilesForModels))
           case (name, obj: OpenapiSchemaObject) =>
             name -> generateClass(allSchemas, name, obj, allTransitiveJsonParamRefs, adtInheritanceMap, jsonSerdeLib, targetScala3)
           case (name, obj: OpenapiSchemaEnum) =>
@@ -323,56 +314,6 @@ class ClassDefinitionGenerator {
       .groupBy(_._1)
       .mapValues(_.map(_._2))
       .toMap
-
-  private def enumSerdeHelperDefn(targetScala3: Boolean): String = {
-    if (targetScala3)
-      """
-        |def enumMap[E: enumextensions.EnumMirror]: Map[String, E] =
-        |  Map.from(
-        |    for e <- enumextensions.EnumMirror[E].values yield e.name.toUpperCase -> e
-        |  )
-        |case class EnumExtraParamSupport[T: enumextensions.EnumMirror](eMap: Map[String, T]) extends ExtraParamSupport[T] {
-        |  // Case-insensitive mapping
-        |  def decode(s: String): sttp.tapir.DecodeResult[T] =
-        |    scala.util
-        |      .Try(eMap(s.toUpperCase))
-        |      .fold(
-        |        _ =>
-        |          sttp.tapir.DecodeResult.Error(
-        |            s,
-        |            new NoSuchElementException(
-        |              s"Could not find value $s for enum ${enumextensions.EnumMirror[T].mirroredName}, available values: ${enumextensions.EnumMirror[T].values.mkString(", ")}"
-        |            )
-        |          ),
-        |        sttp.tapir.DecodeResult.Value(_)
-        |      )
-        |  def encode(t: T): String = t.name
-        |}
-        |def extraCodecSupport[T: enumextensions.EnumMirror]: ExtraParamSupport[T] =
-        |  EnumExtraParamSupport(enumMap[T](using enumextensions.EnumMirror[T]))
-        |""".stripMargin
-    else
-      """
-        |case class EnumExtraParamSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]) extends ExtraParamSupport[T] {
-        |  // Case-insensitive mapping
-        |  def decode(s: String): sttp.tapir.DecodeResult[T] =
-        |    scala.util.Try(T.upperCaseNameValuesToMap(s.toUpperCase))
-        |      .fold(
-        |        _ =>
-        |          sttp.tapir.DecodeResult.Error(
-        |            s,
-        |            new NoSuchElementException(
-        |              s"Could not find value $s for enum ${enumName}, available values: ${T.values.mkString(", ")}"
-        |            )
-        |          ),
-        |        sttp.tapir.DecodeResult.Value(_)
-        |      )
-        |  def encode(t: T): String = t.entryName
-        |}
-        |def extraCodecSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): ExtraParamSupport[T] =
-        |  EnumExtraParamSupport(enumName, T)
-        |""".stripMargin
-  }
 
   private[codegen] def generateMap(
       name: String,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -1,6 +1,7 @@
 package sttp.tapir.codegen
 import io.circe.Json
-import sttp.tapir.codegen.RootGenerator.{indent, mapSchemaSimpleTypeToType, strippedToCamelCase}
+import sttp.tapir.codegen.RootGenerator.{mapSchemaSimpleTypeToType, strippedToCamelCase}
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.json.JsonSerdeLib.JsonSerdeLib
 import sttp.tapir.codegen.XmlSerdeLib.XmlSerdeLib
 import sttp.tapir.codegen.openapi.models.OpenapiModels.{
@@ -12,31 +13,12 @@ import sttp.tapir.codegen.openapi.models.OpenapiModels.{
   OpenapiResponseContent,
   OpenapiResponseDef
 }
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  AnyType,
-  OpenapiSchemaAny,
-  OpenapiSchemaArray,
-  OpenapiSchemaBinary,
-  OpenapiSchemaEnum,
-  OpenapiSchemaMap,
-  OpenapiSchemaObject,
-  OpenapiSchemaOneOf,
-  OpenapiSchemaRef,
-  OpenapiSchemaSimpleType,
-  OpenapiSchemaString
-}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
 import sttp.tapir.codegen.openapi.models._
-import sttp.tapir.codegen.openapi.models.GenerationDirectives.{
-  forceEager,
-  forceReqEager,
-  forceReqStreaming,
-  forceRespEager,
-  forceRespStreaming,
-  forceStreaming,
-  jsonBodyAsString,
-  securityPrefixKey
-}
+import sttp.tapir.codegen.openapi.models.GenerationDirectives._
+import sttp.tapir.codegen.security.{SecurityDefn, SecurityGenerator, SecurityWrapperDefn}
 import sttp.tapir.codegen.util.ErrUtils.bail
+import sttp.tapir.codegen.util.NameHelpers.indent
 import sttp.tapir.codegen.util.{JavaEscape, Location, NameHelpers}
 
 case class EndpointTypes(security: Seq[String], in: Seq[String], err: Seq[String], out: Seq[String]) {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -122,7 +122,8 @@ class EndpointGenerator {
       generateEndpointTypes: Boolean,
       validators: ValidationDefns,
       generateValidators: Boolean,
-      packageReuse: PackageReuseContext
+      packageReuse: PackageReuseContext,
+      seperateFilesForModels: Boolean
   ): EndpointDefs = {
     val capabilities = capabilityImpl(streamingImplementation)
     val components = Option(doc.components).flatten
@@ -144,7 +145,8 @@ class EndpointGenerator {
             doc,
             validators,
             generateValidators,
-            packageReuse
+            packageReuse,
+            seperateFilesForModels
           )
         )
         .foldLeft(GeneratedEndpoints(Nil, Set.empty, false, EndpointDetails.empty))(_ merge _)
@@ -185,7 +187,8 @@ class EndpointGenerator {
       doc: OpenapiDocument,
       validators: ValidationDefns,
       generateValidators: Boolean,
-      packageReuse: PackageReuseContext
+      packageReuse: PackageReuseContext,
+      seperateFilesForModels: Boolean
   )(p: OpenapiPath): GeneratedEndpoints = {
     val parameters = components.map(_.parameters).getOrElse(Map.empty)
     val securitySchemes = components.map(_.securitySchemes).getOrElse(Map.empty)
@@ -252,7 +255,8 @@ class EndpointGenerator {
               validators,
               generateValidators,
               isReused,
-              packageReuse
+              packageReuse,
+              seperateFilesForModels
             )
           val allTypes = EndpointTypes(
             maybeSecurityPath.toSeq.flatMap(_._2) ++ securityTypes.toSeq,
@@ -667,7 +671,8 @@ class EndpointGenerator {
       validators: ValidationDefns,
       generateValidators: Boolean,
       isReused: Boolean,
-      packageReuse: PackageReuseContext
+      packageReuse: PackageReuseContext,
+      seperateFilesForModels: Boolean
   )(implicit
       location: Location
   ) = {
@@ -740,17 +745,18 @@ class EndpointGenerator {
             .groupBy(_._1)
           val aliasDefns =
             if (needsAliases && isReused) {
+              val parentModelPath = packageReuse.modelRoot(seperateFilesForModels) 
               val wrappers = declsByWrapperClassName
                 .map { case (name, seq) =>
-                  s"type $name = ${packageReuse.dependencyModelPath}.$name\nval $name = ${packageReuse.dependencyModelPath}.$name\n"
+                  s"type $name = $parentModelPath.$name\nval $name = $parentModelPath.$name\n"
                 }
                 .toSeq
                 .sorted
                 .mkString("\n")
               Some(s"""
-                      |type $traitName = ${packageReuse.dependencyModelPath}.$traitName
-                      |type ${traitName}Full = ${packageReuse.dependencyModelPath}.${traitName}Full
-                      |val ${traitName}Full = ${packageReuse.dependencyModelPath}.${traitName}Full
+                      |type $traitName = $parentModelPath.$traitName
+                      |type ${traitName}Full = $parentModelPath.${traitName}Full
+                      |val ${traitName}Full = $parentModelPath.${traitName}Full
                       |$wrappers
                       |""".stripMargin)
             } else if (needsAliases) {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -240,7 +240,8 @@ class EndpointGenerator {
               validators,
               generateValidators,
               isReused,
-              packageReuse
+              packageReuse,
+              seperateFilesForModels
             )
           val (outDecl, outTypes, errTypes, inlineDefns) =
             outs(
@@ -490,8 +491,8 @@ class EndpointGenerator {
       case x => bail(s"Can't create non-simple params - found $x")
     }
 
-  private def aliases(packageReuse: PackageReuseContext, types: Seq[String]): String =
-    types.map(s => s"type $s = ${packageReuse.dependencyModelPath}.$s").mkString("\n")
+  private def aliases(packageReuse: PackageReuseContext, types: Seq[String], seperateFilesForModels: Boolean): String =
+    types.map(PackageReuseContext.enumAliasType(_, packageReuse, seperateFilesForModels)).mkString("\n")
 
   private def ins(
       parameters: Seq[OpenapiParameter],
@@ -506,7 +507,8 @@ class EndpointGenerator {
       validators: ValidationDefns,
       generateValidators: Boolean,
       isReused: Boolean,
-      packageReuse: PackageReuseContext
+      packageReuse: PackageReuseContext,
+      seperateFilesForModels: Boolean
   )(implicit location: Location): (String, Option[String], Seq[String], Option[String]) = {
 
     // .in(query[Limit]("limit").description("Maximum number of books to retrieve"))
@@ -543,7 +545,7 @@ class EndpointGenerator {
           validators
         )
 
-      val inlineDefn = maybeInlineDefn.map(d => if (isReused) aliases(packageReuse, inlineTypes) else d)
+      val inlineDefn = maybeInlineDefn.map(d => if (isReused) aliases(packageReuse, inlineTypes, seperateFilesForModels) else d)
       (decl, tpe, inlineDefn)
     }
     val (rqBody, maybeReqType, maybeInlineDefns) = requestBody.flatMap { b =>
@@ -708,7 +710,7 @@ class EndpointGenerator {
             validators
           )
         }
-        val inlineDefn = maybeInlineDefn.map(d => if (isReused) aliases(packageReuse, inlineTypes) else d)
+        val inlineDefn = maybeInlineDefn.map(d => if (isReused) aliases(packageReuse, inlineTypes, seperateFilesForModels) else d)
         (decl, tpe, inlineDefn)
       }
       resp.content match {
@@ -745,7 +747,7 @@ class EndpointGenerator {
             .groupBy(_._1)
           val aliasDefns =
             if (needsAliases && isReused) {
-              val parentModelPath = packageReuse.modelRoot(seperateFilesForModels) 
+              val parentModelPath = packageReuse.modelRoot(seperateFilesForModels)
               val wrappers = declsByWrapperClassName
                 .map { case (name, seq) =>
                   s"type $name = $parentModelPath.$name\nval $name = $parentModelPath.$name\n"

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EnumGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EnumGenerator.scala
@@ -66,4 +66,55 @@ object EnumGenerator {
          |}""".stripMargin :: Nil
     }
   }
+
+  def enumSerdeHelperDefn(targetScala3: Boolean): String = {
+    if (targetScala3)
+      """
+        |def enumMap[E: enumextensions.EnumMirror]: Map[String, E] =
+        |  Map.from(
+        |    for e <- enumextensions.EnumMirror[E].values yield e.name.toUpperCase -> e
+        |  )
+        |case class EnumExtraParamSupport[T: enumextensions.EnumMirror](eMap: Map[String, T]) extends ExtraParamSupport[T] {
+        |  // Case-insensitive mapping
+        |  def decode(s: String): sttp.tapir.DecodeResult[T] =
+        |    scala.util
+        |      .Try(eMap(s.toUpperCase))
+        |      .fold(
+        |        _ =>
+        |          sttp.tapir.DecodeResult.Error(
+        |            s,
+        |            new NoSuchElementException(
+        |              s"Could not find value $s for enum ${enumextensions.EnumMirror[T].mirroredName}, available values: ${enumextensions.EnumMirror[T].values.mkString(", ")}"
+        |            )
+        |          ),
+        |        sttp.tapir.DecodeResult.Value(_)
+        |      )
+        |  def encode(t: T): String = t.name
+        |}
+        |def extraCodecSupport[T: enumextensions.EnumMirror]: ExtraParamSupport[T] =
+        |  EnumExtraParamSupport(enumMap[T](using enumextensions.EnumMirror[T]))
+        |""".stripMargin
+    else
+      """
+        |case class EnumExtraParamSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]) extends ExtraParamSupport[T] {
+        |  // Case-insensitive mapping
+        |  def decode(s: String): sttp.tapir.DecodeResult[T] =
+        |    scala.util.Try(T.upperCaseNameValuesToMap(s.toUpperCase))
+        |      .fold(
+        |        _ =>
+        |          sttp.tapir.DecodeResult.Error(
+        |            s,
+        |            new NoSuchElementException(
+        |              s"Could not find value $s for enum ${enumName}, available values: ${T.values.mkString(", ")}"
+        |            )
+        |          ),
+        |        sttp.tapir.DecodeResult.Value(_)
+        |      )
+        |  def encode(t: T): String = t.entryName
+        |}
+        |def extraCodecSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): ExtraParamSupport[T] =
+        |  EnumExtraParamSupport(enumName, T)
+        |""".stripMargin
+  }
+
 }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -186,7 +186,7 @@ object RootGenerator {
          |}""".stripMargin
     }
 
-    val xmlSerdeObj = xmlSerdes.map(XmlSerdeGenerator.wrapBody(normalisedXmlLib, packagePath, objName, targetScala3, _))
+    val xmlSerdeObj = xmlSerdes.map(XmlSerdeGenerator.wrapBody(normalisedXmlLib, packagePath, objName, targetScala3, _, seperateFilesForModels))
 
     val schemaObjs = if (schemas.size > 1) shimsAndSchemas.zipWithIndex.map { case ((shims, body), idx) =>
       val priorImports = (0 until idx).map { i => s"import $packagePath.${objName}Schemas${i + 1}._" }.mkString("\n")

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -1,9 +1,11 @@
 package sttp.tapir.codegen
 
+import sttp.tapir.codegen.dedup.{GenerationMeta, PackageReuseContext}
 import sttp.tapir.codegen.json.JsonSerdeLib
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{AnyType, OpenapiSchemaAny, OpenapiSchemaBinary, OpenapiSchemaBoolean, OpenapiSchemaByte, OpenapiSchemaDate, OpenapiSchemaDateTime, OpenapiSchemaDouble, OpenapiSchemaDuration, OpenapiSchemaFloat, OpenapiSchemaInt, OpenapiSchemaLong, OpenapiSchemaRef, OpenapiSchemaSimpleType, OpenapiSchemaString, OpenapiSchemaUUID}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
 import sttp.tapir.codegen.openapi.models.SpecificationExtensionRenderer
+import sttp.tapir.codegen.security.SecurityGenerator
 import sttp.tapir.codegen.util.NameHelpers
 
 object XmlSerdeLib extends Enumeration {
@@ -16,47 +18,6 @@ case class FS2(effectType: String = "cats.effect.IO") extends StreamingImplement
 object Pekko extends StreamingImplementation
 object Zio extends StreamingImplementation
 
-object GenerationMeta {
-  val default: GenerationMeta = GenerationMeta(Seq("TapirGeneratedEndpointsSchemas"), false, false, Nil, Set.empty, Nil, 0, Set.empty, Set.empty)
-}
-case class GenerationMeta(
-    schemaFiles: Seq[String],
-    hasValidators: Boolean,
-    schemasContainAny: Boolean,
-    explicitNonObjTypes: Seq[String],
-    security: Set[SecurityWrapperDefn],
-    extensions: Seq[(String, String, String)],
-    schemaObjectCount: Int,
-    allTransitiveJsonParamRefs: Set[String],
-    jsonParamRefs: Set[String],
-) {
-  def partition(securityWrappers: Set[SecurityWrapperDefn]): (Set[SecurityWrapperDefn], Set[SecurityWrapperDefn]) = {
-    val changed = scala.collection.mutable.Set.empty[SecurityWrapperDefn]
-    val m = scala.collection.mutable.Set.empty[SecurityWrapperDefn]
-    val ct = scala.collection.mutable.Set.empty[String]
-    securityWrappers.foreach(w =>
-      if (!security.contains(w)) {
-        changed += w
-        w.schemas.map(_.typeName).foreach(t => ct += t)
-      } else m += w
-    )
-    def checkChanged: Unit = {
-      var changedCount = 0
-      val mSnapshot = m.toSet
-      mSnapshot.foreach(w =>
-        if (w.schemas.map(_.typeName).exists(ct.contains)) {
-          changedCount += 1
-          w.schemas.map(_.typeName).foreach(t => ct += t)
-          changed += w
-          m.remove(w)
-        }
-      )
-      if (changedCount != 0) checkChanged
-    }
-    checkChanged
-    m.toSet -> changed.toSet
-  }
-}
 case class GenerationInfo(allFiles: Map[String, String], meta: GenerationMeta)
 
 object RootGenerator {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -334,11 +334,10 @@ object RootGenerator {
       else None
 
     val maybeModels =
-      if (seperateFilesForModels) None
-      else
-        Some(s"""${indent(2)(mainClassDefns)}
-                |${indent(2)(inlineDefns.mkString("\n"))}
-                |""".stripMargin)
+      if (seperateFilesForModels) ""
+      else s"""${indent(2)(mainClassDefns)}
+              |${indent(2)(inlineDefns.mkString("\n"))}
+              |""".stripMargin
 
     val mainObj = s"""
         |package $packagePath

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -98,7 +98,8 @@ object RootGenerator {
         generateEndpointTypes,
         validators,
         generateValidators,
-        packageReuse
+        packageReuse,
+        seperateFilesForModels
       )
     val modelPackagePath = s"$packagePath.models"
     val GeneratedClassDefinitions(
@@ -284,7 +285,7 @@ object RootGenerator {
          |}""".stripMargin
     val queryParamSupport =
       s"""
-      |$paramListHelpers
+      |${if (!seperateFilesForModels) paramListHelpers else ""}
       |implicit def makePathCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[String, T, sttp.tapir.CodecFormat.TextPlain] = {
       |  sttp.tapir.Codec.string.mapDecode(support.decode)(support.encode)
       |}
@@ -320,6 +321,25 @@ object RootGenerator {
     val mainClassDefns =
       if (seperateFilesForModels) classDefns.getOrElse("", "")
       else classDefns.toSeq.sortBy(_._1).map(_._2).mkString("\n")
+
+    val maybeModelPackage =
+      if (seperateFilesForModels) Some(s"""
+         |package $packagePath
+         |
+         |package object models {
+         |${indent(2)(paramListHelpers)}
+         |${indent(2)(mainClassDefns)}
+         |${indent(2)(inlineDefns.mkString("\n"))}
+         |}""".stripMargin)
+      else None
+
+    val maybeModels =
+      if (seperateFilesForModels) None
+      else
+        Some(s"""${indent(2)(mainClassDefns)}
+                |${indent(2)(inlineDefns.mkString("\n"))}
+                |""".stripMargin)
+
     val mainObj = s"""
         |package $packagePath
         |
@@ -339,9 +359,7 @@ object RootGenerator {
         |  $byteStringDecl
         |  implicit def toByteString(ba: Array[Byte]): ByteString = ba.asInstanceOf[ByteString]
         |
-        |${indent(2)(mainClassDefns)}
-        |${indent(2)(inlineDefns.mkString("\n"))}
-        |
+        |$maybeModels
         |${indent(2)(maybeSpecificationExtensionKeys)}
         |
         |${indent(2)(endpointsInMain)}
@@ -354,14 +372,14 @@ object RootGenerator {
           s"models.$fn" ->
             s"""package $modelPackagePath
                |
-               |import $packagePath.$objName._
+               |//import $packagePath.$objName._
                |
                |$body
                |""".stripMargin
         }
       else Map.empty
     val allFiles = taggedObjs ++ jsonSerdeObj.map(s"${objName}JsonSerdes" -> _) ++ xmlSerdeObj.map(s"${objName}XmlSerdes" -> _) ++
-      validationObj ++ schemaObjs ++ modelFiles + (objName -> mainObj)
+      validationObj ++ schemaObjs ++ modelFiles ++ maybeModelPackage.map("models.package" -> _) + (objName -> mainObj)
     GenerationInfo(
       allFiles,
       GenerationMeta(

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -371,8 +371,6 @@ object RootGenerator {
           s"models.$fn" ->
             s"""package $modelPackagePath
                |
-               |//import $packagePath.$objName._
-               |
                |$body
                |""".stripMargin
         }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -270,11 +270,11 @@ object RootGenerator {
     val paramListHelpers =
       if (packageReuse.reusedSchemas.nonEmpty)
         s"""
-           |type CommaSeparatedValues[T] = ${packageReuse.dependencyModelPath}.CommaSeparatedValues[T]
-           |def CommaSeparatedValues[T](values: List[T]) = ${packageReuse.dependencyModelPath}.CommaSeparatedValues[T](values)
-           |type ExplodedValues[T] = ${packageReuse.dependencyModelPath}.ExplodedValues[T]
-           |def ExplodedValues[T](values: List[T]) = ${packageReuse.dependencyModelPath}.ExplodedValues[T](values)
-           |type ExtraParamSupport[T] = ${packageReuse.dependencyModelPath}.ExtraParamSupport[T]""".stripMargin
+           |type CommaSeparatedValues[T] = ${packageReuse.modelRoot(seperateFilesForModels)}.CommaSeparatedValues[T]
+           |def CommaSeparatedValues[T](values: List[T]) = ${packageReuse.modelRoot(seperateFilesForModels)}.CommaSeparatedValues[T](values)
+           |type ExplodedValues[T] = ${packageReuse.modelRoot(seperateFilesForModels)}.ExplodedValues[T]
+           |def ExplodedValues[T](values: List[T]) = ${packageReuse.modelRoot(seperateFilesForModels)}.ExplodedValues[T](values)
+           |type ExtraParamSupport[T] = ${packageReuse.modelRoot(seperateFilesForModels)}.ExtraParamSupport[T]""".stripMargin
       else
         s"""
          |case class CommaSeparatedValues[T](values: List[T])

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -39,7 +39,8 @@ object RootGenerator {
       generateEndpointTypes: Boolean,
       generateValidators: Boolean,
       useCustomJsoniterSerdes: Boolean,
-      packageReuse: PackageReuseContext = PackageReuseContext.none
+      packageReuse: PackageReuseContext = PackageReuseContext.none,
+      seperateFilesForModels: Boolean = false
   ): GenerationInfo = {
     val doc = unNormalisedDoc.resolveAllOfSchemas
     val normalisedJsonLib = jsonSerdeLib.toLowerCase match {
@@ -99,6 +100,7 @@ object RootGenerator {
         generateValidators,
         packageReuse
       )
+    val modelPackagePath = s"$packagePath.models"
     val GeneratedClassDefinitions(
       classDefns,
       jsonSerdes,
@@ -116,15 +118,16 @@ object RootGenerator {
           jsonSerdeLib = normalisedJsonLib,
           xmlSerdeLib = normalisedXmlLib,
           jsonParamRefs = jsonParamRefs,
-          fullModelPath = s"$packagePath.$objName",
+          fullModelPath = if (seperateFilesForModels) modelPackagePath else s"$packagePath.$objName",
           validateNonDiscriminatedOneOfs = validateNonDiscriminatedOneOfs,
           maxSchemasPerFile = maxSchemasPerFile,
           enumsDefinedOnEndpointParams = enumsDefinedOnEndpointParams,
           xmlParamRefs = xmlParamRefs,
           useCustomJsoniterSerdes = useCustomJsoniterSerdes,
-          packageReuse = packageReuse
+          packageReuse = packageReuse,
+          seperateFilesForModels = seperateFilesForModels
         )
-        .getOrElse(GeneratedClassDefinitions("", None, Nil, None, false, Nil, Set.empty))
+        .getOrElse(GeneratedClassDefinitions(Map.empty, None, Nil, None, false, Nil, Set.empty))
 
     val schemas = shimsAndSchemas.map(_._2)
     val hasJsonSerdes = jsonSerdes.nonEmpty
@@ -133,12 +136,13 @@ object RootGenerator {
     val maybeValidatorImport = if (validators.defns.nonEmpty) s"\nimport $packagePath.${objName}Validators._" else ""
     val maybeJsonImport = if (hasJsonSerdes) s"\nimport $packagePath.${objName}JsonSerdes._" else ""
     val maybeXmlImport = if (hasXmlSerdes) s"\nimport $packagePath.${objName}XmlSerdes._" else ""
+    val maybeModelImport = if (seperateFilesForModels) s"\nimport $modelPackagePath._" else ""
     val maybeSchemaImport =
       if (schemas.size > 1) (1 to schemas.size).map(i => s"import ${objName}Schemas$i._").mkString("\n", "\n", "")
       else if (schemas.size == 1) s"\nimport ${objName}Schemas._"
       else ""
     val internalImports =
-      s"import $packagePath.$objName._$maybeValidatorImport$maybeJsonImport$maybeXmlImport$maybeSchemaImport"
+      s"import $packagePath.$objName._$maybeModelImport$maybeValidatorImport$maybeJsonImport$maybeXmlImport$maybeSchemaImport"
 
     val taggedObjs = endpointsByTag.collect {
       case (Some(headTag), body) if body.nonEmpty =>
@@ -163,7 +167,7 @@ object RootGenerator {
           s"""package $packagePath
              |
              |object ${objName}Validators {
-             |  import $packagePath.$objName._
+             |${indent(2)(s"import $packagePath.$objName._$maybeModelImport")}
              |  import sttp.tapir.{ValidationResult, Validator}
              |
              |${indent(2)(validators.render(packageReuse))}
@@ -175,7 +179,7 @@ object RootGenerator {
       s"""package $packagePath
          |
          |object ${objName}JsonSerdes {
-         |  import $packagePath.$objName._
+         |${indent(2)(s"import $packagePath.$objName._$maybeModelImport")}
          |  import sttp.tapir.generic.auto._
          |${indent(2)(body)}
          |}""".stripMargin
@@ -191,7 +195,7 @@ object RootGenerator {
          |
          |${shims.map(_.replace("object Refs ", s"object Refs$suffix ")).getOrElse("")}
          |object $name {
-         |  import $packagePath.$objName._
+         |${indent(2)(s"import $packagePath.$objName._$maybeModelImport")}
          |  import sttp.tapir.generic.auto._
          |${indent(2)(priorImports)}
          |${indent(2)(body.replace(" Refs.", s" Refs$suffix."))}
@@ -202,7 +206,7 @@ object RootGenerator {
          |
          |${shimsAndSchemas.head._1.getOrElse("")}
          |object ${objName}Schemas {
-         |  import $packagePath.$objName._
+         |${indent(2)(s"import $packagePath.$objName._$maybeModelImport")}
          |  import sttp.tapir.generic.auto._
          |${indent(2)(schemas.head)}
          |}""".stripMargin)
@@ -259,16 +263,28 @@ object RootGenerator {
       }
       .mkString("\n")
     val extraImports =
-      if (endpointsInMain.nonEmpty) s"$maybeValidatorImport$maybeJsonImport$maybeXmlImport$maybeSchemaImport"
+      if (endpointsInMain.nonEmpty) s"$maybeModelImport$maybeValidatorImport$maybeJsonImport$maybeXmlImport$maybeSchemaImport"
       else ""
+
+    val paramListHelpers =
+      if (packageReuse.reusedSchemas.nonEmpty)
+        s"""
+           |type CommaSeparatedValues[T] = ${packageReuse.dependencyModelPath}.CommaSeparatedValues[T]
+           |def CommaSeparatedValues[T](values: List[T]) = ${packageReuse.dependencyModelPath}.CommaSeparatedValues[T](values)
+           |type ExplodedValues[T] = ${packageReuse.dependencyModelPath}.ExplodedValues[T]
+           |def ExplodedValues[T](values: List[T]) = ${packageReuse.dependencyModelPath}.ExplodedValues[T](values)
+           |type ExtraParamSupport[T] = ${packageReuse.dependencyModelPath}.ExtraParamSupport[T]""".stripMargin
+      else
+        s"""
+         |case class CommaSeparatedValues[T](values: List[T])
+         |case class ExplodedValues[T](values: List[T])
+         |trait ExtraParamSupport[T] {
+         |  def decode(s: String): sttp.tapir.DecodeResult[T]
+         |  def encode(t: T): String
+         |}""".stripMargin
     val queryParamSupport =
-      """
-      |case class CommaSeparatedValues[T](values: List[T])
-      |case class ExplodedValues[T](values: List[T])
-      |trait ExtraParamSupport[T] {
-      |  def decode(s: String): sttp.tapir.DecodeResult[T]
-      |  def encode(t: T): String
-      |}
+      s"""
+      |$paramListHelpers
       |implicit def makePathCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[String, T, sttp.tapir.CodecFormat.TextPlain] = {
       |  sttp.tapir.Codec.string.mapDecode(support.decode)(support.encode)
       |}
@@ -301,12 +317,15 @@ object RootGenerator {
       if (packageReuse.reusedSchemas.nonEmpty)
         s"type ByteString = ${packageReuse.depPkg}.$objName.ByteString"
       else "type ByteString <: Array[Byte]"
+    val mainClassDefns =
+      if (seperateFilesForModels) classDefns.getOrElse("", "")
+      else classDefns.toSeq.sortBy(_._1).map(_._2).mkString("\n")
     val mainObj = s"""
         |package $packagePath
         |
         |object $objName {
         |
-        |${indent(2)(imports(normalisedJsonLib) + extraImports)}
+        |${indent(2)(imports(normalisedJsonLib) + extraImports + maybeModelImport)}
         |
         |${indent(2)(customTypes)}
         |${indent(2)(securityTypes)}
@@ -320,7 +339,7 @@ object RootGenerator {
         |  $byteStringDecl
         |  implicit def toByteString(ba: Array[Byte]): ByteString = ba.asInstanceOf[ByteString]
         |
-        |${indent(2)(classDefns)}
+        |${indent(2)(mainClassDefns)}
         |${indent(2)(inlineDefns.mkString("\n"))}
         |
         |${indent(2)(maybeSpecificationExtensionKeys)}
@@ -329,8 +348,20 @@ object RootGenerator {
         |${indent(2)(ServersGenerator.genServerDefinitions(doc.servers, targetScala3).getOrElse(""))}
         |}
         |""".stripMargin
+    val modelFiles =
+      if (seperateFilesForModels)
+        classDefns.filter(_._1.nonEmpty).map { case (fn, body) =>
+          s"models.$fn" ->
+            s"""package $modelPackagePath
+               |
+               |import $packagePath.$objName._
+               |
+               |$body
+               |""".stripMargin
+        }
+      else Map.empty
     val allFiles = taggedObjs ++ jsonSerdeObj.map(s"${objName}JsonSerdes" -> _) ++ xmlSerdeObj.map(s"${objName}XmlSerdes" -> _) ++
-      validationObj ++ schemaObjs + (objName -> mainObj)
+      validationObj ++ schemaObjs ++ modelFiles + (objName -> mainObj)
     GenerationInfo(
       allFiles,
       GenerationMeta(
@@ -342,7 +373,8 @@ object RootGenerator {
         extensions,
         schemaObjs.size,
         allTransitiveJsonParamRefs,
-        jsonParamRefs
+        jsonParamRefs,
+        packageReuse.reusedSchemas
       )
     )
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
@@ -1,37 +1,12 @@
 package sttp.tapir.codegen
 
-import sttp.tapir.codegen.RootGenerator.indent
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.json.JsonSerdeLib
 import sttp.tapir.codegen.json.JsonSerdeLib.JsonSerdeLib
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  AnyType,
-  Discriminator,
-  OpenapiSchemaAllOf,
-  OpenapiSchemaAny,
-  OpenapiSchemaAnyOf,
-  OpenapiSchemaArray,
-  OpenapiSchemaBinary,
-  OpenapiSchemaBoolean,
-  OpenapiSchemaByte,
-  OpenapiSchemaConstantString,
-  OpenapiSchemaDate,
-  OpenapiSchemaDateTime,
-  OpenapiSchemaDuration,
-  OpenapiSchemaEnum,
-  OpenapiSchemaField,
-  OpenapiSchemaMap,
-  OpenapiSchemaNot,
-  OpenapiSchemaNumericType,
-  OpenapiSchemaObject,
-  OpenapiSchemaOneOf,
-  OpenapiSchemaRef,
-  OpenapiSchemaSimpleType,
-  OpenapiSchemaString,
-  OpenapiSchemaStringType,
-  OpenapiSchemaUUID
-}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
+import sttp.tapir.codegen.util.NameHelpers.indent
 
 import scala.collection.mutable
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ValidationGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ValidationGenerator.scala
@@ -1,23 +1,11 @@
 package sttp.tapir.codegen
 
 import io.circe.JsonNumber
-import sttp.tapir.codegen.RootGenerator.indent
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  ArrayRestrictions,
-  ObjectRestrictions,
-  OpenapiSchemaAllOf,
-  OpenapiSchemaArray,
-  OpenapiSchemaEnum,
-  OpenapiSchemaMap,
-  OpenapiSchemaNumericType,
-  OpenapiSchemaObject,
-  OpenapiSchemaOneOf,
-  OpenapiSchemaRef,
-  OpenapiSchemaSimpleType,
-  OpenapiSchemaString
-}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
+import sttp.tapir.codegen.util.NameHelpers.indent
 import sttp.tapir.codegen.util.JavaEscape
 
 import scala.annotation.tailrec

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/XmlSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/XmlSerdeGenerator.scala
@@ -2,6 +2,7 @@ package sttp.tapir.codegen
 
 import sttp.tapir.codegen.RootGenerator.{indent, mapSchemaSimpleTypeToType}
 import sttp.tapir.codegen.XmlSerdeLib.XmlSerdeLib
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaArray,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/XmlSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/XmlSerdeGenerator.scala
@@ -28,7 +28,12 @@ case class ScopedAuxCodecParams(
 )
 
 object XmlSerdeGenerator {
-  def genTopLevelSeqSerdes(xmlSerdeLib: XmlSerdeLib, schema: OpenapiSchemaArray, endpointName: String, position: String): Option[(String, String)] =
+  def genTopLevelSeqSerdes(
+      xmlSerdeLib: XmlSerdeLib,
+      schema: OpenapiSchemaArray,
+      endpointName: String,
+      position: String
+  ): Option[(String, String)] =
     schema match {
       case OpenapiSchemaArray(st: OpenapiSchemaSimpleType, _, c, _) if xmlSerdeLib == XmlSerdeLib.CatsXml =>
         val (t, _) = mapSchemaSimpleTypeToType(st)
@@ -60,13 +65,12 @@ object XmlSerdeGenerator {
           .map { ref =>
             val decoderName = s"${ref}XmlDecoder"
             val encoderName = s"${ref}XmlEncoder"
-            if (PackageReuseContext.isReusedSchema(ref, packageReuse)){
+            if (PackageReuseContext.isReusedSchema(ref, packageReuse)) {
               val inheritedImpl = s"${packageReuse.dependencyModelPath}XmlSerdes"
               s"""
                  |implicit lazy val $decoderName: Decoder[$ref] = $inheritedImpl.$decoderName
                  |implicit lazy val $encoderName: Encoder[$ref] = $inheritedImpl.$encoderName""".stripMargin
-            }
-            else {
+            } else {
               val mappedArraysOfSimpleSchemas: Seq[ScopedAuxCodecParams] =
                 doc.components.toSeq
                   .flatMap(_.schemas.get(ref).map(ref -> _))
@@ -180,11 +184,19 @@ object XmlSerdeGenerator {
       }
   }
 
-  def wrapBody(xmlSerdeLib: XmlSerdeLib, packagePath: String, objName: String, targetScala3: Boolean, body: String): String =
+  def wrapBody(
+      xmlSerdeLib: XmlSerdeLib,
+      packagePath: String,
+      objName: String,
+      targetScala3: Boolean,
+      body: String,
+      seperateFilesForModels: Boolean
+  ): String =
     xmlSerdeLib match {
       case XmlSerdeLib.NoSupport =>
         throw new IllegalStateException("Codegen should not be attempting to generate serdes when specified xml lib is 'none'")
       case XmlSerdeLib.CatsXml =>
+        val maybeModelImport = if (seperateFilesForModels) s"\n  import $packagePath.models._" else ""
         val enumDecoder =
           if (targetScala3)
             """  def enumDecoder[T: scala.reflect.ClassTag](fn: String => T): Decoder[T] =
@@ -219,7 +231,7 @@ object XmlSerdeGenerator {
         s"""package $packagePath
        |
        |object ${objName}XmlSerdes {
-       |  import $packagePath.$objName._
+       |  import $packagePath.$objName._$maybeModelImport
        |  import sttp.tapir.generic.auto._
        |  import cats.data.NonEmptyList
        |  import cats.xml.{NodeContent, Xml, XmlData, XmlNode}

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/dedup/PackageReuseContext.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/dedup/PackageReuseContext.scala
@@ -14,6 +14,7 @@ case class PackageReuseContext(
     reusedEndpointNames: Set[String]
 ) {
   lazy val depPkg: String = dependencyModelPath.split('.').dropRight(1).mkString(".")
+  def modelRoot(seperateFilesForModels: Boolean) = if (seperateFilesForModels) s"$depPkg.models" else dependencyModelPath
 }
 
 object PackageReuseContext {
@@ -41,30 +42,33 @@ object PackageReuseContext {
     )
   }
 
-  def aliasType(name: String, ctx: PackageReuseContext): String =
-    s"type $name = ${ctx.dependencyModelPath}.$name"
-  def enumAliasType(name: String, ctx: PackageReuseContext): String =
-    s"""type $name = ${ctx.dependencyModelPath}.$name
-       |val $name = ${ctx.dependencyModelPath}.$name""".stripMargin
+  def aliasType(name: String, ctx: PackageReuseContext, separateFilesForModels: Boolean): String =
+    s"type $name = ${ctx.modelRoot(separateFilesForModels)}.$name"
+  def enumAliasType(name: String, ctx: PackageReuseContext, separateFilesForModels: Boolean): String = {
+    val parentPkg = ctx.modelRoot(separateFilesForModels )
+    s"""type $name = $parentPkg.$name
+       |val $name = $parentPkg.$name""".stripMargin
+  }
 
   def isReusedSchema(name: String, ctx: PackageReuseContext): Boolean = ctx.reusedSchemas.contains(name)
 }
 
-
 object GenerationMeta {
-  val default: GenerationMeta = GenerationMeta(Seq("TapirGeneratedEndpointsSchemas"), false, false, Nil, Set.empty, Nil, 0, Set.empty, Set.empty)
+  val default: GenerationMeta =
+    GenerationMeta(Seq("TapirGeneratedEndpointsSchemas"), false, false, Nil, Set.empty, Nil, 0, Set.empty, Set.empty, Set.empty)
 }
 case class GenerationMeta(
-                           schemaFiles: Seq[String],
-                           hasValidators: Boolean,
-                           schemasContainAny: Boolean,
-                           explicitNonObjTypes: Seq[String],
-                           security: Set[SecurityWrapperDefn],
-                           extensions: Seq[(String, String, String)],
-                           schemaObjectCount: Int,
-                           allTransitiveJsonParamRefs: Set[String],
-                           jsonParamRefs: Set[String],
-                         ) {
+    schemaFiles: Seq[String],
+    hasValidators: Boolean,
+    schemasContainAny: Boolean,
+    explicitNonObjTypes: Seq[String],
+    security: Set[SecurityWrapperDefn],
+    extensions: Seq[(String, String, String)],
+    schemaObjectCount: Int,
+    allTransitiveJsonParamRefs: Set[String],
+    jsonParamRefs: Set[String],
+    aliasedNames: Set[String]
+) {
   def partition(securityWrappers: Set[SecurityWrapperDefn]): (Set[SecurityWrapperDefn], Set[SecurityWrapperDefn]) = {
     val changed = scala.collection.mutable.Set.empty[SecurityWrapperDefn]
     val m = scala.collection.mutable.Set.empty[SecurityWrapperDefn]

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/dedup/PackageReuseContext.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/dedup/PackageReuseContext.scala
@@ -1,6 +1,8 @@
-package sttp.tapir.codegen
+package sttp.tapir.codegen.dedup
 
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
+import sttp.tapir.codegen.dedup.PackageReuseContext
+import sttp.tapir.codegen.security.SecurityWrapperDefn
 
 /** Describes a dependency package whose models may be reused via type aliases. */
 case class PackageReuseContext(
@@ -46,4 +48,47 @@ object PackageReuseContext {
        |val $name = ${ctx.dependencyModelPath}.$name""".stripMargin
 
   def isReusedSchema(name: String, ctx: PackageReuseContext): Boolean = ctx.reusedSchemas.contains(name)
+}
+
+
+object GenerationMeta {
+  val default: GenerationMeta = GenerationMeta(Seq("TapirGeneratedEndpointsSchemas"), false, false, Nil, Set.empty, Nil, 0, Set.empty, Set.empty)
+}
+case class GenerationMeta(
+                           schemaFiles: Seq[String],
+                           hasValidators: Boolean,
+                           schemasContainAny: Boolean,
+                           explicitNonObjTypes: Seq[String],
+                           security: Set[SecurityWrapperDefn],
+                           extensions: Seq[(String, String, String)],
+                           schemaObjectCount: Int,
+                           allTransitiveJsonParamRefs: Set[String],
+                           jsonParamRefs: Set[String],
+                         ) {
+  def partition(securityWrappers: Set[SecurityWrapperDefn]): (Set[SecurityWrapperDefn], Set[SecurityWrapperDefn]) = {
+    val changed = scala.collection.mutable.Set.empty[SecurityWrapperDefn]
+    val m = scala.collection.mutable.Set.empty[SecurityWrapperDefn]
+    val ct = scala.collection.mutable.Set.empty[String]
+    securityWrappers.foreach(w =>
+      if (!security.contains(w)) {
+        changed += w
+        w.schemas.map(_.typeName).foreach(t => ct += t)
+      } else m += w
+    )
+    def checkChanged: Unit = {
+      var changedCount = 0
+      val mSnapshot = m.toSet
+      mSnapshot.foreach(w =>
+        if (w.schemas.map(_.typeName).exists(ct.contains)) {
+          changedCount += 1
+          w.schemas.map(_.typeName).foreach(t => ct += t)
+          changed += w
+          m.remove(w)
+        }
+      )
+      if (changedCount != 0) checkChanged
+    }
+    checkChanged
+    m.toSet -> changed.toSet
+  }
 }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/dedup/SchemaComparer.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/dedup/SchemaComparer.scala
@@ -1,8 +1,8 @@
-package sttp.tapir.codegen
+package sttp.tapir.codegen.dedup
 
-import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiDocument, OpenapiPath, OpenapiPathMethod, OpenapiRequestBodyDefn, OpenapiResponseDef}
+import sttp.tapir.codegen.openapi.models.OpenapiModels._
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
 import sttp.tapir.codegen.openapi.models.{OpenapiModels, OpenapiSchemaType}
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{Discriminator, OpenapiSchemaAllOf, OpenapiSchemaAny, OpenapiSchemaAnyOf, OpenapiSchemaArray, OpenapiSchemaBoolean, OpenapiSchemaByte, OpenapiSchemaConstantString, OpenapiSchemaDate, OpenapiSchemaDateTime, OpenapiSchemaDouble, OpenapiSchemaDuration, OpenapiSchemaEnum, OpenapiSchemaField, OpenapiSchemaFloat, OpenapiSchemaInt, OpenapiSchemaLong, OpenapiSchemaMap, OpenapiSchemaNot, OpenapiSchemaObject, OpenapiSchemaOneOf, OpenapiSchemaRef, OpenapiSchemaSimpleType, OpenapiSchemaString, OpenapiSchemaUUID}
 
 object SchemaComparer {
   private def resolved(doc: OpenapiDocument, ps: Map[String, OpenapiModels.OpenapiParameter])(

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/CirceSerdeImpl.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/CirceSerdeImpl.scala
@@ -1,6 +1,5 @@
 package sttp.tapir.codegen.json
 
-import sttp.tapir.codegen.PackageReuseContext
 import sttp.tapir.codegen.json.JsonHelpers.{checkForSoundness, inlineEndpointSchemas}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
@@ -23,6 +22,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaStringType,
   OpenapiSchemaUUID
 }
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.util.NameHelpers.{indent, uncapitalise}
 
 object CirceSerdeImpl {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/CirceSerdeImpl.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/CirceSerdeImpl.scala
@@ -66,9 +66,9 @@ object CirceSerdeImpl {
         case (name, schema: OpenapiSchemaObject, true) =>
           circeParentImpl(name) orElse Some(genCirceObjectSerde(name, schema))
         case (name, schema: OpenapiSchemaMap, true) =>
-          circeParentImpl(name) orElse Some(genCirceMapOrArraySerde(name, schema.items))
+          genCirceMapOrArraySerde(name, schema.items).map { case (n, impl) => circeParentImpl(n).getOrElse(impl) }
         case (name, schema: OpenapiSchemaArray, true) =>
-          circeParentImpl(name) orElse Some(genCirceMapOrArraySerde(name, schema.items))
+          genCirceMapOrArraySerde(name, schema.items).map { case (n, impl) => circeParentImpl(n).getOrElse(impl) }
         case (name, schema: OpenapiSchemaOneOf, true) =>
           circeParentImpl(name) orElse Some(
             if (schema.types.exists(!_.isInstanceOf[OpenapiSchemaRef]))
@@ -118,12 +118,13 @@ object CirceSerdeImpl {
     s"""${subs}implicit lazy val ${uncapitalisedName}JsonDecoder: io.circe.Decoder[$name] = io.circe.generic.semiauto.deriveDecoder[$name]
        |implicit lazy val ${uncapitalisedName}JsonEncoder: io.circe.Encoder[$name] = io.circe.generic.semiauto.deriveEncoder[$name]""".stripMargin
   }
-  private def genCirceMapOrArraySerde(name: String, schema: OpenapiSchemaType): String = {
-    val subs = schema match {
-      case `type`: OpenapiSchemaObject => Some(genCirceObjectSerde(s"${name}ObjectsItem", `type`))
-      case _                           => None
+  private def genCirceMapOrArraySerde(name: String, schema: OpenapiSchemaType): Option[(String, String)] = {
+    schema match {
+      case `type`: OpenapiSchemaObject =>
+        val inlineItemName = s"${name}ObjectsItem"
+        Some(inlineItemName -> ("\n" + genCirceObjectSerde(inlineItemName, `type`)))
+      case _ => None
     }
-    subs.fold("")("\n" + _)
   }
 
   private def genCirceAdtSerde(
@@ -242,7 +243,8 @@ object CirceSerdeImpl {
           case s                      =>
             s"case x: ${name}${s.disambiguationSuffix} => io.circe.Encoder[String].apply(x.v.toString)"
         } ++
-        childNameAndSerde.map { case (subName, _) => s"case x: $name${subName} => io.circe.Encoder[$subName].apply(x.v)" }).mkString("\n    ")
+        childNameAndSerde.map { case (subName, _) => s"case x: $name${subName} => io.circe.Encoder[$subName].apply(x.v)" })
+        .mkString("\n    ")
     s"""implicit lazy val ${uncapitalisedName}JsonEncoder: io.circe.Encoder[$name] = io.circe.Encoder.instance {
        |    $encoders
        |  }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/JsonSerdeGenerator.scala
@@ -23,7 +23,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaStringType,
   OpenapiSchemaUUID
 }
-import sttp.tapir.codegen.PackageReuseContext
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.util.NameHelpers.{addName, indent, uncapitalise}
 
 import scala.annotation.tailrec

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/JsoniterSerdeImpl.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/JsoniterSerdeImpl.scala
@@ -1,6 +1,5 @@
 package sttp.tapir.codegen.json
 
-import sttp.tapir.codegen.PackageReuseContext
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
@@ -23,6 +22,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaStringType,
   OpenapiSchemaUUID
 }
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.util.NameHelpers.{addName, indent, uncapitalise}
 
 object JsoniterSerdeImpl {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/ZioSerdeImpl.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/ZioSerdeImpl.scala
@@ -1,6 +1,5 @@
 package sttp.tapir.codegen.json
 
-import sttp.tapir.codegen.PackageReuseContext
 import sttp.tapir.codegen.json.JsonHelpers.{checkForSoundness, inlineEndpointSchemas}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
@@ -23,6 +22,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaStringType,
   OpenapiSchemaUUID
 }
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.util.NameHelpers.{indent, uncapitalise}
 
 object ZioSerdeImpl {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/ZioSerdeImpl.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/ZioSerdeImpl.scala
@@ -55,9 +55,9 @@ object ZioSerdeImpl {
         case (name, schema: OpenapiSchemaObject, true) =>
           zioParentImpl(name) orElse Some(genZioObjectSerde(name, schema))
         case (name, schema: OpenapiSchemaMap, true) =>
-          zioParentImpl(name) orElse Some(genZioMapOrArraySerde(name, schema.items))
+          genZioMapOrArraySerde(name, schema.items).map { case (n, impl) => zioParentImpl(n).getOrElse(impl) }
         case (name, schema: OpenapiSchemaArray, true) =>
-          zioParentImpl(name) orElse Some(genZioMapOrArraySerde(name, schema.items))
+          genZioMapOrArraySerde(name, schema.items).map { case (n, impl) => zioParentImpl(n).getOrElse(impl) }
         case (name, schema: OpenapiSchemaOneOf, true) =>
           zioParentImpl(name) orElse Some(
             if (schema.types.exists(!_.isInstanceOf[OpenapiSchemaRef]))
@@ -105,12 +105,13 @@ object ZioSerdeImpl {
        |implicit lazy val ${uncapitalisedName}JsonEncoder: zio.json.JsonEncoder[$name] = zio.json.DeriveJsonEncoder.gen[$name]""".stripMargin
   }
 
-  private def genZioMapOrArraySerde(name: String, schema: OpenapiSchemaType): String = {
-    val subs = schema match {
-      case `type`: OpenapiSchemaObject => Some(genZioObjectSerde(s"${name}ObjectsItem", `type`))
-      case _                           => None
+  private def genZioMapOrArraySerde(name: String, schema: OpenapiSchemaType): Option[(String, String)] = {
+    schema match {
+      case `type`: OpenapiSchemaObject =>
+        val itemName = s"${name}ObjectsItem"
+        Some(itemName -> ("\n" + genZioObjectSerde(itemName, `type`)))
+      case _ => None
     }
-    subs.fold("")("\n" + _)
   }
 
   private def genZioEnumSerde(name: String): String = {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/security/SecurityGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/security/SecurityGenerator.scala
@@ -1,9 +1,10 @@
-package sttp.tapir.codegen
+package sttp.tapir.codegen.security
 
-import sttp.tapir.codegen.RootGenerator.indent
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType
 import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType.OAuth2FlowType
 import sttp.tapir.codegen.util.ErrUtils.bail
+import sttp.tapir.codegen.util.NameHelpers.indent
 import sttp.tapir.codegen.util.Location
 
 import scala.collection.immutable

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -1,5 +1,6 @@
 package sttp.tapir.codegen
 
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.json.JsonSerdeLib
 import sttp.tapir.codegen.openapi.models.{OpenapiComponent, OpenapiSchemaType}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -471,6 +471,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
             validators = ValidationDefns.empty,
             generateValidators = true,
             packageReuse = PackageReuseContext.none,
+            seperateFilesForModels = false,
           )
           .endpointDecls(None)
     }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -576,7 +576,7 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
         |""".stripMargin
     val gen = new ClassDefinitionGenerator()
     def testOK(useCustomMacros: Boolean, doc: OpenapiDocument) = {
-      val GeneratedClassDefinitions(res, jsonSerdes, _, _, _, _, _) =
+      val generated =
         gen
           .classDefs(
             doc,
@@ -588,8 +588,10 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
           )
           .get
 
-      val fullRes = imports + res + "\n" + jsonSerdes.get
-      res.shouldCompile()
+      val classRepr = generated.classRepr
+      val jsonSerdes = generated.jsonSerdeRepr
+      val fullRes = imports + classRepr + "\n" + jsonSerdes.get
+      classRepr.shouldCompile()
       fullRes.shouldCompile()
       if (useCustomMacros)
         jsonSerdes.get should include(
@@ -619,10 +621,11 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
         |""".stripMargin
     val gen = new ClassDefinitionGenerator()
     def testOK(doc: OpenapiDocument) = {
-      val GeneratedClassDefinitions(res, jsonSerdes, _, _, _, _, _) =
-        gen.classDefs(doc, false, jsonSerdeLib = JsonSerdeLib.Circe, jsonParamRefs = Set("ReqWithVariants")).get
+      val generated = gen.classDefs(doc, false, jsonSerdeLib = JsonSerdeLib.Circe, jsonParamRefs = Set("ReqWithVariants")).get
+      val classRepr = generated.classRepr
+      val jsonSerdes = generated.jsonSerdeRepr
 
-      val fullRes = (res + "\n" + jsonSerdes.get)
+      val fullRes = (classRepr + "\n" + jsonSerdes.get)
       (imports + fullRes).shouldCompile()
       val expectedLines = Seq(
         """implicit lazy val reqWithVariantsJsonEncoder: io.circe.Encoder[ReqWithVariants]""",
@@ -640,5 +643,22 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     )
     failed.isFailure shouldEqual true
     failed.failed.get.getMessage shouldEqual "Problems in non-discriminated oneOf 'ReqWithVariants' declaration: (#/components/schemas/ReqSubtype2 appears before #/components/schemas/ReqSubtype3, but a #/components/schemas/ReqSubtype3 can be a valid #/components/schemas/ReqSubtype2)"
+  }
+
+  it should "split models into separate files when seperateFilesForModels is true" in {
+    val result = new ClassDefinitionGenerator().classDefs(
+      TestHelpers.oneOfDocsWithMapping,
+      targetScala3 = isScala3,
+      jsonSerdeLib = JsonSerdeLib.Circe,
+      jsonParamRefs = Set("ReqWithVariants"),
+      fullModelPath = "foo.bar.models",
+      seperateFilesForModels = true
+    ).get
+
+    result.classReprs.keys should contain("")
+    result.classReprs.keys should contain("ReqWithVariants")
+    result.classReprs("ReqWithVariants") should include("sealed trait ReqWithVariants")
+    result.classReprs("ReqWithVariants") should include("case class ReqSubtype1")
+    result.classReprs.getOrElse("", "") should not include "sealed trait ReqWithVariants"
   }
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -1,6 +1,7 @@
 package sttp.tapir.codegen
 
 import sttp.tapir.codegen.json.JsonSerdeLib
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
 import sttp.tapir.codegen.openapi.models.OpenapiModels.{
   OpenapiDocument,

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -318,7 +318,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
 
   it should "generate attributes for specification extensions on path and operation objects" in {
     val doc = TestHelpers.specificationExtensionDocs
-    val generatedCode = RootGenerator.generateObjects(
+    val generatedObj = RootGenerator.generateObjects(
       doc,
       "sttp.tapir.generated",
       "TapirGeneratedEndpoints",
@@ -332,7 +332,8 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       generateEndpointTypes = false,
       generateValidators = true,
       useCustomJsoniterSerdes = true
-    ).allFiles("TapirGeneratedEndpoints")
+    )
+    val generatedCode = generatedObj.allFiles("TapirGeneratedEndpointsSchemas") + "\n" + generatedObj.allFiles("TapirGeneratedEndpoints")
     generatedCode.shouldCompile()
     val expectedAttrDecls = Seq(
       """.attribute[CustomStringExtensionOnPathExtension](customStringExtensionOnPathExtensionKey, "another string")""",

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -80,6 +80,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           validators = ValidationDefns.empty,
           generateValidators = true,
           packageReuse = PackageReuseContext.none,
+          seperateFilesForModels = false,
         )
         .endpointDecls(None)
     generatedCode should include("val getTestAsdId =")
@@ -172,6 +173,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           validators = ValidationDefns.empty,
           generateValidators = true,
           packageReuse = PackageReuseContext.none,
+          seperateFilesForModels = false,
         )
         .endpointDecls(None)).shouldCompile()
   }
@@ -231,6 +233,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           validators = ValidationDefns.empty,
           generateValidators = true,
           packageReuse = PackageReuseContext.none,
+          seperateFilesForModels = false,
         )
         .endpointDecls(None)
     generatedCode should include(

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
@@ -75,8 +75,10 @@ class PackageReuseContextSpec extends AnyFlatSpec with Matchers {
     )
     ctx.reusedSchemas shouldBe Set("Pet")
     ctx.dependencyModelPath shouldBe "sttp.tapir.generated.core.TapirGeneratedEndpoints"
-    PackageReuseContext.aliasType("Pet", ctx) shouldBe
+    PackageReuseContext.aliasType("Pet", ctx, false) shouldBe
       "type Pet = sttp.tapir.generated.core.TapirGeneratedEndpoints.Pet"
+    PackageReuseContext.aliasType("Pet", ctx, true) shouldBe
+      "type Pet = sttp.tapir.generated.core.models.Pet"
   }
 
   it should "reuse Pet from schema_inheritance sbt-test specs" in {

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
@@ -2,17 +2,9 @@ package sttp.tapir.codegen
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.tapir.codegen.dedup.{GenerationMeta, PackageReuseContext, SchemaComparer}
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  NumericRestrictions,
-  OpenapiSchemaConstantString,
-  OpenapiSchemaEnum,
-  OpenapiSchemaField,
-  OpenapiSchemaInt,
-  OpenapiSchemaObject,
-  OpenapiSchemaRef,
-  OpenapiSchemaString
-}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{NumericRestrictions, OpenapiSchemaConstantString, OpenapiSchemaEnum, OpenapiSchemaField, OpenapiSchemaInt, OpenapiSchemaObject, OpenapiSchemaRef, OpenapiSchemaString}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiInfo
@@ -79,7 +71,7 @@ class PackageReuseContextSpec extends AnyFlatSpec with Matchers {
       petDoc(),
       "sttp.tapir.generated.core",
       "TapirGeneratedEndpoints",
-      GenerationMeta.default,
+      GenerationMeta.default
     )
     ctx.reusedSchemas shouldBe Set("Pet")
     ctx.dependencyModelPath shouldBe "sttp.tapir.generated.core.TapirGeneratedEndpoints"

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/RootGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/RootGeneratorSpec.scala
@@ -152,7 +152,12 @@ class RootGeneratorSpec extends CompileCheckTestBase {
     files.keys should contain("models.Book")
     files("TapirGeneratedEndpoints") should not include "case class Book"
     files("models.Book") should include("case class Book")
-    files.filter(_._1.startsWith("models.")).values.foreach(_ should include("package sttp.tapir.generated.models"))
+    val modelFiles = files.filter(_._1.startsWith("models."))
+    val packageFile = files.find(_._1.endsWith("package")).get
+    modelFiles.filterNot(_._1.endsWith("package")).values.foreach(_ should include("package sttp.tapir.generated.models"))
+    packageFile._2 should not include("package sttp.tapir.generated.models")
+    packageFile._2 should include("package sttp.tapir.generated")
+    packageFile._2 should include("package object models")
   }
 
   Seq("circe", "jsoniter", "zio") foreach testJsonLib

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/RootGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/RootGeneratorSpec.scala
@@ -130,5 +130,30 @@ class RootGeneratorSpec extends CompileCheckTestBase {
     )
   }
 
+  it should "split models into separate files when seperateFilesForModels is true" in {
+    val info = RootGenerator.generateObjects(
+      TestHelpers.myBookshopDoc,
+      "sttp.tapir.generated",
+      "TapirGeneratedEndpoints",
+      targetScala3 = isScala3,
+      useHeadTagForObjectNames = false,
+      jsonSerdeLib = "circe",
+      xmlSerdeLib = "none",
+      streamingImplementation = "fs2",
+      validateNonDiscriminatedOneOfs = true,
+      maxSchemasPerFile = 400,
+      generateEndpointTypes = false,
+      generateValidators = true,
+      useCustomJsoniterSerdes = true,
+      seperateFilesForModels = true
+    )
+    val files = info.allFiles
+    files.keys.exists(_.startsWith("models.")) shouldBe true
+    files.keys should contain("models.Book")
+    files("TapirGeneratedEndpoints") should not include "case class Book"
+    files("models.Book") should include("case class Book")
+    files.filter(_._1.startsWith("models.")).values.foreach(_ should include("package sttp.tapir.generated.models"))
+  }
+
   Seq("circe", "jsoniter", "zio") foreach testJsonLib
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -16,7 +16,8 @@ case class OpenApiConfiguration(
     disableValidatorGeneration: Boolean,
     useCustomJsoniterSerdes: Boolean,
     additionalPackages: List[(String, File)],
-    packageDependencies: Map[String, String]
+    packageDependencies: Map[String, String],
+    seperateFilesForModels: Boolean,
 )
 
 trait OpenapiCodegenKeys {
@@ -41,6 +42,7 @@ trait OpenapiCodegenKeys {
   lazy val openapiUseCustomJsoniterSerdes = settingKey[Boolean](
     "Set to true to enable usage of custom jsoniter macros (decreases compilation flakiness, compatible with jsoniter-scala versions >= 2.36.x)"
   )
+  lazy val openapiSeperateFilesForModels = settingKey[Boolean]("When true, each model will be split into a seperate file (excluding ADTS)")
   lazy val openapiOpenApiConfiguration =
     settingKey[OpenApiConfiguration]("Aggregation of other settings. Manually set value will be disregarded.")
 

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -60,7 +60,8 @@ object OpenapiCodegenPlugin extends AutoPlugin {
       openapiDisableValidatorGeneration.value,
       openapiUseCustomJsoniterSerdes.value,
       openapiAdditionalPackages.value,
-      openapiPackageDependencies.value
+      openapiPackageDependencies.value,
+      openapiSeperateFilesForModels.value
     )
   def openapiCodegenDefaultSettings: Seq[Setting[_]] = Seq(
     openapiSwaggerFile := baseDirectory.value / "swagger.yaml",
@@ -77,6 +78,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
     openapiGenerateEndpointTypes := false,
     openapiDisableValidatorGeneration := false,
     openapiUseCustomJsoniterSerdes := false,
+    openapiSeperateFilesForModels := false,
     standardParamSetting
   )
 
@@ -165,6 +167,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
       sv.startsWith("3"),
       directoryName,
       Some(doc),
-      packageReuse
+      packageReuse,
+      c.seperateFilesForModels
     )
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -3,7 +3,8 @@ package sttp.tapir.sbt
 import sbt._
 import Keys._
 import sbt.nio.Keys.fileInputs
-import sttp.tapir.codegen.{GenerationMeta, OpenApiInputParser, PackageReuseContext}
+import sttp.tapir.codegen.OpenApiInputParser
+import sttp.tapir.codegen.dedup.{GenerationMeta, PackageReuseContext}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 
 object OpenapiCodegenPlugin extends AutoPlugin {

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -1,7 +1,8 @@
 package sttp.tapir.sbt
 
 import sbt._
-import sttp.tapir.codegen.{GenerationMeta, OpenApiInputParser, PackageReuseContext, RootGenerator}
+import sttp.tapir.codegen.{OpenApiInputParser, RootGenerator}
+import sttp.tapir.codegen.dedup.{GenerationMeta, PackageReuseContext}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 
 case class OpenapiCodegenTask(

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -22,7 +22,8 @@ case class OpenapiCodegenTask(
     targetScala3: Boolean,
     overrideDirectoryName: Option[String],
     preParsedDoc: Option[OpenapiDocument] = None,
-    packageReuse: PackageReuseContext = PackageReuseContext.none
+    packageReuse: PackageReuseContext = PackageReuseContext.none,
+    seperateFilesForModels: Boolean = false
 ) {
 
   private val directoryName: String = overrideDirectoryName.getOrElse("sbt-openapi-codegen")
@@ -49,10 +50,15 @@ case class OpenapiCodegenTask(
         generateEndpointTypes,
         !disableValidatorGeneration,
         useCustomJsoniterSerdes,
-        packageReuse
+        packageReuse,
+        seperateFilesForModels
       )
     generationInfo.allFiles.map { case (objectName, fileBody) =>
-      val file = outDirectory / s"$objectName.scala"
+      val segments = objectName.split('.')
+      val file = segments.toList match {
+        case name :: Nil => outDirectory / s"$name.scala"
+        case init :+ last => init.foldLeft(outDirectory)(_ / _) / s"$last.scala"
+      }
       val lines = fileBody.linesIterator.toSeq
       IO.writeLines(file, lines, IO.utf8)
       file

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -5,6 +5,10 @@ import sttp.tapir.codegen.{OpenApiInputParser, RootGenerator}
 import sttp.tapir.codegen.dedup.{GenerationMeta, PackageReuseContext}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
 case class OpenapiCodegenTask(
     inputYaml: File,
     packageName: String,
@@ -53,15 +57,20 @@ case class OpenapiCodegenTask(
         packageReuse,
         seperateFilesForModels
       )
-    generationInfo.allFiles.map { case (objectName, fileBody) =>
-      val segments = objectName.split('.')
-      val file = segments.toList match {
-        case name :: Nil => outDirectory / s"$name.scala"
-        case init :+ last => init.foldLeft(outDirectory)(_ / _) / s"$last.scala"
-      }
-      val lines = fileBody.linesIterator.toSeq
-      IO.writeLines(file, lines, IO.utf8)
-      file
-    }.toSeq -> generationInfo.meta
+    Await.result(
+      Future.traverse(generationInfo.allFiles.toSeq) { case (objectName, fileBody) =>
+        Future[File] {
+          val segments = objectName.split('.')
+          val file = segments.toList match {
+            case name :: Nil  => outDirectory / s"$name.scala"
+            case init :+ last => init.foldLeft(outDirectory)(_ / _) / s"$last.scala"
+          }
+          val lines = fileBody.linesIterator.toSeq
+          IO.writeLines(file, lines, IO.utf8)
+          file
+        }
+      },
+      Duration.Inf
+    ) -> generationInfo.meta
   }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/Expected.scala.txt
@@ -23,6 +23,7 @@ object TapirGeneratedEndpoints {
 
 
 
+
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
   trait ExtraParamSupport[T] {
@@ -82,915 +83,15 @@ object TapirGeneratedEndpoints {
   def extraCodecSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): ExtraParamSupport[T] =
     EnumExtraParamSupport(enumName, T)
 
-  sealed trait AccessPolicyDTOAction extends enumeratum.EnumEntry
-  object AccessPolicyDTOAction extends enumeratum.Enum[AccessPolicyDTOAction] with enumeratum.CirceEnum[AccessPolicyDTOAction] {
-    val values = findValues
-    case object read extends AccessPolicyDTOAction
-  }
 
-  sealed trait AccessPolicySummaryDTOAction extends enumeratum.EnumEntry
-  object AccessPolicySummaryDTOAction extends enumeratum.Enum[AccessPolicySummaryDTOAction] with enumeratum.CirceEnum[AccessPolicySummaryDTOAction] {
-    val values = findValues
-    case object read extends AccessPolicySummaryDTOAction
-  }
-
-  sealed trait ActivateControllerServicesEntityState extends enumeratum.EnumEntry
-  object ActivateControllerServicesEntityState extends enumeratum.Enum[ActivateControllerServicesEntityState] with enumeratum.CirceEnum[ActivateControllerServicesEntityState] {
-    val values = findValues
-    case object ENABLED extends ActivateControllerServicesEntityState
-    case object DISABLED extends ActivateControllerServicesEntityState
-  }
-
-  sealed trait AffectedComponentDTOReferenceType extends enumeratum.EnumEntry
-  object AffectedComponentDTOReferenceType extends enumeratum.Enum[AffectedComponentDTOReferenceType] with enumeratum.CirceEnum[AffectedComponentDTOReferenceType] {
-    val values = findValues
-    case object PROCESSOR extends AffectedComponentDTOReferenceType
-    case object CONTROLLER_SERVICE extends AffectedComponentDTOReferenceType
-    case object INPUT_PORT extends AffectedComponentDTOReferenceType
-    case object OUTPUT_PORT extends AffectedComponentDTOReferenceType
-    case object REMOTE_INPUT_PORT extends AffectedComponentDTOReferenceType
-    case object REMOTE_OUTPUT_PORT extends AffectedComponentDTOReferenceType
-    case object STATELESS_GROUP extends AffectedComponentDTOReferenceType
-  }
-
-  sealed trait AffectedComponentEntityReferenceType extends enumeratum.EnumEntry
-  object AffectedComponentEntityReferenceType extends enumeratum.Enum[AffectedComponentEntityReferenceType] with enumeratum.CirceEnum[AffectedComponentEntityReferenceType] {
-    val values = findValues
-    case object PROCESSOR extends AffectedComponentEntityReferenceType
-    case object CONTROLLER_SERVICE extends AffectedComponentEntityReferenceType
-    case object INPUT_PORT extends AffectedComponentEntityReferenceType
-    case object OUTPUT_PORT extends AffectedComponentEntityReferenceType
-    case object REMOTE_INPUT_PORT extends AffectedComponentEntityReferenceType
-    case object REMOTE_OUTPUT_PORT extends AffectedComponentEntityReferenceType
-  }
-
-  sealed trait ComponentValidationResultDTOReferenceType extends enumeratum.EnumEntry
-  object ComponentValidationResultDTOReferenceType extends enumeratum.Enum[ComponentValidationResultDTOReferenceType] with enumeratum.CirceEnum[ComponentValidationResultDTOReferenceType] {
-    val values = findValues
-    case object PROCESSOR extends ComponentValidationResultDTOReferenceType
-    case object CONTROLLER_SERVICE extends ComponentValidationResultDTOReferenceType
-    case object INPUT_PORT extends ComponentValidationResultDTOReferenceType
-    case object OUTPUT_PORT extends ComponentValidationResultDTOReferenceType
-    case object REMOTE_INPUT_PORT extends ComponentValidationResultDTOReferenceType
-    case object REMOTE_OUTPUT_PORT extends ComponentValidationResultDTOReferenceType
-    case object STATELESS_GROUP extends ComponentValidationResultDTOReferenceType
-  }
-
-  sealed trait ConfigVerificationResultDTOOutcome extends enumeratum.EnumEntry
-  object ConfigVerificationResultDTOOutcome extends enumeratum.Enum[ConfigVerificationResultDTOOutcome] with enumeratum.CirceEnum[ConfigVerificationResultDTOOutcome] {
-    val values = findValues
-    case object SUCCESSFUL extends ConfigVerificationResultDTOOutcome
-    case object FAILED extends ConfigVerificationResultDTOOutcome
-    case object SKIPPED extends ConfigVerificationResultDTOOutcome
-  }
-
-  sealed trait ConnectableComponentType extends enumeratum.EnumEntry
-  object ConnectableComponentType extends enumeratum.Enum[ConnectableComponentType] with enumeratum.CirceEnum[ConnectableComponentType] {
-    val values = findValues
-    case object PROCESSOR extends ConnectableComponentType
-    case object REMOTE_INPUT_PORT extends ConnectableComponentType
-    case object REMOTE_OUTPUT_PORT extends ConnectableComponentType
-    case object INPUT_PORT extends ConnectableComponentType
-    case object OUTPUT_PORT extends ConnectableComponentType
-    case object FUNNEL extends ConnectableComponentType
-  }
-
-  sealed trait ConnectableDTOType extends enumeratum.EnumEntry
-  object ConnectableDTOType extends enumeratum.Enum[ConnectableDTOType] with enumeratum.CirceEnum[ConnectableDTOType] {
-    val values = findValues
-    case object PROCESSOR extends ConnectableDTOType
-    case object REMOTE_INPUT_PORT extends ConnectableDTOType
-    case object REMOTE_OUTPUT_PORT extends ConnectableDTOType
-    case object INPUT_PORT extends ConnectableDTOType
-    case object OUTPUT_PORT extends ConnectableDTOType
-    case object FUNNEL extends ConnectableDTOType
-  }
-
-  sealed trait ConnectionEntityDestinationType extends enumeratum.EnumEntry
-  object ConnectionEntityDestinationType extends enumeratum.Enum[ConnectionEntityDestinationType] with enumeratum.CirceEnum[ConnectionEntityDestinationType] {
-    val values = findValues
-    case object PROCESSOR extends ConnectionEntityDestinationType
-    case object REMOTE_INPUT_PORT extends ConnectionEntityDestinationType
-    case object REMOTE_OUTPUT_PORT extends ConnectionEntityDestinationType
-    case object INPUT_PORT extends ConnectionEntityDestinationType
-    case object OUTPUT_PORT extends ConnectionEntityDestinationType
-    case object FUNNEL extends ConnectionEntityDestinationType
-  }
-
-  sealed trait ConnectionEntitySourceType extends enumeratum.EnumEntry
-  object ConnectionEntitySourceType extends enumeratum.Enum[ConnectionEntitySourceType] with enumeratum.CirceEnum[ConnectionEntitySourceType] {
-    val values = findValues
-    case object PROCESSOR extends ConnectionEntitySourceType
-    case object REMOTE_INPUT_PORT extends ConnectionEntitySourceType
-    case object REMOTE_OUTPUT_PORT extends ConnectionEntitySourceType
-    case object INPUT_PORT extends ConnectionEntitySourceType
-    case object OUTPUT_PORT extends ConnectionEntitySourceType
-    case object FUNNEL extends ConnectionEntitySourceType
-  }
-
-  sealed trait ConnectionStatusSnapshotDTOLoadBalanceStatus extends enumeratum.EnumEntry
-  object ConnectionStatusSnapshotDTOLoadBalanceStatus extends enumeratum.Enum[ConnectionStatusSnapshotDTOLoadBalanceStatus] with enumeratum.CirceEnum[ConnectionStatusSnapshotDTOLoadBalanceStatus] {
-    val values = findValues
-    case object LOAD_BALANCE_NOT_CONFIGURED extends ConnectionStatusSnapshotDTOLoadBalanceStatus
-    case object LOAD_BALANCE_ACTIVE extends ConnectionStatusSnapshotDTOLoadBalanceStatus
-    case object LOAD_BALANCE_INACTIVE extends ConnectionStatusSnapshotDTOLoadBalanceStatus
-  }
-
-  sealed trait ControllerServiceDTOState extends enumeratum.EnumEntry
-  object ControllerServiceDTOState extends enumeratum.Enum[ControllerServiceDTOState] with enumeratum.CirceEnum[ControllerServiceDTOState] {
-    val values = findValues
-    case object ENABLED extends ControllerServiceDTOState
-    case object ENABLING extends ControllerServiceDTOState
-    case object DISABLED extends ControllerServiceDTOState
-    case object DISABLING extends ControllerServiceDTOState
-  }
-
-  sealed trait ControllerServiceDTOValidationStatus extends enumeratum.EnumEntry
-  object ControllerServiceDTOValidationStatus extends enumeratum.Enum[ControllerServiceDTOValidationStatus] with enumeratum.CirceEnum[ControllerServiceDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends ControllerServiceDTOValidationStatus
-    case object INVALID extends ControllerServiceDTOValidationStatus
-    case object VALIDATING extends ControllerServiceDTOValidationStatus
-  }
-
-  sealed trait ControllerServiceReferencingComponentDTOReferenceType extends enumeratum.EnumEntry
-  object ControllerServiceReferencingComponentDTOReferenceType extends enumeratum.Enum[ControllerServiceReferencingComponentDTOReferenceType] with enumeratum.CirceEnum[ControllerServiceReferencingComponentDTOReferenceType] {
-    val values = findValues
-    case object Processor extends ControllerServiceReferencingComponentDTOReferenceType
-    case object ControllerService extends ControllerServiceReferencingComponentDTOReferenceType
-    case object ReportingTask extends ControllerServiceReferencingComponentDTOReferenceType
-    case object FlowRegistryClient extends ControllerServiceReferencingComponentDTOReferenceType
-  }
-
-  sealed trait ControllerServiceRunStatusEntityState extends enumeratum.EnumEntry
-  object ControllerServiceRunStatusEntityState extends enumeratum.Enum[ControllerServiceRunStatusEntityState] with enumeratum.CirceEnum[ControllerServiceRunStatusEntityState] {
-    val values = findValues
-    case object ENABLED extends ControllerServiceRunStatusEntityState
-    case object DISABLED extends ControllerServiceRunStatusEntityState
-  }
-
-  sealed trait ControllerServiceStatusDTORunStatus extends enumeratum.EnumEntry
-  object ControllerServiceStatusDTORunStatus extends enumeratum.Enum[ControllerServiceStatusDTORunStatus] with enumeratum.CirceEnum[ControllerServiceStatusDTORunStatus] {
-    val values = findValues
-    case object ENABLED extends ControllerServiceStatusDTORunStatus
-    case object ENABLING extends ControllerServiceStatusDTORunStatus
-    case object DISABLED extends ControllerServiceStatusDTORunStatus
-    case object DISABLING extends ControllerServiceStatusDTORunStatus
-  }
-
-  sealed trait ControllerServiceStatusDTOValidationStatus extends enumeratum.EnumEntry
-  object ControllerServiceStatusDTOValidationStatus extends enumeratum.Enum[ControllerServiceStatusDTOValidationStatus] with enumeratum.CirceEnum[ControllerServiceStatusDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends ControllerServiceStatusDTOValidationStatus
-    case object INVALID extends ControllerServiceStatusDTOValidationStatus
-    case object VALIDATING extends ControllerServiceStatusDTOValidationStatus
-  }
-
-  sealed trait DynamicPropertyExpressionLanguageScope extends enumeratum.EnumEntry
-  object DynamicPropertyExpressionLanguageScope extends enumeratum.Enum[DynamicPropertyExpressionLanguageScope] with enumeratum.CirceEnum[DynamicPropertyExpressionLanguageScope] {
-    val values = findValues
-    case object NONE extends DynamicPropertyExpressionLanguageScope
-    case object ENVIRONMENT extends DynamicPropertyExpressionLanguageScope
-    case object FLOWFILE_ATTRIBUTES extends DynamicPropertyExpressionLanguageScope
-  }
-
-  sealed trait FlowAnalysisRuleDTOState extends enumeratum.EnumEntry
-  object FlowAnalysisRuleDTOState extends enumeratum.Enum[FlowAnalysisRuleDTOState] with enumeratum.CirceEnum[FlowAnalysisRuleDTOState] {
-    val values = findValues
-    case object ENABLED extends FlowAnalysisRuleDTOState
-    case object DISABLED extends FlowAnalysisRuleDTOState
-  }
-
-  sealed trait FlowAnalysisRuleDTOValidationStatus extends enumeratum.EnumEntry
-  object FlowAnalysisRuleDTOValidationStatus extends enumeratum.Enum[FlowAnalysisRuleDTOValidationStatus] with enumeratum.CirceEnum[FlowAnalysisRuleDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends FlowAnalysisRuleDTOValidationStatus
-    case object INVALID extends FlowAnalysisRuleDTOValidationStatus
-    case object VALIDATING extends FlowAnalysisRuleDTOValidationStatus
-  }
-
-  sealed trait FlowAnalysisRuleRunStatusEntityState extends enumeratum.EnumEntry
-  object FlowAnalysisRuleRunStatusEntityState extends enumeratum.Enum[FlowAnalysisRuleRunStatusEntityState] with enumeratum.CirceEnum[FlowAnalysisRuleRunStatusEntityState] {
-    val values = findValues
-    case object ENABLED extends FlowAnalysisRuleRunStatusEntityState
-    case object DISABLED extends FlowAnalysisRuleRunStatusEntityState
-  }
-
-  sealed trait FlowAnalysisRuleStatusDTORunStatus extends enumeratum.EnumEntry
-  object FlowAnalysisRuleStatusDTORunStatus extends enumeratum.Enum[FlowAnalysisRuleStatusDTORunStatus] with enumeratum.CirceEnum[FlowAnalysisRuleStatusDTORunStatus] {
-    val values = findValues
-    case object ENABLED extends FlowAnalysisRuleStatusDTORunStatus
-    case object DISABLED extends FlowAnalysisRuleStatusDTORunStatus
-  }
-
-  sealed trait FlowAnalysisRuleStatusDTOValidationStatus extends enumeratum.EnumEntry
-  object FlowAnalysisRuleStatusDTOValidationStatus extends enumeratum.Enum[FlowAnalysisRuleStatusDTOValidationStatus] with enumeratum.CirceEnum[FlowAnalysisRuleStatusDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends FlowAnalysisRuleStatusDTOValidationStatus
-    case object INVALID extends FlowAnalysisRuleStatusDTOValidationStatus
-    case object VALIDATING extends FlowAnalysisRuleStatusDTOValidationStatus
-  }
-
-  sealed trait FlowBreadcrumbEntityVersionedFlowState extends enumeratum.EnumEntry
-  object FlowBreadcrumbEntityVersionedFlowState extends enumeratum.Enum[FlowBreadcrumbEntityVersionedFlowState] with enumeratum.CirceEnum[FlowBreadcrumbEntityVersionedFlowState] {
-    val values = findValues
-    case object LOCALLY_MODIFIED extends FlowBreadcrumbEntityVersionedFlowState
-    case object STALE extends FlowBreadcrumbEntityVersionedFlowState
-    case object LOCALLY_MODIFIED_AND_STALE extends FlowBreadcrumbEntityVersionedFlowState
-    case object UP_TO_DATE extends FlowBreadcrumbEntityVersionedFlowState
-    case object SYNC_FAILURE extends FlowBreadcrumbEntityVersionedFlowState
-  }
-
-  sealed trait FlowRegistryClientDTOValidationStatus extends enumeratum.EnumEntry
-  object FlowRegistryClientDTOValidationStatus extends enumeratum.Enum[FlowRegistryClientDTOValidationStatus] with enumeratum.CirceEnum[FlowRegistryClientDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends FlowRegistryClientDTOValidationStatus
-    case object INVALID extends FlowRegistryClientDTOValidationStatus
-    case object VALIDATING extends FlowRegistryClientDTOValidationStatus
-  }
-
-  sealed trait LineageRequestDTOLineageRequestType extends enumeratum.EnumEntry
-  object LineageRequestDTOLineageRequestType extends enumeratum.Enum[LineageRequestDTOLineageRequestType] with enumeratum.CirceEnum[LineageRequestDTOLineageRequestType] {
-    val values = findValues
-    case object PARENTS extends LineageRequestDTOLineageRequestType
-    case object CHILDREN extends LineageRequestDTOLineageRequestType
-    case object FLOWFILE extends LineageRequestDTOLineageRequestType
-  }
-
-  sealed trait ParameterGroupConfigurationEntityParameterSensitivitiesItem extends enumeratum.EnumEntry
-  object ParameterGroupConfigurationEntityParameterSensitivitiesItem extends enumeratum.Enum[ParameterGroupConfigurationEntityParameterSensitivitiesItem] with enumeratum.CirceEnum[ParameterGroupConfigurationEntityParameterSensitivitiesItem] {
-    val values = findValues
-    case object SENSITIVE extends ParameterGroupConfigurationEntityParameterSensitivitiesItem
-    case object NON_SENSITIVE extends ParameterGroupConfigurationEntityParameterSensitivitiesItem
-  }
-
-  sealed trait ParameterProviderDTOValidationStatus extends enumeratum.EnumEntry
-  object ParameterProviderDTOValidationStatus extends enumeratum.Enum[ParameterProviderDTOValidationStatus] with enumeratum.CirceEnum[ParameterProviderDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends ParameterProviderDTOValidationStatus
-    case object INVALID extends ParameterProviderDTOValidationStatus
-    case object VALIDATING extends ParameterProviderDTOValidationStatus
-  }
-
-  sealed trait ParameterStatusDTOStatus extends enumeratum.EnumEntry
-  object ParameterStatusDTOStatus extends enumeratum.Enum[ParameterStatusDTOStatus] with enumeratum.CirceEnum[ParameterStatusDTOStatus] {
-    val values = findValues
-    case object NEW extends ParameterStatusDTOStatus
-    case object CHANGED extends ParameterStatusDTOStatus
-    case object REMOVED extends ParameterStatusDTOStatus
-    case object MISSING_BUT_REFERENCED extends ParameterStatusDTOStatus
-    case object UNCHANGED extends ParameterStatusDTOStatus
-  }
-
-  sealed trait PortDTOPortFunction extends enumeratum.EnumEntry
-  object PortDTOPortFunction extends enumeratum.Enum[PortDTOPortFunction] with enumeratum.CirceEnum[PortDTOPortFunction] {
-    val values = findValues
-    case object STANDARD extends PortDTOPortFunction
-    case object FAILURE extends PortDTOPortFunction
-  }
-
-  sealed trait PortDTOState extends enumeratum.EnumEntry
-  object PortDTOState extends enumeratum.Enum[PortDTOState] with enumeratum.CirceEnum[PortDTOState] {
-    val values = findValues
-    case object RUNNING extends PortDTOState
-    case object STOPPED extends PortDTOState
-    case object DISABLED extends PortDTOState
-  }
-
-  sealed trait PortDTOType extends enumeratum.EnumEntry
-  object PortDTOType extends enumeratum.Enum[PortDTOType] with enumeratum.CirceEnum[PortDTOType] {
-    val values = findValues
-    case object INPUT_PORT extends PortDTOType
-    case object OUTPUT_PORT extends PortDTOType
-  }
-
-  sealed trait PortRunStatusEntityState extends enumeratum.EnumEntry
-  object PortRunStatusEntityState extends enumeratum.Enum[PortRunStatusEntityState] with enumeratum.CirceEnum[PortRunStatusEntityState] {
-    val values = findValues
-    case object RUNNING extends PortRunStatusEntityState
-    case object STOPPED extends PortRunStatusEntityState
-    case object DISABLED extends PortRunStatusEntityState
-  }
-
-  sealed trait PortStatusDTORunStatus extends enumeratum.EnumEntry
-  object PortStatusDTORunStatus extends enumeratum.Enum[PortStatusDTORunStatus] with enumeratum.CirceEnum[PortStatusDTORunStatus] {
-    val values = findValues
-    case object Running extends PortStatusDTORunStatus
-    case object Stopped extends PortStatusDTORunStatus
-    case object Validating extends PortStatusDTORunStatus
-    case object Disabled extends PortStatusDTORunStatus
-    case object Invalid extends PortStatusDTORunStatus
-  }
-
-  sealed trait PortStatusSnapshotDTORunStatus extends enumeratum.EnumEntry
-  object PortStatusSnapshotDTORunStatus extends enumeratum.Enum[PortStatusSnapshotDTORunStatus] with enumeratum.CirceEnum[PortStatusSnapshotDTORunStatus] {
-    val values = findValues
-    case object Running extends PortStatusSnapshotDTORunStatus
-    case object Stopped extends PortStatusSnapshotDTORunStatus
-    case object Validating extends PortStatusSnapshotDTORunStatus
-    case object Disabled extends PortStatusSnapshotDTORunStatus
-    case object Invalid extends PortStatusSnapshotDTORunStatus
-  }
-
-  sealed trait ProcessGroupDTOExecutionEngine extends enumeratum.EnumEntry
-  object ProcessGroupDTOExecutionEngine extends enumeratum.Enum[ProcessGroupDTOExecutionEngine] with enumeratum.CirceEnum[ProcessGroupDTOExecutionEngine] {
-    val values = findValues
-    case object STATELESS extends ProcessGroupDTOExecutionEngine
-    case object STANDARD extends ProcessGroupDTOExecutionEngine
-    case object INHERITED extends ProcessGroupDTOExecutionEngine
-  }
-
-  sealed trait ProcessGroupDTOFlowfileConcurrency extends enumeratum.EnumEntry
-  object ProcessGroupDTOFlowfileConcurrency extends enumeratum.Enum[ProcessGroupDTOFlowfileConcurrency] with enumeratum.CirceEnum[ProcessGroupDTOFlowfileConcurrency] {
-    val values = findValues
-    case object UNBOUNDED extends ProcessGroupDTOFlowfileConcurrency
-    case object SINGLE_FLOWFILE_PER_NODE extends ProcessGroupDTOFlowfileConcurrency
-    case object SINGLE_BATCH_PER_NODE extends ProcessGroupDTOFlowfileConcurrency
-  }
-
-  sealed trait ProcessGroupDTOFlowfileOutboundPolicy extends enumeratum.EnumEntry
-  object ProcessGroupDTOFlowfileOutboundPolicy extends enumeratum.Enum[ProcessGroupDTOFlowfileOutboundPolicy] with enumeratum.CirceEnum[ProcessGroupDTOFlowfileOutboundPolicy] {
-    val values = findValues
-    case object STREAM_WHEN_AVAILABLE extends ProcessGroupDTOFlowfileOutboundPolicy
-    case object BATCH_OUTPUT extends ProcessGroupDTOFlowfileOutboundPolicy
-  }
-
-  sealed trait ProcessGroupDTOStatelessGroupScheduledState extends enumeratum.EnumEntry
-  object ProcessGroupDTOStatelessGroupScheduledState extends enumeratum.Enum[ProcessGroupDTOStatelessGroupScheduledState] with enumeratum.CirceEnum[ProcessGroupDTOStatelessGroupScheduledState] {
-    val values = findValues
-    case object STOPPED extends ProcessGroupDTOStatelessGroupScheduledState
-    case object RUNNING extends ProcessGroupDTOStatelessGroupScheduledState
-  }
-
-  sealed trait ProcessGroupEntityProcessGroupUpdateStrategy extends enumeratum.EnumEntry
-  object ProcessGroupEntityProcessGroupUpdateStrategy extends enumeratum.Enum[ProcessGroupEntityProcessGroupUpdateStrategy] with enumeratum.CirceEnum[ProcessGroupEntityProcessGroupUpdateStrategy] {
-    val values = findValues
-    case object CURRENT_GROUP extends ProcessGroupEntityProcessGroupUpdateStrategy
-    case object CURRENT_GROUP_WITH_CHILDREN extends ProcessGroupEntityProcessGroupUpdateStrategy
-  }
-
-  sealed trait ProcessGroupEntityVersionedFlowState extends enumeratum.EnumEntry
-  object ProcessGroupEntityVersionedFlowState extends enumeratum.Enum[ProcessGroupEntityVersionedFlowState] with enumeratum.CirceEnum[ProcessGroupEntityVersionedFlowState] {
-    val values = findValues
-    case object LOCALLY_MODIFIED extends ProcessGroupEntityVersionedFlowState
-    case object STALE extends ProcessGroupEntityVersionedFlowState
-    case object LOCALLY_MODIFIED_AND_STALE extends ProcessGroupEntityVersionedFlowState
-    case object UP_TO_DATE extends ProcessGroupEntityVersionedFlowState
-    case object SYNC_FAILURE extends ProcessGroupEntityVersionedFlowState
-  }
-
-  sealed trait ProcessGroupStatusSnapshotDTOVersionedFlowState extends enumeratum.EnumEntry
-  object ProcessGroupStatusSnapshotDTOVersionedFlowState extends enumeratum.Enum[ProcessGroupStatusSnapshotDTOVersionedFlowState] with enumeratum.CirceEnum[ProcessGroupStatusSnapshotDTOVersionedFlowState] {
-    val values = findValues
-    case object LOCALLY_MODIFIED extends ProcessGroupStatusSnapshotDTOVersionedFlowState
-    case object STALE extends ProcessGroupStatusSnapshotDTOVersionedFlowState
-    case object LOCALLY_MODIFIED_AND_STALE extends ProcessGroupStatusSnapshotDTOVersionedFlowState
-    case object UP_TO_DATE extends ProcessGroupStatusSnapshotDTOVersionedFlowState
-    case object SYNC_FAILURE extends ProcessGroupStatusSnapshotDTOVersionedFlowState
-  }
-
-  sealed trait ProcessorDTOState extends enumeratum.EnumEntry
-  object ProcessorDTOState extends enumeratum.Enum[ProcessorDTOState] with enumeratum.CirceEnum[ProcessorDTOState] {
-    val values = findValues
-    case object RUNNING extends ProcessorDTOState
-    case object STOPPED extends ProcessorDTOState
-    case object DISABLED extends ProcessorDTOState
-  }
-
-  sealed trait ProcessorDTOValidationStatus extends enumeratum.EnumEntry
-  object ProcessorDTOValidationStatus extends enumeratum.Enum[ProcessorDTOValidationStatus] with enumeratum.CirceEnum[ProcessorDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends ProcessorDTOValidationStatus
-    case object INVALID extends ProcessorDTOValidationStatus
-    case object VALIDATING extends ProcessorDTOValidationStatus
-  }
-
-  sealed trait ProcessorDefinitionInputRequirement extends enumeratum.EnumEntry
-  object ProcessorDefinitionInputRequirement extends enumeratum.Enum[ProcessorDefinitionInputRequirement] with enumeratum.CirceEnum[ProcessorDefinitionInputRequirement] {
-    val values = findValues
-    case object INPUT_REQUIRED extends ProcessorDefinitionInputRequirement
-    case object INPUT_ALLOWED extends ProcessorDefinitionInputRequirement
-    case object INPUT_FORBIDDEN extends ProcessorDefinitionInputRequirement
-  }
-
-  sealed trait ProcessorRunStatusDetailsDTORunStatus extends enumeratum.EnumEntry
-  object ProcessorRunStatusDetailsDTORunStatus extends enumeratum.Enum[ProcessorRunStatusDetailsDTORunStatus] with enumeratum.CirceEnum[ProcessorRunStatusDetailsDTORunStatus] {
-    val values = findValues
-    case object Running extends ProcessorRunStatusDetailsDTORunStatus
-    case object Stopped extends ProcessorRunStatusDetailsDTORunStatus
-    case object Invalid extends ProcessorRunStatusDetailsDTORunStatus
-    case object Validating extends ProcessorRunStatusDetailsDTORunStatus
-    case object Disabled extends ProcessorRunStatusDetailsDTORunStatus
-  }
-
-  sealed trait ProcessorRunStatusEntityState extends enumeratum.EnumEntry
-  object ProcessorRunStatusEntityState extends enumeratum.Enum[ProcessorRunStatusEntityState] with enumeratum.CirceEnum[ProcessorRunStatusEntityState] {
-    val values = findValues
-    case object RUNNING extends ProcessorRunStatusEntityState
-    case object STOPPED extends ProcessorRunStatusEntityState
-    case object DISABLED extends ProcessorRunStatusEntityState
-    case object RUN_ONCE extends ProcessorRunStatusEntityState
-  }
-
-  sealed trait ProcessorStatusDTORunStatus extends enumeratum.EnumEntry
-  object ProcessorStatusDTORunStatus extends enumeratum.Enum[ProcessorStatusDTORunStatus] with enumeratum.CirceEnum[ProcessorStatusDTORunStatus] {
-    val values = findValues
-    case object Running extends ProcessorStatusDTORunStatus
-    case object Stopped extends ProcessorStatusDTORunStatus
-    case object Validating extends ProcessorStatusDTORunStatus
-    case object Disabled extends ProcessorStatusDTORunStatus
-    case object Invalid extends ProcessorStatusDTORunStatus
-  }
-
-  sealed trait ProcessorStatusSnapshotDTOExecutionNode extends enumeratum.EnumEntry
-  object ProcessorStatusSnapshotDTOExecutionNode extends enumeratum.Enum[ProcessorStatusSnapshotDTOExecutionNode] with enumeratum.CirceEnum[ProcessorStatusSnapshotDTOExecutionNode] {
-    val values = findValues
-    case object ALL extends ProcessorStatusSnapshotDTOExecutionNode
-    case object PRIMARY extends ProcessorStatusSnapshotDTOExecutionNode
-  }
-
-  sealed trait ProcessorStatusSnapshotDTORunStatus extends enumeratum.EnumEntry
-  object ProcessorStatusSnapshotDTORunStatus extends enumeratum.Enum[ProcessorStatusSnapshotDTORunStatus] with enumeratum.CirceEnum[ProcessorStatusSnapshotDTORunStatus] {
-    val values = findValues
-    case object Running extends ProcessorStatusSnapshotDTORunStatus
-    case object Stopped extends ProcessorStatusSnapshotDTORunStatus
-    case object Validating extends ProcessorStatusSnapshotDTORunStatus
-    case object Disabled extends ProcessorStatusSnapshotDTORunStatus
-    case object Invalid extends ProcessorStatusSnapshotDTORunStatus
-  }
-
-  sealed trait PropertyDescriptorExpressionLanguageScope extends enumeratum.EnumEntry
-  object PropertyDescriptorExpressionLanguageScope extends enumeratum.Enum[PropertyDescriptorExpressionLanguageScope] with enumeratum.CirceEnum[PropertyDescriptorExpressionLanguageScope] {
-    val values = findValues
-    case object NONE extends PropertyDescriptorExpressionLanguageScope
-    case object ENVIRONMENT extends PropertyDescriptorExpressionLanguageScope
-    case object FLOWFILE_ATTRIBUTES extends PropertyDescriptorExpressionLanguageScope
-  }
-
-  sealed trait PropertyResourceDefinitionCardinality extends enumeratum.EnumEntry
-  object PropertyResourceDefinitionCardinality extends enumeratum.Enum[PropertyResourceDefinitionCardinality] with enumeratum.CirceEnum[PropertyResourceDefinitionCardinality] {
-    val values = findValues
-    case object SINGLE extends PropertyResourceDefinitionCardinality
-    case object MULTIPLE extends PropertyResourceDefinitionCardinality
-  }
-
-  sealed trait PropertyResourceDefinitionResourceTypesItem extends enumeratum.EnumEntry
-  object PropertyResourceDefinitionResourceTypesItem extends enumeratum.Enum[PropertyResourceDefinitionResourceTypesItem] with enumeratum.CirceEnum[PropertyResourceDefinitionResourceTypesItem] {
-    val values = findValues
-    case object FILE extends PropertyResourceDefinitionResourceTypesItem
-    case object DIRECTORY extends PropertyResourceDefinitionResourceTypesItem
-    case object TEXT extends PropertyResourceDefinitionResourceTypesItem
-    case object URL extends PropertyResourceDefinitionResourceTypesItem
-  }
-
-  sealed trait ProvenanceNodeDTOType extends enumeratum.EnumEntry
-  object ProvenanceNodeDTOType extends enumeratum.Enum[ProvenanceNodeDTOType] with enumeratum.CirceEnum[ProvenanceNodeDTOType] {
-    val values = findValues
-    case object FLOWFILE extends ProvenanceNodeDTOType
-    case object EVENT extends ProvenanceNodeDTOType
-  }
-
-  sealed trait RemotePortRunStatusEntityState extends enumeratum.EnumEntry
-  object RemotePortRunStatusEntityState extends enumeratum.Enum[RemotePortRunStatusEntityState] with enumeratum.CirceEnum[RemotePortRunStatusEntityState] {
-    val values = findValues
-    case object TRANSMITTING extends RemotePortRunStatusEntityState
-    case object STOPPED extends RemotePortRunStatusEntityState
-  }
-
-  sealed trait RemoteProcessGroupStatusDTOValidationStatus extends enumeratum.EnumEntry
-  object RemoteProcessGroupStatusDTOValidationStatus extends enumeratum.Enum[RemoteProcessGroupStatusDTOValidationStatus] with enumeratum.CirceEnum[RemoteProcessGroupStatusDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends RemoteProcessGroupStatusDTOValidationStatus
-    case object INVALID extends RemoteProcessGroupStatusDTOValidationStatus
-    case object VALIDATING extends RemoteProcessGroupStatusDTOValidationStatus
-  }
-
-  sealed trait ReplayLastEventRequestEntityNodes extends enumeratum.EnumEntry
-  object ReplayLastEventRequestEntityNodes extends enumeratum.Enum[ReplayLastEventRequestEntityNodes] with enumeratum.CirceEnum[ReplayLastEventRequestEntityNodes] {
-    val values = findValues
-    case object ALL extends ReplayLastEventRequestEntityNodes
-    case object PRIMARY extends ReplayLastEventRequestEntityNodes
-  }
-
-  sealed trait ReplayLastEventResponseEntityNodes extends enumeratum.EnumEntry
-  object ReplayLastEventResponseEntityNodes extends enumeratum.Enum[ReplayLastEventResponseEntityNodes] with enumeratum.CirceEnum[ReplayLastEventResponseEntityNodes] {
-    val values = findValues
-    case object ALL extends ReplayLastEventResponseEntityNodes
-    case object PRIMARY extends ReplayLastEventResponseEntityNodes
-  }
-
-  sealed trait ReportingTaskDTOState extends enumeratum.EnumEntry
-  object ReportingTaskDTOState extends enumeratum.Enum[ReportingTaskDTOState] with enumeratum.CirceEnum[ReportingTaskDTOState] {
-    val values = findValues
-    case object RUNNING extends ReportingTaskDTOState
-    case object STOPPED extends ReportingTaskDTOState
-    case object DISABLED extends ReportingTaskDTOState
-  }
-
-  sealed trait ReportingTaskDTOValidationStatus extends enumeratum.EnumEntry
-  object ReportingTaskDTOValidationStatus extends enumeratum.Enum[ReportingTaskDTOValidationStatus] with enumeratum.CirceEnum[ReportingTaskDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends ReportingTaskDTOValidationStatus
-    case object INVALID extends ReportingTaskDTOValidationStatus
-    case object VALIDATING extends ReportingTaskDTOValidationStatus
-  }
-
-  sealed trait ReportingTaskRunStatusEntityState extends enumeratum.EnumEntry
-  object ReportingTaskRunStatusEntityState extends enumeratum.Enum[ReportingTaskRunStatusEntityState] with enumeratum.CirceEnum[ReportingTaskRunStatusEntityState] {
-    val values = findValues
-    case object RUNNING extends ReportingTaskRunStatusEntityState
-    case object STOPPED extends ReportingTaskRunStatusEntityState
-  }
-
-  sealed trait ReportingTaskStatusDTORunStatus extends enumeratum.EnumEntry
-  object ReportingTaskStatusDTORunStatus extends enumeratum.Enum[ReportingTaskStatusDTORunStatus] with enumeratum.CirceEnum[ReportingTaskStatusDTORunStatus] {
-    val values = findValues
-    case object RUNNING extends ReportingTaskStatusDTORunStatus
-    case object STOPPED extends ReportingTaskStatusDTORunStatus
-    case object DISABLED extends ReportingTaskStatusDTORunStatus
-  }
-
-  sealed trait ReportingTaskStatusDTOValidationStatus extends enumeratum.EnumEntry
-  object ReportingTaskStatusDTOValidationStatus extends enumeratum.Enum[ReportingTaskStatusDTOValidationStatus] with enumeratum.CirceEnum[ReportingTaskStatusDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends ReportingTaskStatusDTOValidationStatus
-    case object INVALID extends ReportingTaskStatusDTOValidationStatus
-    case object VALIDATING extends ReportingTaskStatusDTOValidationStatus
-  }
-
-  sealed trait ScheduleComponentsEntityState extends enumeratum.EnumEntry
-  object ScheduleComponentsEntityState extends enumeratum.Enum[ScheduleComponentsEntityState] with enumeratum.CirceEnum[ScheduleComponentsEntityState] {
-    val values = findValues
-    case object RUNNING extends ScheduleComponentsEntityState
-    case object STOPPED extends ScheduleComponentsEntityState
-    case object ENABLED extends ScheduleComponentsEntityState
-    case object DISABLED extends ScheduleComponentsEntityState
-  }
-
-  sealed trait SchedulingDefaultsDefaultSchedulingStrategy extends enumeratum.EnumEntry
-  object SchedulingDefaultsDefaultSchedulingStrategy extends enumeratum.Enum[SchedulingDefaultsDefaultSchedulingStrategy] with enumeratum.CirceEnum[SchedulingDefaultsDefaultSchedulingStrategy] {
-    val values = findValues
-    case object TIMER_DRIVEN extends SchedulingDefaultsDefaultSchedulingStrategy
-    case object CRON_DRIVEN extends SchedulingDefaultsDefaultSchedulingStrategy
-  }
-
-  sealed trait StatefulScopesItem extends enumeratum.EnumEntry
-  object StatefulScopesItem extends enumeratum.Enum[StatefulScopesItem] with enumeratum.CirceEnum[StatefulScopesItem] {
-    val values = findValues
-    case object CLUSTER extends StatefulScopesItem
-    case object LOCAL extends StatefulScopesItem
-  }
-
-  sealed trait UpdateControllerServiceReferenceRequestEntityState extends enumeratum.EnumEntry
-  object UpdateControllerServiceReferenceRequestEntityState extends enumeratum.Enum[UpdateControllerServiceReferenceRequestEntityState] with enumeratum.CirceEnum[UpdateControllerServiceReferenceRequestEntityState] {
-    val values = findValues
-    case object ENABLED extends UpdateControllerServiceReferenceRequestEntityState
-    case object DISABLED extends UpdateControllerServiceReferenceRequestEntityState
-    case object RUNNING extends UpdateControllerServiceReferenceRequestEntityState
-    case object STOPPED extends UpdateControllerServiceReferenceRequestEntityState
-  }
-
-  sealed trait UseCaseInputRequirement extends enumeratum.EnumEntry
-  object UseCaseInputRequirement extends enumeratum.Enum[UseCaseInputRequirement] with enumeratum.CirceEnum[UseCaseInputRequirement] {
-    val values = findValues
-    case object INPUT_REQUIRED extends UseCaseInputRequirement
-    case object INPUT_ALLOWED extends UseCaseInputRequirement
-    case object INPUT_FORBIDDEN extends UseCaseInputRequirement
-  }
-
-  sealed trait VersionControlInformationDTOState extends enumeratum.EnumEntry
-  object VersionControlInformationDTOState extends enumeratum.Enum[VersionControlInformationDTOState] with enumeratum.CirceEnum[VersionControlInformationDTOState] {
-    val values = findValues
-    case object LOCALLY_MODIFIED extends VersionControlInformationDTOState
-    case object STALE extends VersionControlInformationDTOState
-    case object LOCALLY_MODIFIED_AND_STALE extends VersionControlInformationDTOState
-    case object UP_TO_DATE extends VersionControlInformationDTOState
-    case object SYNC_FAILURE extends VersionControlInformationDTOState
-  }
-
-  sealed trait VersionedConnectionComponentType extends enumeratum.EnumEntry
-  object VersionedConnectionComponentType extends enumeratum.Enum[VersionedConnectionComponentType] with enumeratum.CirceEnum[VersionedConnectionComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedConnectionComponentType
-    case object PROCESSOR extends VersionedConnectionComponentType
-    case object PROCESS_GROUP extends VersionedConnectionComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedConnectionComponentType
-    case object INPUT_PORT extends VersionedConnectionComponentType
-    case object OUTPUT_PORT extends VersionedConnectionComponentType
-    case object REMOTE_INPUT_PORT extends VersionedConnectionComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedConnectionComponentType
-    case object FUNNEL extends VersionedConnectionComponentType
-    case object LABEL extends VersionedConnectionComponentType
-    case object CONTROLLER_SERVICE extends VersionedConnectionComponentType
-    case object REPORTING_TASK extends VersionedConnectionComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedConnectionComponentType
-    case object PARAMETER_CONTEXT extends VersionedConnectionComponentType
-    case object PARAMETER_PROVIDER extends VersionedConnectionComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedConnectionComponentType
-  }
-
-  sealed trait VersionedControllerServiceComponentType extends enumeratum.EnumEntry
-  object VersionedControllerServiceComponentType extends enumeratum.Enum[VersionedControllerServiceComponentType] with enumeratum.CirceEnum[VersionedControllerServiceComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedControllerServiceComponentType
-    case object PROCESSOR extends VersionedControllerServiceComponentType
-    case object PROCESS_GROUP extends VersionedControllerServiceComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedControllerServiceComponentType
-    case object INPUT_PORT extends VersionedControllerServiceComponentType
-    case object OUTPUT_PORT extends VersionedControllerServiceComponentType
-    case object REMOTE_INPUT_PORT extends VersionedControllerServiceComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedControllerServiceComponentType
-    case object FUNNEL extends VersionedControllerServiceComponentType
-    case object LABEL extends VersionedControllerServiceComponentType
-    case object CONTROLLER_SERVICE extends VersionedControllerServiceComponentType
-    case object REPORTING_TASK extends VersionedControllerServiceComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedControllerServiceComponentType
-    case object PARAMETER_CONTEXT extends VersionedControllerServiceComponentType
-    case object PARAMETER_PROVIDER extends VersionedControllerServiceComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedControllerServiceComponentType
-  }
-
-  sealed trait VersionedControllerServiceScheduledState extends enumeratum.EnumEntry
-  object VersionedControllerServiceScheduledState extends enumeratum.Enum[VersionedControllerServiceScheduledState] with enumeratum.CirceEnum[VersionedControllerServiceScheduledState] {
-    val values = findValues
-    case object ENABLED extends VersionedControllerServiceScheduledState
-    case object DISABLED extends VersionedControllerServiceScheduledState
-    case object RUNNING extends VersionedControllerServiceScheduledState
-  }
-
-  sealed trait VersionedFlowDTOAction extends enumeratum.EnumEntry
-  object VersionedFlowDTOAction extends enumeratum.Enum[VersionedFlowDTOAction] with enumeratum.CirceEnum[VersionedFlowDTOAction] {
-    val values = findValues
-    case object COMMIT extends VersionedFlowDTOAction
-    case object FORCE_COMMIT extends VersionedFlowDTOAction
-  }
-
-  sealed trait VersionedFunnelComponentType extends enumeratum.EnumEntry
-  object VersionedFunnelComponentType extends enumeratum.Enum[VersionedFunnelComponentType] with enumeratum.CirceEnum[VersionedFunnelComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedFunnelComponentType
-    case object PROCESSOR extends VersionedFunnelComponentType
-    case object PROCESS_GROUP extends VersionedFunnelComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedFunnelComponentType
-    case object INPUT_PORT extends VersionedFunnelComponentType
-    case object OUTPUT_PORT extends VersionedFunnelComponentType
-    case object REMOTE_INPUT_PORT extends VersionedFunnelComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedFunnelComponentType
-    case object FUNNEL extends VersionedFunnelComponentType
-    case object LABEL extends VersionedFunnelComponentType
-    case object CONTROLLER_SERVICE extends VersionedFunnelComponentType
-    case object REPORTING_TASK extends VersionedFunnelComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedFunnelComponentType
-    case object PARAMETER_CONTEXT extends VersionedFunnelComponentType
-    case object PARAMETER_PROVIDER extends VersionedFunnelComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedFunnelComponentType
-  }
-
-  sealed trait VersionedLabelComponentType extends enumeratum.EnumEntry
-  object VersionedLabelComponentType extends enumeratum.Enum[VersionedLabelComponentType] with enumeratum.CirceEnum[VersionedLabelComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedLabelComponentType
-    case object PROCESSOR extends VersionedLabelComponentType
-    case object PROCESS_GROUP extends VersionedLabelComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedLabelComponentType
-    case object INPUT_PORT extends VersionedLabelComponentType
-    case object OUTPUT_PORT extends VersionedLabelComponentType
-    case object REMOTE_INPUT_PORT extends VersionedLabelComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedLabelComponentType
-    case object FUNNEL extends VersionedLabelComponentType
-    case object LABEL extends VersionedLabelComponentType
-    case object CONTROLLER_SERVICE extends VersionedLabelComponentType
-    case object REPORTING_TASK extends VersionedLabelComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedLabelComponentType
-    case object PARAMETER_CONTEXT extends VersionedLabelComponentType
-    case object PARAMETER_PROVIDER extends VersionedLabelComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedLabelComponentType
-  }
-
-  sealed trait VersionedParameterContextComponentType extends enumeratum.EnumEntry
-  object VersionedParameterContextComponentType extends enumeratum.Enum[VersionedParameterContextComponentType] with enumeratum.CirceEnum[VersionedParameterContextComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedParameterContextComponentType
-    case object PROCESSOR extends VersionedParameterContextComponentType
-    case object PROCESS_GROUP extends VersionedParameterContextComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedParameterContextComponentType
-    case object INPUT_PORT extends VersionedParameterContextComponentType
-    case object OUTPUT_PORT extends VersionedParameterContextComponentType
-    case object REMOTE_INPUT_PORT extends VersionedParameterContextComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedParameterContextComponentType
-    case object FUNNEL extends VersionedParameterContextComponentType
-    case object LABEL extends VersionedParameterContextComponentType
-    case object CONTROLLER_SERVICE extends VersionedParameterContextComponentType
-    case object REPORTING_TASK extends VersionedParameterContextComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedParameterContextComponentType
-    case object PARAMETER_CONTEXT extends VersionedParameterContextComponentType
-    case object PARAMETER_PROVIDER extends VersionedParameterContextComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedParameterContextComponentType
-  }
-
-  sealed trait VersionedPortComponentType extends enumeratum.EnumEntry
-  object VersionedPortComponentType extends enumeratum.Enum[VersionedPortComponentType] with enumeratum.CirceEnum[VersionedPortComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedPortComponentType
-    case object PROCESSOR extends VersionedPortComponentType
-    case object PROCESS_GROUP extends VersionedPortComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedPortComponentType
-    case object INPUT_PORT extends VersionedPortComponentType
-    case object OUTPUT_PORT extends VersionedPortComponentType
-    case object REMOTE_INPUT_PORT extends VersionedPortComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedPortComponentType
-    case object FUNNEL extends VersionedPortComponentType
-    case object LABEL extends VersionedPortComponentType
-    case object CONTROLLER_SERVICE extends VersionedPortComponentType
-    case object REPORTING_TASK extends VersionedPortComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedPortComponentType
-    case object PARAMETER_CONTEXT extends VersionedPortComponentType
-    case object PARAMETER_PROVIDER extends VersionedPortComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedPortComponentType
-  }
-
-  sealed trait VersionedPortPortFunction extends enumeratum.EnumEntry
-  object VersionedPortPortFunction extends enumeratum.Enum[VersionedPortPortFunction] with enumeratum.CirceEnum[VersionedPortPortFunction] {
-    val values = findValues
-    case object STANDARD extends VersionedPortPortFunction
-    case object FAILURE extends VersionedPortPortFunction
-  }
-
-  sealed trait VersionedPortScheduledState extends enumeratum.EnumEntry
-  object VersionedPortScheduledState extends enumeratum.Enum[VersionedPortScheduledState] with enumeratum.CirceEnum[VersionedPortScheduledState] {
-    val values = findValues
-    case object ENABLED extends VersionedPortScheduledState
-    case object DISABLED extends VersionedPortScheduledState
-    case object RUNNING extends VersionedPortScheduledState
-  }
-
-  sealed trait VersionedPortType extends enumeratum.EnumEntry
-  object VersionedPortType extends enumeratum.Enum[VersionedPortType] with enumeratum.CirceEnum[VersionedPortType] {
-    val values = findValues
-    case object INPUT_PORT extends VersionedPortType
-    case object OUTPUT_PORT extends VersionedPortType
-  }
-
-  sealed trait VersionedProcessGroupComponentType extends enumeratum.EnumEntry
-  object VersionedProcessGroupComponentType extends enumeratum.Enum[VersionedProcessGroupComponentType] with enumeratum.CirceEnum[VersionedProcessGroupComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedProcessGroupComponentType
-    case object PROCESSOR extends VersionedProcessGroupComponentType
-    case object PROCESS_GROUP extends VersionedProcessGroupComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedProcessGroupComponentType
-    case object INPUT_PORT extends VersionedProcessGroupComponentType
-    case object OUTPUT_PORT extends VersionedProcessGroupComponentType
-    case object REMOTE_INPUT_PORT extends VersionedProcessGroupComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedProcessGroupComponentType
-    case object FUNNEL extends VersionedProcessGroupComponentType
-    case object LABEL extends VersionedProcessGroupComponentType
-    case object CONTROLLER_SERVICE extends VersionedProcessGroupComponentType
-    case object REPORTING_TASK extends VersionedProcessGroupComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedProcessGroupComponentType
-    case object PARAMETER_CONTEXT extends VersionedProcessGroupComponentType
-    case object PARAMETER_PROVIDER extends VersionedProcessGroupComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedProcessGroupComponentType
-  }
-
-  sealed trait VersionedProcessGroupExecutionEngine extends enumeratum.EnumEntry
-  object VersionedProcessGroupExecutionEngine extends enumeratum.Enum[VersionedProcessGroupExecutionEngine] with enumeratum.CirceEnum[VersionedProcessGroupExecutionEngine] {
-    val values = findValues
-    case object STANDARD extends VersionedProcessGroupExecutionEngine
-    case object STATELESS extends VersionedProcessGroupExecutionEngine
-    case object INHERITED extends VersionedProcessGroupExecutionEngine
-  }
-
-  sealed trait VersionedProcessGroupScheduledState extends enumeratum.EnumEntry
-  object VersionedProcessGroupScheduledState extends enumeratum.Enum[VersionedProcessGroupScheduledState] with enumeratum.CirceEnum[VersionedProcessGroupScheduledState] {
-    val values = findValues
-    case object ENABLED extends VersionedProcessGroupScheduledState
-    case object DISABLED extends VersionedProcessGroupScheduledState
-    case object RUNNING extends VersionedProcessGroupScheduledState
-  }
-
-  sealed trait VersionedProcessorComponentType extends enumeratum.EnumEntry
-  object VersionedProcessorComponentType extends enumeratum.Enum[VersionedProcessorComponentType] with enumeratum.CirceEnum[VersionedProcessorComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedProcessorComponentType
-    case object PROCESSOR extends VersionedProcessorComponentType
-    case object PROCESS_GROUP extends VersionedProcessorComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedProcessorComponentType
-    case object INPUT_PORT extends VersionedProcessorComponentType
-    case object OUTPUT_PORT extends VersionedProcessorComponentType
-    case object REMOTE_INPUT_PORT extends VersionedProcessorComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedProcessorComponentType
-    case object FUNNEL extends VersionedProcessorComponentType
-    case object LABEL extends VersionedProcessorComponentType
-    case object CONTROLLER_SERVICE extends VersionedProcessorComponentType
-    case object REPORTING_TASK extends VersionedProcessorComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedProcessorComponentType
-    case object PARAMETER_CONTEXT extends VersionedProcessorComponentType
-    case object PARAMETER_PROVIDER extends VersionedProcessorComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedProcessorComponentType
-  }
-
-  sealed trait VersionedProcessorScheduledState extends enumeratum.EnumEntry
-  object VersionedProcessorScheduledState extends enumeratum.Enum[VersionedProcessorScheduledState] with enumeratum.CirceEnum[VersionedProcessorScheduledState] {
-    val values = findValues
-    case object ENABLED extends VersionedProcessorScheduledState
-    case object DISABLED extends VersionedProcessorScheduledState
-    case object RUNNING extends VersionedProcessorScheduledState
-  }
-
-  sealed trait VersionedRemoteGroupPortComponentType extends enumeratum.EnumEntry
-  object VersionedRemoteGroupPortComponentType extends enumeratum.Enum[VersionedRemoteGroupPortComponentType] with enumeratum.CirceEnum[VersionedRemoteGroupPortComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedRemoteGroupPortComponentType
-    case object PROCESSOR extends VersionedRemoteGroupPortComponentType
-    case object PROCESS_GROUP extends VersionedRemoteGroupPortComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedRemoteGroupPortComponentType
-    case object INPUT_PORT extends VersionedRemoteGroupPortComponentType
-    case object OUTPUT_PORT extends VersionedRemoteGroupPortComponentType
-    case object REMOTE_INPUT_PORT extends VersionedRemoteGroupPortComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedRemoteGroupPortComponentType
-    case object FUNNEL extends VersionedRemoteGroupPortComponentType
-    case object LABEL extends VersionedRemoteGroupPortComponentType
-    case object CONTROLLER_SERVICE extends VersionedRemoteGroupPortComponentType
-    case object REPORTING_TASK extends VersionedRemoteGroupPortComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedRemoteGroupPortComponentType
-    case object PARAMETER_CONTEXT extends VersionedRemoteGroupPortComponentType
-    case object PARAMETER_PROVIDER extends VersionedRemoteGroupPortComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedRemoteGroupPortComponentType
-  }
-
-  sealed trait VersionedRemoteGroupPortScheduledState extends enumeratum.EnumEntry
-  object VersionedRemoteGroupPortScheduledState extends enumeratum.Enum[VersionedRemoteGroupPortScheduledState] with enumeratum.CirceEnum[VersionedRemoteGroupPortScheduledState] {
-    val values = findValues
-    case object ENABLED extends VersionedRemoteGroupPortScheduledState
-    case object DISABLED extends VersionedRemoteGroupPortScheduledState
-    case object RUNNING extends VersionedRemoteGroupPortScheduledState
-  }
-
-  sealed trait VersionedRemoteProcessGroupComponentType extends enumeratum.EnumEntry
-  object VersionedRemoteProcessGroupComponentType extends enumeratum.Enum[VersionedRemoteProcessGroupComponentType] with enumeratum.CirceEnum[VersionedRemoteProcessGroupComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedRemoteProcessGroupComponentType
-    case object PROCESSOR extends VersionedRemoteProcessGroupComponentType
-    case object PROCESS_GROUP extends VersionedRemoteProcessGroupComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedRemoteProcessGroupComponentType
-    case object INPUT_PORT extends VersionedRemoteProcessGroupComponentType
-    case object OUTPUT_PORT extends VersionedRemoteProcessGroupComponentType
-    case object REMOTE_INPUT_PORT extends VersionedRemoteProcessGroupComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedRemoteProcessGroupComponentType
-    case object FUNNEL extends VersionedRemoteProcessGroupComponentType
-    case object LABEL extends VersionedRemoteProcessGroupComponentType
-    case object CONTROLLER_SERVICE extends VersionedRemoteProcessGroupComponentType
-    case object REPORTING_TASK extends VersionedRemoteProcessGroupComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedRemoteProcessGroupComponentType
-    case object PARAMETER_CONTEXT extends VersionedRemoteProcessGroupComponentType
-    case object PARAMETER_PROVIDER extends VersionedRemoteProcessGroupComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedRemoteProcessGroupComponentType
-  }
-
-  sealed trait VersionedReportingTaskComponentType extends enumeratum.EnumEntry
-  object VersionedReportingTaskComponentType extends enumeratum.Enum[VersionedReportingTaskComponentType] with enumeratum.CirceEnum[VersionedReportingTaskComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedReportingTaskComponentType
-    case object PROCESSOR extends VersionedReportingTaskComponentType
-    case object PROCESS_GROUP extends VersionedReportingTaskComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedReportingTaskComponentType
-    case object INPUT_PORT extends VersionedReportingTaskComponentType
-    case object OUTPUT_PORT extends VersionedReportingTaskComponentType
-    case object REMOTE_INPUT_PORT extends VersionedReportingTaskComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedReportingTaskComponentType
-    case object FUNNEL extends VersionedReportingTaskComponentType
-    case object LABEL extends VersionedReportingTaskComponentType
-    case object CONTROLLER_SERVICE extends VersionedReportingTaskComponentType
-    case object REPORTING_TASK extends VersionedReportingTaskComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedReportingTaskComponentType
-    case object PARAMETER_CONTEXT extends VersionedReportingTaskComponentType
-    case object PARAMETER_PROVIDER extends VersionedReportingTaskComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedReportingTaskComponentType
-  }
-
-  sealed trait VersionedReportingTaskScheduledState extends enumeratum.EnumEntry
-  object VersionedReportingTaskScheduledState extends enumeratum.Enum[VersionedReportingTaskScheduledState] with enumeratum.CirceEnum[VersionedReportingTaskScheduledState] {
-    val values = findValues
-    case object ENABLED extends VersionedReportingTaskScheduledState
-    case object DISABLED extends VersionedReportingTaskScheduledState
-    case object RUNNING extends VersionedReportingTaskScheduledState
-  }
-
-  sealed trait VersionedResourceDefinitionCardinality extends enumeratum.EnumEntry
-  object VersionedResourceDefinitionCardinality extends enumeratum.Enum[VersionedResourceDefinitionCardinality] with enumeratum.CirceEnum[VersionedResourceDefinitionCardinality] {
-    val values = findValues
-    case object SINGLE extends VersionedResourceDefinitionCardinality
-    case object MULTIPLE extends VersionedResourceDefinitionCardinality
-  }
-
-  sealed trait VersionedResourceDefinitionResourceTypesItem extends enumeratum.EnumEntry
-  object VersionedResourceDefinitionResourceTypesItem extends enumeratum.Enum[VersionedResourceDefinitionResourceTypesItem] with enumeratum.CirceEnum[VersionedResourceDefinitionResourceTypesItem] {
-    val values = findValues
-    case object FILE extends VersionedResourceDefinitionResourceTypesItem
-    case object DIRECTORY extends VersionedResourceDefinitionResourceTypesItem
-    case object TEXT extends VersionedResourceDefinitionResourceTypesItem
-    case object URL extends VersionedResourceDefinitionResourceTypesItem
-  }
+  type ActionDetailsDTO = io.circe.JsonObject
+  type BulletinBoardPatternParameterStr = String
+  type ClientIdParameterStr = String
+  type ComponentDetailsDTO = io.circe.JsonObject
+  type DateTimeParameterDT = java.time.Instant
+  type IntegerParameterInt = Int
+  type LongParameterInt = Long
+  type StreamingOutput = io.circe.JsonObject
   case class AboutDTO (
     buildBranch: Option[String] = None,
     buildRevision: Option[String] = None,
@@ -1017,6 +118,12 @@ object TapirGeneratedEndpoints {
     users: Option[Set[TenantEntity]] = None,
     versionedComponentId: Option[String] = None
   )
+
+  sealed trait AccessPolicyDTOAction extends enumeratum.EnumEntry
+  object AccessPolicyDTOAction extends enumeratum.Enum[AccessPolicyDTOAction] with enumeratum.CirceEnum[AccessPolicyDTOAction] {
+    val values = findValues
+    case object read extends AccessPolicyDTOAction
+  }
   case class AccessPolicyEntity (
     bulletins: Option[Seq[BulletinEntity]] = None,
     component: Option[AccessPolicyDTO] = None,
@@ -1038,6 +145,12 @@ object TapirGeneratedEndpoints {
     resource: Option[String] = None,
     versionedComponentId: Option[String] = None
   )
+
+  sealed trait AccessPolicySummaryDTOAction extends enumeratum.EnumEntry
+  object AccessPolicySummaryDTOAction extends enumeratum.Enum[AccessPolicySummaryDTOAction] with enumeratum.CirceEnum[AccessPolicySummaryDTOAction] {
+    val values = findValues
+    case object read extends AccessPolicySummaryDTOAction
+  }
   case class AccessPolicySummaryEntity (
     bulletins: Option[Seq[BulletinEntity]] = None,
     component: Option[AccessPolicySummaryDTO] = None,
@@ -1072,6 +185,13 @@ object TapirGeneratedEndpoints {
     id: Option[String] = None,
     state: Option[ActivateControllerServicesEntityState] = None
   )
+
+  sealed trait ActivateControllerServicesEntityState extends enumeratum.EnumEntry
+  object ActivateControllerServicesEntityState extends enumeratum.Enum[ActivateControllerServicesEntityState] with enumeratum.CirceEnum[ActivateControllerServicesEntityState] {
+    val values = findValues
+    case object ENABLED extends ActivateControllerServicesEntityState
+    case object DISABLED extends ActivateControllerServicesEntityState
+  }
   case class AdditionalDetailsEntity (
     additionalDetails: Option[String] = None
   )
@@ -1084,6 +204,18 @@ object TapirGeneratedEndpoints {
     state: Option[String] = None,
     validationErrors: Option[Seq[String]] = None
   )
+
+  sealed trait AffectedComponentDTOReferenceType extends enumeratum.EnumEntry
+  object AffectedComponentDTOReferenceType extends enumeratum.Enum[AffectedComponentDTOReferenceType] with enumeratum.CirceEnum[AffectedComponentDTOReferenceType] {
+    val values = findValues
+    case object PROCESSOR extends AffectedComponentDTOReferenceType
+    case object CONTROLLER_SERVICE extends AffectedComponentDTOReferenceType
+    case object INPUT_PORT extends AffectedComponentDTOReferenceType
+    case object OUTPUT_PORT extends AffectedComponentDTOReferenceType
+    case object REMOTE_INPUT_PORT extends AffectedComponentDTOReferenceType
+    case object REMOTE_OUTPUT_PORT extends AffectedComponentDTOReferenceType
+    case object STATELESS_GROUP extends AffectedComponentDTOReferenceType
+  }
   case class AffectedComponentEntity (
     bulletins: Option[Seq[BulletinEntity]] = None,
     component: Option[AffectedComponentDTO] = None,
@@ -1096,6 +228,17 @@ object TapirGeneratedEndpoints {
     revision: Option[RevisionDTO] = None,
     uri: Option[String] = None
   )
+
+  sealed trait AffectedComponentEntityReferenceType extends enumeratum.EnumEntry
+  object AffectedComponentEntityReferenceType extends enumeratum.Enum[AffectedComponentEntityReferenceType] with enumeratum.CirceEnum[AffectedComponentEntityReferenceType] {
+    val values = findValues
+    case object PROCESSOR extends AffectedComponentEntityReferenceType
+    case object CONTROLLER_SERVICE extends AffectedComponentEntityReferenceType
+    case object INPUT_PORT extends AffectedComponentEntityReferenceType
+    case object OUTPUT_PORT extends AffectedComponentEntityReferenceType
+    case object REMOTE_INPUT_PORT extends AffectedComponentEntityReferenceType
+    case object REMOTE_OUTPUT_PORT extends AffectedComponentEntityReferenceType
+  }
   case class AllowableValueDTO (
     description: Option[String] = None,
     displayName: Option[String] = None,
@@ -1303,6 +446,18 @@ object TapirGeneratedEndpoints {
     state: Option[String] = None,
     validationErrors: Option[Seq[String]] = None
   )
+
+  sealed trait ComponentValidationResultDTOReferenceType extends enumeratum.EnumEntry
+  object ComponentValidationResultDTOReferenceType extends enumeratum.Enum[ComponentValidationResultDTOReferenceType] with enumeratum.CirceEnum[ComponentValidationResultDTOReferenceType] {
+    val values = findValues
+    case object PROCESSOR extends ComponentValidationResultDTOReferenceType
+    case object CONTROLLER_SERVICE extends ComponentValidationResultDTOReferenceType
+    case object INPUT_PORT extends ComponentValidationResultDTOReferenceType
+    case object OUTPUT_PORT extends ComponentValidationResultDTOReferenceType
+    case object REMOTE_INPUT_PORT extends ComponentValidationResultDTOReferenceType
+    case object REMOTE_OUTPUT_PORT extends ComponentValidationResultDTOReferenceType
+    case object STATELESS_GROUP extends ComponentValidationResultDTOReferenceType
+  }
   case class ComponentValidationResultEntity (
     bulletins: Option[Seq[BulletinEntity]] = None,
     component: Option[ComponentValidationResultDTO] = None,
@@ -1321,6 +476,14 @@ object TapirGeneratedEndpoints {
     outcome: Option[ConfigVerificationResultDTOOutcome] = None,
     verificationStepName: Option[String] = None
   )
+
+  sealed trait ConfigVerificationResultDTOOutcome extends enumeratum.EnumEntry
+  object ConfigVerificationResultDTOOutcome extends enumeratum.Enum[ConfigVerificationResultDTOOutcome] with enumeratum.CirceEnum[ConfigVerificationResultDTOOutcome] {
+    val values = findValues
+    case object SUCCESSFUL extends ConfigVerificationResultDTOOutcome
+    case object FAILED extends ConfigVerificationResultDTOOutcome
+    case object SKIPPED extends ConfigVerificationResultDTOOutcome
+  }
   case class ConfigurationAnalysisDTO (
     componentId: Option[String] = None,
     properties: Option[Map[String, String]] = None,
@@ -1338,6 +501,17 @@ object TapirGeneratedEndpoints {
     name: Option[String] = None,
     `type`: Option[ConnectableComponentType] = None
   )
+
+  sealed trait ConnectableComponentType extends enumeratum.EnumEntry
+  object ConnectableComponentType extends enumeratum.Enum[ConnectableComponentType] with enumeratum.CirceEnum[ConnectableComponentType] {
+    val values = findValues
+    case object PROCESSOR extends ConnectableComponentType
+    case object REMOTE_INPUT_PORT extends ConnectableComponentType
+    case object REMOTE_OUTPUT_PORT extends ConnectableComponentType
+    case object INPUT_PORT extends ConnectableComponentType
+    case object OUTPUT_PORT extends ConnectableComponentType
+    case object FUNNEL extends ConnectableComponentType
+  }
   case class ConnectableDTO (
     comments: Option[String] = None,
     exists: Option[Boolean] = None,
@@ -1349,6 +523,17 @@ object TapirGeneratedEndpoints {
     `type`: ConnectableDTOType,
     versionedComponentId: Option[String] = None
   )
+
+  sealed trait ConnectableDTOType extends enumeratum.EnumEntry
+  object ConnectableDTOType extends enumeratum.Enum[ConnectableDTOType] with enumeratum.CirceEnum[ConnectableDTOType] {
+    val values = findValues
+    case object PROCESSOR extends ConnectableDTOType
+    case object REMOTE_INPUT_PORT extends ConnectableDTOType
+    case object REMOTE_OUTPUT_PORT extends ConnectableDTOType
+    case object INPUT_PORT extends ConnectableDTOType
+    case object OUTPUT_PORT extends ConnectableDTOType
+    case object FUNNEL extends ConnectableDTOType
+  }
   case class ConnectionDTO (
     availableRelationships: Option[Set[String]] = None,
     backPressureDataSizeThreshold: Option[String] = None,
@@ -1392,6 +577,28 @@ object TapirGeneratedEndpoints {
     status: Option[ConnectionStatusDTO] = None,
     uri: Option[String] = None
   )
+
+  sealed trait ConnectionEntityDestinationType extends enumeratum.EnumEntry
+  object ConnectionEntityDestinationType extends enumeratum.Enum[ConnectionEntityDestinationType] with enumeratum.CirceEnum[ConnectionEntityDestinationType] {
+    val values = findValues
+    case object PROCESSOR extends ConnectionEntityDestinationType
+    case object REMOTE_INPUT_PORT extends ConnectionEntityDestinationType
+    case object REMOTE_OUTPUT_PORT extends ConnectionEntityDestinationType
+    case object INPUT_PORT extends ConnectionEntityDestinationType
+    case object OUTPUT_PORT extends ConnectionEntityDestinationType
+    case object FUNNEL extends ConnectionEntityDestinationType
+  }
+
+  sealed trait ConnectionEntitySourceType extends enumeratum.EnumEntry
+  object ConnectionEntitySourceType extends enumeratum.Enum[ConnectionEntitySourceType] with enumeratum.CirceEnum[ConnectionEntitySourceType] {
+    val values = findValues
+    case object PROCESSOR extends ConnectionEntitySourceType
+    case object REMOTE_INPUT_PORT extends ConnectionEntitySourceType
+    case object REMOTE_OUTPUT_PORT extends ConnectionEntitySourceType
+    case object INPUT_PORT extends ConnectionEntitySourceType
+    case object OUTPUT_PORT extends ConnectionEntitySourceType
+    case object FUNNEL extends ConnectionEntitySourceType
+  }
   case class ConnectionStatisticsDTO (
     aggregateSnapshot: Option[ConnectionStatisticsSnapshotDTO] = None,
     id: Option[String] = None,
@@ -1462,6 +669,14 @@ object TapirGeneratedEndpoints {
     sourceId: Option[String] = None,
     sourceName: Option[String] = None
   )
+
+  sealed trait ConnectionStatusSnapshotDTOLoadBalanceStatus extends enumeratum.EnumEntry
+  object ConnectionStatusSnapshotDTOLoadBalanceStatus extends enumeratum.Enum[ConnectionStatusSnapshotDTOLoadBalanceStatus] with enumeratum.CirceEnum[ConnectionStatusSnapshotDTOLoadBalanceStatus] {
+    val values = findValues
+    case object LOAD_BALANCE_NOT_CONFIGURED extends ConnectionStatusSnapshotDTOLoadBalanceStatus
+    case object LOAD_BALANCE_ACTIVE extends ConnectionStatusSnapshotDTOLoadBalanceStatus
+    case object LOAD_BALANCE_INACTIVE extends ConnectionStatusSnapshotDTOLoadBalanceStatus
+  }
   case class ConnectionStatusSnapshotEntity (
     canRead: Option[Boolean] = None,
     connectionStatusSnapshot: Option[ConnectionStatusSnapshotDTO] = None,
@@ -1552,6 +767,23 @@ object TapirGeneratedEndpoints {
     validationStatus: Option[ControllerServiceDTOValidationStatus] = None,
     versionedComponentId: Option[String] = None
   )
+
+  sealed trait ControllerServiceDTOState extends enumeratum.EnumEntry
+  object ControllerServiceDTOState extends enumeratum.Enum[ControllerServiceDTOState] with enumeratum.CirceEnum[ControllerServiceDTOState] {
+    val values = findValues
+    case object ENABLED extends ControllerServiceDTOState
+    case object ENABLING extends ControllerServiceDTOState
+    case object DISABLED extends ControllerServiceDTOState
+    case object DISABLING extends ControllerServiceDTOState
+  }
+
+  sealed trait ControllerServiceDTOValidationStatus extends enumeratum.EnumEntry
+  object ControllerServiceDTOValidationStatus extends enumeratum.Enum[ControllerServiceDTOValidationStatus] with enumeratum.CirceEnum[ControllerServiceDTOValidationStatus] {
+    val values = findValues
+    case object VALID extends ControllerServiceDTOValidationStatus
+    case object INVALID extends ControllerServiceDTOValidationStatus
+    case object VALIDATING extends ControllerServiceDTOValidationStatus
+  }
   case class ControllerServiceDefinition (
     additionalDetails: Option[Boolean] = None,
     artifact: Option[String] = None,
@@ -1603,6 +835,15 @@ object TapirGeneratedEndpoints {
     `type`: Option[String] = None,
     validationErrors: Option[Seq[String]] = None
   )
+
+  sealed trait ControllerServiceReferencingComponentDTOReferenceType extends enumeratum.EnumEntry
+  object ControllerServiceReferencingComponentDTOReferenceType extends enumeratum.Enum[ControllerServiceReferencingComponentDTOReferenceType] with enumeratum.CirceEnum[ControllerServiceReferencingComponentDTOReferenceType] {
+    val values = findValues
+    case object Processor extends ControllerServiceReferencingComponentDTOReferenceType
+    case object ControllerService extends ControllerServiceReferencingComponentDTOReferenceType
+    case object ReportingTask extends ControllerServiceReferencingComponentDTOReferenceType
+    case object FlowRegistryClient extends ControllerServiceReferencingComponentDTOReferenceType
+  }
   case class ControllerServiceReferencingComponentEntity (
     bulletins: Option[Seq[BulletinEntity]] = None,
     component: Option[ControllerServiceReferencingComponentDTO] = None,
@@ -1623,11 +864,35 @@ object TapirGeneratedEndpoints {
     state: Option[ControllerServiceRunStatusEntityState] = None,
     uiOnly: Option[Boolean] = None
   )
+
+  sealed trait ControllerServiceRunStatusEntityState extends enumeratum.EnumEntry
+  object ControllerServiceRunStatusEntityState extends enumeratum.Enum[ControllerServiceRunStatusEntityState] with enumeratum.CirceEnum[ControllerServiceRunStatusEntityState] {
+    val values = findValues
+    case object ENABLED extends ControllerServiceRunStatusEntityState
+    case object DISABLED extends ControllerServiceRunStatusEntityState
+  }
   case class ControllerServiceStatusDTO (
     activeThreadCount: Option[Int] = None,
     runStatus: Option[ControllerServiceStatusDTORunStatus] = None,
     validationStatus: Option[ControllerServiceStatusDTOValidationStatus] = None
   )
+
+  sealed trait ControllerServiceStatusDTORunStatus extends enumeratum.EnumEntry
+  object ControllerServiceStatusDTORunStatus extends enumeratum.Enum[ControllerServiceStatusDTORunStatus] with enumeratum.CirceEnum[ControllerServiceStatusDTORunStatus] {
+    val values = findValues
+    case object ENABLED extends ControllerServiceStatusDTORunStatus
+    case object ENABLING extends ControllerServiceStatusDTORunStatus
+    case object DISABLED extends ControllerServiceStatusDTORunStatus
+    case object DISABLING extends ControllerServiceStatusDTORunStatus
+  }
+
+  sealed trait ControllerServiceStatusDTOValidationStatus extends enumeratum.EnumEntry
+  object ControllerServiceStatusDTOValidationStatus extends enumeratum.Enum[ControllerServiceStatusDTOValidationStatus] with enumeratum.CirceEnum[ControllerServiceStatusDTOValidationStatus] {
+    val values = findValues
+    case object VALID extends ControllerServiceStatusDTOValidationStatus
+    case object INVALID extends ControllerServiceStatusDTOValidationStatus
+    case object VALIDATING extends ControllerServiceStatusDTOValidationStatus
+  }
   case class ControllerServiceTypesEntity (
     controllerServiceTypes: Option[Set[DocumentedTypeDTO]] = None
   )
@@ -1783,6 +1048,14 @@ object TapirGeneratedEndpoints {
     name: Option[String] = None,
     value: Option[String] = None
   )
+
+  sealed trait DynamicPropertyExpressionLanguageScope extends enumeratum.EnumEntry
+  object DynamicPropertyExpressionLanguageScope extends enumeratum.Enum[DynamicPropertyExpressionLanguageScope] with enumeratum.CirceEnum[DynamicPropertyExpressionLanguageScope] {
+    val values = findValues
+    case object NONE extends DynamicPropertyExpressionLanguageScope
+    case object ENVIRONMENT extends DynamicPropertyExpressionLanguageScope
+    case object FLOWFILE_ATTRIBUTES extends DynamicPropertyExpressionLanguageScope
+  }
   case class DynamicRelationship (
     description: Option[String] = None,
     name: Option[String] = None
@@ -1823,6 +1096,21 @@ object TapirGeneratedEndpoints {
     validationStatus: Option[FlowAnalysisRuleDTOValidationStatus] = None,
     versionedComponentId: Option[String] = None
   )
+
+  sealed trait FlowAnalysisRuleDTOState extends enumeratum.EnumEntry
+  object FlowAnalysisRuleDTOState extends enumeratum.Enum[FlowAnalysisRuleDTOState] with enumeratum.CirceEnum[FlowAnalysisRuleDTOState] {
+    val values = findValues
+    case object ENABLED extends FlowAnalysisRuleDTOState
+    case object DISABLED extends FlowAnalysisRuleDTOState
+  }
+
+  sealed trait FlowAnalysisRuleDTOValidationStatus extends enumeratum.EnumEntry
+  object FlowAnalysisRuleDTOValidationStatus extends enumeratum.Enum[FlowAnalysisRuleDTOValidationStatus] with enumeratum.CirceEnum[FlowAnalysisRuleDTOValidationStatus] {
+    val values = findValues
+    case object VALID extends FlowAnalysisRuleDTOValidationStatus
+    case object INVALID extends FlowAnalysisRuleDTOValidationStatus
+    case object VALIDATING extends FlowAnalysisRuleDTOValidationStatus
+  }
   case class FlowAnalysisRuleDefinition (
     additionalDetails: Option[Boolean] = None,
     artifact: Option[String] = None,
@@ -1864,11 +1152,33 @@ object TapirGeneratedEndpoints {
     revision: Option[RevisionDTO] = None,
     state: Option[FlowAnalysisRuleRunStatusEntityState] = None
   )
+
+  sealed trait FlowAnalysisRuleRunStatusEntityState extends enumeratum.EnumEntry
+  object FlowAnalysisRuleRunStatusEntityState extends enumeratum.Enum[FlowAnalysisRuleRunStatusEntityState] with enumeratum.CirceEnum[FlowAnalysisRuleRunStatusEntityState] {
+    val values = findValues
+    case object ENABLED extends FlowAnalysisRuleRunStatusEntityState
+    case object DISABLED extends FlowAnalysisRuleRunStatusEntityState
+  }
   case class FlowAnalysisRuleStatusDTO (
     activeThreadCount: Option[Int] = None,
     runStatus: Option[FlowAnalysisRuleStatusDTORunStatus] = None,
     validationStatus: Option[FlowAnalysisRuleStatusDTOValidationStatus] = None
   )
+
+  sealed trait FlowAnalysisRuleStatusDTORunStatus extends enumeratum.EnumEntry
+  object FlowAnalysisRuleStatusDTORunStatus extends enumeratum.Enum[FlowAnalysisRuleStatusDTORunStatus] with enumeratum.CirceEnum[FlowAnalysisRuleStatusDTORunStatus] {
+    val values = findValues
+    case object ENABLED extends FlowAnalysisRuleStatusDTORunStatus
+    case object DISABLED extends FlowAnalysisRuleStatusDTORunStatus
+  }
+
+  sealed trait FlowAnalysisRuleStatusDTOValidationStatus extends enumeratum.EnumEntry
+  object FlowAnalysisRuleStatusDTOValidationStatus extends enumeratum.Enum[FlowAnalysisRuleStatusDTOValidationStatus] with enumeratum.CirceEnum[FlowAnalysisRuleStatusDTOValidationStatus] {
+    val values = findValues
+    case object VALID extends FlowAnalysisRuleStatusDTOValidationStatus
+    case object INVALID extends FlowAnalysisRuleStatusDTOValidationStatus
+    case object VALIDATING extends FlowAnalysisRuleStatusDTOValidationStatus
+  }
   case class FlowAnalysisRuleTypesEntity (
     flowAnalysisRuleTypes: Option[Set[DocumentedTypeDTO]] = None
   )
@@ -1901,6 +1211,16 @@ object TapirGeneratedEndpoints {
     permissions: Option[PermissionsDTO] = None,
     versionedFlowState: Option[FlowBreadcrumbEntityVersionedFlowState] = None
   )
+
+  sealed trait FlowBreadcrumbEntityVersionedFlowState extends enumeratum.EnumEntry
+  object FlowBreadcrumbEntityVersionedFlowState extends enumeratum.Enum[FlowBreadcrumbEntityVersionedFlowState] with enumeratum.CirceEnum[FlowBreadcrumbEntityVersionedFlowState] {
+    val values = findValues
+    case object LOCALLY_MODIFIED extends FlowBreadcrumbEntityVersionedFlowState
+    case object STALE extends FlowBreadcrumbEntityVersionedFlowState
+    case object LOCALLY_MODIFIED_AND_STALE extends FlowBreadcrumbEntityVersionedFlowState
+    case object UP_TO_DATE extends FlowBreadcrumbEntityVersionedFlowState
+    case object SYNC_FAILURE extends FlowBreadcrumbEntityVersionedFlowState
+  }
   case class FlowComparisonEntity (
     componentDifferences: Option[Set[ComponentDifferenceDTO]] = None
   )
@@ -2016,6 +1336,14 @@ object TapirGeneratedEndpoints {
     validationErrors: Option[Seq[String]] = None,
     validationStatus: Option[FlowRegistryClientDTOValidationStatus] = None
   )
+
+  sealed trait FlowRegistryClientDTOValidationStatus extends enumeratum.EnumEntry
+  object FlowRegistryClientDTOValidationStatus extends enumeratum.Enum[FlowRegistryClientDTOValidationStatus] with enumeratum.CirceEnum[FlowRegistryClientDTOValidationStatus] {
+    val values = findValues
+    case object VALID extends FlowRegistryClientDTOValidationStatus
+    case object INVALID extends FlowRegistryClientDTOValidationStatus
+    case object VALIDATING extends FlowRegistryClientDTOValidationStatus
+  }
   case class FlowRegistryClientEntity (
     bulletins: Option[Seq[BulletinEntity]] = None,
     component: Option[FlowRegistryClientDTO] = None,
@@ -2149,6 +1477,14 @@ object TapirGeneratedEndpoints {
     lineageRequestType: Option[LineageRequestDTOLineageRequestType] = None,
     uuid: Option[String] = None
   )
+
+  sealed trait LineageRequestDTOLineageRequestType extends enumeratum.EnumEntry
+  object LineageRequestDTOLineageRequestType extends enumeratum.Enum[LineageRequestDTOLineageRequestType] with enumeratum.CirceEnum[LineageRequestDTOLineageRequestType] {
+    val values = findValues
+    case object PARENTS extends LineageRequestDTOLineageRequestType
+    case object CHILDREN extends LineageRequestDTOLineageRequestType
+    case object FLOWFILE extends LineageRequestDTOLineageRequestType
+  }
   case class LineageResultsDTO (
     errors: Option[Set[String]] = None,
     links: Option[Seq[ProvenanceLinkDTO]] = None,
@@ -2411,6 +1747,13 @@ object TapirGeneratedEndpoints {
     parameterSensitivities: Option[Map[String, ParameterGroupConfigurationEntityParameterSensitivitiesItem]] = None,
     synchronized: Option[Boolean] = None
   )
+
+  sealed trait ParameterGroupConfigurationEntityParameterSensitivitiesItem extends enumeratum.EnumEntry
+  object ParameterGroupConfigurationEntityParameterSensitivitiesItem extends enumeratum.Enum[ParameterGroupConfigurationEntityParameterSensitivitiesItem] with enumeratum.CirceEnum[ParameterGroupConfigurationEntityParameterSensitivitiesItem] {
+    val values = findValues
+    case object SENSITIVE extends ParameterGroupConfigurationEntityParameterSensitivitiesItem
+    case object NON_SENSITIVE extends ParameterGroupConfigurationEntityParameterSensitivitiesItem
+  }
   case class ParameterProviderApplyParametersRequestDTO (
     complete: Option[Boolean] = None,
     failureReason: Option[String] = None,
@@ -2469,6 +1812,14 @@ object TapirGeneratedEndpoints {
     validationStatus: Option[ParameterProviderDTOValidationStatus] = None,
     versionedComponentId: Option[String] = None
   )
+
+  sealed trait ParameterProviderDTOValidationStatus extends enumeratum.EnumEntry
+  object ParameterProviderDTOValidationStatus extends enumeratum.Enum[ParameterProviderDTOValidationStatus] with enumeratum.CirceEnum[ParameterProviderDTOValidationStatus] {
+    val values = findValues
+    case object VALID extends ParameterProviderDTOValidationStatus
+    case object INVALID extends ParameterProviderDTOValidationStatus
+    case object VALIDATING extends ParameterProviderDTOValidationStatus
+  }
   case class ParameterProviderDefinition (
     additionalDetails: Option[Boolean] = None,
     artifact: Option[String] = None,
@@ -2548,6 +1899,16 @@ object TapirGeneratedEndpoints {
     parameter: Option[ParameterEntity] = None,
     status: Option[ParameterStatusDTOStatus] = None
   )
+
+  sealed trait ParameterStatusDTOStatus extends enumeratum.EnumEntry
+  object ParameterStatusDTOStatus extends enumeratum.Enum[ParameterStatusDTOStatus] with enumeratum.CirceEnum[ParameterStatusDTOStatus] {
+    val values = findValues
+    case object NEW extends ParameterStatusDTOStatus
+    case object CHANGED extends ParameterStatusDTOStatus
+    case object REMOVED extends ParameterStatusDTOStatus
+    case object MISSING_BUT_REFERENCED extends ParameterStatusDTOStatus
+    case object UNCHANGED extends ParameterStatusDTOStatus
+  }
   case class PasteRequestEntity (
     copyResponse: Option[CopyResponseEntity] = None,
     disconnectedNodeAcknowledged: Option[Boolean] = None,
@@ -2585,6 +1946,28 @@ object TapirGeneratedEndpoints {
     validationErrors: Option[Seq[String]] = None,
     versionedComponentId: Option[String] = None
   )
+
+  sealed trait PortDTOPortFunction extends enumeratum.EnumEntry
+  object PortDTOPortFunction extends enumeratum.Enum[PortDTOPortFunction] with enumeratum.CirceEnum[PortDTOPortFunction] {
+    val values = findValues
+    case object STANDARD extends PortDTOPortFunction
+    case object FAILURE extends PortDTOPortFunction
+  }
+
+  sealed trait PortDTOState extends enumeratum.EnumEntry
+  object PortDTOState extends enumeratum.Enum[PortDTOState] with enumeratum.CirceEnum[PortDTOState] {
+    val values = findValues
+    case object RUNNING extends PortDTOState
+    case object STOPPED extends PortDTOState
+    case object DISABLED extends PortDTOState
+  }
+
+  sealed trait PortDTOType extends enumeratum.EnumEntry
+  object PortDTOType extends enumeratum.Enum[PortDTOType] with enumeratum.CirceEnum[PortDTOType] {
+    val values = findValues
+    case object INPUT_PORT extends PortDTOType
+    case object OUTPUT_PORT extends PortDTOType
+  }
   case class PortEntity (
     allowRemoteAccess: Option[Boolean] = None,
     bulletins: Option[Seq[BulletinEntity]] = None,
@@ -2604,6 +1987,14 @@ object TapirGeneratedEndpoints {
     revision: Option[RevisionDTO] = None,
     state: Option[PortRunStatusEntityState] = None
   )
+
+  sealed trait PortRunStatusEntityState extends enumeratum.EnumEntry
+  object PortRunStatusEntityState extends enumeratum.Enum[PortRunStatusEntityState] with enumeratum.CirceEnum[PortRunStatusEntityState] {
+    val values = findValues
+    case object RUNNING extends PortRunStatusEntityState
+    case object STOPPED extends PortRunStatusEntityState
+    case object DISABLED extends PortRunStatusEntityState
+  }
   case class PortStatusDTO (
     aggregateSnapshot: Option[PortStatusSnapshotDTO] = None,
     groupId: Option[String] = None,
@@ -2614,6 +2005,16 @@ object TapirGeneratedEndpoints {
     statsLastRefreshed: Option[String] = None,
     transmitting: Option[Boolean] = None
   )
+
+  sealed trait PortStatusDTORunStatus extends enumeratum.EnumEntry
+  object PortStatusDTORunStatus extends enumeratum.Enum[PortStatusDTORunStatus] with enumeratum.CirceEnum[PortStatusDTORunStatus] {
+    val values = findValues
+    case object Running extends PortStatusDTORunStatus
+    case object Stopped extends PortStatusDTORunStatus
+    case object Validating extends PortStatusDTORunStatus
+    case object Disabled extends PortStatusDTORunStatus
+    case object Invalid extends PortStatusDTORunStatus
+  }
   case class PortStatusEntity (
     canRead: Option[Boolean] = None,
     portStatus: Option[PortStatusDTO] = None
@@ -2632,6 +2033,16 @@ object TapirGeneratedEndpoints {
     runStatus: Option[PortStatusSnapshotDTORunStatus] = None,
     transmitting: Option[Boolean] = None
   )
+
+  sealed trait PortStatusSnapshotDTORunStatus extends enumeratum.EnumEntry
+  object PortStatusSnapshotDTORunStatus extends enumeratum.Enum[PortStatusSnapshotDTORunStatus] with enumeratum.CirceEnum[PortStatusSnapshotDTORunStatus] {
+    val values = findValues
+    case object Running extends PortStatusSnapshotDTORunStatus
+    case object Stopped extends PortStatusSnapshotDTORunStatus
+    case object Validating extends PortStatusSnapshotDTORunStatus
+    case object Disabled extends PortStatusSnapshotDTORunStatus
+    case object Invalid extends PortStatusSnapshotDTORunStatus
+  }
   case class PortStatusSnapshotEntity (
     canRead: Option[Boolean] = None,
     id: Option[String] = None,
@@ -2691,6 +2102,36 @@ object TapirGeneratedEndpoints {
     versionControlInformation: Option[VersionControlInformationDTO] = None,
     versionedComponentId: Option[String] = None
   )
+
+  sealed trait ProcessGroupDTOExecutionEngine extends enumeratum.EnumEntry
+  object ProcessGroupDTOExecutionEngine extends enumeratum.Enum[ProcessGroupDTOExecutionEngine] with enumeratum.CirceEnum[ProcessGroupDTOExecutionEngine] {
+    val values = findValues
+    case object STATELESS extends ProcessGroupDTOExecutionEngine
+    case object STANDARD extends ProcessGroupDTOExecutionEngine
+    case object INHERITED extends ProcessGroupDTOExecutionEngine
+  }
+
+  sealed trait ProcessGroupDTOFlowfileConcurrency extends enumeratum.EnumEntry
+  object ProcessGroupDTOFlowfileConcurrency extends enumeratum.Enum[ProcessGroupDTOFlowfileConcurrency] with enumeratum.CirceEnum[ProcessGroupDTOFlowfileConcurrency] {
+    val values = findValues
+    case object UNBOUNDED extends ProcessGroupDTOFlowfileConcurrency
+    case object SINGLE_FLOWFILE_PER_NODE extends ProcessGroupDTOFlowfileConcurrency
+    case object SINGLE_BATCH_PER_NODE extends ProcessGroupDTOFlowfileConcurrency
+  }
+
+  sealed trait ProcessGroupDTOFlowfileOutboundPolicy extends enumeratum.EnumEntry
+  object ProcessGroupDTOFlowfileOutboundPolicy extends enumeratum.Enum[ProcessGroupDTOFlowfileOutboundPolicy] with enumeratum.CirceEnum[ProcessGroupDTOFlowfileOutboundPolicy] {
+    val values = findValues
+    case object STREAM_WHEN_AVAILABLE extends ProcessGroupDTOFlowfileOutboundPolicy
+    case object BATCH_OUTPUT extends ProcessGroupDTOFlowfileOutboundPolicy
+  }
+
+  sealed trait ProcessGroupDTOStatelessGroupScheduledState extends enumeratum.EnumEntry
+  object ProcessGroupDTOStatelessGroupScheduledState extends enumeratum.Enum[ProcessGroupDTOStatelessGroupScheduledState] with enumeratum.CirceEnum[ProcessGroupDTOStatelessGroupScheduledState] {
+    val values = findValues
+    case object STOPPED extends ProcessGroupDTOStatelessGroupScheduledState
+    case object RUNNING extends ProcessGroupDTOStatelessGroupScheduledState
+  }
   case class ProcessGroupEntity (
     activeRemotePortCount: Option[Int] = None,
     bulletins: Option[Seq[BulletinEntity]] = None,
@@ -2723,6 +2164,23 @@ object TapirGeneratedEndpoints {
     versionedFlowSnapshot: Option[RegisteredFlowSnapshot] = None,
     versionedFlowState: Option[ProcessGroupEntityVersionedFlowState] = None
   )
+
+  sealed trait ProcessGroupEntityProcessGroupUpdateStrategy extends enumeratum.EnumEntry
+  object ProcessGroupEntityProcessGroupUpdateStrategy extends enumeratum.Enum[ProcessGroupEntityProcessGroupUpdateStrategy] with enumeratum.CirceEnum[ProcessGroupEntityProcessGroupUpdateStrategy] {
+    val values = findValues
+    case object CURRENT_GROUP extends ProcessGroupEntityProcessGroupUpdateStrategy
+    case object CURRENT_GROUP_WITH_CHILDREN extends ProcessGroupEntityProcessGroupUpdateStrategy
+  }
+
+  sealed trait ProcessGroupEntityVersionedFlowState extends enumeratum.EnumEntry
+  object ProcessGroupEntityVersionedFlowState extends enumeratum.Enum[ProcessGroupEntityVersionedFlowState] with enumeratum.CirceEnum[ProcessGroupEntityVersionedFlowState] {
+    val values = findValues
+    case object LOCALLY_MODIFIED extends ProcessGroupEntityVersionedFlowState
+    case object STALE extends ProcessGroupEntityVersionedFlowState
+    case object LOCALLY_MODIFIED_AND_STALE extends ProcessGroupEntityVersionedFlowState
+    case object UP_TO_DATE extends ProcessGroupEntityVersionedFlowState
+    case object SYNC_FAILURE extends ProcessGroupEntityVersionedFlowState
+  }
   case class ProcessGroupFlowDTO (
     breadcrumb: Option[FlowBreadcrumbEntity] = None,
     flow: Option[FlowDTO] = None,
@@ -2812,6 +2270,16 @@ object TapirGeneratedEndpoints {
     versionedFlowState: Option[ProcessGroupStatusSnapshotDTOVersionedFlowState] = None,
     written: Option[String] = None
   )
+
+  sealed trait ProcessGroupStatusSnapshotDTOVersionedFlowState extends enumeratum.EnumEntry
+  object ProcessGroupStatusSnapshotDTOVersionedFlowState extends enumeratum.Enum[ProcessGroupStatusSnapshotDTOVersionedFlowState] with enumeratum.CirceEnum[ProcessGroupStatusSnapshotDTOVersionedFlowState] {
+    val values = findValues
+    case object LOCALLY_MODIFIED extends ProcessGroupStatusSnapshotDTOVersionedFlowState
+    case object STALE extends ProcessGroupStatusSnapshotDTOVersionedFlowState
+    case object LOCALLY_MODIFIED_AND_STALE extends ProcessGroupStatusSnapshotDTOVersionedFlowState
+    case object UP_TO_DATE extends ProcessGroupStatusSnapshotDTOVersionedFlowState
+    case object SYNC_FAILURE extends ProcessGroupStatusSnapshotDTOVersionedFlowState
+  }
   case class ProcessGroupStatusSnapshotEntity (
     canRead: Option[Boolean] = None,
     id: Option[String] = None,
@@ -2890,6 +2358,22 @@ object TapirGeneratedEndpoints {
     validationStatus: Option[ProcessorDTOValidationStatus] = None,
     versionedComponentId: Option[String] = None
   )
+
+  sealed trait ProcessorDTOState extends enumeratum.EnumEntry
+  object ProcessorDTOState extends enumeratum.Enum[ProcessorDTOState] with enumeratum.CirceEnum[ProcessorDTOState] {
+    val values = findValues
+    case object RUNNING extends ProcessorDTOState
+    case object STOPPED extends ProcessorDTOState
+    case object DISABLED extends ProcessorDTOState
+  }
+
+  sealed trait ProcessorDTOValidationStatus extends enumeratum.EnumEntry
+  object ProcessorDTOValidationStatus extends enumeratum.Enum[ProcessorDTOValidationStatus] with enumeratum.CirceEnum[ProcessorDTOValidationStatus] {
+    val values = findValues
+    case object VALID extends ProcessorDTOValidationStatus
+    case object INVALID extends ProcessorDTOValidationStatus
+    case object VALIDATING extends ProcessorDTOValidationStatus
+  }
   case class ProcessorDefinition (
     additionalDetails: Option[Boolean] = None,
     artifact: Option[String] = None,
@@ -2935,6 +2419,14 @@ object TapirGeneratedEndpoints {
     version: Option[String] = None,
     writesAttributes: Option[Seq[Attribute]] = None
   )
+
+  sealed trait ProcessorDefinitionInputRequirement extends enumeratum.EnumEntry
+  object ProcessorDefinitionInputRequirement extends enumeratum.Enum[ProcessorDefinitionInputRequirement] with enumeratum.CirceEnum[ProcessorDefinitionInputRequirement] {
+    val values = findValues
+    case object INPUT_REQUIRED extends ProcessorDefinitionInputRequirement
+    case object INPUT_ALLOWED extends ProcessorDefinitionInputRequirement
+    case object INPUT_FORBIDDEN extends ProcessorDefinitionInputRequirement
+  }
   case class ProcessorEntity (
     bulletins: Option[Seq[BulletinEntity]] = None,
     component: Option[ProcessorDTO] = None,
@@ -2955,6 +2447,16 @@ object TapirGeneratedEndpoints {
     runStatus: Option[ProcessorRunStatusDetailsDTORunStatus] = None,
     validationErrors: Option[Set[String]] = None
   )
+
+  sealed trait ProcessorRunStatusDetailsDTORunStatus extends enumeratum.EnumEntry
+  object ProcessorRunStatusDetailsDTORunStatus extends enumeratum.Enum[ProcessorRunStatusDetailsDTORunStatus] with enumeratum.CirceEnum[ProcessorRunStatusDetailsDTORunStatus] {
+    val values = findValues
+    case object Running extends ProcessorRunStatusDetailsDTORunStatus
+    case object Stopped extends ProcessorRunStatusDetailsDTORunStatus
+    case object Invalid extends ProcessorRunStatusDetailsDTORunStatus
+    case object Validating extends ProcessorRunStatusDetailsDTORunStatus
+    case object Disabled extends ProcessorRunStatusDetailsDTORunStatus
+  }
   case class ProcessorRunStatusDetailsEntity (
     permissions: Option[PermissionsDTO] = None,
     revision: Option[RevisionDTO] = None,
@@ -2965,6 +2467,15 @@ object TapirGeneratedEndpoints {
     revision: Option[RevisionDTO] = None,
     state: Option[ProcessorRunStatusEntityState] = None
   )
+
+  sealed trait ProcessorRunStatusEntityState extends enumeratum.EnumEntry
+  object ProcessorRunStatusEntityState extends enumeratum.Enum[ProcessorRunStatusEntityState] with enumeratum.CirceEnum[ProcessorRunStatusEntityState] {
+    val values = findValues
+    case object RUNNING extends ProcessorRunStatusEntityState
+    case object STOPPED extends ProcessorRunStatusEntityState
+    case object DISABLED extends ProcessorRunStatusEntityState
+    case object RUN_ONCE extends ProcessorRunStatusEntityState
+  }
   case class ProcessorStatusDTO (
     aggregateSnapshot: Option[ProcessorStatusSnapshotDTO] = None,
     groupId: Option[String] = None,
@@ -2975,6 +2486,16 @@ object TapirGeneratedEndpoints {
     statsLastRefreshed: Option[String] = None,
     `type`: Option[String] = None
   )
+
+  sealed trait ProcessorStatusDTORunStatus extends enumeratum.EnumEntry
+  object ProcessorStatusDTORunStatus extends enumeratum.Enum[ProcessorStatusDTORunStatus] with enumeratum.CirceEnum[ProcessorStatusDTORunStatus] {
+    val values = findValues
+    case object Running extends ProcessorStatusDTORunStatus
+    case object Stopped extends ProcessorStatusDTORunStatus
+    case object Validating extends ProcessorStatusDTORunStatus
+    case object Disabled extends ProcessorStatusDTORunStatus
+    case object Invalid extends ProcessorStatusDTORunStatus
+  }
   case class ProcessorStatusEntity (
     canRead: Option[Boolean] = None,
     processorStatus: Option[ProcessorStatusDTO] = None
@@ -3004,6 +2525,23 @@ object TapirGeneratedEndpoints {
     `type`: Option[String] = None,
     written: Option[String] = None
   )
+
+  sealed trait ProcessorStatusSnapshotDTOExecutionNode extends enumeratum.EnumEntry
+  object ProcessorStatusSnapshotDTOExecutionNode extends enumeratum.Enum[ProcessorStatusSnapshotDTOExecutionNode] with enumeratum.CirceEnum[ProcessorStatusSnapshotDTOExecutionNode] {
+    val values = findValues
+    case object ALL extends ProcessorStatusSnapshotDTOExecutionNode
+    case object PRIMARY extends ProcessorStatusSnapshotDTOExecutionNode
+  }
+
+  sealed trait ProcessorStatusSnapshotDTORunStatus extends enumeratum.EnumEntry
+  object ProcessorStatusSnapshotDTORunStatus extends enumeratum.Enum[ProcessorStatusSnapshotDTORunStatus] with enumeratum.CirceEnum[ProcessorStatusSnapshotDTORunStatus] {
+    val values = findValues
+    case object Running extends ProcessorStatusSnapshotDTORunStatus
+    case object Stopped extends ProcessorStatusSnapshotDTORunStatus
+    case object Validating extends ProcessorStatusSnapshotDTORunStatus
+    case object Disabled extends ProcessorStatusSnapshotDTORunStatus
+    case object Invalid extends ProcessorStatusSnapshotDTORunStatus
+  }
   case class ProcessorStatusSnapshotEntity (
     canRead: Option[Boolean] = None,
     id: Option[String] = None,
@@ -3049,6 +2587,14 @@ object TapirGeneratedEndpoints {
     validRegex: Option[String] = None,
     validator: Option[String] = None
   )
+
+  sealed trait PropertyDescriptorExpressionLanguageScope extends enumeratum.EnumEntry
+  object PropertyDescriptorExpressionLanguageScope extends enumeratum.Enum[PropertyDescriptorExpressionLanguageScope] with enumeratum.CirceEnum[PropertyDescriptorExpressionLanguageScope] {
+    val values = findValues
+    case object NONE extends PropertyDescriptorExpressionLanguageScope
+    case object ENVIRONMENT extends PropertyDescriptorExpressionLanguageScope
+    case object FLOWFILE_ATTRIBUTES extends PropertyDescriptorExpressionLanguageScope
+  }
   case class PropertyDescriptorDTO (
     allowableValues: Option[Seq[AllowableValueEntity]] = None,
     defaultValue: Option[String] = None,
@@ -3074,6 +2620,22 @@ object TapirGeneratedEndpoints {
     cardinality: Option[PropertyResourceDefinitionCardinality] = None,
     resourceTypes: Option[Set[PropertyResourceDefinitionResourceTypesItem]] = None
   )
+
+  sealed trait PropertyResourceDefinitionCardinality extends enumeratum.EnumEntry
+  object PropertyResourceDefinitionCardinality extends enumeratum.Enum[PropertyResourceDefinitionCardinality] with enumeratum.CirceEnum[PropertyResourceDefinitionCardinality] {
+    val values = findValues
+    case object SINGLE extends PropertyResourceDefinitionCardinality
+    case object MULTIPLE extends PropertyResourceDefinitionCardinality
+  }
+
+  sealed trait PropertyResourceDefinitionResourceTypesItem extends enumeratum.EnumEntry
+  object PropertyResourceDefinitionResourceTypesItem extends enumeratum.Enum[PropertyResourceDefinitionResourceTypesItem] with enumeratum.CirceEnum[PropertyResourceDefinitionResourceTypesItem] {
+    val values = findValues
+    case object FILE extends PropertyResourceDefinitionResourceTypesItem
+    case object DIRECTORY extends PropertyResourceDefinitionResourceTypesItem
+    case object TEXT extends PropertyResourceDefinitionResourceTypesItem
+    case object URL extends PropertyResourceDefinitionResourceTypesItem
+  }
   case class ProvenanceDTO (
     expiration: Option[String] = None,
     finished: Option[Boolean] = None,
@@ -3151,6 +2713,13 @@ object TapirGeneratedEndpoints {
     timestamp: Option[String] = None,
     `type`: Option[ProvenanceNodeDTOType] = None
   )
+
+  sealed trait ProvenanceNodeDTOType extends enumeratum.EnumEntry
+  object ProvenanceNodeDTOType extends enumeratum.Enum[ProvenanceNodeDTOType] with enumeratum.CirceEnum[ProvenanceNodeDTOType] {
+    val values = findValues
+    case object FLOWFILE extends ProvenanceNodeDTOType
+    case object EVENT extends ProvenanceNodeDTOType
+  }
   case class ProvenanceOptionsDTO (
     searchableFields: Option[Seq[ProvenanceSearchableFieldDTO]] = None
   )
@@ -3245,6 +2814,13 @@ object TapirGeneratedEndpoints {
     revision: Option[RevisionDTO] = None,
     state: Option[RemotePortRunStatusEntityState] = None
   )
+
+  sealed trait RemotePortRunStatusEntityState extends enumeratum.EnumEntry
+  object RemotePortRunStatusEntityState extends enumeratum.Enum[RemotePortRunStatusEntityState] with enumeratum.CirceEnum[RemotePortRunStatusEntityState] {
+    val values = findValues
+    case object TRANSMITTING extends RemotePortRunStatusEntityState
+    case object STOPPED extends RemotePortRunStatusEntityState
+  }
   case class RemoteProcessGroupContentsDTO (
     inputPorts: Option[Set[RemoteProcessGroupPortDTO]] = None,
     outputPorts: Option[Set[RemoteProcessGroupPortDTO]] = None
@@ -3330,6 +2906,14 @@ object TapirGeneratedEndpoints {
     transmissionStatus: Option[String] = None,
     validationStatus: Option[RemoteProcessGroupStatusDTOValidationStatus] = None
   )
+
+  sealed trait RemoteProcessGroupStatusDTOValidationStatus extends enumeratum.EnumEntry
+  object RemoteProcessGroupStatusDTOValidationStatus extends enumeratum.Enum[RemoteProcessGroupStatusDTOValidationStatus] with enumeratum.CirceEnum[RemoteProcessGroupStatusDTOValidationStatus] {
+    val values = findValues
+    case object VALID extends RemoteProcessGroupStatusDTOValidationStatus
+    case object INVALID extends RemoteProcessGroupStatusDTOValidationStatus
+    case object VALIDATING extends RemoteProcessGroupStatusDTOValidationStatus
+  }
   case class RemoteProcessGroupStatusEntity (
     canRead: Option[Boolean] = None,
     remoteProcessGroupStatus: Option[RemoteProcessGroupStatusDTO] = None
@@ -3360,12 +2944,26 @@ object TapirGeneratedEndpoints {
     componentId: Option[String] = None,
     nodes: Option[ReplayLastEventRequestEntityNodes] = None
   )
+
+  sealed trait ReplayLastEventRequestEntityNodes extends enumeratum.EnumEntry
+  object ReplayLastEventRequestEntityNodes extends enumeratum.Enum[ReplayLastEventRequestEntityNodes] with enumeratum.CirceEnum[ReplayLastEventRequestEntityNodes] {
+    val values = findValues
+    case object ALL extends ReplayLastEventRequestEntityNodes
+    case object PRIMARY extends ReplayLastEventRequestEntityNodes
+  }
   case class ReplayLastEventResponseEntity (
     aggregateSnapshot: Option[ReplayLastEventSnapshotDTO] = None,
     componentId: Option[String] = None,
     nodeSnapshots: Option[Seq[NodeReplayLastEventSnapshotDTO]] = None,
     nodes: Option[ReplayLastEventResponseEntityNodes] = None
   )
+
+  sealed trait ReplayLastEventResponseEntityNodes extends enumeratum.EnumEntry
+  object ReplayLastEventResponseEntityNodes extends enumeratum.Enum[ReplayLastEventResponseEntityNodes] with enumeratum.CirceEnum[ReplayLastEventResponseEntityNodes] {
+    val values = findValues
+    case object ALL extends ReplayLastEventResponseEntityNodes
+    case object PRIMARY extends ReplayLastEventResponseEntityNodes
+  }
   case class ReplayLastEventSnapshotDTO (
     eventAvailable: Option[Boolean] = None,
     eventsReplayed: Option[Seq[Long]] = None,
@@ -3399,6 +2997,22 @@ object TapirGeneratedEndpoints {
     validationStatus: Option[ReportingTaskDTOValidationStatus] = None,
     versionedComponentId: Option[String] = None
   )
+
+  sealed trait ReportingTaskDTOState extends enumeratum.EnumEntry
+  object ReportingTaskDTOState extends enumeratum.Enum[ReportingTaskDTOState] with enumeratum.CirceEnum[ReportingTaskDTOState] {
+    val values = findValues
+    case object RUNNING extends ReportingTaskDTOState
+    case object STOPPED extends ReportingTaskDTOState
+    case object DISABLED extends ReportingTaskDTOState
+  }
+
+  sealed trait ReportingTaskDTOValidationStatus extends enumeratum.EnumEntry
+  object ReportingTaskDTOValidationStatus extends enumeratum.Enum[ReportingTaskDTOValidationStatus] with enumeratum.CirceEnum[ReportingTaskDTOValidationStatus] {
+    val values = findValues
+    case object VALID extends ReportingTaskDTOValidationStatus
+    case object INVALID extends ReportingTaskDTOValidationStatus
+    case object VALIDATING extends ReportingTaskDTOValidationStatus
+  }
   case class ReportingTaskDefinition (
     additionalDetails: Option[Boolean] = None,
     artifact: Option[String] = None,
@@ -3443,11 +3057,34 @@ object TapirGeneratedEndpoints {
     revision: Option[RevisionDTO] = None,
     state: Option[ReportingTaskRunStatusEntityState] = None
   )
+
+  sealed trait ReportingTaskRunStatusEntityState extends enumeratum.EnumEntry
+  object ReportingTaskRunStatusEntityState extends enumeratum.Enum[ReportingTaskRunStatusEntityState] with enumeratum.CirceEnum[ReportingTaskRunStatusEntityState] {
+    val values = findValues
+    case object RUNNING extends ReportingTaskRunStatusEntityState
+    case object STOPPED extends ReportingTaskRunStatusEntityState
+  }
   case class ReportingTaskStatusDTO (
     activeThreadCount: Option[Int] = None,
     runStatus: Option[ReportingTaskStatusDTORunStatus] = None,
     validationStatus: Option[ReportingTaskStatusDTOValidationStatus] = None
   )
+
+  sealed trait ReportingTaskStatusDTORunStatus extends enumeratum.EnumEntry
+  object ReportingTaskStatusDTORunStatus extends enumeratum.Enum[ReportingTaskStatusDTORunStatus] with enumeratum.CirceEnum[ReportingTaskStatusDTORunStatus] {
+    val values = findValues
+    case object RUNNING extends ReportingTaskStatusDTORunStatus
+    case object STOPPED extends ReportingTaskStatusDTORunStatus
+    case object DISABLED extends ReportingTaskStatusDTORunStatus
+  }
+
+  sealed trait ReportingTaskStatusDTOValidationStatus extends enumeratum.EnumEntry
+  object ReportingTaskStatusDTOValidationStatus extends enumeratum.Enum[ReportingTaskStatusDTOValidationStatus] with enumeratum.CirceEnum[ReportingTaskStatusDTOValidationStatus] {
+    val values = findValues
+    case object VALID extends ReportingTaskStatusDTOValidationStatus
+    case object INVALID extends ReportingTaskStatusDTOValidationStatus
+    case object VALIDATING extends ReportingTaskStatusDTOValidationStatus
+  }
   case class ReportingTaskTypesEntity (
     reportingTaskTypes: Option[Set[DocumentedTypeDTO]] = None
   )
@@ -3504,6 +3141,15 @@ object TapirGeneratedEndpoints {
     id: Option[String] = None,
     state: Option[ScheduleComponentsEntityState] = None
   )
+
+  sealed trait ScheduleComponentsEntityState extends enumeratum.EnumEntry
+  object ScheduleComponentsEntityState extends enumeratum.Enum[ScheduleComponentsEntityState] with enumeratum.CirceEnum[ScheduleComponentsEntityState] {
+    val values = findValues
+    case object RUNNING extends ScheduleComponentsEntityState
+    case object STOPPED extends ScheduleComponentsEntityState
+    case object ENABLED extends ScheduleComponentsEntityState
+    case object DISABLED extends ScheduleComponentsEntityState
+  }
   case class SchedulingDefaults (
     defaultConcurrentTasksBySchedulingStrategy: Option[Map[String, Int]] = None,
     defaultMaxConcurrentTasks: Option[String] = None,
@@ -3514,6 +3160,13 @@ object TapirGeneratedEndpoints {
     penalizationPeriodMillis: Option[Long] = None,
     yieldDurationMillis: Option[Long] = None
   )
+
+  sealed trait SchedulingDefaultsDefaultSchedulingStrategy extends enumeratum.EnumEntry
+  object SchedulingDefaultsDefaultSchedulingStrategy extends enumeratum.Enum[SchedulingDefaultsDefaultSchedulingStrategy] with enumeratum.CirceEnum[SchedulingDefaultsDefaultSchedulingStrategy] {
+    val values = findValues
+    case object TIMER_DRIVEN extends SchedulingDefaultsDefaultSchedulingStrategy
+    case object CRON_DRIVEN extends SchedulingDefaultsDefaultSchedulingStrategy
+  }
   case class SearchResultGroupDTO (
     id: String,
     name: Option[String] = None
@@ -3572,6 +3225,13 @@ object TapirGeneratedEndpoints {
     description: Option[String] = None,
     scopes: Option[Set[StatefulScopesItem]] = None
   )
+
+  sealed trait StatefulScopesItem extends enumeratum.EnumEntry
+  object StatefulScopesItem extends enumeratum.Enum[StatefulScopesItem] with enumeratum.CirceEnum[StatefulScopesItem] {
+    val values = findValues
+    case object CLUSTER extends StatefulScopesItem
+    case object LOCAL extends StatefulScopesItem
+  }
   case class StatusDescriptorDTO (
     description: Option[String] = None,
     field: Option[String] = None,
@@ -3688,6 +3348,15 @@ object TapirGeneratedEndpoints {
     state: Option[UpdateControllerServiceReferenceRequestEntityState] = None,
     uiOnly: Option[Boolean] = None
   )
+
+  sealed trait UpdateControllerServiceReferenceRequestEntityState extends enumeratum.EnumEntry
+  object UpdateControllerServiceReferenceRequestEntityState extends enumeratum.Enum[UpdateControllerServiceReferenceRequestEntityState] with enumeratum.CirceEnum[UpdateControllerServiceReferenceRequestEntityState] {
+    val values = findValues
+    case object ENABLED extends UpdateControllerServiceReferenceRequestEntityState
+    case object DISABLED extends UpdateControllerServiceReferenceRequestEntityState
+    case object RUNNING extends UpdateControllerServiceReferenceRequestEntityState
+    case object STOPPED extends UpdateControllerServiceReferenceRequestEntityState
+  }
   case class UseCase (
     configuration: Option[String] = None,
     description: Option[String] = None,
@@ -3695,6 +3364,14 @@ object TapirGeneratedEndpoints {
     keywords: Option[Seq[String]] = None,
     notes: Option[String] = None
   )
+
+  sealed trait UseCaseInputRequirement extends enumeratum.EnumEntry
+  object UseCaseInputRequirement extends enumeratum.Enum[UseCaseInputRequirement] with enumeratum.CirceEnum[UseCaseInputRequirement] {
+    val values = findValues
+    case object INPUT_REQUIRED extends UseCaseInputRequirement
+    case object INPUT_ALLOWED extends UseCaseInputRequirement
+    case object INPUT_FORBIDDEN extends UseCaseInputRequirement
+  }
   case class UserDTO (
     accessPolicies: Option[Set[AccessPolicySummaryEntity]] = None,
     configurable: Option[Boolean] = None,
@@ -3786,6 +3463,16 @@ object TapirGeneratedEndpoints {
     storageLocation: Option[String] = None,
     version: Option[String] = None
   )
+
+  sealed trait VersionControlInformationDTOState extends enumeratum.EnumEntry
+  object VersionControlInformationDTOState extends enumeratum.Enum[VersionControlInformationDTOState] with enumeratum.CirceEnum[VersionControlInformationDTOState] {
+    val values = findValues
+    case object LOCALLY_MODIFIED extends VersionControlInformationDTOState
+    case object STALE extends VersionControlInformationDTOState
+    case object LOCALLY_MODIFIED_AND_STALE extends VersionControlInformationDTOState
+    case object UP_TO_DATE extends VersionControlInformationDTOState
+    case object SYNC_FAILURE extends VersionControlInformationDTOState
+  }
   case class VersionControlInformationEntity (
     disconnectedNodeAcknowledged: Option[Boolean] = None,
     processGroupRevision: Option[RevisionDTO] = None,
@@ -3829,6 +3516,27 @@ object TapirGeneratedEndpoints {
     source: Option[ConnectableComponent] = None,
     zIndex: Option[Long] = None
   )
+
+  sealed trait VersionedConnectionComponentType extends enumeratum.EnumEntry
+  object VersionedConnectionComponentType extends enumeratum.Enum[VersionedConnectionComponentType] with enumeratum.CirceEnum[VersionedConnectionComponentType] {
+    val values = findValues
+    case object CONNECTION extends VersionedConnectionComponentType
+    case object PROCESSOR extends VersionedConnectionComponentType
+    case object PROCESS_GROUP extends VersionedConnectionComponentType
+    case object REMOTE_PROCESS_GROUP extends VersionedConnectionComponentType
+    case object INPUT_PORT extends VersionedConnectionComponentType
+    case object OUTPUT_PORT extends VersionedConnectionComponentType
+    case object REMOTE_INPUT_PORT extends VersionedConnectionComponentType
+    case object REMOTE_OUTPUT_PORT extends VersionedConnectionComponentType
+    case object FUNNEL extends VersionedConnectionComponentType
+    case object LABEL extends VersionedConnectionComponentType
+    case object CONTROLLER_SERVICE extends VersionedConnectionComponentType
+    case object REPORTING_TASK extends VersionedConnectionComponentType
+    case object FLOW_ANALYSIS_RULE extends VersionedConnectionComponentType
+    case object PARAMETER_CONTEXT extends VersionedConnectionComponentType
+    case object PARAMETER_PROVIDER extends VersionedConnectionComponentType
+    case object FLOW_REGISTRY_CLIENT extends VersionedConnectionComponentType
+  }
   case class VersionedControllerService (
     annotationData: Option[String] = None,
     bulletinLevel: Option[String] = None,
@@ -3846,6 +3554,35 @@ object TapirGeneratedEndpoints {
     scheduledState: Option[VersionedControllerServiceScheduledState] = None,
     `type`: Option[String] = None
   )
+
+  sealed trait VersionedControllerServiceComponentType extends enumeratum.EnumEntry
+  object VersionedControllerServiceComponentType extends enumeratum.Enum[VersionedControllerServiceComponentType] with enumeratum.CirceEnum[VersionedControllerServiceComponentType] {
+    val values = findValues
+    case object CONNECTION extends VersionedControllerServiceComponentType
+    case object PROCESSOR extends VersionedControllerServiceComponentType
+    case object PROCESS_GROUP extends VersionedControllerServiceComponentType
+    case object REMOTE_PROCESS_GROUP extends VersionedControllerServiceComponentType
+    case object INPUT_PORT extends VersionedControllerServiceComponentType
+    case object OUTPUT_PORT extends VersionedControllerServiceComponentType
+    case object REMOTE_INPUT_PORT extends VersionedControllerServiceComponentType
+    case object REMOTE_OUTPUT_PORT extends VersionedControllerServiceComponentType
+    case object FUNNEL extends VersionedControllerServiceComponentType
+    case object LABEL extends VersionedControllerServiceComponentType
+    case object CONTROLLER_SERVICE extends VersionedControllerServiceComponentType
+    case object REPORTING_TASK extends VersionedControllerServiceComponentType
+    case object FLOW_ANALYSIS_RULE extends VersionedControllerServiceComponentType
+    case object PARAMETER_CONTEXT extends VersionedControllerServiceComponentType
+    case object PARAMETER_PROVIDER extends VersionedControllerServiceComponentType
+    case object FLOW_REGISTRY_CLIENT extends VersionedControllerServiceComponentType
+  }
+
+  sealed trait VersionedControllerServiceScheduledState extends enumeratum.EnumEntry
+  object VersionedControllerServiceScheduledState extends enumeratum.Enum[VersionedControllerServiceScheduledState] with enumeratum.CirceEnum[VersionedControllerServiceScheduledState] {
+    val values = findValues
+    case object ENABLED extends VersionedControllerServiceScheduledState
+    case object DISABLED extends VersionedControllerServiceScheduledState
+    case object RUNNING extends VersionedControllerServiceScheduledState
+  }
   case class VersionedFlowCoordinates (
     branch: Option[String] = None,
     bucketId: Option[String] = None,
@@ -3865,6 +3602,13 @@ object TapirGeneratedEndpoints {
     flowName: Option[String] = None,
     registryId: Option[String] = None
   )
+
+  sealed trait VersionedFlowDTOAction extends enumeratum.EnumEntry
+  object VersionedFlowDTOAction extends enumeratum.Enum[VersionedFlowDTOAction] with enumeratum.CirceEnum[VersionedFlowDTOAction] {
+    val values = findValues
+    case object COMMIT extends VersionedFlowDTOAction
+    case object FORCE_COMMIT extends VersionedFlowDTOAction
+  }
   case class VersionedFlowEntity (
     versionedFlow: Option[VersionedFlowDTO] = None
   )
@@ -3910,6 +3654,27 @@ object TapirGeneratedEndpoints {
     name: Option[String] = None,
     position: Option[Position] = None
   )
+
+  sealed trait VersionedFunnelComponentType extends enumeratum.EnumEntry
+  object VersionedFunnelComponentType extends enumeratum.Enum[VersionedFunnelComponentType] with enumeratum.CirceEnum[VersionedFunnelComponentType] {
+    val values = findValues
+    case object CONNECTION extends VersionedFunnelComponentType
+    case object PROCESSOR extends VersionedFunnelComponentType
+    case object PROCESS_GROUP extends VersionedFunnelComponentType
+    case object REMOTE_PROCESS_GROUP extends VersionedFunnelComponentType
+    case object INPUT_PORT extends VersionedFunnelComponentType
+    case object OUTPUT_PORT extends VersionedFunnelComponentType
+    case object REMOTE_INPUT_PORT extends VersionedFunnelComponentType
+    case object REMOTE_OUTPUT_PORT extends VersionedFunnelComponentType
+    case object FUNNEL extends VersionedFunnelComponentType
+    case object LABEL extends VersionedFunnelComponentType
+    case object CONTROLLER_SERVICE extends VersionedFunnelComponentType
+    case object REPORTING_TASK extends VersionedFunnelComponentType
+    case object FLOW_ANALYSIS_RULE extends VersionedFunnelComponentType
+    case object PARAMETER_CONTEXT extends VersionedFunnelComponentType
+    case object PARAMETER_PROVIDER extends VersionedFunnelComponentType
+    case object FLOW_REGISTRY_CLIENT extends VersionedFunnelComponentType
+  }
   case class VersionedLabel (
     comments: Option[String] = None,
     componentType: Option[VersionedLabelComponentType] = None,
@@ -3924,6 +3689,27 @@ object TapirGeneratedEndpoints {
     width: Option[Double] = None,
     zIndex: Option[Long] = None
   )
+
+  sealed trait VersionedLabelComponentType extends enumeratum.EnumEntry
+  object VersionedLabelComponentType extends enumeratum.Enum[VersionedLabelComponentType] with enumeratum.CirceEnum[VersionedLabelComponentType] {
+    val values = findValues
+    case object CONNECTION extends VersionedLabelComponentType
+    case object PROCESSOR extends VersionedLabelComponentType
+    case object PROCESS_GROUP extends VersionedLabelComponentType
+    case object REMOTE_PROCESS_GROUP extends VersionedLabelComponentType
+    case object INPUT_PORT extends VersionedLabelComponentType
+    case object OUTPUT_PORT extends VersionedLabelComponentType
+    case object REMOTE_INPUT_PORT extends VersionedLabelComponentType
+    case object REMOTE_OUTPUT_PORT extends VersionedLabelComponentType
+    case object FUNNEL extends VersionedLabelComponentType
+    case object LABEL extends VersionedLabelComponentType
+    case object CONTROLLER_SERVICE extends VersionedLabelComponentType
+    case object REPORTING_TASK extends VersionedLabelComponentType
+    case object FLOW_ANALYSIS_RULE extends VersionedLabelComponentType
+    case object PARAMETER_CONTEXT extends VersionedLabelComponentType
+    case object PARAMETER_PROVIDER extends VersionedLabelComponentType
+    case object FLOW_REGISTRY_CLIENT extends VersionedLabelComponentType
+  }
   case class VersionedParameter (
     description: Option[String] = None,
     name: Option[String] = None,
@@ -3947,6 +3733,27 @@ object TapirGeneratedEndpoints {
     position: Option[Position] = None,
     synchronized: Option[Boolean] = None
   )
+
+  sealed trait VersionedParameterContextComponentType extends enumeratum.EnumEntry
+  object VersionedParameterContextComponentType extends enumeratum.Enum[VersionedParameterContextComponentType] with enumeratum.CirceEnum[VersionedParameterContextComponentType] {
+    val values = findValues
+    case object CONNECTION extends VersionedParameterContextComponentType
+    case object PROCESSOR extends VersionedParameterContextComponentType
+    case object PROCESS_GROUP extends VersionedParameterContextComponentType
+    case object REMOTE_PROCESS_GROUP extends VersionedParameterContextComponentType
+    case object INPUT_PORT extends VersionedParameterContextComponentType
+    case object OUTPUT_PORT extends VersionedParameterContextComponentType
+    case object REMOTE_INPUT_PORT extends VersionedParameterContextComponentType
+    case object REMOTE_OUTPUT_PORT extends VersionedParameterContextComponentType
+    case object FUNNEL extends VersionedParameterContextComponentType
+    case object LABEL extends VersionedParameterContextComponentType
+    case object CONTROLLER_SERVICE extends VersionedParameterContextComponentType
+    case object REPORTING_TASK extends VersionedParameterContextComponentType
+    case object FLOW_ANALYSIS_RULE extends VersionedParameterContextComponentType
+    case object PARAMETER_CONTEXT extends VersionedParameterContextComponentType
+    case object PARAMETER_PROVIDER extends VersionedParameterContextComponentType
+    case object FLOW_REGISTRY_CLIENT extends VersionedParameterContextComponentType
+  }
   case class VersionedPort (
     allowRemoteAccess: Option[Boolean] = None,
     comments: Option[String] = None,
@@ -3961,6 +3768,49 @@ object TapirGeneratedEndpoints {
     scheduledState: Option[VersionedPortScheduledState] = None,
     `type`: Option[VersionedPortType] = None
   )
+
+  sealed trait VersionedPortComponentType extends enumeratum.EnumEntry
+  object VersionedPortComponentType extends enumeratum.Enum[VersionedPortComponentType] with enumeratum.CirceEnum[VersionedPortComponentType] {
+    val values = findValues
+    case object CONNECTION extends VersionedPortComponentType
+    case object PROCESSOR extends VersionedPortComponentType
+    case object PROCESS_GROUP extends VersionedPortComponentType
+    case object REMOTE_PROCESS_GROUP extends VersionedPortComponentType
+    case object INPUT_PORT extends VersionedPortComponentType
+    case object OUTPUT_PORT extends VersionedPortComponentType
+    case object REMOTE_INPUT_PORT extends VersionedPortComponentType
+    case object REMOTE_OUTPUT_PORT extends VersionedPortComponentType
+    case object FUNNEL extends VersionedPortComponentType
+    case object LABEL extends VersionedPortComponentType
+    case object CONTROLLER_SERVICE extends VersionedPortComponentType
+    case object REPORTING_TASK extends VersionedPortComponentType
+    case object FLOW_ANALYSIS_RULE extends VersionedPortComponentType
+    case object PARAMETER_CONTEXT extends VersionedPortComponentType
+    case object PARAMETER_PROVIDER extends VersionedPortComponentType
+    case object FLOW_REGISTRY_CLIENT extends VersionedPortComponentType
+  }
+
+  sealed trait VersionedPortPortFunction extends enumeratum.EnumEntry
+  object VersionedPortPortFunction extends enumeratum.Enum[VersionedPortPortFunction] with enumeratum.CirceEnum[VersionedPortPortFunction] {
+    val values = findValues
+    case object STANDARD extends VersionedPortPortFunction
+    case object FAILURE extends VersionedPortPortFunction
+  }
+
+  sealed trait VersionedPortScheduledState extends enumeratum.EnumEntry
+  object VersionedPortScheduledState extends enumeratum.Enum[VersionedPortScheduledState] with enumeratum.CirceEnum[VersionedPortScheduledState] {
+    val values = findValues
+    case object ENABLED extends VersionedPortScheduledState
+    case object DISABLED extends VersionedPortScheduledState
+    case object RUNNING extends VersionedPortScheduledState
+  }
+
+  sealed trait VersionedPortType extends enumeratum.EnumEntry
+  object VersionedPortType extends enumeratum.Enum[VersionedPortType] with enumeratum.CirceEnum[VersionedPortType] {
+    val values = findValues
+    case object INPUT_PORT extends VersionedPortType
+    case object OUTPUT_PORT extends VersionedPortType
+  }
   case class VersionedProcessGroup (
     comments: Option[String] = None,
     componentType: Option[VersionedProcessGroupComponentType] = None,
@@ -3991,6 +3841,43 @@ object TapirGeneratedEndpoints {
     statelessFlowTimeout: Option[String] = None,
     versionedFlowCoordinates: Option[VersionedFlowCoordinates] = None
   )
+
+  sealed trait VersionedProcessGroupComponentType extends enumeratum.EnumEntry
+  object VersionedProcessGroupComponentType extends enumeratum.Enum[VersionedProcessGroupComponentType] with enumeratum.CirceEnum[VersionedProcessGroupComponentType] {
+    val values = findValues
+    case object CONNECTION extends VersionedProcessGroupComponentType
+    case object PROCESSOR extends VersionedProcessGroupComponentType
+    case object PROCESS_GROUP extends VersionedProcessGroupComponentType
+    case object REMOTE_PROCESS_GROUP extends VersionedProcessGroupComponentType
+    case object INPUT_PORT extends VersionedProcessGroupComponentType
+    case object OUTPUT_PORT extends VersionedProcessGroupComponentType
+    case object REMOTE_INPUT_PORT extends VersionedProcessGroupComponentType
+    case object REMOTE_OUTPUT_PORT extends VersionedProcessGroupComponentType
+    case object FUNNEL extends VersionedProcessGroupComponentType
+    case object LABEL extends VersionedProcessGroupComponentType
+    case object CONTROLLER_SERVICE extends VersionedProcessGroupComponentType
+    case object REPORTING_TASK extends VersionedProcessGroupComponentType
+    case object FLOW_ANALYSIS_RULE extends VersionedProcessGroupComponentType
+    case object PARAMETER_CONTEXT extends VersionedProcessGroupComponentType
+    case object PARAMETER_PROVIDER extends VersionedProcessGroupComponentType
+    case object FLOW_REGISTRY_CLIENT extends VersionedProcessGroupComponentType
+  }
+
+  sealed trait VersionedProcessGroupExecutionEngine extends enumeratum.EnumEntry
+  object VersionedProcessGroupExecutionEngine extends enumeratum.Enum[VersionedProcessGroupExecutionEngine] with enumeratum.CirceEnum[VersionedProcessGroupExecutionEngine] {
+    val values = findValues
+    case object STANDARD extends VersionedProcessGroupExecutionEngine
+    case object STATELESS extends VersionedProcessGroupExecutionEngine
+    case object INHERITED extends VersionedProcessGroupExecutionEngine
+  }
+
+  sealed trait VersionedProcessGroupScheduledState extends enumeratum.EnumEntry
+  object VersionedProcessGroupScheduledState extends enumeratum.Enum[VersionedProcessGroupScheduledState] with enumeratum.CirceEnum[VersionedProcessGroupScheduledState] {
+    val values = findValues
+    case object ENABLED extends VersionedProcessGroupScheduledState
+    case object DISABLED extends VersionedProcessGroupScheduledState
+    case object RUNNING extends VersionedProcessGroupScheduledState
+  }
   case class VersionedProcessor (
     annotationData: Option[String] = None,
     autoTerminatedRelationships: Option[Set[String]] = None,
@@ -4020,6 +3907,35 @@ object TapirGeneratedEndpoints {
     `type`: Option[String] = None,
     yieldDuration: Option[String] = None
   )
+
+  sealed trait VersionedProcessorComponentType extends enumeratum.EnumEntry
+  object VersionedProcessorComponentType extends enumeratum.Enum[VersionedProcessorComponentType] with enumeratum.CirceEnum[VersionedProcessorComponentType] {
+    val values = findValues
+    case object CONNECTION extends VersionedProcessorComponentType
+    case object PROCESSOR extends VersionedProcessorComponentType
+    case object PROCESS_GROUP extends VersionedProcessorComponentType
+    case object REMOTE_PROCESS_GROUP extends VersionedProcessorComponentType
+    case object INPUT_PORT extends VersionedProcessorComponentType
+    case object OUTPUT_PORT extends VersionedProcessorComponentType
+    case object REMOTE_INPUT_PORT extends VersionedProcessorComponentType
+    case object REMOTE_OUTPUT_PORT extends VersionedProcessorComponentType
+    case object FUNNEL extends VersionedProcessorComponentType
+    case object LABEL extends VersionedProcessorComponentType
+    case object CONTROLLER_SERVICE extends VersionedProcessorComponentType
+    case object REPORTING_TASK extends VersionedProcessorComponentType
+    case object FLOW_ANALYSIS_RULE extends VersionedProcessorComponentType
+    case object PARAMETER_CONTEXT extends VersionedProcessorComponentType
+    case object PARAMETER_PROVIDER extends VersionedProcessorComponentType
+    case object FLOW_REGISTRY_CLIENT extends VersionedProcessorComponentType
+  }
+
+  sealed trait VersionedProcessorScheduledState extends enumeratum.EnumEntry
+  object VersionedProcessorScheduledState extends enumeratum.Enum[VersionedProcessorScheduledState] with enumeratum.CirceEnum[VersionedProcessorScheduledState] {
+    val values = findValues
+    case object ENABLED extends VersionedProcessorScheduledState
+    case object DISABLED extends VersionedProcessorScheduledState
+    case object RUNNING extends VersionedProcessorScheduledState
+  }
   case class VersionedPropertyDescriptor (
     displayName: Option[String] = None,
     dynamic: Option[Boolean] = None,
@@ -4043,6 +3959,35 @@ object TapirGeneratedEndpoints {
     targetId: Option[String] = None,
     useCompression: Option[Boolean] = None
   )
+
+  sealed trait VersionedRemoteGroupPortComponentType extends enumeratum.EnumEntry
+  object VersionedRemoteGroupPortComponentType extends enumeratum.Enum[VersionedRemoteGroupPortComponentType] with enumeratum.CirceEnum[VersionedRemoteGroupPortComponentType] {
+    val values = findValues
+    case object CONNECTION extends VersionedRemoteGroupPortComponentType
+    case object PROCESSOR extends VersionedRemoteGroupPortComponentType
+    case object PROCESS_GROUP extends VersionedRemoteGroupPortComponentType
+    case object REMOTE_PROCESS_GROUP extends VersionedRemoteGroupPortComponentType
+    case object INPUT_PORT extends VersionedRemoteGroupPortComponentType
+    case object OUTPUT_PORT extends VersionedRemoteGroupPortComponentType
+    case object REMOTE_INPUT_PORT extends VersionedRemoteGroupPortComponentType
+    case object REMOTE_OUTPUT_PORT extends VersionedRemoteGroupPortComponentType
+    case object FUNNEL extends VersionedRemoteGroupPortComponentType
+    case object LABEL extends VersionedRemoteGroupPortComponentType
+    case object CONTROLLER_SERVICE extends VersionedRemoteGroupPortComponentType
+    case object REPORTING_TASK extends VersionedRemoteGroupPortComponentType
+    case object FLOW_ANALYSIS_RULE extends VersionedRemoteGroupPortComponentType
+    case object PARAMETER_CONTEXT extends VersionedRemoteGroupPortComponentType
+    case object PARAMETER_PROVIDER extends VersionedRemoteGroupPortComponentType
+    case object FLOW_REGISTRY_CLIENT extends VersionedRemoteGroupPortComponentType
+  }
+
+  sealed trait VersionedRemoteGroupPortScheduledState extends enumeratum.EnumEntry
+  object VersionedRemoteGroupPortScheduledState extends enumeratum.Enum[VersionedRemoteGroupPortScheduledState] with enumeratum.CirceEnum[VersionedRemoteGroupPortScheduledState] {
+    val values = findValues
+    case object ENABLED extends VersionedRemoteGroupPortScheduledState
+    case object DISABLED extends VersionedRemoteGroupPortScheduledState
+    case object RUNNING extends VersionedRemoteGroupPortScheduledState
+  }
   case class VersionedRemoteProcessGroup (
     comments: Option[String] = None,
     communicationsTimeout: Option[String] = None,
@@ -4063,6 +4008,27 @@ object TapirGeneratedEndpoints {
     transportProtocol: Option[String] = None,
     yieldDuration: Option[String] = None
   )
+
+  sealed trait VersionedRemoteProcessGroupComponentType extends enumeratum.EnumEntry
+  object VersionedRemoteProcessGroupComponentType extends enumeratum.Enum[VersionedRemoteProcessGroupComponentType] with enumeratum.CirceEnum[VersionedRemoteProcessGroupComponentType] {
+    val values = findValues
+    case object CONNECTION extends VersionedRemoteProcessGroupComponentType
+    case object PROCESSOR extends VersionedRemoteProcessGroupComponentType
+    case object PROCESS_GROUP extends VersionedRemoteProcessGroupComponentType
+    case object REMOTE_PROCESS_GROUP extends VersionedRemoteProcessGroupComponentType
+    case object INPUT_PORT extends VersionedRemoteProcessGroupComponentType
+    case object OUTPUT_PORT extends VersionedRemoteProcessGroupComponentType
+    case object REMOTE_INPUT_PORT extends VersionedRemoteProcessGroupComponentType
+    case object REMOTE_OUTPUT_PORT extends VersionedRemoteProcessGroupComponentType
+    case object FUNNEL extends VersionedRemoteProcessGroupComponentType
+    case object LABEL extends VersionedRemoteProcessGroupComponentType
+    case object CONTROLLER_SERVICE extends VersionedRemoteProcessGroupComponentType
+    case object REPORTING_TASK extends VersionedRemoteProcessGroupComponentType
+    case object FLOW_ANALYSIS_RULE extends VersionedRemoteProcessGroupComponentType
+    case object PARAMETER_CONTEXT extends VersionedRemoteProcessGroupComponentType
+    case object PARAMETER_PROVIDER extends VersionedRemoteProcessGroupComponentType
+    case object FLOW_REGISTRY_CLIENT extends VersionedRemoteProcessGroupComponentType
+  }
   case class VersionedReportingTask (
     annotationData: Option[String] = None,
     bundle: Option[Bundle] = None,
@@ -4080,6 +4046,35 @@ object TapirGeneratedEndpoints {
     schedulingStrategy: Option[String] = None,
     `type`: Option[String] = None
   )
+
+  sealed trait VersionedReportingTaskComponentType extends enumeratum.EnumEntry
+  object VersionedReportingTaskComponentType extends enumeratum.Enum[VersionedReportingTaskComponentType] with enumeratum.CirceEnum[VersionedReportingTaskComponentType] {
+    val values = findValues
+    case object CONNECTION extends VersionedReportingTaskComponentType
+    case object PROCESSOR extends VersionedReportingTaskComponentType
+    case object PROCESS_GROUP extends VersionedReportingTaskComponentType
+    case object REMOTE_PROCESS_GROUP extends VersionedReportingTaskComponentType
+    case object INPUT_PORT extends VersionedReportingTaskComponentType
+    case object OUTPUT_PORT extends VersionedReportingTaskComponentType
+    case object REMOTE_INPUT_PORT extends VersionedReportingTaskComponentType
+    case object REMOTE_OUTPUT_PORT extends VersionedReportingTaskComponentType
+    case object FUNNEL extends VersionedReportingTaskComponentType
+    case object LABEL extends VersionedReportingTaskComponentType
+    case object CONTROLLER_SERVICE extends VersionedReportingTaskComponentType
+    case object REPORTING_TASK extends VersionedReportingTaskComponentType
+    case object FLOW_ANALYSIS_RULE extends VersionedReportingTaskComponentType
+    case object PARAMETER_CONTEXT extends VersionedReportingTaskComponentType
+    case object PARAMETER_PROVIDER extends VersionedReportingTaskComponentType
+    case object FLOW_REGISTRY_CLIENT extends VersionedReportingTaskComponentType
+  }
+
+  sealed trait VersionedReportingTaskScheduledState extends enumeratum.EnumEntry
+  object VersionedReportingTaskScheduledState extends enumeratum.Enum[VersionedReportingTaskScheduledState] with enumeratum.CirceEnum[VersionedReportingTaskScheduledState] {
+    val values = findValues
+    case object ENABLED extends VersionedReportingTaskScheduledState
+    case object DISABLED extends VersionedReportingTaskScheduledState
+    case object RUNNING extends VersionedReportingTaskScheduledState
+  }
   case class VersionedReportingTaskImportRequestEntity (
     disconnectedNodeAcknowledged: Option[Boolean] = None,
     reportingTaskSnapshot: Option[VersionedReportingTaskSnapshot] = None
@@ -4096,14 +4091,22 @@ object TapirGeneratedEndpoints {
     cardinality: Option[VersionedResourceDefinitionCardinality] = None,
     resourceTypes: Option[Set[VersionedResourceDefinitionResourceTypesItem]] = None
   )
-  type ActionDetailsDTO = io.circe.JsonObject
-  type BulletinBoardPatternParameterStr = String
-  type ClientIdParameterStr = String
-  type ComponentDetailsDTO = io.circe.JsonObject
-  type DateTimeParameterDT = java.time.Instant
-  type IntegerParameterInt = Int
-  type LongParameterInt = Long
-  type StreamingOutput = io.circe.JsonObject
+
+  sealed trait VersionedResourceDefinitionCardinality extends enumeratum.EnumEntry
+  object VersionedResourceDefinitionCardinality extends enumeratum.Enum[VersionedResourceDefinitionCardinality] with enumeratum.CirceEnum[VersionedResourceDefinitionCardinality] {
+    val values = findValues
+    case object SINGLE extends VersionedResourceDefinitionCardinality
+    case object MULTIPLE extends VersionedResourceDefinitionCardinality
+  }
+
+  sealed trait VersionedResourceDefinitionResourceTypesItem extends enumeratum.EnumEntry
+  object VersionedResourceDefinitionResourceTypesItem extends enumeratum.Enum[VersionedResourceDefinitionResourceTypesItem] with enumeratum.CirceEnum[VersionedResourceDefinitionResourceTypesItem] {
+    val values = findValues
+    case object FILE extends VersionedResourceDefinitionResourceTypesItem
+    case object DIRECTORY extends VersionedResourceDefinitionResourceTypesItem
+    case object TEXT extends VersionedResourceDefinitionResourceTypesItem
+    case object URL extends VersionedResourceDefinitionResourceTypesItem
+  }
   case class CreateAccessTokenRequest (
     password: Option[String] = None,
     username: Option[String] = None

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/Expected.scala.txt
@@ -8,11 +8,13 @@ object TapirGeneratedEndpoints {
   import sttp.tapir.generic.auto._
   import sttp.tapir.json.circe._
   import io.circe.generic.semiauto._
-  
+
+  import sttp.tapir.generated.models._
   import sttp.tapir.generated.TapirGeneratedEndpointsJsonSerdes._
   import sttp.tapir.generated.TapirGeneratedEndpointsXmlSerdes._
   import TapirGeneratedEndpointsSchemas1._
   import TapirGeneratedEndpointsSchemas2._
+  import sttp.tapir.generated.models._
 
   case class `*/*CodecFormat`() extends CodecFormat {
     override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "*", subType = "*")
@@ -21,15 +23,9 @@ object TapirGeneratedEndpoints {
     override val mediaType: sttp.model.MediaType = sttp.model.MediaType.unsafeApply(mainType = "application", subType = "x-www-form-urlencoded")
   }
 
+  
 
-
-
-  case class CommaSeparatedValues[T](values: List[T])
-  case class ExplodedValues[T](values: List[T])
-  trait ExtraParamSupport[T] {
-    def decode(s: String): sttp.tapir.DecodeResult[T]
-    def encode(t: T): String
-  }
+  
   implicit def makePathCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[String, T, sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.string.mapDecode(support.decode)(support.encode)
   }
@@ -64,4111 +60,6 @@ object TapirGeneratedEndpoints {
   type ByteString <: Array[Byte]
   implicit def toByteString(ba: Array[Byte]): ByteString = ba.asInstanceOf[ByteString]
 
-  case class EnumExtraParamSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]) extends ExtraParamSupport[T] {
-    // Case-insensitive mapping
-    def decode(s: String): sttp.tapir.DecodeResult[T] =
-      scala.util.Try(T.upperCaseNameValuesToMap(s.toUpperCase))
-        .fold(
-          _ =>
-            sttp.tapir.DecodeResult.Error(
-              s,
-              new NoSuchElementException(
-                s"Could not find value $s for enum ${enumName}, available values: ${T.values.mkString(", ")}"
-              )
-            ),
-          sttp.tapir.DecodeResult.Value(_)
-        )
-    def encode(t: T): String = t.entryName
-  }
-  def extraCodecSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): ExtraParamSupport[T] =
-    EnumExtraParamSupport(enumName, T)
-
-
-  type ActionDetailsDTO = io.circe.JsonObject
-  type BulletinBoardPatternParameterStr = String
-  type ClientIdParameterStr = String
-  type ComponentDetailsDTO = io.circe.JsonObject
-  type DateTimeParameterDT = java.time.Instant
-  type IntegerParameterInt = Int
-  type LongParameterInt = Long
-  type StreamingOutput = io.circe.JsonObject
-  case class AboutDTO (
-    buildBranch: Option[String] = None,
-    buildRevision: Option[String] = None,
-    buildTag: Option[String] = None,
-    buildTimestamp: Option[String] = None,
-    contentViewerUrl: Option[String] = None,
-    timezone: Option[String] = None,
-    title: Option[String] = None,
-    uri: Option[String] = None,
-    version: Option[String] = None
-  )
-  case class AboutEntity (
-    about: Option[AboutDTO] = None
-  )
-  case class AccessPolicyDTO (
-    action: Option[AccessPolicyDTOAction] = None,
-    componentReference: Option[ComponentReferenceEntity] = None,
-    configurable: Option[Boolean] = None,
-    id: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    position: Option[PositionDTO] = None,
-    resource: Option[String] = None,
-    userGroups: Option[Set[TenantEntity]] = None,
-    users: Option[Set[TenantEntity]] = None,
-    versionedComponentId: Option[String] = None
-  )
-
-  sealed trait AccessPolicyDTOAction extends enumeratum.EnumEntry
-  object AccessPolicyDTOAction extends enumeratum.Enum[AccessPolicyDTOAction] with enumeratum.CirceEnum[AccessPolicyDTOAction] {
-    val values = findValues
-    case object read extends AccessPolicyDTOAction
-  }
-  case class AccessPolicyEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[AccessPolicyDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    generated: Option[String] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class AccessPolicySummaryDTO (
-    action: Option[AccessPolicySummaryDTOAction] = None,
-    componentReference: Option[ComponentReferenceEntity] = None,
-    configurable: Option[Boolean] = None,
-    id: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    position: Option[PositionDTO] = None,
-    resource: Option[String] = None,
-    versionedComponentId: Option[String] = None
-  )
-
-  sealed trait AccessPolicySummaryDTOAction extends enumeratum.EnumEntry
-  object AccessPolicySummaryDTOAction extends enumeratum.Enum[AccessPolicySummaryDTOAction] with enumeratum.CirceEnum[AccessPolicySummaryDTOAction] {
-    val values = findValues
-    case object read extends AccessPolicySummaryDTOAction
-  }
-  case class AccessPolicySummaryEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[AccessPolicySummaryDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class ActionDTO (
-    actionDetails: Option[ActionDetailsDTO] = None,
-    componentDetails: Option[ComponentDetailsDTO] = None,
-    id: Option[Int] = None,
-    operation: Option[String] = None,
-    sourceId: Option[String] = None,
-    sourceName: Option[String] = None,
-    sourceType: Option[String] = None,
-    timestamp: Option[String] = None,
-    userIdentity: Option[String] = None
-  )
-  case class ActionEntity (
-    action: Option[ActionDTO] = None,
-    canRead: Option[Boolean] = None,
-    id: Option[Int] = None,
-    sourceId: Option[String] = None,
-    timestamp: Option[String] = None
-  )
-  case class ActivateControllerServicesEntity (
-    components: Option[Map[String, RevisionDTO]] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    state: Option[ActivateControllerServicesEntityState] = None
-  )
-
-  sealed trait ActivateControllerServicesEntityState extends enumeratum.EnumEntry
-  object ActivateControllerServicesEntityState extends enumeratum.Enum[ActivateControllerServicesEntityState] with enumeratum.CirceEnum[ActivateControllerServicesEntityState] {
-    val values = findValues
-    case object ENABLED extends ActivateControllerServicesEntityState
-    case object DISABLED extends ActivateControllerServicesEntityState
-  }
-  case class AdditionalDetailsEntity (
-    additionalDetails: Option[String] = None
-  )
-  case class AffectedComponentDTO (
-    activeThreadCount: Option[Int] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    processGroupId: Option[String] = None,
-    referenceType: Option[AffectedComponentDTOReferenceType] = None,
-    state: Option[String] = None,
-    validationErrors: Option[Seq[String]] = None
-  )
-
-  sealed trait AffectedComponentDTOReferenceType extends enumeratum.EnumEntry
-  object AffectedComponentDTOReferenceType extends enumeratum.Enum[AffectedComponentDTOReferenceType] with enumeratum.CirceEnum[AffectedComponentDTOReferenceType] {
-    val values = findValues
-    case object PROCESSOR extends AffectedComponentDTOReferenceType
-    case object CONTROLLER_SERVICE extends AffectedComponentDTOReferenceType
-    case object INPUT_PORT extends AffectedComponentDTOReferenceType
-    case object OUTPUT_PORT extends AffectedComponentDTOReferenceType
-    case object REMOTE_INPUT_PORT extends AffectedComponentDTOReferenceType
-    case object REMOTE_OUTPUT_PORT extends AffectedComponentDTOReferenceType
-    case object STATELESS_GROUP extends AffectedComponentDTOReferenceType
-  }
-  case class AffectedComponentEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[AffectedComponentDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    processGroup: Option[ProcessGroupNameDTO] = None,
-    referenceType: Option[AffectedComponentEntityReferenceType] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-
-  sealed trait AffectedComponentEntityReferenceType extends enumeratum.EnumEntry
-  object AffectedComponentEntityReferenceType extends enumeratum.Enum[AffectedComponentEntityReferenceType] with enumeratum.CirceEnum[AffectedComponentEntityReferenceType] {
-    val values = findValues
-    case object PROCESSOR extends AffectedComponentEntityReferenceType
-    case object CONTROLLER_SERVICE extends AffectedComponentEntityReferenceType
-    case object INPUT_PORT extends AffectedComponentEntityReferenceType
-    case object OUTPUT_PORT extends AffectedComponentEntityReferenceType
-    case object REMOTE_INPUT_PORT extends AffectedComponentEntityReferenceType
-    case object REMOTE_OUTPUT_PORT extends AffectedComponentEntityReferenceType
-  }
-  case class AllowableValueDTO (
-    description: Option[String] = None,
-    displayName: Option[String] = None,
-    value: Option[String] = None
-  )
-  case class AllowableValueEntity (
-    allowableValue: Option[AllowableValueDTO] = None,
-    canRead: Option[Boolean] = None
-  )
-  case class AssetDTO (
-    digest: Option[String] = None,
-    id: Option[String] = None,
-    missingContent: Option[Boolean] = None,
-    name: Option[String] = None
-  )
-  case class AssetEntity (
-    asset: Option[AssetDTO] = None
-  )
-  case class AssetReferenceDTO (
-    id: Option[String] = None,
-    name: Option[String] = None
-  )
-  case class AssetsEntity (
-    assets: Option[Seq[AssetEntity]] = None
-  )
-  case class Attribute (
-    description: Option[String] = None,
-    name: Option[String] = None
-  )
-  case class AttributeDTO (
-    name: Option[String] = None,
-    previousValue: Option[String] = None,
-    value: Option[String] = None
-  )
-  case class AuthenticationConfigurationDTO (
-    externalLoginRequired: Option[Boolean] = None,
-    loginSupported: Option[Boolean] = None,
-    loginUri: Option[String] = None,
-    logoutUri: Option[String] = None
-  )
-  case class AuthenticationConfigurationEntity (
-    authenticationConfiguration: Option[AuthenticationConfigurationDTO] = None
-  )
-  case class BannerDTO (
-    footerText: Option[String] = None,
-    headerText: Option[String] = None
-  )
-  case class BannerEntity (
-    banners: Option[BannerDTO] = None
-  )
-  case class BatchSettingsDTO (
-    count: Option[Int] = None,
-    duration: Option[String] = None,
-    size: Option[String] = None
-  )
-  case class BatchSize (
-    count: Option[Int] = None,
-    duration: Option[String] = None,
-    size: Option[String] = None
-  )
-  case class BuildInfo (
-    compiler: Option[String] = None,
-    compilerFlags: Option[String] = None,
-    revision: Option[String] = None,
-    targetArch: Option[String] = None,
-    timestamp: Option[Long] = None,
-    version: Option[String] = None
-  )
-  case class BulletinBoardDTO (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    generated: Option[String] = None
-  )
-  case class BulletinBoardEntity (
-    bulletinBoard: Option[BulletinBoardDTO] = None
-  )
-  case class BulletinBoardPatternParameter (
-    pattern: Option[io.circe.JsonObject] = None,
-    rawPattern: Option[String] = None
-  )
-  case class BulletinDTO (
-    category: Option[String] = None,
-    groupId: Option[String] = None,
-    id: Option[Long] = None,
-    level: Option[String] = None,
-    message: Option[String] = None,
-    nodeAddress: Option[String] = None,
-    sourceId: Option[String] = None,
-    sourceName: Option[String] = None,
-    sourceType: Option[String] = None,
-    timestamp: Option[String] = None
-  )
-  case class BulletinEntity (
-    bulletin: Option[BulletinDTO] = None,
-    canRead: Option[Boolean] = None,
-    groupId: Option[String] = None,
-    id: Option[Long] = None,
-    nodeAddress: Option[String] = None,
-    sourceId: Option[String] = None,
-    timestamp: Option[String] = None
-  )
-  case class Bundle (
-    artifact: Option[String] = None,
-    group: Option[String] = None,
-    version: Option[String] = None
-  )
-  case class BundleDTO (
-    artifact: Option[String] = None,
-    group: Option[String] = None,
-    version: Option[String] = None
-  )
-  case class ClientIdParameter (
-    clientId: Option[String] = None
-  )
-  case class ClusterDTO (
-    generated: Option[String] = None,
-    nodes: Option[Seq[NodeDTO]] = None
-  )
-  case class ClusterEntity (
-    cluster: Option[ClusterDTO] = None
-  )
-  case class ClusterSearchResultsEntity (
-    nodeResults: Option[Seq[NodeSearchResultDTO]] = None
-  )
-  case class ClusterSummaryDTO (
-    clustered: Option[Boolean] = None,
-    connectedNodeCount: Option[Int] = None,
-    connectedNodes: Option[String] = None,
-    connectedToCluster: Option[Boolean] = None,
-    totalNodeCount: Option[Int] = None
-  )
-  case class ClusterSummaryEntity (
-    clusterSummary: Option[ClusterSummaryDTO] = None
-  )
-  case class ComponentDifferenceDTO (
-    componentId: Option[String] = None,
-    componentName: Option[String] = None,
-    componentType: Option[String] = None,
-    differences: Option[Seq[DifferenceDTO]] = None,
-    processGroupId: Option[String] = None
-  )
-  case class ComponentHistoryDTO (
-    componentId: Option[String] = None,
-    propertyHistory: Option[Map[String, PropertyHistoryDTO]] = None
-  )
-  case class ComponentHistoryEntity (
-    componentHistory: Option[ComponentHistoryDTO] = None
-  )
-  case class ComponentManifest (
-    apis: Option[Seq[DefinedType]] = None,
-    controllerServices: Option[Seq[ControllerServiceDefinition]] = None,
-    flowAnalysisRules: Option[Seq[FlowAnalysisRuleDefinition]] = None,
-    parameterProviders: Option[Seq[ParameterProviderDefinition]] = None,
-    processors: Option[Seq[ProcessorDefinition]] = None,
-    reportingTasks: Option[Seq[ReportingTaskDefinition]] = None
-  )
-  case class ComponentReferenceDTO (
-    id: Option[String] = None,
-    name: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    position: Option[PositionDTO] = None,
-    versionedComponentId: Option[String] = None
-  )
-  case class ComponentReferenceEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[ComponentReferenceDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class ComponentRestrictionPermissionDTO (
-    permissions: Option[PermissionsDTO] = None,
-    requiredPermission: Option[RequiredPermissionDTO] = None
-  )
-  case class ComponentSearchResultDTO (
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    matches: Option[Seq[String]] = None,
-    name: Option[String] = None,
-    parentGroup: Option[SearchResultGroupDTO] = None,
-    versionedGroup: Option[SearchResultGroupDTO] = None
-  )
-  case class ComponentStateDTO (
-    clusterState: Option[StateMapDTO] = None,
-    componentId: Option[String] = None,
-    dropStateKeySupported: Option[Boolean] = None,
-    localState: Option[StateMapDTO] = None,
-    stateDescription: Option[String] = None
-  )
-  case class ComponentStateEntity (
-    componentState: Option[ComponentStateDTO] = None
-  )
-  case class ComponentValidationResultDTO (
-    activeThreadCount: Option[Int] = None,
-    currentlyValid: Option[Boolean] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    processGroupId: Option[String] = None,
-    referenceType: Option[ComponentValidationResultDTOReferenceType] = None,
-    resultantValidationErrors: Option[Seq[String]] = None,
-    resultsValid: Option[Boolean] = None,
-    state: Option[String] = None,
-    validationErrors: Option[Seq[String]] = None
-  )
-
-  sealed trait ComponentValidationResultDTOReferenceType extends enumeratum.EnumEntry
-  object ComponentValidationResultDTOReferenceType extends enumeratum.Enum[ComponentValidationResultDTOReferenceType] with enumeratum.CirceEnum[ComponentValidationResultDTOReferenceType] {
-    val values = findValues
-    case object PROCESSOR extends ComponentValidationResultDTOReferenceType
-    case object CONTROLLER_SERVICE extends ComponentValidationResultDTOReferenceType
-    case object INPUT_PORT extends ComponentValidationResultDTOReferenceType
-    case object OUTPUT_PORT extends ComponentValidationResultDTOReferenceType
-    case object REMOTE_INPUT_PORT extends ComponentValidationResultDTOReferenceType
-    case object REMOTE_OUTPUT_PORT extends ComponentValidationResultDTOReferenceType
-    case object STATELESS_GROUP extends ComponentValidationResultDTOReferenceType
-  }
-  case class ComponentValidationResultEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[ComponentValidationResultDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class ComponentValidationResultsEntity (
-    validationResults: Option[Seq[ComponentValidationResultEntity]] = None
-  )
-  case class ConfigVerificationResultDTO (
-    explanation: Option[String] = None,
-    outcome: Option[ConfigVerificationResultDTOOutcome] = None,
-    verificationStepName: Option[String] = None
-  )
-
-  sealed trait ConfigVerificationResultDTOOutcome extends enumeratum.EnumEntry
-  object ConfigVerificationResultDTOOutcome extends enumeratum.Enum[ConfigVerificationResultDTOOutcome] with enumeratum.CirceEnum[ConfigVerificationResultDTOOutcome] {
-    val values = findValues
-    case object SUCCESSFUL extends ConfigVerificationResultDTOOutcome
-    case object FAILED extends ConfigVerificationResultDTOOutcome
-    case object SKIPPED extends ConfigVerificationResultDTOOutcome
-  }
-  case class ConfigurationAnalysisDTO (
-    componentId: Option[String] = None,
-    properties: Option[Map[String, String]] = None,
-    referencedAttributes: Option[Map[String, String]] = None,
-    supportsVerification: Option[Boolean] = None
-  )
-  case class ConfigurationAnalysisEntity (
-    configurationAnalysis: Option[ConfigurationAnalysisDTO] = None
-  )
-  case class ConnectableComponent (
-    comments: Option[String] = None,
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    instanceIdentifier: Option[String] = None,
-    name: Option[String] = None,
-    `type`: Option[ConnectableComponentType] = None
-  )
-
-  sealed trait ConnectableComponentType extends enumeratum.EnumEntry
-  object ConnectableComponentType extends enumeratum.Enum[ConnectableComponentType] with enumeratum.CirceEnum[ConnectableComponentType] {
-    val values = findValues
-    case object PROCESSOR extends ConnectableComponentType
-    case object REMOTE_INPUT_PORT extends ConnectableComponentType
-    case object REMOTE_OUTPUT_PORT extends ConnectableComponentType
-    case object INPUT_PORT extends ConnectableComponentType
-    case object OUTPUT_PORT extends ConnectableComponentType
-    case object FUNNEL extends ConnectableComponentType
-  }
-  case class ConnectableDTO (
-    comments: Option[String] = None,
-    exists: Option[Boolean] = None,
-    groupId: String,
-    id: String,
-    name: Option[String] = None,
-    running: Option[Boolean] = None,
-    transmitting: Option[Boolean] = None,
-    `type`: ConnectableDTOType,
-    versionedComponentId: Option[String] = None
-  )
-
-  sealed trait ConnectableDTOType extends enumeratum.EnumEntry
-  object ConnectableDTOType extends enumeratum.Enum[ConnectableDTOType] with enumeratum.CirceEnum[ConnectableDTOType] {
-    val values = findValues
-    case object PROCESSOR extends ConnectableDTOType
-    case object REMOTE_INPUT_PORT extends ConnectableDTOType
-    case object REMOTE_OUTPUT_PORT extends ConnectableDTOType
-    case object INPUT_PORT extends ConnectableDTOType
-    case object OUTPUT_PORT extends ConnectableDTOType
-    case object FUNNEL extends ConnectableDTOType
-  }
-  case class ConnectionDTO (
-    availableRelationships: Option[Set[String]] = None,
-    backPressureDataSizeThreshold: Option[String] = None,
-    backPressureObjectThreshold: Option[Long] = None,
-    bends: Option[Seq[PositionDTO]] = None,
-    destination: Option[ConnectableDTO] = None,
-    flowFileExpiration: Option[String] = None,
-    getzIndex: Option[Long] = None,
-    id: Option[String] = None,
-    labelIndex: Option[Int] = None,
-    loadBalanceCompression: Option[String] = None,
-    loadBalancePartitionAttribute: Option[String] = None,
-    loadBalanceStatus: Option[String] = None,
-    loadBalanceStrategy: Option[String] = None,
-    name: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    position: Option[PositionDTO] = None,
-    prioritizers: Option[Seq[String]] = None,
-    retriedRelationships: Option[Set[String]] = None,
-    selectedRelationships: Option[Set[String]] = None,
-    source: Option[ConnectableDTO] = None,
-    versionedComponentId: Option[String] = None
-  )
-  case class ConnectionEntity (
-    bends: Option[Seq[PositionDTO]] = None,
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[ConnectionDTO] = None,
-    destinationGroupId: Option[String] = None,
-    destinationId: Option[String] = None,
-    destinationType: ConnectionEntityDestinationType,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    getzIndex: Option[Long] = None,
-    id: Option[String] = None,
-    labelIndex: Option[Int] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    sourceGroupId: Option[String] = None,
-    sourceId: Option[String] = None,
-    sourceType: ConnectionEntitySourceType,
-    status: Option[ConnectionStatusDTO] = None,
-    uri: Option[String] = None
-  )
-
-  sealed trait ConnectionEntityDestinationType extends enumeratum.EnumEntry
-  object ConnectionEntityDestinationType extends enumeratum.Enum[ConnectionEntityDestinationType] with enumeratum.CirceEnum[ConnectionEntityDestinationType] {
-    val values = findValues
-    case object PROCESSOR extends ConnectionEntityDestinationType
-    case object REMOTE_INPUT_PORT extends ConnectionEntityDestinationType
-    case object REMOTE_OUTPUT_PORT extends ConnectionEntityDestinationType
-    case object INPUT_PORT extends ConnectionEntityDestinationType
-    case object OUTPUT_PORT extends ConnectionEntityDestinationType
-    case object FUNNEL extends ConnectionEntityDestinationType
-  }
-
-  sealed trait ConnectionEntitySourceType extends enumeratum.EnumEntry
-  object ConnectionEntitySourceType extends enumeratum.Enum[ConnectionEntitySourceType] with enumeratum.CirceEnum[ConnectionEntitySourceType] {
-    val values = findValues
-    case object PROCESSOR extends ConnectionEntitySourceType
-    case object REMOTE_INPUT_PORT extends ConnectionEntitySourceType
-    case object REMOTE_OUTPUT_PORT extends ConnectionEntitySourceType
-    case object INPUT_PORT extends ConnectionEntitySourceType
-    case object OUTPUT_PORT extends ConnectionEntitySourceType
-    case object FUNNEL extends ConnectionEntitySourceType
-  }
-  case class ConnectionStatisticsDTO (
-    aggregateSnapshot: Option[ConnectionStatisticsSnapshotDTO] = None,
-    id: Option[String] = None,
-    nodeSnapshots: Option[Seq[NodeConnectionStatisticsSnapshotDTO]] = None,
-    statsLastRefreshed: Option[String] = None
-  )
-  case class ConnectionStatisticsEntity (
-    canRead: Option[Boolean] = None,
-    connectionStatistics: Option[ConnectionStatisticsDTO] = None
-  )
-  case class ConnectionStatisticsSnapshotDTO (
-    id: Option[String] = None,
-    predictedBytesAtNextInterval: Option[Long] = None,
-    predictedCountAtNextInterval: Option[Int] = None,
-    predictedMillisUntilBytesBackpressure: Option[Long] = None,
-    predictedMillisUntilCountBackpressure: Option[Long] = None,
-    predictedPercentBytes: Option[Int] = None,
-    predictedPercentCount: Option[Int] = None,
-    predictionIntervalMillis: Option[Long] = None
-  )
-  case class ConnectionStatusDTO (
-    aggregateSnapshot: Option[ConnectionStatusSnapshotDTO] = None,
-    destinationId: Option[String] = None,
-    destinationName: Option[String] = None,
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    nodeSnapshots: Option[Seq[NodeConnectionStatusSnapshotDTO]] = None,
-    sourceId: Option[String] = None,
-    sourceName: Option[String] = None,
-    statsLastRefreshed: Option[String] = None
-  )
-  case class ConnectionStatusEntity (
-    canRead: Option[Boolean] = None,
-    connectionStatus: Option[ConnectionStatusDTO] = None
-  )
-  case class ConnectionStatusPredictionsSnapshotDTO (
-    predictedBytesAtNextInterval: Option[Long] = None,
-    predictedCountAtNextInterval: Option[Int] = None,
-    predictedMillisUntilBytesBackpressure: Option[Long] = None,
-    predictedMillisUntilCountBackpressure: Option[Long] = None,
-    predictedPercentBytes: Option[Int] = None,
-    predictedPercentCount: Option[Int] = None,
-    predictionIntervalSeconds: Option[Int] = None
-  )
-  case class ConnectionStatusSnapshotDTO (
-    bytesIn: Option[Long] = None,
-    bytesOut: Option[Long] = None,
-    bytesQueued: Option[Long] = None,
-    destinationId: Option[String] = None,
-    destinationName: Option[String] = None,
-    flowFileAvailability: Option[String] = None,
-    flowFilesIn: Option[Int] = None,
-    flowFilesOut: Option[Int] = None,
-    flowFilesQueued: Option[Int] = None,
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    input: Option[String] = None,
-    loadBalanceStatus: Option[ConnectionStatusSnapshotDTOLoadBalanceStatus] = None,
-    name: Option[String] = None,
-    output: Option[String] = None,
-    percentUseBytes: Option[Int] = None,
-    percentUseCount: Option[Int] = None,
-    predictions: Option[ConnectionStatusPredictionsSnapshotDTO] = None,
-    queued: Option[String] = None,
-    queuedCount: Option[String] = None,
-    queuedSize: Option[String] = None,
-    sourceId: Option[String] = None,
-    sourceName: Option[String] = None
-  )
-
-  sealed trait ConnectionStatusSnapshotDTOLoadBalanceStatus extends enumeratum.EnumEntry
-  object ConnectionStatusSnapshotDTOLoadBalanceStatus extends enumeratum.Enum[ConnectionStatusSnapshotDTOLoadBalanceStatus] with enumeratum.CirceEnum[ConnectionStatusSnapshotDTOLoadBalanceStatus] {
-    val values = findValues
-    case object LOAD_BALANCE_NOT_CONFIGURED extends ConnectionStatusSnapshotDTOLoadBalanceStatus
-    case object LOAD_BALANCE_ACTIVE extends ConnectionStatusSnapshotDTOLoadBalanceStatus
-    case object LOAD_BALANCE_INACTIVE extends ConnectionStatusSnapshotDTOLoadBalanceStatus
-  }
-  case class ConnectionStatusSnapshotEntity (
-    canRead: Option[Boolean] = None,
-    connectionStatusSnapshot: Option[ConnectionStatusSnapshotDTO] = None,
-    id: Option[String] = None
-  )
-  case class ConnectionsEntity (
-    connections: Option[Set[ConnectionEntity]] = None
-  )
-  case class ContentViewerDTO (
-    displayName: Option[String] = None,
-    supportedMimeTypes: Option[Seq[SupportedMimeTypesDTO]] = None,
-    uri: Option[String] = None
-  )
-  case class ContentViewerEntity (
-    contentViewers: Option[Seq[ContentViewerDTO]] = None
-  )
-  case class ControllerBulletinsEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    controllerServiceBulletins: Option[Seq[BulletinEntity]] = None,
-    flowAnalysisRuleBulletins: Option[Seq[BulletinEntity]] = None,
-    flowRegistryClientBulletins: Option[Seq[BulletinEntity]] = None,
-    parameterProviderBulletins: Option[Seq[BulletinEntity]] = None,
-    reportingTaskBulletins: Option[Seq[BulletinEntity]] = None
-  )
-  case class ControllerConfigurationDTO (
-    maxTimerDrivenThreadCount: Option[Int] = None
-  )
-  case class ControllerConfigurationEntity (
-    component: Option[ControllerConfigurationDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    permissions: Option[PermissionsDTO] = None,
-    revision: Option[RevisionDTO] = None
-  )
-  case class ControllerDTO (
-    activeRemotePortCount: Option[Int] = None,
-    comments: Option[String] = None,
-    disabledCount: Option[Int] = None,
-    id: Option[String] = None,
-    inactiveRemotePortCount: Option[Int] = None,
-    inputPortCount: Option[Int] = None,
-    inputPorts: Option[Set[PortDTO]] = None,
-    instanceId: Option[String] = None,
-    invalidCount: Option[Int] = None,
-    name: Option[String] = None,
-    outputPortCount: Option[Int] = None,
-    outputPorts: Option[Set[PortDTO]] = None,
-    remoteSiteHttpListeningPort: Option[Int] = None,
-    remoteSiteListeningPort: Option[Int] = None,
-    runningCount: Option[Int] = None,
-    siteToSiteSecure: Option[Boolean] = None,
-    stoppedCount: Option[Int] = None
-  )
-  case class ControllerEntity (
-    controller: Option[ControllerDTO] = None
-  )
-  case class ControllerServiceAPI (
-    bundle: Option[Bundle] = None,
-    `type`: Option[String] = None
-  )
-  case class ControllerServiceApiDTO (
-    bundle: Option[BundleDTO] = None,
-    `type`: Option[String] = None
-  )
-  case class ControllerServiceDTO (
-    annotationData: Option[String] = None,
-    bulletinLevel: Option[String] = None,
-    bundle: Option[BundleDTO] = None,
-    comments: Option[String] = None,
-    controllerServiceApis: Option[Seq[ControllerServiceApiDTO]] = None,
-    customUiUrl: Option[String] = None,
-    deprecated: Option[Boolean] = None,
-    descriptors: Option[Map[String, PropertyDescriptorDTO]] = None,
-    extensionMissing: Option[Boolean] = None,
-    id: Option[String] = None,
-    multipleVersionsAvailable: Option[Boolean] = None,
-    name: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    persistsState: Option[Boolean] = None,
-    position: Option[PositionDTO] = None,
-    properties: Option[Map[String, String]] = None,
-    referencingComponents: Option[Set[ControllerServiceReferencingComponentEntity]] = None,
-    restricted: Option[Boolean] = None,
-    sensitiveDynamicPropertyNames: Option[Set[String]] = None,
-    state: Option[ControllerServiceDTOState] = None,
-    supportsSensitiveDynamicProperties: Option[Boolean] = None,
-    `type`: Option[String] = None,
-    validationErrors: Option[Seq[String]] = None,
-    validationStatus: Option[ControllerServiceDTOValidationStatus] = None,
-    versionedComponentId: Option[String] = None
-  )
-
-  sealed trait ControllerServiceDTOState extends enumeratum.EnumEntry
-  object ControllerServiceDTOState extends enumeratum.Enum[ControllerServiceDTOState] with enumeratum.CirceEnum[ControllerServiceDTOState] {
-    val values = findValues
-    case object ENABLED extends ControllerServiceDTOState
-    case object ENABLING extends ControllerServiceDTOState
-    case object DISABLED extends ControllerServiceDTOState
-    case object DISABLING extends ControllerServiceDTOState
-  }
-
-  sealed trait ControllerServiceDTOValidationStatus extends enumeratum.EnumEntry
-  object ControllerServiceDTOValidationStatus extends enumeratum.Enum[ControllerServiceDTOValidationStatus] with enumeratum.CirceEnum[ControllerServiceDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends ControllerServiceDTOValidationStatus
-    case object INVALID extends ControllerServiceDTOValidationStatus
-    case object VALIDATING extends ControllerServiceDTOValidationStatus
-  }
-  case class ControllerServiceDefinition (
-    additionalDetails: Option[Boolean] = None,
-    artifact: Option[String] = None,
-    buildInfo: Option[BuildInfo] = None,
-    deprecated: Option[Boolean] = None,
-    deprecationAlternatives: Option[Set[String]] = None,
-    deprecationReason: Option[String] = None,
-    dynamicProperties: Option[Seq[DynamicProperty]] = None,
-    explicitRestrictions: Option[Set[Restriction]] = None,
-    group: Option[String] = None,
-    propertyDescriptors: Option[Map[String, PropertyDescriptor]] = None,
-    providedApiImplementations: Option[Seq[DefinedType]] = None,
-    restricted: Option[Boolean] = None,
-    restrictedExplanation: Option[String] = None,
-    seeAlso: Option[Set[String]] = None,
-    stateful: Option[Stateful] = None,
-    supportsDynamicProperties: Option[Boolean] = None,
-    supportsSensitiveDynamicProperties: Option[Boolean] = None,
-    systemResourceConsiderations: Option[Seq[SystemResourceConsideration]] = None,
-    tags: Option[Set[String]] = None,
-    `type`: Option[String] = None,
-    typeDescription: Option[String] = None,
-    version: Option[String] = None
-  )
-  case class ControllerServiceEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[ControllerServiceDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    operatePermissions: Option[PermissionsDTO] = None,
-    parentGroupId: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    status: Option[ControllerServiceStatusDTO] = None,
-    uri: Option[String] = None
-  )
-  case class ControllerServiceReferencingComponentDTO (
-    activeThreadCount: Option[Int] = None,
-    descriptors: Option[Map[String, PropertyDescriptorDTO]] = None,
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    properties: Option[Map[String, String]] = None,
-    referenceCycle: Option[Boolean] = None,
-    referenceType: Option[ControllerServiceReferencingComponentDTOReferenceType] = None,
-    referencingComponents: Option[Set[ControllerServiceReferencingComponentEntity]] = None,
-    state: Option[String] = None,
-    `type`: Option[String] = None,
-    validationErrors: Option[Seq[String]] = None
-  )
-
-  sealed trait ControllerServiceReferencingComponentDTOReferenceType extends enumeratum.EnumEntry
-  object ControllerServiceReferencingComponentDTOReferenceType extends enumeratum.Enum[ControllerServiceReferencingComponentDTOReferenceType] with enumeratum.CirceEnum[ControllerServiceReferencingComponentDTOReferenceType] {
-    val values = findValues
-    case object Processor extends ControllerServiceReferencingComponentDTOReferenceType
-    case object ControllerService extends ControllerServiceReferencingComponentDTOReferenceType
-    case object ReportingTask extends ControllerServiceReferencingComponentDTOReferenceType
-    case object FlowRegistryClient extends ControllerServiceReferencingComponentDTOReferenceType
-  }
-  case class ControllerServiceReferencingComponentEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[ControllerServiceReferencingComponentDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    operatePermissions: Option[PermissionsDTO] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class ControllerServiceReferencingComponentsEntity (
-    controllerServiceReferencingComponents: Option[Set[ControllerServiceReferencingComponentEntity]] = None
-  )
-  case class ControllerServiceRunStatusEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    revision: Option[RevisionDTO] = None,
-    state: Option[ControllerServiceRunStatusEntityState] = None,
-    uiOnly: Option[Boolean] = None
-  )
-
-  sealed trait ControllerServiceRunStatusEntityState extends enumeratum.EnumEntry
-  object ControllerServiceRunStatusEntityState extends enumeratum.Enum[ControllerServiceRunStatusEntityState] with enumeratum.CirceEnum[ControllerServiceRunStatusEntityState] {
-    val values = findValues
-    case object ENABLED extends ControllerServiceRunStatusEntityState
-    case object DISABLED extends ControllerServiceRunStatusEntityState
-  }
-  case class ControllerServiceStatusDTO (
-    activeThreadCount: Option[Int] = None,
-    runStatus: Option[ControllerServiceStatusDTORunStatus] = None,
-    validationStatus: Option[ControllerServiceStatusDTOValidationStatus] = None
-  )
-
-  sealed trait ControllerServiceStatusDTORunStatus extends enumeratum.EnumEntry
-  object ControllerServiceStatusDTORunStatus extends enumeratum.Enum[ControllerServiceStatusDTORunStatus] with enumeratum.CirceEnum[ControllerServiceStatusDTORunStatus] {
-    val values = findValues
-    case object ENABLED extends ControllerServiceStatusDTORunStatus
-    case object ENABLING extends ControllerServiceStatusDTORunStatus
-    case object DISABLED extends ControllerServiceStatusDTORunStatus
-    case object DISABLING extends ControllerServiceStatusDTORunStatus
-  }
-
-  sealed trait ControllerServiceStatusDTOValidationStatus extends enumeratum.EnumEntry
-  object ControllerServiceStatusDTOValidationStatus extends enumeratum.Enum[ControllerServiceStatusDTOValidationStatus] with enumeratum.CirceEnum[ControllerServiceStatusDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends ControllerServiceStatusDTOValidationStatus
-    case object INVALID extends ControllerServiceStatusDTOValidationStatus
-    case object VALIDATING extends ControllerServiceStatusDTOValidationStatus
-  }
-  case class ControllerServiceTypesEntity (
-    controllerServiceTypes: Option[Set[DocumentedTypeDTO]] = None
-  )
-  case class ControllerServicesEntity (
-    controllerServices: Option[Set[ControllerServiceEntity]] = None,
-    currentTime: Option[String] = None
-  )
-  case class ControllerStatusDTO (
-    activeRemotePortCount: Option[Int] = None,
-    activeThreadCount: Option[Int] = None,
-    bytesQueued: Option[Long] = None,
-    disabledCount: Option[Int] = None,
-    flowFilesQueued: Option[Int] = None,
-    inactiveRemotePortCount: Option[Int] = None,
-    invalidCount: Option[Int] = None,
-    locallyModifiedAndStaleCount: Option[Int] = None,
-    locallyModifiedCount: Option[Int] = None,
-    queued: Option[String] = None,
-    runningCount: Option[Int] = None,
-    staleCount: Option[Int] = None,
-    stoppedCount: Option[Int] = None,
-    syncFailureCount: Option[Int] = None,
-    terminatedThreadCount: Option[Int] = None,
-    upToDateCount: Option[Int] = None
-  )
-  case class ControllerStatusEntity (
-    controllerStatus: Option[ControllerStatusDTO] = None
-  )
-  case class CopyRequestEntity (
-    connections: Option[Set[String]] = None,
-    funnels: Option[Set[String]] = None,
-    inputPorts: Option[Set[String]] = None,
-    labels: Option[Set[String]] = None,
-    outputPorts: Option[Set[String]] = None,
-    processGroups: Option[Set[String]] = None,
-    processors: Option[Set[String]] = None,
-    remoteProcessGroups: Option[Set[String]] = None
-  )
-  case class CopyResponseEntity (
-    connections: Option[Set[VersionedConnection]] = None,
-    externalControllerServiceReferences: Option[Map[String, ExternalControllerServiceReference]] = None,
-    funnels: Option[Set[VersionedFunnel]] = None,
-    id: Option[String] = None,
-    inputPorts: Option[Set[VersionedPort]] = None,
-    labels: Option[Set[VersionedLabel]] = None,
-    outputPorts: Option[Set[VersionedPort]] = None,
-    parameterContexts: Option[Map[String, VersionedParameterContext]] = None,
-    parameterProviders: Option[Map[String, ParameterProviderReference]] = None,
-    processGroups: Option[Set[VersionedProcessGroup]] = None,
-    processors: Option[Set[VersionedProcessor]] = None,
-    remoteProcessGroups: Option[Set[VersionedRemoteProcessGroup]] = None
-  )
-  case class CopySnippetRequestEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    originX: Option[Double] = None,
-    originY: Option[Double] = None,
-    snippetId: Option[String] = None
-  )
-  case class CounterDTO (
-    context: Option[String] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    value: Option[String] = None,
-    valueCount: Option[Long] = None
-  )
-  case class CounterEntity (
-    counter: Option[CounterDTO] = None
-  )
-  case class CountersDTO (
-    aggregateSnapshot: Option[CountersSnapshotDTO] = None,
-    nodeSnapshots: Option[Seq[NodeCountersSnapshotDTO]] = None
-  )
-  case class CountersEntity (
-    counters: Option[CountersDTO] = None
-  )
-  case class CountersSnapshotDTO (
-    counters: Option[Seq[CounterDTO]] = None,
-    generated: Option[String] = None
-  )
-  case class CreateActiveRequestEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    processGroupId: Option[String] = None
-  )
-  case class CurrentUserEntity (
-    anonymous: Option[Boolean] = None,
-    canVersionFlows: Option[Boolean] = None,
-    componentRestrictionPermissions: Option[Set[ComponentRestrictionPermissionDTO]] = None,
-    controllerPermissions: Option[PermissionsDTO] = None,
-    countersPermissions: Option[PermissionsDTO] = None,
-    identity: Option[String] = None,
-    logoutSupported: Option[Boolean] = None,
-    parameterContextPermissions: Option[PermissionsDTO] = None,
-    policiesPermissions: Option[PermissionsDTO] = None,
-    provenancePermissions: Option[PermissionsDTO] = None,
-    restrictedComponentsPermissions: Option[PermissionsDTO] = None,
-    systemPermissions: Option[PermissionsDTO] = None,
-    tenantsPermissions: Option[PermissionsDTO] = None
-  )
-  case class DateTimeParameter (
-    dateTime: Option[java.time.Instant] = None
-  )
-  case class DefinedType (
-    artifact: Option[String] = None,
-    group: Option[String] = None,
-    `type`: Option[String] = None,
-    typeDescription: Option[String] = None,
-    version: Option[String] = None
-  )
-  case class DifferenceDTO (
-    difference: Option[String] = None,
-    differenceType: Option[String] = None
-  )
-  case class DimensionsDTO (
-    height: Option[Double] = None,
-    width: Option[Double] = None
-  )
-  case class DocumentedTypeDTO (
-    bundle: Option[BundleDTO] = None,
-    controllerServiceApis: Option[Seq[ControllerServiceApiDTO]] = None,
-    deprecationReason: Option[String] = None,
-    description: Option[String] = None,
-    explicitRestrictions: Option[Set[ExplicitRestrictionDTO]] = None,
-    restricted: Option[Boolean] = None,
-    tags: Option[Set[String]] = None,
-    `type`: Option[String] = None,
-    usageRestriction: Option[String] = None
-  )
-  case class DropRequestDTO (
-    current: Option[String] = None,
-    currentCount: Option[Int] = None,
-    currentSize: Option[Long] = None,
-    dropped: Option[String] = None,
-    droppedCount: Option[Int] = None,
-    droppedSize: Option[Long] = None,
-    failureReason: Option[String] = None,
-    finished: Option[Boolean] = None,
-    id: Option[String] = None,
-    lastUpdated: Option[String] = None,
-    original: Option[String] = None,
-    originalCount: Option[Int] = None,
-    originalSize: Option[Long] = None,
-    percentCompleted: Option[Int] = None,
-    state: Option[String] = None,
-    submissionTime: Option[String] = None,
-    uri: Option[String] = None
-  )
-  case class DropRequestEntity (
-    dropRequest: Option[DropRequestDTO] = None
-  )
-  case class DynamicProperty (
-    description: Option[String] = None,
-    expressionLanguageScope: Option[DynamicPropertyExpressionLanguageScope] = None,
-    name: Option[String] = None,
-    value: Option[String] = None
-  )
-
-  sealed trait DynamicPropertyExpressionLanguageScope extends enumeratum.EnumEntry
-  object DynamicPropertyExpressionLanguageScope extends enumeratum.Enum[DynamicPropertyExpressionLanguageScope] with enumeratum.CirceEnum[DynamicPropertyExpressionLanguageScope] {
-    val values = findValues
-    case object NONE extends DynamicPropertyExpressionLanguageScope
-    case object ENVIRONMENT extends DynamicPropertyExpressionLanguageScope
-    case object FLOWFILE_ATTRIBUTES extends DynamicPropertyExpressionLanguageScope
-  }
-  case class DynamicRelationship (
-    description: Option[String] = None,
-    name: Option[String] = None
-  )
-  case class ExplicitRestrictionDTO (
-    explanation: Option[String] = None,
-    requiredPermission: Option[RequiredPermissionDTO] = None
-  )
-  case class ExternalControllerServiceReference (
-    identifier: Option[String] = None,
-    name: Option[String] = None
-  )
-  case class FlowAnalysisResultEntity (
-    flowAnalysisPending: Option[Boolean] = None,
-    ruleViolations: Option[Seq[FlowAnalysisRuleViolationDTO]] = None,
-    rules: Option[Seq[FlowAnalysisRuleDTO]] = None
-  )
-  case class FlowAnalysisRuleDTO (
-    bundle: Option[BundleDTO] = None,
-    comments: Option[String] = None,
-    deprecated: Option[Boolean] = None,
-    descriptors: Option[Map[String, PropertyDescriptorDTO]] = None,
-    enforcementPolicy: Option[String] = None,
-    extensionMissing: Option[Boolean] = None,
-    id: Option[String] = None,
-    multipleVersionsAvailable: Option[Boolean] = None,
-    name: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    persistsState: Option[Boolean] = None,
-    position: Option[PositionDTO] = None,
-    properties: Option[Map[String, String]] = None,
-    restricted: Option[Boolean] = None,
-    sensitiveDynamicPropertyNames: Option[Set[String]] = None,
-    state: Option[FlowAnalysisRuleDTOState] = None,
-    supportsSensitiveDynamicProperties: Option[Boolean] = None,
-    `type`: Option[String] = None,
-    validationErrors: Option[Seq[String]] = None,
-    validationStatus: Option[FlowAnalysisRuleDTOValidationStatus] = None,
-    versionedComponentId: Option[String] = None
-  )
-
-  sealed trait FlowAnalysisRuleDTOState extends enumeratum.EnumEntry
-  object FlowAnalysisRuleDTOState extends enumeratum.Enum[FlowAnalysisRuleDTOState] with enumeratum.CirceEnum[FlowAnalysisRuleDTOState] {
-    val values = findValues
-    case object ENABLED extends FlowAnalysisRuleDTOState
-    case object DISABLED extends FlowAnalysisRuleDTOState
-  }
-
-  sealed trait FlowAnalysisRuleDTOValidationStatus extends enumeratum.EnumEntry
-  object FlowAnalysisRuleDTOValidationStatus extends enumeratum.Enum[FlowAnalysisRuleDTOValidationStatus] with enumeratum.CirceEnum[FlowAnalysisRuleDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends FlowAnalysisRuleDTOValidationStatus
-    case object INVALID extends FlowAnalysisRuleDTOValidationStatus
-    case object VALIDATING extends FlowAnalysisRuleDTOValidationStatus
-  }
-  case class FlowAnalysisRuleDefinition (
-    additionalDetails: Option[Boolean] = None,
-    artifact: Option[String] = None,
-    buildInfo: Option[BuildInfo] = None,
-    deprecated: Option[Boolean] = None,
-    deprecationAlternatives: Option[Set[String]] = None,
-    deprecationReason: Option[String] = None,
-    dynamicProperties: Option[Seq[DynamicProperty]] = None,
-    explicitRestrictions: Option[Set[Restriction]] = None,
-    group: Option[String] = None,
-    propertyDescriptors: Option[Map[String, PropertyDescriptor]] = None,
-    providedApiImplementations: Option[Seq[DefinedType]] = None,
-    restricted: Option[Boolean] = None,
-    restrictedExplanation: Option[String] = None,
-    seeAlso: Option[Set[String]] = None,
-    stateful: Option[Stateful] = None,
-    supportsDynamicProperties: Option[Boolean] = None,
-    supportsSensitiveDynamicProperties: Option[Boolean] = None,
-    systemResourceConsiderations: Option[Seq[SystemResourceConsideration]] = None,
-    tags: Option[Set[String]] = None,
-    `type`: Option[String] = None,
-    typeDescription: Option[String] = None,
-    version: Option[String] = None
-  )
-  case class FlowAnalysisRuleEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[FlowAnalysisRuleDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    operatePermissions: Option[PermissionsDTO] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    status: Option[FlowAnalysisRuleStatusDTO] = None,
-    uri: Option[String] = None
-  )
-  case class FlowAnalysisRuleRunStatusEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    revision: Option[RevisionDTO] = None,
-    state: Option[FlowAnalysisRuleRunStatusEntityState] = None
-  )
-
-  sealed trait FlowAnalysisRuleRunStatusEntityState extends enumeratum.EnumEntry
-  object FlowAnalysisRuleRunStatusEntityState extends enumeratum.Enum[FlowAnalysisRuleRunStatusEntityState] with enumeratum.CirceEnum[FlowAnalysisRuleRunStatusEntityState] {
-    val values = findValues
-    case object ENABLED extends FlowAnalysisRuleRunStatusEntityState
-    case object DISABLED extends FlowAnalysisRuleRunStatusEntityState
-  }
-  case class FlowAnalysisRuleStatusDTO (
-    activeThreadCount: Option[Int] = None,
-    runStatus: Option[FlowAnalysisRuleStatusDTORunStatus] = None,
-    validationStatus: Option[FlowAnalysisRuleStatusDTOValidationStatus] = None
-  )
-
-  sealed trait FlowAnalysisRuleStatusDTORunStatus extends enumeratum.EnumEntry
-  object FlowAnalysisRuleStatusDTORunStatus extends enumeratum.Enum[FlowAnalysisRuleStatusDTORunStatus] with enumeratum.CirceEnum[FlowAnalysisRuleStatusDTORunStatus] {
-    val values = findValues
-    case object ENABLED extends FlowAnalysisRuleStatusDTORunStatus
-    case object DISABLED extends FlowAnalysisRuleStatusDTORunStatus
-  }
-
-  sealed trait FlowAnalysisRuleStatusDTOValidationStatus extends enumeratum.EnumEntry
-  object FlowAnalysisRuleStatusDTOValidationStatus extends enumeratum.Enum[FlowAnalysisRuleStatusDTOValidationStatus] with enumeratum.CirceEnum[FlowAnalysisRuleStatusDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends FlowAnalysisRuleStatusDTOValidationStatus
-    case object INVALID extends FlowAnalysisRuleStatusDTOValidationStatus
-    case object VALIDATING extends FlowAnalysisRuleStatusDTOValidationStatus
-  }
-  case class FlowAnalysisRuleTypesEntity (
-    flowAnalysisRuleTypes: Option[Set[DocumentedTypeDTO]] = None
-  )
-  case class FlowAnalysisRuleViolationDTO (
-    enabled: Option[Boolean] = None,
-    enforcementPolicy: Option[String] = None,
-    groupId: Option[String] = None,
-    issueId: Option[String] = None,
-    ruleId: Option[String] = None,
-    scope: Option[String] = None,
-    subjectComponentType: Option[String] = None,
-    subjectDisplayName: Option[String] = None,
-    subjectId: Option[String] = None,
-    subjectPermissionDto: Option[PermissionsDTO] = None,
-    violationMessage: Option[String] = None
-  )
-  case class FlowAnalysisRulesEntity (
-    currentTime: Option[String] = None,
-    flowAnalysisRules: Option[Set[FlowAnalysisRuleEntity]] = None
-  )
-  case class FlowBreadcrumbDTO (
-    id: Option[String] = None,
-    name: Option[String] = None,
-    versionControlInformation: Option[VersionControlInformationDTO] = None
-  )
-  case class FlowBreadcrumbEntity (
-    breadcrumb: Option[FlowBreadcrumbDTO] = None,
-    id: Option[String] = None,
-    parentBreadcrumb: Option[FlowBreadcrumbEntity] = None,
-    permissions: Option[PermissionsDTO] = None,
-    versionedFlowState: Option[FlowBreadcrumbEntityVersionedFlowState] = None
-  )
-
-  sealed trait FlowBreadcrumbEntityVersionedFlowState extends enumeratum.EnumEntry
-  object FlowBreadcrumbEntityVersionedFlowState extends enumeratum.Enum[FlowBreadcrumbEntityVersionedFlowState] with enumeratum.CirceEnum[FlowBreadcrumbEntityVersionedFlowState] {
-    val values = findValues
-    case object LOCALLY_MODIFIED extends FlowBreadcrumbEntityVersionedFlowState
-    case object STALE extends FlowBreadcrumbEntityVersionedFlowState
-    case object LOCALLY_MODIFIED_AND_STALE extends FlowBreadcrumbEntityVersionedFlowState
-    case object UP_TO_DATE extends FlowBreadcrumbEntityVersionedFlowState
-    case object SYNC_FAILURE extends FlowBreadcrumbEntityVersionedFlowState
-  }
-  case class FlowComparisonEntity (
-    componentDifferences: Option[Set[ComponentDifferenceDTO]] = None
-  )
-  case class FlowConfigurationDTO (
-    currentTime: Option[String] = None,
-    defaultBackPressureDataSizeThreshold: Option[String] = None,
-    defaultBackPressureObjectThreshold: Option[Long] = None,
-    supportsConfigurableAuthorizer: Option[Boolean] = None,
-    supportsConfigurableUsersAndGroups: Option[Boolean] = None,
-    supportsManagedAuthorizer: Option[Boolean] = None,
-    timeOffset: Option[Int] = None
-  )
-  case class FlowConfigurationEntity (
-    flowConfiguration: Option[FlowConfigurationDTO] = None
-  )
-  case class FlowDTO (
-    connections: Option[Set[ConnectionEntity]] = None,
-    funnels: Option[Set[FunnelEntity]] = None,
-    inputPorts: Option[Set[PortEntity]] = None,
-    labels: Option[Set[LabelEntity]] = None,
-    outputPorts: Option[Set[PortEntity]] = None,
-    processGroups: Option[Set[ProcessGroupEntity]] = None,
-    processors: Option[Set[ProcessorEntity]] = None,
-    remoteProcessGroups: Option[Set[RemoteProcessGroupEntity]] = None
-  )
-  case class FlowEntity (
-    flow: Option[FlowDTO] = None
-  )
-  case class FlowFileDTO (
-    attributes: Option[Map[String, String]] = None,
-    clusterNodeAddress: Option[String] = None,
-    clusterNodeId: Option[String] = None,
-    contentClaimContainer: Option[String] = None,
-    contentClaimFileSize: Option[String] = None,
-    contentClaimFileSizeBytes: Option[Long] = None,
-    contentClaimIdentifier: Option[String] = None,
-    contentClaimOffset: Option[Long] = None,
-    contentClaimSection: Option[String] = None,
-    filename: Option[String] = None,
-    lineageDuration: Option[Long] = None,
-    mimeType: Option[String] = None,
-    penalized: Option[Boolean] = None,
-    penaltyExpiresIn: Option[Long] = None,
-    position: Option[Int] = None,
-    queuedDuration: Option[Long] = None,
-    size: Option[Long] = None,
-    uri: Option[String] = None,
-    uuid: Option[String] = None
-  )
-  case class FlowFileEntity (
-    flowFile: Option[FlowFileDTO] = None
-  )
-  case class FlowFileSummaryDTO (
-    clusterNodeAddress: Option[String] = None,
-    clusterNodeId: Option[String] = None,
-    filename: Option[String] = None,
-    lineageDuration: Option[Long] = None,
-    mimeType: Option[String] = None,
-    penalized: Option[Boolean] = None,
-    penaltyExpiresIn: Option[Long] = None,
-    position: Option[Int] = None,
-    queuedDuration: Option[Long] = None,
-    size: Option[Long] = None,
-    uri: Option[String] = None,
-    uuid: Option[String] = None
-  )
-  case class FlowRegistryBranchDTO (
-    name: Option[String] = None
-  )
-  case class FlowRegistryBranchEntity (
-    branch: Option[FlowRegistryBranchDTO] = None
-  )
-  case class FlowRegistryBranchesEntity (
-    branches: Option[Set[FlowRegistryBranchEntity]] = None
-  )
-  case class FlowRegistryBucket (
-    createdTimestamp: Option[Long] = None,
-    description: Option[String] = None,
-    identifier: Option[String] = None,
-    name: Option[String] = None,
-    permissions: Option[FlowRegistryPermissions] = None
-  )
-  case class FlowRegistryBucketDTO (
-    created: Option[Long] = None,
-    description: Option[String] = None,
-    id: Option[String] = None,
-    name: Option[String] = None
-  )
-  case class FlowRegistryBucketEntity (
-    bucket: Option[FlowRegistryBucketDTO] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None
-  )
-  case class FlowRegistryBucketsEntity (
-    buckets: Option[Set[FlowRegistryBucketEntity]] = None
-  )
-  case class FlowRegistryClientDTO (
-    annotationData: Option[String] = None,
-    bundle: Option[BundleDTO] = None,
-    deprecated: Option[Boolean] = None,
-    description: Option[String] = None,
-    descriptors: Option[Map[String, PropertyDescriptorDTO]] = None,
-    extensionMissing: Option[Boolean] = None,
-    id: Option[String] = None,
-    multipleVersionsAvailable: Option[Boolean] = None,
-    name: Option[String] = None,
-    properties: Option[Map[String, String]] = None,
-    restricted: Option[Boolean] = None,
-    sensitiveDynamicPropertyNames: Option[Set[String]] = None,
-    supportsBranching: Option[Boolean] = None,
-    supportsSensitiveDynamicProperties: Option[Boolean] = None,
-    `type`: Option[String] = None,
-    validationErrors: Option[Seq[String]] = None,
-    validationStatus: Option[FlowRegistryClientDTOValidationStatus] = None
-  )
-
-  sealed trait FlowRegistryClientDTOValidationStatus extends enumeratum.EnumEntry
-  object FlowRegistryClientDTOValidationStatus extends enumeratum.Enum[FlowRegistryClientDTOValidationStatus] with enumeratum.CirceEnum[FlowRegistryClientDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends FlowRegistryClientDTOValidationStatus
-    case object INVALID extends FlowRegistryClientDTOValidationStatus
-    case object VALIDATING extends FlowRegistryClientDTOValidationStatus
-  }
-  case class FlowRegistryClientEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[FlowRegistryClientDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    operatePermissions: Option[PermissionsDTO] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class FlowRegistryClientTypesEntity (
-    flowRegistryClientTypes: Option[Set[DocumentedTypeDTO]] = None
-  )
-  case class FlowRegistryClientsEntity (
-    currentTime: Option[String] = None,
-    registries: Option[Set[FlowRegistryClientEntity]] = None
-  )
-  case class FlowRegistryPermissions (
-    canDelete: Option[Boolean] = None,
-    canRead: Option[Boolean] = None,
-    canWrite: Option[Boolean] = None
-  )
-  case class FlowSnippetDTO (
-    connections: Option[Set[ConnectionDTO]] = None,
-    controllerServices: Option[Set[ControllerServiceDTO]] = None,
-    funnels: Option[Set[FunnelDTO]] = None,
-    inputPorts: Option[Set[PortDTO]] = None,
-    labels: Option[Set[LabelDTO]] = None,
-    outputPorts: Option[Set[PortDTO]] = None,
-    processGroups: Option[Set[ProcessGroupDTO]] = None,
-    processors: Option[Set[ProcessorDTO]] = None,
-    remoteProcessGroups: Option[Set[RemoteProcessGroupDTO]] = None
-  )
-  case class FunnelDTO (
-    id: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    position: Option[PositionDTO] = None,
-    versionedComponentId: Option[String] = None
-  )
-  case class FunnelEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[FunnelDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class FunnelsEntity (
-    funnels: Option[Set[FunnelEntity]] = None
-  )
-  case class GarbageCollectionDTO (
-    collectionCount: Option[Long] = None,
-    collectionMillis: Option[Long] = None,
-    collectionTime: Option[String] = None,
-    name: Option[String] = None
-  )
-  case class HistoryDTO (
-    actions: Option[Seq[ActionEntity]] = None,
-    lastRefreshed: Option[String] = None,
-    total: Option[Int] = None
-  )
-  case class HistoryEntity (
-    history: Option[HistoryDTO] = None
-  )
-  case class InputPortsEntity (
-    inputPorts: Option[Set[PortEntity]] = None
-  )
-  case class IntegerParameter (
-    integer: Option[Int] = None
-  )
-  case class JmxMetricsResultDTO (
-    attributeName: Option[String] = None,
-    attributeValue: Option[io.circe.JsonObject] = None,
-    beanName: Option[String] = None
-  )
-  case class JmxMetricsResultsEntity (
-    jmxMetricsResults: Option[Seq[JmxMetricsResultDTO]] = None
-  )
-  case class LabelDTO (
-    getzIndex: Option[Long] = None,
-    height: Option[Double] = None,
-    id: Option[String] = None,
-    label: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    position: Option[PositionDTO] = None,
-    style: Option[Map[String, String]] = None,
-    versionedComponentId: Option[String] = None,
-    width: Option[Double] = None
-  )
-  case class LabelEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[LabelDTO] = None,
-    dimensions: Option[DimensionsDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    getzIndex: Option[Long] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class LabelsEntity (
-    labels: Option[Set[LabelEntity]] = None
-  )
-  case class LatestProvenanceEventsDTO (
-    componentId: Option[String] = None,
-    provenanceEvents: Option[Seq[ProvenanceEventDTO]] = None
-  )
-  case class LatestProvenanceEventsEntity (
-    latestProvenanceEvents: Option[LatestProvenanceEventsDTO] = None
-  )
-  case class LineageDTO (
-    expiration: Option[String] = None,
-    finished: Option[Boolean] = None,
-    id: Option[String] = None,
-    percentCompleted: Option[Int] = None,
-    request: Option[LineageRequestDTO] = None,
-    results: Option[LineageResultsDTO] = None,
-    submissionTime: Option[String] = None,
-    uri: Option[String] = None
-  )
-  case class LineageEntity (
-    lineage: Option[LineageDTO] = None
-  )
-  case class LineageRequestDTO (
-    clusterNodeId: Option[String] = None,
-    eventId: Option[Long] = None,
-    lineageRequestType: Option[LineageRequestDTOLineageRequestType] = None,
-    uuid: Option[String] = None
-  )
-
-  sealed trait LineageRequestDTOLineageRequestType extends enumeratum.EnumEntry
-  object LineageRequestDTOLineageRequestType extends enumeratum.Enum[LineageRequestDTOLineageRequestType] with enumeratum.CirceEnum[LineageRequestDTOLineageRequestType] {
-    val values = findValues
-    case object PARENTS extends LineageRequestDTOLineageRequestType
-    case object CHILDREN extends LineageRequestDTOLineageRequestType
-    case object FLOWFILE extends LineageRequestDTOLineageRequestType
-  }
-  case class LineageResultsDTO (
-    errors: Option[Set[String]] = None,
-    links: Option[Seq[ProvenanceLinkDTO]] = None,
-    nodes: Option[Seq[ProvenanceNodeDTO]] = None
-  )
-  case class ListingRequestDTO (
-    destinationRunning: Option[Boolean] = None,
-    failureReason: Option[String] = None,
-    finished: Option[Boolean] = None,
-    flowFileSummaries: Option[Seq[FlowFileSummaryDTO]] = None,
-    id: Option[String] = None,
-    lastUpdated: Option[String] = None,
-    maxResults: Option[Int] = None,
-    percentCompleted: Option[Int] = None,
-    queueSize: Option[QueueSizeDTO] = None,
-    sourceRunning: Option[Boolean] = None,
-    state: Option[String] = None,
-    submissionTime: Option[String] = None,
-    uri: Option[String] = None
-  )
-  case class ListingRequestEntity (
-    listingRequest: Option[ListingRequestDTO] = None
-  )
-  case class LongParameter (
-    long: Option[Long] = None
-  )
-  case class MultiProcessorUseCase (
-    configurations: Option[Seq[ProcessorConfiguration]] = None,
-    description: Option[String] = None,
-    keywords: Option[Seq[String]] = None,
-    notes: Option[String] = None
-  )
-  case class NarCoordinateDTO (
-    artifact: Option[String] = None,
-    group: Option[String] = None,
-    version: Option[String] = None
-  )
-  case class NarDetailsEntity (
-    controllerServiceTypes: Option[Set[DocumentedTypeDTO]] = None,
-    dependentCoordinates: Option[Set[NarCoordinateDTO]] = None,
-    flowAnalysisRuleTypes: Option[Set[DocumentedTypeDTO]] = None,
-    flowRegistryClientTypes: Option[Set[DocumentedTypeDTO]] = None,
-    narSummary: Option[NarSummaryDTO] = None,
-    parameterProviderTypes: Option[Set[DocumentedTypeDTO]] = None,
-    processorTypes: Option[Set[DocumentedTypeDTO]] = None,
-    reportingTaskTypes: Option[Set[DocumentedTypeDTO]] = None
-  )
-  case class NarSummariesEntity (
-    currentTime: Option[String] = None,
-    narSummaries: Option[Seq[NarSummaryEntity]] = None
-  )
-  case class NarSummaryDTO (
-    buildTime: Option[String] = None,
-    coordinate: Option[NarCoordinateDTO] = None,
-    createdBy: Option[String] = None,
-    dependencyCoordinate: Option[NarCoordinateDTO] = None,
-    digest: Option[String] = None,
-    extensionCount: Option[Int] = None,
-    failureMessage: Option[String] = None,
-    identifier: Option[String] = None,
-    installComplete: Option[Boolean] = None,
-    sourceIdentifier: Option[String] = None,
-    sourceType: Option[String] = None,
-    state: Option[String] = None
-  )
-  case class NarSummaryEntity (
-    narSummary: Option[NarSummaryDTO] = None
-  )
-  case class NodeConnectionStatisticsSnapshotDTO (
-    address: Option[String] = None,
-    apiPort: Option[Int] = None,
-    nodeId: Option[String] = None,
-    statisticsSnapshot: Option[ConnectionStatisticsSnapshotDTO] = None
-  )
-  case class NodeConnectionStatusSnapshotDTO (
-    address: Option[String] = None,
-    apiPort: Option[Int] = None,
-    nodeId: Option[String] = None,
-    statusSnapshot: Option[ConnectionStatusSnapshotDTO] = None
-  )
-  case class NodeCountersSnapshotDTO (
-    address: Option[String] = None,
-    apiPort: Option[Int] = None,
-    nodeId: Option[String] = None,
-    snapshot: Option[CountersSnapshotDTO] = None
-  )
-  case class NodeDTO (
-    activeThreadCount: Option[Int] = None,
-    address: Option[String] = None,
-    apiPort: Option[Int] = None,
-    bytesQueued: Option[Long] = None,
-    connectionRequested: Option[String] = None,
-    events: Option[Seq[NodeEventDTO]] = None,
-    flowFileBytes: Option[Long] = None,
-    flowFilesQueued: Option[Int] = None,
-    heartbeat: Option[String] = None,
-    nodeId: Option[String] = None,
-    nodeStartTime: Option[String] = None,
-    queued: Option[String] = None,
-    roles: Option[Set[String]] = None,
-    status: Option[String] = None
-  )
-  case class NodeEntity (
-    node: Option[NodeDTO] = None
-  )
-  case class NodeEventDTO (
-    category: Option[String] = None,
-    message: Option[String] = None,
-    timestamp: Option[String] = None
-  )
-  case class NodePortStatusSnapshotDTO (
-    address: Option[String] = None,
-    apiPort: Option[Int] = None,
-    nodeId: Option[String] = None,
-    statusSnapshot: Option[PortStatusSnapshotDTO] = None
-  )
-  case class NodeProcessGroupStatusSnapshotDTO (
-    address: Option[String] = None,
-    apiPort: Option[Int] = None,
-    nodeId: Option[String] = None,
-    statusSnapshot: Option[ProcessGroupStatusSnapshotDTO] = None
-  )
-  case class NodeProcessorStatusSnapshotDTO (
-    address: Option[String] = None,
-    apiPort: Option[Int] = None,
-    nodeId: Option[String] = None,
-    statusSnapshot: Option[ProcessorStatusSnapshotDTO] = None
-  )
-  case class NodeRemoteProcessGroupStatusSnapshotDTO (
-    address: Option[String] = None,
-    apiPort: Option[Int] = None,
-    nodeId: Option[String] = None,
-    statusSnapshot: Option[RemoteProcessGroupStatusSnapshotDTO] = None
-  )
-  case class NodeReplayLastEventSnapshotDTO (
-    address: Option[String] = None,
-    apiPort: Option[Int] = None,
-    nodeId: Option[String] = None,
-    snapshot: Option[ReplayLastEventSnapshotDTO] = None
-  )
-  case class NodeSearchResultDTO (
-    address: Option[String] = None,
-    id: Option[String] = None
-  )
-  case class NodeStatusSnapshotsDTO (
-    address: Option[String] = None,
-    apiPort: Option[Int] = None,
-    nodeId: Option[String] = None,
-    statusSnapshots: Option[Seq[StatusSnapshotDTO]] = None
-  )
-  case class NodeSystemDiagnosticsSnapshotDTO (
-    address: Option[String] = None,
-    apiPort: Option[Int] = None,
-    nodeId: Option[String] = None,
-    snapshot: Option[SystemDiagnosticsSnapshotDTO] = None
-  )
-  case class OutputPortsEntity (
-    outputPorts: Option[Set[PortEntity]] = None
-  )
-  case class ParameterContextDTO (
-    boundProcessGroups: Option[Set[ProcessGroupEntity]] = None,
-    description: Option[String] = None,
-    id: Option[String] = None,
-    inheritedParameterContexts: Option[Seq[ParameterContextReferenceEntity]] = None,
-    name: Option[String] = None,
-    parameterProviderConfiguration: Option[ParameterProviderConfigurationEntity] = None,
-    parameters: Option[Set[ParameterEntity]] = None
-  )
-  case class ParameterContextEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[ParameterContextDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class ParameterContextReferenceDTO (
-    id: Option[String] = None,
-    name: Option[String] = None
-  )
-  case class ParameterContextReferenceEntity (
-    component: Option[ParameterContextReferenceDTO] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None
-  )
-  case class ParameterContextUpdateEntity (
-    parameterContext: Option[ParameterContextDTO] = None,
-    parameterContextRevision: Option[RevisionDTO] = None,
-    referencingComponents: Option[Set[AffectedComponentEntity]] = None
-  )
-  case class ParameterContextUpdateRequestDTO (
-    complete: Option[Boolean] = None,
-    failureReason: Option[String] = None,
-    lastUpdated: Option[java.time.Instant] = None,
-    parameterContext: Option[ParameterContextDTO] = None,
-    percentCompleted: Option[Int] = None,
-    referencingComponents: Option[Set[AffectedComponentEntity]] = None,
-    requestId: Option[String] = None,
-    state: Option[String] = None,
-    submissionTime: Option[java.time.Instant] = None,
-    updateSteps: Option[Seq[ParameterContextUpdateStepDTO]] = None,
-    uri: Option[String] = None
-  )
-  case class ParameterContextUpdateRequestEntity (
-    parameterContextRevision: Option[RevisionDTO] = None,
-    request: Option[ParameterContextUpdateRequestDTO] = None
-  )
-  case class ParameterContextUpdateStepDTO (
-    complete: Option[Boolean] = None,
-    description: Option[String] = None,
-    failureReason: Option[String] = None
-  )
-  case class ParameterContextValidationRequestDTO (
-    complete: Option[Boolean] = None,
-    componentValidationResults: Option[ComponentValidationResultsEntity] = None,
-    failureReason: Option[String] = None,
-    lastUpdated: Option[java.time.Instant] = None,
-    parameterContext: Option[ParameterContextDTO] = None,
-    percentCompleted: Option[Int] = None,
-    requestId: Option[String] = None,
-    state: Option[String] = None,
-    submissionTime: Option[java.time.Instant] = None,
-    updateSteps: Option[Seq[ParameterContextValidationStepDTO]] = None,
-    uri: Option[String] = None
-  )
-  case class ParameterContextValidationRequestEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    request: Option[ParameterContextValidationRequestDTO] = None
-  )
-  case class ParameterContextValidationStepDTO (
-    complete: Option[Boolean] = None,
-    description: Option[String] = None,
-    failureReason: Option[String] = None
-  )
-  case class ParameterContextsEntity (
-    currentTime: Option[String] = None,
-    parameterContexts: Option[Set[ParameterContextEntity]] = None
-  )
-  case class ParameterDTO (
-    description: Option[String] = None,
-    inherited: Option[Boolean] = None,
-    name: Option[String] = None,
-    parameterContext: Option[ParameterContextReferenceEntity] = None,
-    provided: Option[Boolean] = None,
-    referencedAssets: Option[Seq[AssetReferenceDTO]] = None,
-    referencingComponents: Option[Set[AffectedComponentEntity]] = None,
-    sensitive: Option[Boolean] = None,
-    value: Option[String] = None,
-    valueRemoved: Option[Boolean] = None
-  )
-  case class ParameterEntity (
-    canWrite: Option[Boolean] = None,
-    parameter: Option[ParameterDTO] = None
-  )
-  case class ParameterGroupConfigurationEntity (
-    groupName: Option[String] = None,
-    parameterContextName: Option[String] = None,
-    parameterSensitivities: Option[Map[String, ParameterGroupConfigurationEntityParameterSensitivitiesItem]] = None,
-    synchronized: Option[Boolean] = None
-  )
-
-  sealed trait ParameterGroupConfigurationEntityParameterSensitivitiesItem extends enumeratum.EnumEntry
-  object ParameterGroupConfigurationEntityParameterSensitivitiesItem extends enumeratum.Enum[ParameterGroupConfigurationEntityParameterSensitivitiesItem] with enumeratum.CirceEnum[ParameterGroupConfigurationEntityParameterSensitivitiesItem] {
-    val values = findValues
-    case object SENSITIVE extends ParameterGroupConfigurationEntityParameterSensitivitiesItem
-    case object NON_SENSITIVE extends ParameterGroupConfigurationEntityParameterSensitivitiesItem
-  }
-  case class ParameterProviderApplyParametersRequestDTO (
-    complete: Option[Boolean] = None,
-    failureReason: Option[String] = None,
-    lastUpdated: Option[java.time.Instant] = None,
-    parameterContextUpdates: Option[Seq[ParameterContextUpdateEntity]] = None,
-    parameterProvider: Option[ParameterProviderDTO] = None,
-    percentCompleted: Option[Int] = None,
-    referencingComponents: Option[Set[AffectedComponentEntity]] = None,
-    requestId: Option[String] = None,
-    state: Option[String] = None,
-    submissionTime: Option[java.time.Instant] = None,
-    updateSteps: Option[Seq[ParameterProviderApplyParametersUpdateStepDTO]] = None,
-    uri: Option[String] = None
-  )
-  case class ParameterProviderApplyParametersRequestEntity (
-    request: Option[ParameterProviderApplyParametersRequestDTO] = None
-  )
-  case class ParameterProviderApplyParametersUpdateStepDTO (
-    complete: Option[Boolean] = None,
-    description: Option[String] = None,
-    failureReason: Option[String] = None
-  )
-  case class ParameterProviderConfigurationDTO (
-    parameterGroupName: Option[String] = None,
-    parameterProviderId: Option[String] = None,
-    parameterProviderName: Option[String] = None,
-    synchronized: Option[Boolean] = None
-  )
-  case class ParameterProviderConfigurationEntity (
-    component: Option[ParameterProviderConfigurationDTO] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None
-  )
-  case class ParameterProviderDTO (
-    affectedComponents: Option[Set[AffectedComponentEntity]] = None,
-    annotationData: Option[String] = None,
-    bundle: Option[BundleDTO] = None,
-    comments: Option[String] = None,
-    customUiUrl: Option[String] = None,
-    deprecated: Option[Boolean] = None,
-    descriptors: Option[Map[String, PropertyDescriptorDTO]] = None,
-    extensionMissing: Option[Boolean] = None,
-    id: Option[String] = None,
-    multipleVersionsAvailable: Option[Boolean] = None,
-    name: Option[String] = None,
-    parameterGroupConfigurations: Option[Seq[ParameterGroupConfigurationEntity]] = None,
-    parameterStatus: Option[Set[ParameterStatusDTO]] = None,
-    parentGroupId: Option[String] = None,
-    persistsState: Option[Boolean] = None,
-    position: Option[PositionDTO] = None,
-    properties: Option[Map[String, String]] = None,
-    referencingParameterContexts: Option[Set[ParameterProviderReferencingComponentEntity]] = None,
-    restricted: Option[Boolean] = None,
-    `type`: Option[String] = None,
-    validationErrors: Option[Seq[String]] = None,
-    validationStatus: Option[ParameterProviderDTOValidationStatus] = None,
-    versionedComponentId: Option[String] = None
-  )
-
-  sealed trait ParameterProviderDTOValidationStatus extends enumeratum.EnumEntry
-  object ParameterProviderDTOValidationStatus extends enumeratum.Enum[ParameterProviderDTOValidationStatus] with enumeratum.CirceEnum[ParameterProviderDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends ParameterProviderDTOValidationStatus
-    case object INVALID extends ParameterProviderDTOValidationStatus
-    case object VALIDATING extends ParameterProviderDTOValidationStatus
-  }
-  case class ParameterProviderDefinition (
-    additionalDetails: Option[Boolean] = None,
-    artifact: Option[String] = None,
-    buildInfo: Option[BuildInfo] = None,
-    deprecated: Option[Boolean] = None,
-    deprecationAlternatives: Option[Set[String]] = None,
-    deprecationReason: Option[String] = None,
-    dynamicProperties: Option[Seq[DynamicProperty]] = None,
-    explicitRestrictions: Option[Set[Restriction]] = None,
-    group: Option[String] = None,
-    propertyDescriptors: Option[Map[String, PropertyDescriptor]] = None,
-    providedApiImplementations: Option[Seq[DefinedType]] = None,
-    restricted: Option[Boolean] = None,
-    restrictedExplanation: Option[String] = None,
-    seeAlso: Option[Set[String]] = None,
-    stateful: Option[Stateful] = None,
-    supportsDynamicProperties: Option[Boolean] = None,
-    supportsSensitiveDynamicProperties: Option[Boolean] = None,
-    systemResourceConsiderations: Option[Seq[SystemResourceConsideration]] = None,
-    tags: Option[Set[String]] = None,
-    `type`: Option[String] = None,
-    typeDescription: Option[String] = None,
-    version: Option[String] = None
-  )
-  case class ParameterProviderEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[ParameterProviderDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class ParameterProviderParameterApplicationEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    parameterGroupConfigurations: Option[Seq[ParameterGroupConfigurationEntity]] = None,
-    revision: Option[RevisionDTO] = None
-  )
-  case class ParameterProviderParameterFetchEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    revision: Option[RevisionDTO] = None
-  )
-  case class ParameterProviderReference (
-    bundle: Option[Bundle] = None,
-    identifier: Option[String] = None,
-    name: Option[String] = None,
-    `type`: Option[String] = None
-  )
-  case class ParameterProviderReferencingComponentDTO (
-    id: Option[String] = None,
-    name: Option[String] = None
-  )
-  case class ParameterProviderReferencingComponentEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[ParameterProviderReferencingComponentDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class ParameterProviderReferencingComponentsEntity (
-    parameterProviderReferencingComponents: Option[Set[ParameterProviderReferencingComponentEntity]] = None
-  )
-  case class ParameterProviderTypesEntity (
-    parameterProviderTypes: Option[Set[DocumentedTypeDTO]] = None
-  )
-  case class ParameterProvidersEntity (
-    currentTime: Option[String] = None,
-    parameterProviders: Option[Set[ParameterProviderEntity]] = None
-  )
-  case class ParameterStatusDTO (
-    parameter: Option[ParameterEntity] = None,
-    status: Option[ParameterStatusDTOStatus] = None
-  )
-
-  sealed trait ParameterStatusDTOStatus extends enumeratum.EnumEntry
-  object ParameterStatusDTOStatus extends enumeratum.Enum[ParameterStatusDTOStatus] with enumeratum.CirceEnum[ParameterStatusDTOStatus] {
-    val values = findValues
-    case object NEW extends ParameterStatusDTOStatus
-    case object CHANGED extends ParameterStatusDTOStatus
-    case object REMOVED extends ParameterStatusDTOStatus
-    case object MISSING_BUT_REFERENCED extends ParameterStatusDTOStatus
-    case object UNCHANGED extends ParameterStatusDTOStatus
-  }
-  case class PasteRequestEntity (
-    copyResponse: Option[CopyResponseEntity] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    revision: Option[RevisionDTO] = None
-  )
-  case class PasteResponseEntity (
-    flow: Option[FlowDTO] = None,
-    revision: Option[RevisionDTO] = None
-  )
-  case class PeerDTO (
-    flowFileCount: Option[Int] = None,
-    hostname: Option[String] = None,
-    port: Option[Int] = None,
-    secure: Option[Boolean] = None
-  )
-  case class PeersEntity (
-    peers: Option[Seq[PeerDTO]] = None
-  )
-  case class PermissionsDTO (
-    canRead: Option[Boolean] = None,
-    canWrite: Option[Boolean] = None
-  )
-  case class PortDTO (
-    allowRemoteAccess: Option[Boolean] = None,
-    comments: Option[String] = None,
-    concurrentlySchedulableTaskCount: Option[Int] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    portFunction: Option[PortDTOPortFunction] = None,
-    position: Option[PositionDTO] = None,
-    state: Option[PortDTOState] = None,
-    transmitting: Option[Boolean] = None,
-    `type`: Option[PortDTOType] = None,
-    validationErrors: Option[Seq[String]] = None,
-    versionedComponentId: Option[String] = None
-  )
-
-  sealed trait PortDTOPortFunction extends enumeratum.EnumEntry
-  object PortDTOPortFunction extends enumeratum.Enum[PortDTOPortFunction] with enumeratum.CirceEnum[PortDTOPortFunction] {
-    val values = findValues
-    case object STANDARD extends PortDTOPortFunction
-    case object FAILURE extends PortDTOPortFunction
-  }
-
-  sealed trait PortDTOState extends enumeratum.EnumEntry
-  object PortDTOState extends enumeratum.Enum[PortDTOState] with enumeratum.CirceEnum[PortDTOState] {
-    val values = findValues
-    case object RUNNING extends PortDTOState
-    case object STOPPED extends PortDTOState
-    case object DISABLED extends PortDTOState
-  }
-
-  sealed trait PortDTOType extends enumeratum.EnumEntry
-  object PortDTOType extends enumeratum.Enum[PortDTOType] with enumeratum.CirceEnum[PortDTOType] {
-    val values = findValues
-    case object INPUT_PORT extends PortDTOType
-    case object OUTPUT_PORT extends PortDTOType
-  }
-  case class PortEntity (
-    allowRemoteAccess: Option[Boolean] = None,
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[PortDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    operatePermissions: Option[PermissionsDTO] = None,
-    permissions: Option[PermissionsDTO] = None,
-    portType: Option[String] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    status: Option[PortStatusDTO] = None,
-    uri: Option[String] = None
-  )
-  case class PortRunStatusEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    revision: Option[RevisionDTO] = None,
-    state: Option[PortRunStatusEntityState] = None
-  )
-
-  sealed trait PortRunStatusEntityState extends enumeratum.EnumEntry
-  object PortRunStatusEntityState extends enumeratum.Enum[PortRunStatusEntityState] with enumeratum.CirceEnum[PortRunStatusEntityState] {
-    val values = findValues
-    case object RUNNING extends PortRunStatusEntityState
-    case object STOPPED extends PortRunStatusEntityState
-    case object DISABLED extends PortRunStatusEntityState
-  }
-  case class PortStatusDTO (
-    aggregateSnapshot: Option[PortStatusSnapshotDTO] = None,
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    nodeSnapshots: Option[Seq[NodePortStatusSnapshotDTO]] = None,
-    runStatus: Option[PortStatusDTORunStatus] = None,
-    statsLastRefreshed: Option[String] = None,
-    transmitting: Option[Boolean] = None
-  )
-
-  sealed trait PortStatusDTORunStatus extends enumeratum.EnumEntry
-  object PortStatusDTORunStatus extends enumeratum.Enum[PortStatusDTORunStatus] with enumeratum.CirceEnum[PortStatusDTORunStatus] {
-    val values = findValues
-    case object Running extends PortStatusDTORunStatus
-    case object Stopped extends PortStatusDTORunStatus
-    case object Validating extends PortStatusDTORunStatus
-    case object Disabled extends PortStatusDTORunStatus
-    case object Invalid extends PortStatusDTORunStatus
-  }
-  case class PortStatusEntity (
-    canRead: Option[Boolean] = None,
-    portStatus: Option[PortStatusDTO] = None
-  )
-  case class PortStatusSnapshotDTO (
-    activeThreadCount: Option[Int] = None,
-    bytesIn: Option[Long] = None,
-    bytesOut: Option[Long] = None,
-    flowFilesIn: Option[Int] = None,
-    flowFilesOut: Option[Int] = None,
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    input: Option[String] = None,
-    name: Option[String] = None,
-    output: Option[String] = None,
-    runStatus: Option[PortStatusSnapshotDTORunStatus] = None,
-    transmitting: Option[Boolean] = None
-  )
-
-  sealed trait PortStatusSnapshotDTORunStatus extends enumeratum.EnumEntry
-  object PortStatusSnapshotDTORunStatus extends enumeratum.Enum[PortStatusSnapshotDTORunStatus] with enumeratum.CirceEnum[PortStatusSnapshotDTORunStatus] {
-    val values = findValues
-    case object Running extends PortStatusSnapshotDTORunStatus
-    case object Stopped extends PortStatusSnapshotDTORunStatus
-    case object Validating extends PortStatusSnapshotDTORunStatus
-    case object Disabled extends PortStatusSnapshotDTORunStatus
-    case object Invalid extends PortStatusSnapshotDTORunStatus
-  }
-  case class PortStatusSnapshotEntity (
-    canRead: Option[Boolean] = None,
-    id: Option[String] = None,
-    portStatusSnapshot: Option[PortStatusSnapshotDTO] = None
-  )
-  case class Position (
-    x: Option[Double] = None,
-    y: Option[Double] = None
-  )
-  case class PositionDTO (
-    x: Option[Double] = None,
-    y: Option[Double] = None
-  )
-  case class PreviousValueDTO (
-    previousValue: Option[String] = None,
-    timestamp: Option[String] = None,
-    userIdentity: Option[String] = None
-  )
-  case class PrioritizerTypesEntity (
-    prioritizerTypes: Option[Set[DocumentedTypeDTO]] = None
-  )
-  case class ProcessGroupDTO (
-    activeRemotePortCount: Option[Int] = None,
-    comments: Option[String] = None,
-    contents: Option[FlowSnippetDTO] = None,
-    defaultBackPressureDataSizeThreshold: Option[String] = None,
-    defaultBackPressureObjectThreshold: Option[Long] = None,
-    defaultFlowFileExpiration: Option[String] = None,
-    disabledCount: Option[Int] = None,
-    executionEngine: Option[ProcessGroupDTOExecutionEngine] = None,
-    flowfileConcurrency: Option[ProcessGroupDTOFlowfileConcurrency] = None,
-    flowfileOutboundPolicy: Option[ProcessGroupDTOFlowfileOutboundPolicy] = None,
-    id: Option[String] = None,
-    inactiveRemotePortCount: Option[Int] = None,
-    inputPortCount: Option[Int] = None,
-    invalidCount: Option[Int] = None,
-    localInputPortCount: Option[Int] = None,
-    localOutputPortCount: Option[Int] = None,
-    locallyModifiedAndStaleCount: Option[Int] = None,
-    locallyModifiedCount: Option[Int] = None,
-    logFileSuffix: Option[String] = None,
-    maxConcurrentTasks: Option[Int] = None,
-    name: Option[String] = None,
-    outputPortCount: Option[Int] = None,
-    parameterContext: Option[ParameterContextReferenceEntity] = None,
-    parentGroupId: Option[String] = None,
-    position: Option[PositionDTO] = None,
-    publicInputPortCount: Option[Int] = None,
-    publicOutputPortCount: Option[Int] = None,
-    runningCount: Option[Int] = None,
-    staleCount: Option[Int] = None,
-    statelessFlowTimeout: Option[String] = None,
-    statelessGroupScheduledState: Option[ProcessGroupDTOStatelessGroupScheduledState] = None,
-    stoppedCount: Option[Int] = None,
-    syncFailureCount: Option[Int] = None,
-    upToDateCount: Option[Int] = None,
-    versionControlInformation: Option[VersionControlInformationDTO] = None,
-    versionedComponentId: Option[String] = None
-  )
-
-  sealed trait ProcessGroupDTOExecutionEngine extends enumeratum.EnumEntry
-  object ProcessGroupDTOExecutionEngine extends enumeratum.Enum[ProcessGroupDTOExecutionEngine] with enumeratum.CirceEnum[ProcessGroupDTOExecutionEngine] {
-    val values = findValues
-    case object STATELESS extends ProcessGroupDTOExecutionEngine
-    case object STANDARD extends ProcessGroupDTOExecutionEngine
-    case object INHERITED extends ProcessGroupDTOExecutionEngine
-  }
-
-  sealed trait ProcessGroupDTOFlowfileConcurrency extends enumeratum.EnumEntry
-  object ProcessGroupDTOFlowfileConcurrency extends enumeratum.Enum[ProcessGroupDTOFlowfileConcurrency] with enumeratum.CirceEnum[ProcessGroupDTOFlowfileConcurrency] {
-    val values = findValues
-    case object UNBOUNDED extends ProcessGroupDTOFlowfileConcurrency
-    case object SINGLE_FLOWFILE_PER_NODE extends ProcessGroupDTOFlowfileConcurrency
-    case object SINGLE_BATCH_PER_NODE extends ProcessGroupDTOFlowfileConcurrency
-  }
-
-  sealed trait ProcessGroupDTOFlowfileOutboundPolicy extends enumeratum.EnumEntry
-  object ProcessGroupDTOFlowfileOutboundPolicy extends enumeratum.Enum[ProcessGroupDTOFlowfileOutboundPolicy] with enumeratum.CirceEnum[ProcessGroupDTOFlowfileOutboundPolicy] {
-    val values = findValues
-    case object STREAM_WHEN_AVAILABLE extends ProcessGroupDTOFlowfileOutboundPolicy
-    case object BATCH_OUTPUT extends ProcessGroupDTOFlowfileOutboundPolicy
-  }
-
-  sealed trait ProcessGroupDTOStatelessGroupScheduledState extends enumeratum.EnumEntry
-  object ProcessGroupDTOStatelessGroupScheduledState extends enumeratum.Enum[ProcessGroupDTOStatelessGroupScheduledState] with enumeratum.CirceEnum[ProcessGroupDTOStatelessGroupScheduledState] {
-    val values = findValues
-    case object STOPPED extends ProcessGroupDTOStatelessGroupScheduledState
-    case object RUNNING extends ProcessGroupDTOStatelessGroupScheduledState
-  }
-  case class ProcessGroupEntity (
-    activeRemotePortCount: Option[Int] = None,
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[ProcessGroupDTO] = None,
-    disabledCount: Option[Int] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    inactiveRemotePortCount: Option[Int] = None,
-    inputPortCount: Option[Int] = None,
-    invalidCount: Option[Int] = None,
-    localInputPortCount: Option[Int] = None,
-    localOutputPortCount: Option[Int] = None,
-    locallyModifiedAndStaleCount: Option[Int] = None,
-    locallyModifiedCount: Option[Int] = None,
-    outputPortCount: Option[Int] = None,
-    parameterContext: Option[ParameterContextReferenceEntity] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    processGroupUpdateStrategy: Option[ProcessGroupEntityProcessGroupUpdateStrategy] = None,
-    publicInputPortCount: Option[Int] = None,
-    publicOutputPortCount: Option[Int] = None,
-    revision: Option[RevisionDTO] = None,
-    runningCount: Option[Int] = None,
-    staleCount: Option[Int] = None,
-    status: Option[ProcessGroupStatusDTO] = None,
-    stoppedCount: Option[Int] = None,
-    syncFailureCount: Option[Int] = None,
-    upToDateCount: Option[Int] = None,
-    uri: Option[String] = None,
-    versionedFlowSnapshot: Option[RegisteredFlowSnapshot] = None,
-    versionedFlowState: Option[ProcessGroupEntityVersionedFlowState] = None
-  )
-
-  sealed trait ProcessGroupEntityProcessGroupUpdateStrategy extends enumeratum.EnumEntry
-  object ProcessGroupEntityProcessGroupUpdateStrategy extends enumeratum.Enum[ProcessGroupEntityProcessGroupUpdateStrategy] with enumeratum.CirceEnum[ProcessGroupEntityProcessGroupUpdateStrategy] {
-    val values = findValues
-    case object CURRENT_GROUP extends ProcessGroupEntityProcessGroupUpdateStrategy
-    case object CURRENT_GROUP_WITH_CHILDREN extends ProcessGroupEntityProcessGroupUpdateStrategy
-  }
-
-  sealed trait ProcessGroupEntityVersionedFlowState extends enumeratum.EnumEntry
-  object ProcessGroupEntityVersionedFlowState extends enumeratum.Enum[ProcessGroupEntityVersionedFlowState] with enumeratum.CirceEnum[ProcessGroupEntityVersionedFlowState] {
-    val values = findValues
-    case object LOCALLY_MODIFIED extends ProcessGroupEntityVersionedFlowState
-    case object STALE extends ProcessGroupEntityVersionedFlowState
-    case object LOCALLY_MODIFIED_AND_STALE extends ProcessGroupEntityVersionedFlowState
-    case object UP_TO_DATE extends ProcessGroupEntityVersionedFlowState
-    case object SYNC_FAILURE extends ProcessGroupEntityVersionedFlowState
-  }
-  case class ProcessGroupFlowDTO (
-    breadcrumb: Option[FlowBreadcrumbEntity] = None,
-    flow: Option[FlowDTO] = None,
-    id: Option[String] = None,
-    lastRefreshed: Option[String] = None,
-    parameterContext: Option[ParameterContextReferenceEntity] = None,
-    parentGroupId: Option[String] = None,
-    uri: Option[String] = None
-  )
-  case class ProcessGroupFlowEntity (
-    permissions: Option[PermissionsDTO] = None,
-    processGroupFlow: Option[ProcessGroupFlowDTO] = None,
-    revision: Option[RevisionDTO] = None
-  )
-  case class ProcessGroupImportEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    processGroupRevision: Option[RevisionDTO] = None,
-    versionedFlowSnapshot: Option[RegisteredFlowSnapshot] = None
-  )
-  case class ProcessGroupNameDTO (
-    id: Option[String] = None,
-    name: Option[String] = None
-  )
-  case class ProcessGroupReplaceRequestDTO (
-    complete: Option[Boolean] = None,
-    failureReason: Option[String] = None,
-    lastUpdated: Option[String] = None,
-    percentCompleted: Option[Int] = None,
-    processGroupId: Option[String] = None,
-    requestId: Option[String] = None,
-    state: Option[String] = None,
-    uri: Option[String] = None
-  )
-  case class ProcessGroupReplaceRequestEntity (
-    processGroupRevision: Option[RevisionDTO] = None,
-    request: Option[ProcessGroupReplaceRequestDTO] = None,
-    versionedFlowSnapshot: Option[RegisteredFlowSnapshot] = None
-  )
-  case class ProcessGroupStatusDTO (
-    aggregateSnapshot: Option[ProcessGroupStatusSnapshotDTO] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    nodeSnapshots: Option[Seq[NodeProcessGroupStatusSnapshotDTO]] = None,
-    statsLastRefreshed: Option[String] = None
-  )
-  case class ProcessGroupStatusEntity (
-    canRead: Option[Boolean] = None,
-    processGroupStatus: Option[ProcessGroupStatusDTO] = None
-  )
-  case class ProcessGroupStatusSnapshotDTO (
-    activeThreadCount: Option[Int] = None,
-    bytesIn: Option[Long] = None,
-    bytesOut: Option[Long] = None,
-    bytesQueued: Option[Long] = None,
-    bytesRead: Option[Long] = None,
-    bytesReceived: Option[Long] = None,
-    bytesSent: Option[Long] = None,
-    bytesTransferred: Option[Long] = None,
-    bytesWritten: Option[Long] = None,
-    connectionStatusSnapshots: Option[Seq[ConnectionStatusSnapshotEntity]] = None,
-    flowFilesIn: Option[Int] = None,
-    flowFilesOut: Option[Int] = None,
-    flowFilesQueued: Option[Int] = None,
-    flowFilesReceived: Option[Int] = None,
-    flowFilesSent: Option[Int] = None,
-    flowFilesTransferred: Option[Int] = None,
-    id: Option[String] = None,
-    input: Option[String] = None,
-    inputPortStatusSnapshots: Option[Seq[PortStatusSnapshotEntity]] = None,
-    name: Option[String] = None,
-    output: Option[String] = None,
-    outputPortStatusSnapshots: Option[Seq[PortStatusSnapshotEntity]] = None,
-    processGroupStatusSnapshots: Option[Seq[ProcessGroupStatusSnapshotEntity]] = None,
-    processingNanos: Option[Long] = None,
-    processingPerformanceStatus: Option[ProcessingPerformanceStatusDTO] = None,
-    processorStatusSnapshots: Option[Seq[ProcessorStatusSnapshotEntity]] = None,
-    queued: Option[String] = None,
-    queuedCount: Option[String] = None,
-    queuedSize: Option[String] = None,
-    read: Option[String] = None,
-    received: Option[String] = None,
-    remoteProcessGroupStatusSnapshots: Option[Seq[RemoteProcessGroupStatusSnapshotEntity]] = None,
-    sent: Option[String] = None,
-    statelessActiveThreadCount: Option[Int] = None,
-    terminatedThreadCount: Option[Int] = None,
-    transferred: Option[String] = None,
-    versionedFlowState: Option[ProcessGroupStatusSnapshotDTOVersionedFlowState] = None,
-    written: Option[String] = None
-  )
-
-  sealed trait ProcessGroupStatusSnapshotDTOVersionedFlowState extends enumeratum.EnumEntry
-  object ProcessGroupStatusSnapshotDTOVersionedFlowState extends enumeratum.Enum[ProcessGroupStatusSnapshotDTOVersionedFlowState] with enumeratum.CirceEnum[ProcessGroupStatusSnapshotDTOVersionedFlowState] {
-    val values = findValues
-    case object LOCALLY_MODIFIED extends ProcessGroupStatusSnapshotDTOVersionedFlowState
-    case object STALE extends ProcessGroupStatusSnapshotDTOVersionedFlowState
-    case object LOCALLY_MODIFIED_AND_STALE extends ProcessGroupStatusSnapshotDTOVersionedFlowState
-    case object UP_TO_DATE extends ProcessGroupStatusSnapshotDTOVersionedFlowState
-    case object SYNC_FAILURE extends ProcessGroupStatusSnapshotDTOVersionedFlowState
-  }
-  case class ProcessGroupStatusSnapshotEntity (
-    canRead: Option[Boolean] = None,
-    id: Option[String] = None,
-    processGroupStatusSnapshot: Option[ProcessGroupStatusSnapshotDTO] = None
-  )
-  case class ProcessGroupUploadEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    flowSnapshot: Option[RegisteredFlowSnapshot] = None,
-    groupId: Option[String] = None,
-    groupName: Option[String] = None,
-    positionDTO: Option[PositionDTO] = None,
-    revisionDTO: Option[RevisionDTO] = None
-  )
-  case class ProcessGroupsEntity (
-    processGroups: Option[Set[ProcessGroupEntity]] = None
-  )
-  case class ProcessingPerformanceStatusDTO (
-    contentReadDuration: Option[Long] = None,
-    contentWriteDuration: Option[Long] = None,
-    cpuDuration: Option[Long] = None,
-    garbageCollectionDuration: Option[Long] = None,
-    identifier: Option[String] = None,
-    sessionCommitDuration: Option[Long] = None
-  )
-  case class ProcessorConfigDTO (
-    annotationData: Option[String] = None,
-    autoTerminatedRelationships: Option[Set[String]] = None,
-    backoffMechanism: Option[String] = None,
-    bulletinLevel: Option[String] = None,
-    comments: Option[String] = None,
-    concurrentlySchedulableTaskCount: Option[Int] = None,
-    customUiUrl: Option[String] = None,
-    defaultConcurrentTasks: Option[Map[String, String]] = None,
-    defaultSchedulingPeriod: Option[Map[String, String]] = None,
-    descriptors: Option[Map[String, PropertyDescriptorDTO]] = None,
-    executionNode: Option[String] = None,
-    lossTolerant: Option[Boolean] = None,
-    maxBackoffPeriod: Option[String] = None,
-    penaltyDuration: Option[String] = None,
-    properties: Option[Map[String, String]] = None,
-    retriedRelationships: Option[Set[String]] = None,
-    retryCount: Option[Int] = None,
-    runDurationMillis: Option[Long] = None,
-    schedulingPeriod: Option[String] = None,
-    schedulingStrategy: Option[String] = None,
-    sensitiveDynamicPropertyNames: Option[Set[String]] = None,
-    yieldDuration: Option[String] = None
-  )
-  case class ProcessorConfiguration (
-    configuration: Option[String] = None,
-    processorClassName: Option[String] = None
-  )
-  case class ProcessorDTO (
-    bundle: Option[BundleDTO] = None,
-    config: Option[ProcessorConfigDTO] = None,
-    deprecated: Option[Boolean] = None,
-    description: Option[String] = None,
-    executionNodeRestricted: Option[Boolean] = None,
-    extensionMissing: Option[Boolean] = None,
-    id: Option[String] = None,
-    inputRequirement: Option[String] = None,
-    multipleVersionsAvailable: Option[Boolean] = None,
-    name: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    persistsState: Option[Boolean] = None,
-    position: Option[PositionDTO] = None,
-    relationships: Option[Seq[RelationshipDTO]] = None,
-    restricted: Option[Boolean] = None,
-    state: Option[ProcessorDTOState] = None,
-    style: Option[Map[String, String]] = None,
-    supportsBatching: Option[Boolean] = None,
-    supportsParallelProcessing: Option[Boolean] = None,
-    supportsSensitiveDynamicProperties: Option[Boolean] = None,
-    `type`: Option[String] = None,
-    validationErrors: Option[Seq[String]] = None,
-    validationStatus: Option[ProcessorDTOValidationStatus] = None,
-    versionedComponentId: Option[String] = None
-  )
-
-  sealed trait ProcessorDTOState extends enumeratum.EnumEntry
-  object ProcessorDTOState extends enumeratum.Enum[ProcessorDTOState] with enumeratum.CirceEnum[ProcessorDTOState] {
-    val values = findValues
-    case object RUNNING extends ProcessorDTOState
-    case object STOPPED extends ProcessorDTOState
-    case object DISABLED extends ProcessorDTOState
-  }
-
-  sealed trait ProcessorDTOValidationStatus extends enumeratum.EnumEntry
-  object ProcessorDTOValidationStatus extends enumeratum.Enum[ProcessorDTOValidationStatus] with enumeratum.CirceEnum[ProcessorDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends ProcessorDTOValidationStatus
-    case object INVALID extends ProcessorDTOValidationStatus
-    case object VALIDATING extends ProcessorDTOValidationStatus
-  }
-  case class ProcessorDefinition (
-    additionalDetails: Option[Boolean] = None,
-    artifact: Option[String] = None,
-    buildInfo: Option[BuildInfo] = None,
-    defaultBulletinLevel: Option[String] = None,
-    defaultConcurrentTasksBySchedulingStrategy: Option[Map[String, Int]] = None,
-    defaultPenaltyDuration: Option[String] = None,
-    defaultSchedulingPeriodBySchedulingStrategy: Option[Map[String, String]] = None,
-    defaultSchedulingStrategy: Option[String] = None,
-    defaultYieldDuration: Option[String] = None,
-    deprecated: Option[Boolean] = None,
-    deprecationAlternatives: Option[Set[String]] = None,
-    deprecationReason: Option[String] = None,
-    dynamicProperties: Option[Seq[DynamicProperty]] = None,
-    dynamicRelationship: Option[DynamicRelationship] = None,
-    explicitRestrictions: Option[Set[Restriction]] = None,
-    group: Option[String] = None,
-    inputRequirement: Option[ProcessorDefinitionInputRequirement] = None,
-    multiProcessorUseCases: Option[Seq[MultiProcessorUseCase]] = None,
-    primaryNodeOnly: Option[Boolean] = None,
-    propertyDescriptors: Option[Map[String, PropertyDescriptor]] = None,
-    providedApiImplementations: Option[Seq[DefinedType]] = None,
-    readsAttributes: Option[Seq[Attribute]] = None,
-    restricted: Option[Boolean] = None,
-    restrictedExplanation: Option[String] = None,
-    seeAlso: Option[Set[String]] = None,
-    sideEffectFree: Option[Boolean] = None,
-    stateful: Option[Stateful] = None,
-    supportedRelationships: Option[Seq[Relationship]] = None,
-    supportedSchedulingStrategies: Option[Seq[String]] = None,
-    supportsBatching: Option[Boolean] = None,
-    supportsDynamicProperties: Option[Boolean] = None,
-    supportsDynamicRelationships: Option[Boolean] = None,
-    supportsSensitiveDynamicProperties: Option[Boolean] = None,
-    systemResourceConsiderations: Option[Seq[SystemResourceConsideration]] = None,
-    tags: Option[Set[String]] = None,
-    triggerSerially: Option[Boolean] = None,
-    triggerWhenAnyDestinationAvailable: Option[Boolean] = None,
-    triggerWhenEmpty: Option[Boolean] = None,
-    `type`: Option[String] = None,
-    typeDescription: Option[String] = None,
-    useCases: Option[Seq[UseCase]] = None,
-    version: Option[String] = None,
-    writesAttributes: Option[Seq[Attribute]] = None
-  )
-
-  sealed trait ProcessorDefinitionInputRequirement extends enumeratum.EnumEntry
-  object ProcessorDefinitionInputRequirement extends enumeratum.Enum[ProcessorDefinitionInputRequirement] with enumeratum.CirceEnum[ProcessorDefinitionInputRequirement] {
-    val values = findValues
-    case object INPUT_REQUIRED extends ProcessorDefinitionInputRequirement
-    case object INPUT_ALLOWED extends ProcessorDefinitionInputRequirement
-    case object INPUT_FORBIDDEN extends ProcessorDefinitionInputRequirement
-  }
-  case class ProcessorEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[ProcessorDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    inputRequirement: Option[String] = None,
-    operatePermissions: Option[PermissionsDTO] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    status: Option[ProcessorStatusDTO] = None,
-    uri: Option[String] = None
-  )
-  case class ProcessorRunStatusDetailsDTO (
-    activeThreadCount: Option[Int] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    runStatus: Option[ProcessorRunStatusDetailsDTORunStatus] = None,
-    validationErrors: Option[Set[String]] = None
-  )
-
-  sealed trait ProcessorRunStatusDetailsDTORunStatus extends enumeratum.EnumEntry
-  object ProcessorRunStatusDetailsDTORunStatus extends enumeratum.Enum[ProcessorRunStatusDetailsDTORunStatus] with enumeratum.CirceEnum[ProcessorRunStatusDetailsDTORunStatus] {
-    val values = findValues
-    case object Running extends ProcessorRunStatusDetailsDTORunStatus
-    case object Stopped extends ProcessorRunStatusDetailsDTORunStatus
-    case object Invalid extends ProcessorRunStatusDetailsDTORunStatus
-    case object Validating extends ProcessorRunStatusDetailsDTORunStatus
-    case object Disabled extends ProcessorRunStatusDetailsDTORunStatus
-  }
-  case class ProcessorRunStatusDetailsEntity (
-    permissions: Option[PermissionsDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    runStatusDetails: Option[ProcessorRunStatusDetailsDTO] = None
-  )
-  case class ProcessorRunStatusEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    revision: Option[RevisionDTO] = None,
-    state: Option[ProcessorRunStatusEntityState] = None
-  )
-
-  sealed trait ProcessorRunStatusEntityState extends enumeratum.EnumEntry
-  object ProcessorRunStatusEntityState extends enumeratum.Enum[ProcessorRunStatusEntityState] with enumeratum.CirceEnum[ProcessorRunStatusEntityState] {
-    val values = findValues
-    case object RUNNING extends ProcessorRunStatusEntityState
-    case object STOPPED extends ProcessorRunStatusEntityState
-    case object DISABLED extends ProcessorRunStatusEntityState
-    case object RUN_ONCE extends ProcessorRunStatusEntityState
-  }
-  case class ProcessorStatusDTO (
-    aggregateSnapshot: Option[ProcessorStatusSnapshotDTO] = None,
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    nodeSnapshots: Option[Seq[NodeProcessorStatusSnapshotDTO]] = None,
-    runStatus: Option[ProcessorStatusDTORunStatus] = None,
-    statsLastRefreshed: Option[String] = None,
-    `type`: Option[String] = None
-  )
-
-  sealed trait ProcessorStatusDTORunStatus extends enumeratum.EnumEntry
-  object ProcessorStatusDTORunStatus extends enumeratum.Enum[ProcessorStatusDTORunStatus] with enumeratum.CirceEnum[ProcessorStatusDTORunStatus] {
-    val values = findValues
-    case object Running extends ProcessorStatusDTORunStatus
-    case object Stopped extends ProcessorStatusDTORunStatus
-    case object Validating extends ProcessorStatusDTORunStatus
-    case object Disabled extends ProcessorStatusDTORunStatus
-    case object Invalid extends ProcessorStatusDTORunStatus
-  }
-  case class ProcessorStatusEntity (
-    canRead: Option[Boolean] = None,
-    processorStatus: Option[ProcessorStatusDTO] = None
-  )
-  case class ProcessorStatusSnapshotDTO (
-    activeThreadCount: Option[Int] = None,
-    bytesIn: Option[Long] = None,
-    bytesOut: Option[Long] = None,
-    bytesRead: Option[Long] = None,
-    bytesWritten: Option[Long] = None,
-    executionNode: Option[ProcessorStatusSnapshotDTOExecutionNode] = None,
-    flowFilesIn: Option[Int] = None,
-    flowFilesOut: Option[Int] = None,
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    input: Option[String] = None,
-    name: Option[String] = None,
-    output: Option[String] = None,
-    processingPerformanceStatus: Option[ProcessingPerformanceStatusDTO] = None,
-    read: Option[String] = None,
-    runStatus: Option[ProcessorStatusSnapshotDTORunStatus] = None,
-    taskCount: Option[Int] = None,
-    tasks: Option[String] = None,
-    tasksDuration: Option[String] = None,
-    tasksDurationNanos: Option[Long] = None,
-    terminatedThreadCount: Option[Int] = None,
-    `type`: Option[String] = None,
-    written: Option[String] = None
-  )
-
-  sealed trait ProcessorStatusSnapshotDTOExecutionNode extends enumeratum.EnumEntry
-  object ProcessorStatusSnapshotDTOExecutionNode extends enumeratum.Enum[ProcessorStatusSnapshotDTOExecutionNode] with enumeratum.CirceEnum[ProcessorStatusSnapshotDTOExecutionNode] {
-    val values = findValues
-    case object ALL extends ProcessorStatusSnapshotDTOExecutionNode
-    case object PRIMARY extends ProcessorStatusSnapshotDTOExecutionNode
-  }
-
-  sealed trait ProcessorStatusSnapshotDTORunStatus extends enumeratum.EnumEntry
-  object ProcessorStatusSnapshotDTORunStatus extends enumeratum.Enum[ProcessorStatusSnapshotDTORunStatus] with enumeratum.CirceEnum[ProcessorStatusSnapshotDTORunStatus] {
-    val values = findValues
-    case object Running extends ProcessorStatusSnapshotDTORunStatus
-    case object Stopped extends ProcessorStatusSnapshotDTORunStatus
-    case object Validating extends ProcessorStatusSnapshotDTORunStatus
-    case object Disabled extends ProcessorStatusSnapshotDTORunStatus
-    case object Invalid extends ProcessorStatusSnapshotDTORunStatus
-  }
-  case class ProcessorStatusSnapshotEntity (
-    canRead: Option[Boolean] = None,
-    id: Option[String] = None,
-    processorStatusSnapshot: Option[ProcessorStatusSnapshotDTO] = None
-  )
-  case class ProcessorTypesEntity (
-    processorTypes: Option[Set[DocumentedTypeDTO]] = None
-  )
-  case class ProcessorsEntity (
-    processors: Option[Set[ProcessorEntity]] = None
-  )
-  case class ProcessorsRunStatusDetailsEntity (
-    runStatusDetails: Option[Seq[ProcessorRunStatusDetailsEntity]] = None
-  )
-  case class PropertyAllowableValue (
-    description: Option[String] = None,
-    displayName: Option[String] = None,
-    value: Option[String] = None
-  )
-  case class PropertyDependency (
-    dependentValues: Option[Seq[String]] = None,
-    propertyDisplayName: Option[String] = None,
-    propertyName: Option[String] = None
-  )
-  case class PropertyDependencyDTO (
-    dependentValues: Option[Set[String]] = None,
-    propertyName: Option[String] = None
-  )
-  case class PropertyDescriptor (
-    allowableValues: Option[Seq[PropertyAllowableValue]] = None,
-    defaultValue: Option[String] = None,
-    dependencies: Option[Seq[PropertyDependency]] = None,
-    description: Option[String] = None,
-    displayName: Option[String] = None,
-    dynamic: Option[Boolean] = None,
-    expressionLanguageScope: Option[PropertyDescriptorExpressionLanguageScope] = None,
-    expressionLanguageScopeDescription: Option[String] = None,
-    name: Option[String] = None,
-    required: Option[Boolean] = None,
-    resourceDefinition: Option[PropertyResourceDefinition] = None,
-    sensitive: Option[Boolean] = None,
-    typeProvidedByValue: Option[DefinedType] = None,
-    validRegex: Option[String] = None,
-    validator: Option[String] = None
-  )
-
-  sealed trait PropertyDescriptorExpressionLanguageScope extends enumeratum.EnumEntry
-  object PropertyDescriptorExpressionLanguageScope extends enumeratum.Enum[PropertyDescriptorExpressionLanguageScope] with enumeratum.CirceEnum[PropertyDescriptorExpressionLanguageScope] {
-    val values = findValues
-    case object NONE extends PropertyDescriptorExpressionLanguageScope
-    case object ENVIRONMENT extends PropertyDescriptorExpressionLanguageScope
-    case object FLOWFILE_ATTRIBUTES extends PropertyDescriptorExpressionLanguageScope
-  }
-  case class PropertyDescriptorDTO (
-    allowableValues: Option[Seq[AllowableValueEntity]] = None,
-    defaultValue: Option[String] = None,
-    dependencies: Option[Seq[PropertyDependencyDTO]] = None,
-    description: Option[String] = None,
-    displayName: Option[String] = None,
-    dynamic: Option[Boolean] = None,
-    expressionLanguageScope: Option[String] = None,
-    identifiesControllerService: Option[String] = None,
-    identifiesControllerServiceBundle: Option[BundleDTO] = None,
-    name: Option[String] = None,
-    required: Option[Boolean] = None,
-    sensitive: Option[Boolean] = None,
-    supportsEl: Option[Boolean] = None
-  )
-  case class PropertyDescriptorEntity (
-    propertyDescriptor: Option[PropertyDescriptorDTO] = None
-  )
-  case class PropertyHistoryDTO (
-    previousValues: Option[Seq[PreviousValueDTO]] = None
-  )
-  case class PropertyResourceDefinition (
-    cardinality: Option[PropertyResourceDefinitionCardinality] = None,
-    resourceTypes: Option[Set[PropertyResourceDefinitionResourceTypesItem]] = None
-  )
-
-  sealed trait PropertyResourceDefinitionCardinality extends enumeratum.EnumEntry
-  object PropertyResourceDefinitionCardinality extends enumeratum.Enum[PropertyResourceDefinitionCardinality] with enumeratum.CirceEnum[PropertyResourceDefinitionCardinality] {
-    val values = findValues
-    case object SINGLE extends PropertyResourceDefinitionCardinality
-    case object MULTIPLE extends PropertyResourceDefinitionCardinality
-  }
-
-  sealed trait PropertyResourceDefinitionResourceTypesItem extends enumeratum.EnumEntry
-  object PropertyResourceDefinitionResourceTypesItem extends enumeratum.Enum[PropertyResourceDefinitionResourceTypesItem] with enumeratum.CirceEnum[PropertyResourceDefinitionResourceTypesItem] {
-    val values = findValues
-    case object FILE extends PropertyResourceDefinitionResourceTypesItem
-    case object DIRECTORY extends PropertyResourceDefinitionResourceTypesItem
-    case object TEXT extends PropertyResourceDefinitionResourceTypesItem
-    case object URL extends PropertyResourceDefinitionResourceTypesItem
-  }
-  case class ProvenanceDTO (
-    expiration: Option[String] = None,
-    finished: Option[Boolean] = None,
-    id: Option[String] = None,
-    percentCompleted: Option[Int] = None,
-    request: Option[ProvenanceRequestDTO] = None,
-    results: Option[ProvenanceResultsDTO] = None,
-    submissionTime: Option[String] = None,
-    uri: Option[String] = None
-  )
-  case class ProvenanceEntity (
-    provenance: Option[ProvenanceDTO] = None
-  )
-  case class ProvenanceEventDTO (
-    alternateIdentifierUri: Option[String] = None,
-    attributes: Option[Seq[AttributeDTO]] = None,
-    childUuids: Option[Seq[String]] = None,
-    clusterNodeAddress: Option[String] = None,
-    clusterNodeId: Option[String] = None,
-    componentId: Option[String] = None,
-    componentName: Option[String] = None,
-    componentType: Option[String] = None,
-    contentEqual: Option[Boolean] = None,
-    details: Option[String] = None,
-    eventDuration: Option[Long] = None,
-    eventId: Option[Long] = None,
-    eventTime: Option[String] = None,
-    eventType: Option[String] = None,
-    fileSize: Option[String] = None,
-    fileSizeBytes: Option[Long] = None,
-    flowFileUuid: Option[String] = None,
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    inputContentAvailable: Option[Boolean] = None,
-    inputContentClaimContainer: Option[String] = None,
-    inputContentClaimFileSize: Option[String] = None,
-    inputContentClaimFileSizeBytes: Option[Long] = None,
-    inputContentClaimIdentifier: Option[String] = None,
-    inputContentClaimOffset: Option[Long] = None,
-    inputContentClaimSection: Option[String] = None,
-    lineageDuration: Option[Long] = None,
-    outputContentAvailable: Option[Boolean] = None,
-    outputContentClaimContainer: Option[String] = None,
-    outputContentClaimFileSize: Option[String] = None,
-    outputContentClaimFileSizeBytes: Option[Long] = None,
-    outputContentClaimIdentifier: Option[String] = None,
-    outputContentClaimOffset: Option[Long] = None,
-    outputContentClaimSection: Option[String] = None,
-    parentUuids: Option[Seq[String]] = None,
-    relationship: Option[String] = None,
-    replayAvailable: Option[Boolean] = None,
-    replayExplanation: Option[String] = None,
-    sourceConnectionIdentifier: Option[String] = None,
-    sourceSystemFlowFileId: Option[String] = None,
-    transitUri: Option[String] = None
-  )
-  case class ProvenanceEventEntity (
-    provenanceEvent: Option[ProvenanceEventDTO] = None
-  )
-  case class ProvenanceLinkDTO (
-    flowFileUuid: Option[String] = None,
-    millis: Option[Long] = None,
-    sourceId: Option[String] = None,
-    targetId: Option[String] = None,
-    timestamp: Option[String] = None
-  )
-  case class ProvenanceNodeDTO (
-    childUuids: Option[Seq[String]] = None,
-    clusterNodeIdentifier: Option[String] = None,
-    eventType: Option[String] = None,
-    flowFileUuid: Option[String] = None,
-    id: Option[String] = None,
-    millis: Option[Long] = None,
-    parentUuids: Option[Seq[String]] = None,
-    timestamp: Option[String] = None,
-    `type`: Option[ProvenanceNodeDTOType] = None
-  )
-
-  sealed trait ProvenanceNodeDTOType extends enumeratum.EnumEntry
-  object ProvenanceNodeDTOType extends enumeratum.Enum[ProvenanceNodeDTOType] with enumeratum.CirceEnum[ProvenanceNodeDTOType] {
-    val values = findValues
-    case object FLOWFILE extends ProvenanceNodeDTOType
-    case object EVENT extends ProvenanceNodeDTOType
-  }
-  case class ProvenanceOptionsDTO (
-    searchableFields: Option[Seq[ProvenanceSearchableFieldDTO]] = None
-  )
-  case class ProvenanceOptionsEntity (
-    provenanceOptions: Option[ProvenanceOptionsDTO] = None
-  )
-  case class ProvenanceRequestDTO (
-    clusterNodeId: Option[String] = None,
-    endDate: Option[String] = None,
-    incrementalResults: Option[Boolean] = None,
-    maxResults: Option[Int] = None,
-    maximumFileSize: Option[String] = None,
-    minimumFileSize: Option[String] = None,
-    searchTerms: Option[Map[String, ProvenanceSearchValueDTO]] = None,
-    startDate: Option[String] = None,
-    summarize: Option[Boolean] = None
-  )
-  case class ProvenanceResultsDTO (
-    errors: Option[Set[String]] = None,
-    generated: Option[String] = None,
-    oldestEvent: Option[String] = None,
-    provenanceEvents: Option[Seq[ProvenanceEventDTO]] = None,
-    timeOffset: Option[Int] = None,
-    total: Option[String] = None,
-    totalCount: Option[Long] = None
-  )
-  case class ProvenanceSearchValueDTO (
-    inverse: Option[Boolean] = None,
-    value: Option[String] = None
-  )
-  case class ProvenanceSearchableFieldDTO (
-    field: Option[String] = None,
-    id: Option[String] = None,
-    label: Option[String] = None,
-    `type`: Option[String] = None
-  )
-  case class QueueSizeDTO (
-    byteCount: Option[Long] = None,
-    objectCount: Option[Int] = None
-  )
-  case class RegisteredFlow (
-    branch: Option[String] = None,
-    bucketIdentifier: Option[String] = None,
-    bucketName: Option[String] = None,
-    createdTimestamp: Option[Long] = None,
-    description: Option[String] = None,
-    identifier: Option[String] = None,
-    lastModifiedTimestamp: Option[Long] = None,
-    name: Option[String] = None,
-    permissions: Option[FlowRegistryPermissions] = None,
-    versionCount: Option[Long] = None,
-    versionInfo: Option[RegisteredFlowVersionInfo] = None
-  )
-  case class RegisteredFlowSnapshot (
-    bucket: Option[FlowRegistryBucket] = None,
-    externalControllerServices: Option[Map[String, ExternalControllerServiceReference]] = None,
-    flow: Option[RegisteredFlow] = None,
-    flowContents: Option[VersionedProcessGroup] = None,
-    flowEncodingVersion: Option[String] = None,
-    latest: Option[Boolean] = None,
-    parameterContexts: Option[Map[String, VersionedParameterContext]] = None,
-    parameterProviders: Option[Map[String, ParameterProviderReference]] = None,
-    snapshotMetadata: Option[RegisteredFlowSnapshotMetadata] = None
-  )
-  case class RegisteredFlowSnapshotMetadata (
-    author: Option[String] = None,
-    branch: Option[String] = None,
-    bucketIdentifier: Option[String] = None,
-    comments: Option[String] = None,
-    flowIdentifier: Option[String] = None,
-    flowName: Option[String] = None,
-    registryIdentifier: Option[String] = None,
-    registryName: Option[String] = None,
-    timestamp: Option[Long] = None,
-    version: Option[String] = None
-  )
-  case class RegisteredFlowVersionInfo (
-    version: Option[Long] = None
-  )
-  case class Relationship (
-    description: Option[String] = None,
-    name: Option[String] = None
-  )
-  case class RelationshipDTO (
-    autoTerminate: Option[Boolean] = None,
-    description: Option[String] = None,
-    name: Option[String] = None,
-    retry: Option[Boolean] = None
-  )
-  case class RemotePortRunStatusEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    revision: Option[RevisionDTO] = None,
-    state: Option[RemotePortRunStatusEntityState] = None
-  )
-
-  sealed trait RemotePortRunStatusEntityState extends enumeratum.EnumEntry
-  object RemotePortRunStatusEntityState extends enumeratum.Enum[RemotePortRunStatusEntityState] with enumeratum.CirceEnum[RemotePortRunStatusEntityState] {
-    val values = findValues
-    case object TRANSMITTING extends RemotePortRunStatusEntityState
-    case object STOPPED extends RemotePortRunStatusEntityState
-  }
-  case class RemoteProcessGroupContentsDTO (
-    inputPorts: Option[Set[RemoteProcessGroupPortDTO]] = None,
-    outputPorts: Option[Set[RemoteProcessGroupPortDTO]] = None
-  )
-  case class RemoteProcessGroupDTO (
-    activeRemoteInputPortCount: Option[Int] = None,
-    activeRemoteOutputPortCount: Option[Int] = None,
-    authorizationIssues: Option[Seq[String]] = None,
-    comments: Option[String] = None,
-    communicationsTimeout: Option[String] = None,
-    contents: Option[RemoteProcessGroupContentsDTO] = None,
-    flowRefreshed: Option[String] = None,
-    id: Option[String] = None,
-    inactiveRemoteInputPortCount: Option[Int] = None,
-    inactiveRemoteOutputPortCount: Option[Int] = None,
-    inputPortCount: Option[Int] = None,
-    localNetworkInterface: Option[String] = None,
-    name: Option[String] = None,
-    outputPortCount: Option[Int] = None,
-    parentGroupId: Option[String] = None,
-    position: Option[PositionDTO] = None,
-    proxyHost: Option[String] = None,
-    proxyPassword: Option[String] = None,
-    proxyPort: Option[Int] = None,
-    proxyUser: Option[String] = None,
-    targetSecure: Option[Boolean] = None,
-    targetUri: Option[String] = None,
-    targetUris: Option[String] = None,
-    transmitting: Option[Boolean] = None,
-    transportProtocol: Option[String] = None,
-    validationErrors: Option[Seq[String]] = None,
-    versionedComponentId: Option[String] = None,
-    yieldDuration: Option[String] = None
-  )
-  case class RemoteProcessGroupEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[RemoteProcessGroupDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    inputPortCount: Option[Int] = None,
-    operatePermissions: Option[PermissionsDTO] = None,
-    outputPortCount: Option[Int] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    status: Option[RemoteProcessGroupStatusDTO] = None,
-    uri: Option[String] = None
-  )
-  case class RemoteProcessGroupPortDTO (
-    batchSettings: Option[BatchSettingsDTO] = None,
-    comments: Option[String] = None,
-    concurrentlySchedulableTaskCount: Option[Int] = None,
-    connected: Option[Boolean] = None,
-    exists: Option[Boolean] = None,
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    targetId: Option[String] = None,
-    targetRunning: Option[Boolean] = None,
-    transmitting: Option[Boolean] = None,
-    useCompression: Option[Boolean] = None,
-    versionedComponentId: Option[String] = None
-  )
-  case class RemoteProcessGroupPortEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    operatePermissions: Option[PermissionsDTO] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    remoteProcessGroupPort: Option[RemoteProcessGroupPortDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class RemoteProcessGroupStatusDTO (
-    aggregateSnapshot: Option[RemoteProcessGroupStatusSnapshotDTO] = None,
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    nodeSnapshots: Option[Seq[NodeRemoteProcessGroupStatusSnapshotDTO]] = None,
-    statsLastRefreshed: Option[String] = None,
-    targetUri: Option[String] = None,
-    transmissionStatus: Option[String] = None,
-    validationStatus: Option[RemoteProcessGroupStatusDTOValidationStatus] = None
-  )
-
-  sealed trait RemoteProcessGroupStatusDTOValidationStatus extends enumeratum.EnumEntry
-  object RemoteProcessGroupStatusDTOValidationStatus extends enumeratum.Enum[RemoteProcessGroupStatusDTOValidationStatus] with enumeratum.CirceEnum[RemoteProcessGroupStatusDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends RemoteProcessGroupStatusDTOValidationStatus
-    case object INVALID extends RemoteProcessGroupStatusDTOValidationStatus
-    case object VALIDATING extends RemoteProcessGroupStatusDTOValidationStatus
-  }
-  case class RemoteProcessGroupStatusEntity (
-    canRead: Option[Boolean] = None,
-    remoteProcessGroupStatus: Option[RemoteProcessGroupStatusDTO] = None
-  )
-  case class RemoteProcessGroupStatusSnapshotDTO (
-    activeThreadCount: Option[Int] = None,
-    bytesReceived: Option[Long] = None,
-    bytesSent: Option[Long] = None,
-    flowFilesReceived: Option[Int] = None,
-    flowFilesSent: Option[Int] = None,
-    groupId: Option[String] = None,
-    id: Option[String] = None,
-    name: Option[String] = None,
-    received: Option[String] = None,
-    sent: Option[String] = None,
-    targetUri: Option[String] = None,
-    transmissionStatus: Option[String] = None
-  )
-  case class RemoteProcessGroupStatusSnapshotEntity (
-    canRead: Option[Boolean] = None,
-    id: Option[String] = None,
-    remoteProcessGroupStatusSnapshot: Option[RemoteProcessGroupStatusSnapshotDTO] = None
-  )
-  case class RemoteProcessGroupsEntity (
-    remoteProcessGroups: Option[Set[RemoteProcessGroupEntity]] = None
-  )
-  case class ReplayLastEventRequestEntity (
-    componentId: Option[String] = None,
-    nodes: Option[ReplayLastEventRequestEntityNodes] = None
-  )
-
-  sealed trait ReplayLastEventRequestEntityNodes extends enumeratum.EnumEntry
-  object ReplayLastEventRequestEntityNodes extends enumeratum.Enum[ReplayLastEventRequestEntityNodes] with enumeratum.CirceEnum[ReplayLastEventRequestEntityNodes] {
-    val values = findValues
-    case object ALL extends ReplayLastEventRequestEntityNodes
-    case object PRIMARY extends ReplayLastEventRequestEntityNodes
-  }
-  case class ReplayLastEventResponseEntity (
-    aggregateSnapshot: Option[ReplayLastEventSnapshotDTO] = None,
-    componentId: Option[String] = None,
-    nodeSnapshots: Option[Seq[NodeReplayLastEventSnapshotDTO]] = None,
-    nodes: Option[ReplayLastEventResponseEntityNodes] = None
-  )
-
-  sealed trait ReplayLastEventResponseEntityNodes extends enumeratum.EnumEntry
-  object ReplayLastEventResponseEntityNodes extends enumeratum.Enum[ReplayLastEventResponseEntityNodes] with enumeratum.CirceEnum[ReplayLastEventResponseEntityNodes] {
-    val values = findValues
-    case object ALL extends ReplayLastEventResponseEntityNodes
-    case object PRIMARY extends ReplayLastEventResponseEntityNodes
-  }
-  case class ReplayLastEventSnapshotDTO (
-    eventAvailable: Option[Boolean] = None,
-    eventsReplayed: Option[Seq[Long]] = None,
-    failureExplanation: Option[String] = None
-  )
-  case class ReportingTaskDTO (
-    activeThreadCount: Option[Int] = None,
-    annotationData: Option[String] = None,
-    bundle: Option[BundleDTO] = None,
-    comments: Option[String] = None,
-    customUiUrl: Option[String] = None,
-    defaultSchedulingPeriod: Option[Map[String, String]] = None,
-    deprecated: Option[Boolean] = None,
-    descriptors: Option[Map[String, PropertyDescriptorDTO]] = None,
-    extensionMissing: Option[Boolean] = None,
-    id: Option[String] = None,
-    multipleVersionsAvailable: Option[Boolean] = None,
-    name: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    persistsState: Option[Boolean] = None,
-    position: Option[PositionDTO] = None,
-    properties: Option[Map[String, String]] = None,
-    restricted: Option[Boolean] = None,
-    schedulingPeriod: Option[String] = None,
-    schedulingStrategy: Option[String] = None,
-    sensitiveDynamicPropertyNames: Option[Set[String]] = None,
-    state: Option[ReportingTaskDTOState] = None,
-    supportsSensitiveDynamicProperties: Option[Boolean] = None,
-    `type`: Option[String] = None,
-    validationErrors: Option[Seq[String]] = None,
-    validationStatus: Option[ReportingTaskDTOValidationStatus] = None,
-    versionedComponentId: Option[String] = None
-  )
-
-  sealed trait ReportingTaskDTOState extends enumeratum.EnumEntry
-  object ReportingTaskDTOState extends enumeratum.Enum[ReportingTaskDTOState] with enumeratum.CirceEnum[ReportingTaskDTOState] {
-    val values = findValues
-    case object RUNNING extends ReportingTaskDTOState
-    case object STOPPED extends ReportingTaskDTOState
-    case object DISABLED extends ReportingTaskDTOState
-  }
-
-  sealed trait ReportingTaskDTOValidationStatus extends enumeratum.EnumEntry
-  object ReportingTaskDTOValidationStatus extends enumeratum.Enum[ReportingTaskDTOValidationStatus] with enumeratum.CirceEnum[ReportingTaskDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends ReportingTaskDTOValidationStatus
-    case object INVALID extends ReportingTaskDTOValidationStatus
-    case object VALIDATING extends ReportingTaskDTOValidationStatus
-  }
-  case class ReportingTaskDefinition (
-    additionalDetails: Option[Boolean] = None,
-    artifact: Option[String] = None,
-    buildInfo: Option[BuildInfo] = None,
-    defaultSchedulingPeriodBySchedulingStrategy: Option[Map[String, String]] = None,
-    defaultSchedulingStrategy: Option[String] = None,
-    deprecated: Option[Boolean] = None,
-    deprecationAlternatives: Option[Set[String]] = None,
-    deprecationReason: Option[String] = None,
-    dynamicProperties: Option[Seq[DynamicProperty]] = None,
-    explicitRestrictions: Option[Set[Restriction]] = None,
-    group: Option[String] = None,
-    propertyDescriptors: Option[Map[String, PropertyDescriptor]] = None,
-    providedApiImplementations: Option[Seq[DefinedType]] = None,
-    restricted: Option[Boolean] = None,
-    restrictedExplanation: Option[String] = None,
-    seeAlso: Option[Set[String]] = None,
-    stateful: Option[Stateful] = None,
-    supportedSchedulingStrategies: Option[Seq[String]] = None,
-    supportsDynamicProperties: Option[Boolean] = None,
-    supportsSensitiveDynamicProperties: Option[Boolean] = None,
-    systemResourceConsiderations: Option[Seq[SystemResourceConsideration]] = None,
-    tags: Option[Set[String]] = None,
-    `type`: Option[String] = None,
-    typeDescription: Option[String] = None,
-    version: Option[String] = None
-  )
-  case class ReportingTaskEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[ReportingTaskDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    operatePermissions: Option[PermissionsDTO] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    status: Option[ReportingTaskStatusDTO] = None,
-    uri: Option[String] = None
-  )
-  case class ReportingTaskRunStatusEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    revision: Option[RevisionDTO] = None,
-    state: Option[ReportingTaskRunStatusEntityState] = None
-  )
-
-  sealed trait ReportingTaskRunStatusEntityState extends enumeratum.EnumEntry
-  object ReportingTaskRunStatusEntityState extends enumeratum.Enum[ReportingTaskRunStatusEntityState] with enumeratum.CirceEnum[ReportingTaskRunStatusEntityState] {
-    val values = findValues
-    case object RUNNING extends ReportingTaskRunStatusEntityState
-    case object STOPPED extends ReportingTaskRunStatusEntityState
-  }
-  case class ReportingTaskStatusDTO (
-    activeThreadCount: Option[Int] = None,
-    runStatus: Option[ReportingTaskStatusDTORunStatus] = None,
-    validationStatus: Option[ReportingTaskStatusDTOValidationStatus] = None
-  )
-
-  sealed trait ReportingTaskStatusDTORunStatus extends enumeratum.EnumEntry
-  object ReportingTaskStatusDTORunStatus extends enumeratum.Enum[ReportingTaskStatusDTORunStatus] with enumeratum.CirceEnum[ReportingTaskStatusDTORunStatus] {
-    val values = findValues
-    case object RUNNING extends ReportingTaskStatusDTORunStatus
-    case object STOPPED extends ReportingTaskStatusDTORunStatus
-    case object DISABLED extends ReportingTaskStatusDTORunStatus
-  }
-
-  sealed trait ReportingTaskStatusDTOValidationStatus extends enumeratum.EnumEntry
-  object ReportingTaskStatusDTOValidationStatus extends enumeratum.Enum[ReportingTaskStatusDTOValidationStatus] with enumeratum.CirceEnum[ReportingTaskStatusDTOValidationStatus] {
-    val values = findValues
-    case object VALID extends ReportingTaskStatusDTOValidationStatus
-    case object INVALID extends ReportingTaskStatusDTOValidationStatus
-    case object VALIDATING extends ReportingTaskStatusDTOValidationStatus
-  }
-  case class ReportingTaskTypesEntity (
-    reportingTaskTypes: Option[Set[DocumentedTypeDTO]] = None
-  )
-  case class ReportingTasksEntity (
-    currentTime: Option[String] = None,
-    reportingTasks: Option[Set[ReportingTaskEntity]] = None
-  )
-  case class RequiredPermissionDTO (
-    id: Option[String] = None,
-    label: Option[String] = None
-  )
-  case class ResourceClaimDetailsDTO (
-    awaitingDestruction: Option[Boolean] = None,
-    claimantCount: Option[Int] = None,
-    container: Option[String] = None,
-    identifier: Option[String] = None,
-    inUse: Option[Boolean] = None,
-    section: Option[String] = None,
-    writable: Option[Boolean] = None
-  )
-  case class ResourceDTO (
-    identifier: Option[String] = None,
-    name: Option[String] = None
-  )
-  case class ResourcesEntity (
-    resources: Option[Seq[ResourceDTO]] = None
-  )
-  case class Restriction (
-    explanation: Option[String] = None,
-    requiredPermission: Option[String] = None
-  )
-  case class RevisionDTO (
-    clientId: Option[String] = None,
-    lastModifier: Option[String] = None,
-    version: Option[Long] = None
-  )
-  case class RunStatusDetailsRequestEntity (
-    processorIds: Option[Set[String]] = None
-  )
-  case class RuntimeManifest (
-    agentType: Option[String] = None,
-    buildInfo: Option[BuildInfo] = None,
-    bundles: Option[Seq[Bundle]] = None,
-    identifier: Option[String] = None,
-    schedulingDefaults: Option[SchedulingDefaults] = None,
-    version: Option[String] = None
-  )
-  case class RuntimeManifestEntity (
-    runtimeManifest: Option[RuntimeManifest] = None
-  )
-  case class ScheduleComponentsEntity (
-    components: Option[Map[String, RevisionDTO]] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    state: Option[ScheduleComponentsEntityState] = None
-  )
-
-  sealed trait ScheduleComponentsEntityState extends enumeratum.EnumEntry
-  object ScheduleComponentsEntityState extends enumeratum.Enum[ScheduleComponentsEntityState] with enumeratum.CirceEnum[ScheduleComponentsEntityState] {
-    val values = findValues
-    case object RUNNING extends ScheduleComponentsEntityState
-    case object STOPPED extends ScheduleComponentsEntityState
-    case object ENABLED extends ScheduleComponentsEntityState
-    case object DISABLED extends ScheduleComponentsEntityState
-  }
-  case class SchedulingDefaults (
-    defaultConcurrentTasksBySchedulingStrategy: Option[Map[String, Int]] = None,
-    defaultMaxConcurrentTasks: Option[String] = None,
-    defaultRunDurationNanos: Option[Long] = None,
-    defaultSchedulingPeriodMillis: Option[Long] = None,
-    defaultSchedulingPeriodsBySchedulingStrategy: Option[Map[String, String]] = None,
-    defaultSchedulingStrategy: Option[SchedulingDefaultsDefaultSchedulingStrategy] = None,
-    penalizationPeriodMillis: Option[Long] = None,
-    yieldDurationMillis: Option[Long] = None
-  )
-
-  sealed trait SchedulingDefaultsDefaultSchedulingStrategy extends enumeratum.EnumEntry
-  object SchedulingDefaultsDefaultSchedulingStrategy extends enumeratum.Enum[SchedulingDefaultsDefaultSchedulingStrategy] with enumeratum.CirceEnum[SchedulingDefaultsDefaultSchedulingStrategy] {
-    val values = findValues
-    case object TIMER_DRIVEN extends SchedulingDefaultsDefaultSchedulingStrategy
-    case object CRON_DRIVEN extends SchedulingDefaultsDefaultSchedulingStrategy
-  }
-  case class SearchResultGroupDTO (
-    id: String,
-    name: Option[String] = None
-  )
-  case class SearchResultsDTO (
-    connectionResults: Option[Seq[ComponentSearchResultDTO]] = None,
-    controllerServiceNodeResults: Option[Seq[ComponentSearchResultDTO]] = None,
-    funnelResults: Option[Seq[ComponentSearchResultDTO]] = None,
-    inputPortResults: Option[Seq[ComponentSearchResultDTO]] = None,
-    labelResults: Option[Seq[ComponentSearchResultDTO]] = None,
-    outputPortResults: Option[Seq[ComponentSearchResultDTO]] = None,
-    parameterContextResults: Option[Seq[ComponentSearchResultDTO]] = None,
-    parameterProviderNodeResults: Option[Seq[ComponentSearchResultDTO]] = None,
-    parameterResults: Option[Seq[ComponentSearchResultDTO]] = None,
-    processGroupResults: Option[Seq[ComponentSearchResultDTO]] = None,
-    processorResults: Option[Seq[ComponentSearchResultDTO]] = None,
-    remoteProcessGroupResults: Option[Seq[ComponentSearchResultDTO]] = None
-  )
-  case class SearchResultsEntity (
-    searchResultsDTO: Option[SearchResultsDTO] = None
-  )
-  case class SnippetDTO (
-    connections: Option[Map[String, RevisionDTO]] = None,
-    funnels: Option[Map[String, RevisionDTO]] = None,
-    id: Option[String] = None,
-    inputPorts: Option[Map[String, RevisionDTO]] = None,
-    labels: Option[Map[String, RevisionDTO]] = None,
-    outputPorts: Option[Map[String, RevisionDTO]] = None,
-    parentGroupId: Option[String] = None,
-    processGroups: Option[Map[String, RevisionDTO]] = None,
-    processors: Option[Map[String, RevisionDTO]] = None,
-    remoteProcessGroups: Option[Map[String, RevisionDTO]] = None,
-    uri: Option[String] = None
-  )
-  case class SnippetEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    snippet: Option[SnippetDTO] = None
-  )
-  case class StartVersionControlRequestEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    processGroupRevision: Option[RevisionDTO] = None,
-    versionedFlow: Option[VersionedFlowDTO] = None
-  )
-  case class StateEntryDTO (
-    clusterNodeAddress: Option[String] = None,
-    clusterNodeId: Option[String] = None,
-    key: Option[String] = None,
-    value: Option[String] = None
-  )
-  case class StateMapDTO (
-    scope: Option[String] = None,
-    state: Option[Seq[StateEntryDTO]] = None,
-    totalEntryCount: Option[Int] = None
-  )
-  case class Stateful (
-    description: Option[String] = None,
-    scopes: Option[Set[StatefulScopesItem]] = None
-  )
-
-  sealed trait StatefulScopesItem extends enumeratum.EnumEntry
-  object StatefulScopesItem extends enumeratum.Enum[StatefulScopesItem] with enumeratum.CirceEnum[StatefulScopesItem] {
-    val values = findValues
-    case object CLUSTER extends StatefulScopesItem
-    case object LOCAL extends StatefulScopesItem
-  }
-  case class StatusDescriptorDTO (
-    description: Option[String] = None,
-    field: Option[String] = None,
-    formatter: Option[String] = None,
-    label: Option[String] = None
-  )
-  case class StatusHistoryDTO (
-    aggregateSnapshots: Option[Seq[StatusSnapshotDTO]] = None,
-    componentDetails: Option[Map[String, String]] = None,
-    fieldDescriptors: Option[Seq[StatusDescriptorDTO]] = None,
-    generated: Option[String] = None,
-    nodeSnapshots: Option[Seq[NodeStatusSnapshotsDTO]] = None
-  )
-  case class StatusHistoryEntity (
-    canRead: Option[Boolean] = None,
-    statusHistory: Option[StatusHistoryDTO] = None
-  )
-  case class StatusSnapshotDTO (
-    statusMetrics: Option[Map[String, Long]] = None,
-    timestamp: Option[java.time.Instant] = None
-  )
-  case class StorageUsageDTO (
-    freeSpace: Option[String] = None,
-    freeSpaceBytes: Option[Long] = None,
-    identifier: Option[String] = None,
-    totalSpace: Option[String] = None,
-    totalSpaceBytes: Option[Long] = None,
-    usedSpace: Option[String] = None,
-    usedSpaceBytes: Option[Long] = None,
-    utilization: Option[String] = None
-  )
-  case class SubmitReplayRequestEntity (
-    clusterNodeId: Option[String] = None,
-    eventId: Option[Long] = None
-  )
-  case class SupportedMimeTypesDTO (
-    displayName: Option[String] = None,
-    mimeTypes: Option[Seq[String]] = None
-  )
-  case class SystemDiagnosticsDTO (
-    aggregateSnapshot: Option[SystemDiagnosticsSnapshotDTO] = None,
-    nodeSnapshots: Option[Seq[NodeSystemDiagnosticsSnapshotDTO]] = None
-  )
-  case class SystemDiagnosticsEntity (
-    systemDiagnostics: Option[SystemDiagnosticsDTO] = None
-  )
-  case class SystemDiagnosticsSnapshotDTO (
-    availableProcessors: Option[Int] = None,
-    contentRepositoryStorageUsage: Option[Set[StorageUsageDTO]] = None,
-    daemonThreads: Option[Int] = None,
-    flowFileRepositoryStorageUsage: Option[StorageUsageDTO] = None,
-    freeHeap: Option[String] = None,
-    freeHeapBytes: Option[Long] = None,
-    freeNonHeap: Option[String] = None,
-    freeNonHeapBytes: Option[Long] = None,
-    garbageCollection: Option[Set[GarbageCollectionDTO]] = None,
-    heapUtilization: Option[String] = None,
-    maxHeap: Option[String] = None,
-    maxHeapBytes: Option[Long] = None,
-    maxNonHeap: Option[String] = None,
-    maxNonHeapBytes: Option[Long] = None,
-    nonHeapUtilization: Option[String] = None,
-    processorLoadAverage: Option[Double] = None,
-    provenanceRepositoryStorageUsage: Option[Set[StorageUsageDTO]] = None,
-    resourceClaimDetails: Option[Seq[ResourceClaimDetailsDTO]] = None,
-    statsLastRefreshed: Option[String] = None,
-    totalHeap: Option[String] = None,
-    totalHeapBytes: Option[Long] = None,
-    totalNonHeap: Option[String] = None,
-    totalNonHeapBytes: Option[Long] = None,
-    totalThreads: Option[Int] = None,
-    uptime: Option[String] = None,
-    usedHeap: Option[String] = None,
-    usedHeapBytes: Option[Long] = None,
-    usedNonHeap: Option[String] = None,
-    usedNonHeapBytes: Option[Long] = None,
-    versionInfo: Option[VersionInfoDTO] = None
-  )
-  case class SystemResourceConsideration (
-    description: Option[String] = None,
-    resource: Option[String] = None
-  )
-  case class TenantDTO (
-    configurable: Option[Boolean] = None,
-    id: Option[String] = None,
-    identity: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    position: Option[PositionDTO] = None,
-    versionedComponentId: Option[String] = None
-  )
-  case class TenantEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[TenantDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class TenantsEntity (
-    userGroups: Option[Seq[TenantEntity]] = None,
-    users: Option[Seq[TenantEntity]] = None
-  )
-  case class TransactionResultEntity (
-    flowFileSent: Option[Int] = None,
-    message: Option[String] = None,
-    responseCode: Option[Int] = None
-  )
-  case class UpdateControllerServiceReferenceRequestEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    referencingComponentRevisions: Option[Map[String, RevisionDTO]] = None,
-    state: Option[UpdateControllerServiceReferenceRequestEntityState] = None,
-    uiOnly: Option[Boolean] = None
-  )
-
-  sealed trait UpdateControllerServiceReferenceRequestEntityState extends enumeratum.EnumEntry
-  object UpdateControllerServiceReferenceRequestEntityState extends enumeratum.Enum[UpdateControllerServiceReferenceRequestEntityState] with enumeratum.CirceEnum[UpdateControllerServiceReferenceRequestEntityState] {
-    val values = findValues
-    case object ENABLED extends UpdateControllerServiceReferenceRequestEntityState
-    case object DISABLED extends UpdateControllerServiceReferenceRequestEntityState
-    case object RUNNING extends UpdateControllerServiceReferenceRequestEntityState
-    case object STOPPED extends UpdateControllerServiceReferenceRequestEntityState
-  }
-  case class UseCase (
-    configuration: Option[String] = None,
-    description: Option[String] = None,
-    inputRequirement: Option[UseCaseInputRequirement] = None,
-    keywords: Option[Seq[String]] = None,
-    notes: Option[String] = None
-  )
-
-  sealed trait UseCaseInputRequirement extends enumeratum.EnumEntry
-  object UseCaseInputRequirement extends enumeratum.Enum[UseCaseInputRequirement] with enumeratum.CirceEnum[UseCaseInputRequirement] {
-    val values = findValues
-    case object INPUT_REQUIRED extends UseCaseInputRequirement
-    case object INPUT_ALLOWED extends UseCaseInputRequirement
-    case object INPUT_FORBIDDEN extends UseCaseInputRequirement
-  }
-  case class UserDTO (
-    accessPolicies: Option[Set[AccessPolicySummaryEntity]] = None,
-    configurable: Option[Boolean] = None,
-    id: Option[String] = None,
-    identity: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    position: Option[PositionDTO] = None,
-    userGroups: Option[Set[TenantEntity]] = None,
-    versionedComponentId: Option[String] = None
-  )
-  case class UserEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[UserDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class UserGroupDTO (
-    accessPolicies: Option[Set[AccessPolicyEntity]] = None,
-    configurable: Option[Boolean] = None,
-    id: Option[String] = None,
-    identity: Option[String] = None,
-    parentGroupId: Option[String] = None,
-    position: Option[PositionDTO] = None,
-    users: Option[Set[TenantEntity]] = None,
-    versionedComponentId: Option[String] = None
-  )
-  case class UserGroupEntity (
-    bulletins: Option[Seq[BulletinEntity]] = None,
-    component: Option[UserGroupDTO] = None,
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    id: Option[String] = None,
-    permissions: Option[PermissionsDTO] = None,
-    position: Option[PositionDTO] = None,
-    revision: Option[RevisionDTO] = None,
-    uri: Option[String] = None
-  )
-  case class UserGroupsEntity (
-    userGroups: Option[Seq[UserGroupEntity]] = None
-  )
-  case class UsersEntity (
-    generated: Option[String] = None,
-    users: Option[Seq[UserEntity]] = None
-  )
-  case class VerifyConfigRequestDTO (
-    attributes: Option[Map[String, String]] = None,
-    complete: Option[Boolean] = None,
-    componentId: Option[String] = None,
-    failureReason: Option[String] = None,
-    lastUpdated: Option[java.time.Instant] = None,
-    percentCompleted: Option[Int] = None,
-    properties: Option[Map[String, String]] = None,
-    requestId: Option[String] = None,
-    results: Option[Seq[ConfigVerificationResultDTO]] = None,
-    state: Option[String] = None,
-    submissionTime: Option[java.time.Instant] = None,
-    updateSteps: Option[Seq[VerifyConfigUpdateStepDTO]] = None,
-    uri: Option[String] = None
-  )
-  case class VerifyConfigRequestEntity (
-    request: Option[VerifyConfigRequestDTO] = None
-  )
-  case class VerifyConfigUpdateStepDTO (
-    complete: Option[Boolean] = None,
-    description: Option[String] = None,
-    failureReason: Option[String] = None
-  )
-  case class VersionControlComponentMappingEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    processGroupRevision: Option[RevisionDTO] = None,
-    versionControlComponentMapping: Option[Map[String, String]] = None,
-    versionControlInformation: Option[VersionControlInformationDTO] = None
-  )
-  case class VersionControlInformationDTO (
-    branch: Option[String] = None,
-    bucketId: Option[String] = None,
-    bucketName: Option[String] = None,
-    flowDescription: Option[String] = None,
-    flowId: Option[String] = None,
-    flowName: Option[String] = None,
-    groupId: Option[String] = None,
-    registryId: Option[String] = None,
-    registryName: Option[String] = None,
-    state: Option[VersionControlInformationDTOState] = None,
-    stateExplanation: Option[String] = None,
-    storageLocation: Option[String] = None,
-    version: Option[String] = None
-  )
-
-  sealed trait VersionControlInformationDTOState extends enumeratum.EnumEntry
-  object VersionControlInformationDTOState extends enumeratum.Enum[VersionControlInformationDTOState] with enumeratum.CirceEnum[VersionControlInformationDTOState] {
-    val values = findValues
-    case object LOCALLY_MODIFIED extends VersionControlInformationDTOState
-    case object STALE extends VersionControlInformationDTOState
-    case object LOCALLY_MODIFIED_AND_STALE extends VersionControlInformationDTOState
-    case object UP_TO_DATE extends VersionControlInformationDTOState
-    case object SYNC_FAILURE extends VersionControlInformationDTOState
-  }
-  case class VersionControlInformationEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    processGroupRevision: Option[RevisionDTO] = None,
-    versionControlInformation: Option[VersionControlInformationDTO] = None
-  )
-  case class VersionInfoDTO (
-    buildBranch: Option[String] = None,
-    buildRevision: Option[String] = None,
-    buildTag: Option[String] = None,
-    buildTimestamp: Option[java.time.Instant] = None,
-    javaVendor: Option[String] = None,
-    javaVersion: Option[String] = None,
-    niFiVersion: Option[String] = None,
-    osArchitecture: Option[String] = None,
-    osName: Option[String] = None,
-    osVersion: Option[String] = None
-  )
-  case class VersionedAsset (
-    identifier: Option[String] = None,
-    name: Option[String] = None
-  )
-  case class VersionedConnection (
-    backPressureDataSizeThreshold: Option[String] = None,
-    backPressureObjectThreshold: Option[Long] = None,
-    bends: Option[Seq[Position]] = None,
-    comments: Option[String] = None,
-    componentType: Option[VersionedConnectionComponentType] = None,
-    destination: Option[ConnectableComponent] = None,
-    flowFileExpiration: Option[String] = None,
-    groupIdentifier: Option[String] = None,
-    identifier: Option[String] = None,
-    instanceIdentifier: Option[String] = None,
-    labelIndex: Option[Int] = None,
-    loadBalanceCompression: Option[String] = None,
-    loadBalanceStrategy: Option[String] = None,
-    name: Option[String] = None,
-    partitioningAttribute: Option[String] = None,
-    position: Option[Position] = None,
-    prioritizers: Option[Seq[String]] = None,
-    selectedRelationships: Option[Set[String]] = None,
-    source: Option[ConnectableComponent] = None,
-    zIndex: Option[Long] = None
-  )
-
-  sealed trait VersionedConnectionComponentType extends enumeratum.EnumEntry
-  object VersionedConnectionComponentType extends enumeratum.Enum[VersionedConnectionComponentType] with enumeratum.CirceEnum[VersionedConnectionComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedConnectionComponentType
-    case object PROCESSOR extends VersionedConnectionComponentType
-    case object PROCESS_GROUP extends VersionedConnectionComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedConnectionComponentType
-    case object INPUT_PORT extends VersionedConnectionComponentType
-    case object OUTPUT_PORT extends VersionedConnectionComponentType
-    case object REMOTE_INPUT_PORT extends VersionedConnectionComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedConnectionComponentType
-    case object FUNNEL extends VersionedConnectionComponentType
-    case object LABEL extends VersionedConnectionComponentType
-    case object CONTROLLER_SERVICE extends VersionedConnectionComponentType
-    case object REPORTING_TASK extends VersionedConnectionComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedConnectionComponentType
-    case object PARAMETER_CONTEXT extends VersionedConnectionComponentType
-    case object PARAMETER_PROVIDER extends VersionedConnectionComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedConnectionComponentType
-  }
-  case class VersionedControllerService (
-    annotationData: Option[String] = None,
-    bulletinLevel: Option[String] = None,
-    bundle: Option[Bundle] = None,
-    comments: Option[String] = None,
-    componentType: Option[VersionedControllerServiceComponentType] = None,
-    controllerServiceApis: Option[Seq[ControllerServiceAPI]] = None,
-    groupIdentifier: Option[String] = None,
-    identifier: Option[String] = None,
-    instanceIdentifier: Option[String] = None,
-    name: Option[String] = None,
-    position: Option[Position] = None,
-    properties: Option[Map[String, String]] = None,
-    propertyDescriptors: Option[Map[String, VersionedPropertyDescriptor]] = None,
-    scheduledState: Option[VersionedControllerServiceScheduledState] = None,
-    `type`: Option[String] = None
-  )
-
-  sealed trait VersionedControllerServiceComponentType extends enumeratum.EnumEntry
-  object VersionedControllerServiceComponentType extends enumeratum.Enum[VersionedControllerServiceComponentType] with enumeratum.CirceEnum[VersionedControllerServiceComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedControllerServiceComponentType
-    case object PROCESSOR extends VersionedControllerServiceComponentType
-    case object PROCESS_GROUP extends VersionedControllerServiceComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedControllerServiceComponentType
-    case object INPUT_PORT extends VersionedControllerServiceComponentType
-    case object OUTPUT_PORT extends VersionedControllerServiceComponentType
-    case object REMOTE_INPUT_PORT extends VersionedControllerServiceComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedControllerServiceComponentType
-    case object FUNNEL extends VersionedControllerServiceComponentType
-    case object LABEL extends VersionedControllerServiceComponentType
-    case object CONTROLLER_SERVICE extends VersionedControllerServiceComponentType
-    case object REPORTING_TASK extends VersionedControllerServiceComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedControllerServiceComponentType
-    case object PARAMETER_CONTEXT extends VersionedControllerServiceComponentType
-    case object PARAMETER_PROVIDER extends VersionedControllerServiceComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedControllerServiceComponentType
-  }
-
-  sealed trait VersionedControllerServiceScheduledState extends enumeratum.EnumEntry
-  object VersionedControllerServiceScheduledState extends enumeratum.Enum[VersionedControllerServiceScheduledState] with enumeratum.CirceEnum[VersionedControllerServiceScheduledState] {
-    val values = findValues
-    case object ENABLED extends VersionedControllerServiceScheduledState
-    case object DISABLED extends VersionedControllerServiceScheduledState
-    case object RUNNING extends VersionedControllerServiceScheduledState
-  }
-  case class VersionedFlowCoordinates (
-    branch: Option[String] = None,
-    bucketId: Option[String] = None,
-    flowId: Option[String] = None,
-    latest: Option[Boolean] = None,
-    registryId: Option[String] = None,
-    storageLocation: Option[String] = None,
-    version: Option[String] = None
-  )
-  case class VersionedFlowDTO (
-    action: Option[VersionedFlowDTOAction] = None,
-    branch: Option[String] = None,
-    bucketId: Option[String] = None,
-    comments: Option[String] = None,
-    description: Option[String] = None,
-    flowId: Option[String] = None,
-    flowName: Option[String] = None,
-    registryId: Option[String] = None
-  )
-
-  sealed trait VersionedFlowDTOAction extends enumeratum.EnumEntry
-  object VersionedFlowDTOAction extends enumeratum.Enum[VersionedFlowDTOAction] with enumeratum.CirceEnum[VersionedFlowDTOAction] {
-    val values = findValues
-    case object COMMIT extends VersionedFlowDTOAction
-    case object FORCE_COMMIT extends VersionedFlowDTOAction
-  }
-  case class VersionedFlowEntity (
-    versionedFlow: Option[VersionedFlowDTO] = None
-  )
-  case class VersionedFlowSnapshotEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    processGroupRevision: Option[RevisionDTO] = None,
-    registryId: Option[String] = None,
-    updateDescendantVersionedFlows: Option[Boolean] = None,
-    versionedFlow: Option[RegisteredFlowSnapshot] = None,
-    versionedFlowSnapshot: Option[RegisteredFlowSnapshot] = None
-  )
-  case class VersionedFlowSnapshotMetadataEntity (
-    registryId: Option[String] = None,
-    versionedFlowSnapshotMetadata: Option[RegisteredFlowSnapshotMetadata] = None
-  )
-  case class VersionedFlowSnapshotMetadataSetEntity (
-    versionedFlowSnapshotMetadataSet: Option[Set[VersionedFlowSnapshotMetadataEntity]] = None
-  )
-  case class VersionedFlowUpdateRequestDTO (
-    complete: Option[Boolean] = None,
-    failureReason: Option[String] = None,
-    lastUpdated: Option[String] = None,
-    percentCompleted: Option[Int] = None,
-    processGroupId: Option[String] = None,
-    requestId: Option[String] = None,
-    state: Option[String] = None,
-    uri: Option[String] = None,
-    versionControlInformation: Option[VersionControlInformationDTO] = None
-  )
-  case class VersionedFlowUpdateRequestEntity (
-    processGroupRevision: Option[RevisionDTO] = None,
-    request: Option[VersionedFlowUpdateRequestDTO] = None
-  )
-  case class VersionedFlowsEntity (
-    versionedFlows: Option[Set[VersionedFlowEntity]] = None
-  )
-  case class VersionedFunnel (
-    comments: Option[String] = None,
-    componentType: Option[VersionedFunnelComponentType] = None,
-    groupIdentifier: Option[String] = None,
-    identifier: Option[String] = None,
-    instanceIdentifier: Option[String] = None,
-    name: Option[String] = None,
-    position: Option[Position] = None
-  )
-
-  sealed trait VersionedFunnelComponentType extends enumeratum.EnumEntry
-  object VersionedFunnelComponentType extends enumeratum.Enum[VersionedFunnelComponentType] with enumeratum.CirceEnum[VersionedFunnelComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedFunnelComponentType
-    case object PROCESSOR extends VersionedFunnelComponentType
-    case object PROCESS_GROUP extends VersionedFunnelComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedFunnelComponentType
-    case object INPUT_PORT extends VersionedFunnelComponentType
-    case object OUTPUT_PORT extends VersionedFunnelComponentType
-    case object REMOTE_INPUT_PORT extends VersionedFunnelComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedFunnelComponentType
-    case object FUNNEL extends VersionedFunnelComponentType
-    case object LABEL extends VersionedFunnelComponentType
-    case object CONTROLLER_SERVICE extends VersionedFunnelComponentType
-    case object REPORTING_TASK extends VersionedFunnelComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedFunnelComponentType
-    case object PARAMETER_CONTEXT extends VersionedFunnelComponentType
-    case object PARAMETER_PROVIDER extends VersionedFunnelComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedFunnelComponentType
-  }
-  case class VersionedLabel (
-    comments: Option[String] = None,
-    componentType: Option[VersionedLabelComponentType] = None,
-    groupIdentifier: Option[String] = None,
-    height: Option[Double] = None,
-    identifier: Option[String] = None,
-    instanceIdentifier: Option[String] = None,
-    label: Option[String] = None,
-    name: Option[String] = None,
-    position: Option[Position] = None,
-    style: Option[Map[String, String]] = None,
-    width: Option[Double] = None,
-    zIndex: Option[Long] = None
-  )
-
-  sealed trait VersionedLabelComponentType extends enumeratum.EnumEntry
-  object VersionedLabelComponentType extends enumeratum.Enum[VersionedLabelComponentType] with enumeratum.CirceEnum[VersionedLabelComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedLabelComponentType
-    case object PROCESSOR extends VersionedLabelComponentType
-    case object PROCESS_GROUP extends VersionedLabelComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedLabelComponentType
-    case object INPUT_PORT extends VersionedLabelComponentType
-    case object OUTPUT_PORT extends VersionedLabelComponentType
-    case object REMOTE_INPUT_PORT extends VersionedLabelComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedLabelComponentType
-    case object FUNNEL extends VersionedLabelComponentType
-    case object LABEL extends VersionedLabelComponentType
-    case object CONTROLLER_SERVICE extends VersionedLabelComponentType
-    case object REPORTING_TASK extends VersionedLabelComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedLabelComponentType
-    case object PARAMETER_CONTEXT extends VersionedLabelComponentType
-    case object PARAMETER_PROVIDER extends VersionedLabelComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedLabelComponentType
-  }
-  case class VersionedParameter (
-    description: Option[String] = None,
-    name: Option[String] = None,
-    provided: Option[Boolean] = None,
-    referencedAssets: Option[Seq[VersionedAsset]] = None,
-    sensitive: Option[Boolean] = None,
-    value: Option[String] = None
-  )
-  case class VersionedParameterContext (
-    comments: Option[String] = None,
-    componentType: Option[VersionedParameterContextComponentType] = None,
-    description: Option[String] = None,
-    groupIdentifier: Option[String] = None,
-    identifier: Option[String] = None,
-    inheritedParameterContexts: Option[Seq[String]] = None,
-    instanceIdentifier: Option[String] = None,
-    name: Option[String] = None,
-    parameterGroupName: Option[String] = None,
-    parameterProvider: Option[String] = None,
-    parameters: Option[Set[VersionedParameter]] = None,
-    position: Option[Position] = None,
-    synchronized: Option[Boolean] = None
-  )
-
-  sealed trait VersionedParameterContextComponentType extends enumeratum.EnumEntry
-  object VersionedParameterContextComponentType extends enumeratum.Enum[VersionedParameterContextComponentType] with enumeratum.CirceEnum[VersionedParameterContextComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedParameterContextComponentType
-    case object PROCESSOR extends VersionedParameterContextComponentType
-    case object PROCESS_GROUP extends VersionedParameterContextComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedParameterContextComponentType
-    case object INPUT_PORT extends VersionedParameterContextComponentType
-    case object OUTPUT_PORT extends VersionedParameterContextComponentType
-    case object REMOTE_INPUT_PORT extends VersionedParameterContextComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedParameterContextComponentType
-    case object FUNNEL extends VersionedParameterContextComponentType
-    case object LABEL extends VersionedParameterContextComponentType
-    case object CONTROLLER_SERVICE extends VersionedParameterContextComponentType
-    case object REPORTING_TASK extends VersionedParameterContextComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedParameterContextComponentType
-    case object PARAMETER_CONTEXT extends VersionedParameterContextComponentType
-    case object PARAMETER_PROVIDER extends VersionedParameterContextComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedParameterContextComponentType
-  }
-  case class VersionedPort (
-    allowRemoteAccess: Option[Boolean] = None,
-    comments: Option[String] = None,
-    componentType: Option[VersionedPortComponentType] = None,
-    concurrentlySchedulableTaskCount: Option[Int] = None,
-    groupIdentifier: Option[String] = None,
-    identifier: Option[String] = None,
-    instanceIdentifier: Option[String] = None,
-    name: Option[String] = None,
-    portFunction: Option[VersionedPortPortFunction] = None,
-    position: Option[Position] = None,
-    scheduledState: Option[VersionedPortScheduledState] = None,
-    `type`: Option[VersionedPortType] = None
-  )
-
-  sealed trait VersionedPortComponentType extends enumeratum.EnumEntry
-  object VersionedPortComponentType extends enumeratum.Enum[VersionedPortComponentType] with enumeratum.CirceEnum[VersionedPortComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedPortComponentType
-    case object PROCESSOR extends VersionedPortComponentType
-    case object PROCESS_GROUP extends VersionedPortComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedPortComponentType
-    case object INPUT_PORT extends VersionedPortComponentType
-    case object OUTPUT_PORT extends VersionedPortComponentType
-    case object REMOTE_INPUT_PORT extends VersionedPortComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedPortComponentType
-    case object FUNNEL extends VersionedPortComponentType
-    case object LABEL extends VersionedPortComponentType
-    case object CONTROLLER_SERVICE extends VersionedPortComponentType
-    case object REPORTING_TASK extends VersionedPortComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedPortComponentType
-    case object PARAMETER_CONTEXT extends VersionedPortComponentType
-    case object PARAMETER_PROVIDER extends VersionedPortComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedPortComponentType
-  }
-
-  sealed trait VersionedPortPortFunction extends enumeratum.EnumEntry
-  object VersionedPortPortFunction extends enumeratum.Enum[VersionedPortPortFunction] with enumeratum.CirceEnum[VersionedPortPortFunction] {
-    val values = findValues
-    case object STANDARD extends VersionedPortPortFunction
-    case object FAILURE extends VersionedPortPortFunction
-  }
-
-  sealed trait VersionedPortScheduledState extends enumeratum.EnumEntry
-  object VersionedPortScheduledState extends enumeratum.Enum[VersionedPortScheduledState] with enumeratum.CirceEnum[VersionedPortScheduledState] {
-    val values = findValues
-    case object ENABLED extends VersionedPortScheduledState
-    case object DISABLED extends VersionedPortScheduledState
-    case object RUNNING extends VersionedPortScheduledState
-  }
-
-  sealed trait VersionedPortType extends enumeratum.EnumEntry
-  object VersionedPortType extends enumeratum.Enum[VersionedPortType] with enumeratum.CirceEnum[VersionedPortType] {
-    val values = findValues
-    case object INPUT_PORT extends VersionedPortType
-    case object OUTPUT_PORT extends VersionedPortType
-  }
-  case class VersionedProcessGroup (
-    comments: Option[String] = None,
-    componentType: Option[VersionedProcessGroupComponentType] = None,
-    connections: Option[Set[VersionedConnection]] = None,
-    controllerServices: Option[Set[VersionedControllerService]] = None,
-    defaultBackPressureDataSizeThreshold: Option[String] = None,
-    defaultBackPressureObjectThreshold: Option[Long] = None,
-    defaultFlowFileExpiration: Option[String] = None,
-    executionEngine: Option[VersionedProcessGroupExecutionEngine] = None,
-    flowFileConcurrency: Option[String] = None,
-    flowFileOutboundPolicy: Option[String] = None,
-    funnels: Option[Set[VersionedFunnel]] = None,
-    groupIdentifier: Option[String] = None,
-    identifier: Option[String] = None,
-    inputPorts: Option[Set[VersionedPort]] = None,
-    instanceIdentifier: Option[String] = None,
-    labels: Option[Set[VersionedLabel]] = None,
-    logFileSuffix: Option[String] = None,
-    maxConcurrentTasks: Option[Int] = None,
-    name: Option[String] = None,
-    outputPorts: Option[Set[VersionedPort]] = None,
-    parameterContextName: Option[String] = None,
-    position: Option[Position] = None,
-    processGroups: Option[Set[VersionedProcessGroup]] = None,
-    processors: Option[Set[VersionedProcessor]] = None,
-    remoteProcessGroups: Option[Set[VersionedRemoteProcessGroup]] = None,
-    scheduledState: Option[VersionedProcessGroupScheduledState] = None,
-    statelessFlowTimeout: Option[String] = None,
-    versionedFlowCoordinates: Option[VersionedFlowCoordinates] = None
-  )
-
-  sealed trait VersionedProcessGroupComponentType extends enumeratum.EnumEntry
-  object VersionedProcessGroupComponentType extends enumeratum.Enum[VersionedProcessGroupComponentType] with enumeratum.CirceEnum[VersionedProcessGroupComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedProcessGroupComponentType
-    case object PROCESSOR extends VersionedProcessGroupComponentType
-    case object PROCESS_GROUP extends VersionedProcessGroupComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedProcessGroupComponentType
-    case object INPUT_PORT extends VersionedProcessGroupComponentType
-    case object OUTPUT_PORT extends VersionedProcessGroupComponentType
-    case object REMOTE_INPUT_PORT extends VersionedProcessGroupComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedProcessGroupComponentType
-    case object FUNNEL extends VersionedProcessGroupComponentType
-    case object LABEL extends VersionedProcessGroupComponentType
-    case object CONTROLLER_SERVICE extends VersionedProcessGroupComponentType
-    case object REPORTING_TASK extends VersionedProcessGroupComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedProcessGroupComponentType
-    case object PARAMETER_CONTEXT extends VersionedProcessGroupComponentType
-    case object PARAMETER_PROVIDER extends VersionedProcessGroupComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedProcessGroupComponentType
-  }
-
-  sealed trait VersionedProcessGroupExecutionEngine extends enumeratum.EnumEntry
-  object VersionedProcessGroupExecutionEngine extends enumeratum.Enum[VersionedProcessGroupExecutionEngine] with enumeratum.CirceEnum[VersionedProcessGroupExecutionEngine] {
-    val values = findValues
-    case object STANDARD extends VersionedProcessGroupExecutionEngine
-    case object STATELESS extends VersionedProcessGroupExecutionEngine
-    case object INHERITED extends VersionedProcessGroupExecutionEngine
-  }
-
-  sealed trait VersionedProcessGroupScheduledState extends enumeratum.EnumEntry
-  object VersionedProcessGroupScheduledState extends enumeratum.Enum[VersionedProcessGroupScheduledState] with enumeratum.CirceEnum[VersionedProcessGroupScheduledState] {
-    val values = findValues
-    case object ENABLED extends VersionedProcessGroupScheduledState
-    case object DISABLED extends VersionedProcessGroupScheduledState
-    case object RUNNING extends VersionedProcessGroupScheduledState
-  }
-  case class VersionedProcessor (
-    annotationData: Option[String] = None,
-    autoTerminatedRelationships: Option[Set[String]] = None,
-    backoffMechanism: Option[String] = None,
-    bulletinLevel: Option[String] = None,
-    bundle: Option[Bundle] = None,
-    comments: Option[String] = None,
-    componentType: Option[VersionedProcessorComponentType] = None,
-    concurrentlySchedulableTaskCount: Option[Int] = None,
-    executionNode: Option[String] = None,
-    groupIdentifier: Option[String] = None,
-    identifier: Option[String] = None,
-    instanceIdentifier: Option[String] = None,
-    maxBackoffPeriod: Option[String] = None,
-    name: Option[String] = None,
-    penaltyDuration: Option[String] = None,
-    position: Option[Position] = None,
-    properties: Option[Map[String, String]] = None,
-    propertyDescriptors: Option[Map[String, VersionedPropertyDescriptor]] = None,
-    retriedRelationships: Option[Set[String]] = None,
-    retryCount: Option[Int] = None,
-    runDurationMillis: Option[Long] = None,
-    scheduledState: Option[VersionedProcessorScheduledState] = None,
-    schedulingPeriod: Option[String] = None,
-    schedulingStrategy: Option[String] = None,
-    style: Option[Map[String, String]] = None,
-    `type`: Option[String] = None,
-    yieldDuration: Option[String] = None
-  )
-
-  sealed trait VersionedProcessorComponentType extends enumeratum.EnumEntry
-  object VersionedProcessorComponentType extends enumeratum.Enum[VersionedProcessorComponentType] with enumeratum.CirceEnum[VersionedProcessorComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedProcessorComponentType
-    case object PROCESSOR extends VersionedProcessorComponentType
-    case object PROCESS_GROUP extends VersionedProcessorComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedProcessorComponentType
-    case object INPUT_PORT extends VersionedProcessorComponentType
-    case object OUTPUT_PORT extends VersionedProcessorComponentType
-    case object REMOTE_INPUT_PORT extends VersionedProcessorComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedProcessorComponentType
-    case object FUNNEL extends VersionedProcessorComponentType
-    case object LABEL extends VersionedProcessorComponentType
-    case object CONTROLLER_SERVICE extends VersionedProcessorComponentType
-    case object REPORTING_TASK extends VersionedProcessorComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedProcessorComponentType
-    case object PARAMETER_CONTEXT extends VersionedProcessorComponentType
-    case object PARAMETER_PROVIDER extends VersionedProcessorComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedProcessorComponentType
-  }
-
-  sealed trait VersionedProcessorScheduledState extends enumeratum.EnumEntry
-  object VersionedProcessorScheduledState extends enumeratum.Enum[VersionedProcessorScheduledState] with enumeratum.CirceEnum[VersionedProcessorScheduledState] {
-    val values = findValues
-    case object ENABLED extends VersionedProcessorScheduledState
-    case object DISABLED extends VersionedProcessorScheduledState
-    case object RUNNING extends VersionedProcessorScheduledState
-  }
-  case class VersionedPropertyDescriptor (
-    displayName: Option[String] = None,
-    dynamic: Option[Boolean] = None,
-    identifiesControllerService: Option[Boolean] = None,
-    name: Option[String] = None,
-    resourceDefinition: Option[VersionedResourceDefinition] = None,
-    sensitive: Option[Boolean] = None
-  )
-  case class VersionedRemoteGroupPort (
-    batchSize: Option[BatchSize] = None,
-    comments: Option[String] = None,
-    componentType: Option[VersionedRemoteGroupPortComponentType] = None,
-    concurrentlySchedulableTaskCount: Option[Int] = None,
-    groupIdentifier: Option[String] = None,
-    identifier: Option[String] = None,
-    instanceIdentifier: Option[String] = None,
-    name: Option[String] = None,
-    position: Option[Position] = None,
-    remoteGroupId: Option[String] = None,
-    scheduledState: Option[VersionedRemoteGroupPortScheduledState] = None,
-    targetId: Option[String] = None,
-    useCompression: Option[Boolean] = None
-  )
-
-  sealed trait VersionedRemoteGroupPortComponentType extends enumeratum.EnumEntry
-  object VersionedRemoteGroupPortComponentType extends enumeratum.Enum[VersionedRemoteGroupPortComponentType] with enumeratum.CirceEnum[VersionedRemoteGroupPortComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedRemoteGroupPortComponentType
-    case object PROCESSOR extends VersionedRemoteGroupPortComponentType
-    case object PROCESS_GROUP extends VersionedRemoteGroupPortComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedRemoteGroupPortComponentType
-    case object INPUT_PORT extends VersionedRemoteGroupPortComponentType
-    case object OUTPUT_PORT extends VersionedRemoteGroupPortComponentType
-    case object REMOTE_INPUT_PORT extends VersionedRemoteGroupPortComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedRemoteGroupPortComponentType
-    case object FUNNEL extends VersionedRemoteGroupPortComponentType
-    case object LABEL extends VersionedRemoteGroupPortComponentType
-    case object CONTROLLER_SERVICE extends VersionedRemoteGroupPortComponentType
-    case object REPORTING_TASK extends VersionedRemoteGroupPortComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedRemoteGroupPortComponentType
-    case object PARAMETER_CONTEXT extends VersionedRemoteGroupPortComponentType
-    case object PARAMETER_PROVIDER extends VersionedRemoteGroupPortComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedRemoteGroupPortComponentType
-  }
-
-  sealed trait VersionedRemoteGroupPortScheduledState extends enumeratum.EnumEntry
-  object VersionedRemoteGroupPortScheduledState extends enumeratum.Enum[VersionedRemoteGroupPortScheduledState] with enumeratum.CirceEnum[VersionedRemoteGroupPortScheduledState] {
-    val values = findValues
-    case object ENABLED extends VersionedRemoteGroupPortScheduledState
-    case object DISABLED extends VersionedRemoteGroupPortScheduledState
-    case object RUNNING extends VersionedRemoteGroupPortScheduledState
-  }
-  case class VersionedRemoteProcessGroup (
-    comments: Option[String] = None,
-    communicationsTimeout: Option[String] = None,
-    componentType: Option[VersionedRemoteProcessGroupComponentType] = None,
-    groupIdentifier: Option[String] = None,
-    identifier: Option[String] = None,
-    inputPorts: Option[Set[VersionedRemoteGroupPort]] = None,
-    instanceIdentifier: Option[String] = None,
-    localNetworkInterface: Option[String] = None,
-    name: Option[String] = None,
-    outputPorts: Option[Set[VersionedRemoteGroupPort]] = None,
-    position: Option[Position] = None,
-    proxyHost: Option[String] = None,
-    proxyPassword: Option[String] = None,
-    proxyPort: Option[Int] = None,
-    proxyUser: Option[String] = None,
-    targetUris: Option[String] = None,
-    transportProtocol: Option[String] = None,
-    yieldDuration: Option[String] = None
-  )
-
-  sealed trait VersionedRemoteProcessGroupComponentType extends enumeratum.EnumEntry
-  object VersionedRemoteProcessGroupComponentType extends enumeratum.Enum[VersionedRemoteProcessGroupComponentType] with enumeratum.CirceEnum[VersionedRemoteProcessGroupComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedRemoteProcessGroupComponentType
-    case object PROCESSOR extends VersionedRemoteProcessGroupComponentType
-    case object PROCESS_GROUP extends VersionedRemoteProcessGroupComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedRemoteProcessGroupComponentType
-    case object INPUT_PORT extends VersionedRemoteProcessGroupComponentType
-    case object OUTPUT_PORT extends VersionedRemoteProcessGroupComponentType
-    case object REMOTE_INPUT_PORT extends VersionedRemoteProcessGroupComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedRemoteProcessGroupComponentType
-    case object FUNNEL extends VersionedRemoteProcessGroupComponentType
-    case object LABEL extends VersionedRemoteProcessGroupComponentType
-    case object CONTROLLER_SERVICE extends VersionedRemoteProcessGroupComponentType
-    case object REPORTING_TASK extends VersionedRemoteProcessGroupComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedRemoteProcessGroupComponentType
-    case object PARAMETER_CONTEXT extends VersionedRemoteProcessGroupComponentType
-    case object PARAMETER_PROVIDER extends VersionedRemoteProcessGroupComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedRemoteProcessGroupComponentType
-  }
-  case class VersionedReportingTask (
-    annotationData: Option[String] = None,
-    bundle: Option[Bundle] = None,
-    comments: Option[String] = None,
-    componentType: Option[VersionedReportingTaskComponentType] = None,
-    groupIdentifier: Option[String] = None,
-    identifier: Option[String] = None,
-    instanceIdentifier: Option[String] = None,
-    name: Option[String] = None,
-    position: Option[Position] = None,
-    properties: Option[Map[String, String]] = None,
-    propertyDescriptors: Option[Map[String, VersionedPropertyDescriptor]] = None,
-    scheduledState: Option[VersionedReportingTaskScheduledState] = None,
-    schedulingPeriod: Option[String] = None,
-    schedulingStrategy: Option[String] = None,
-    `type`: Option[String] = None
-  )
-
-  sealed trait VersionedReportingTaskComponentType extends enumeratum.EnumEntry
-  object VersionedReportingTaskComponentType extends enumeratum.Enum[VersionedReportingTaskComponentType] with enumeratum.CirceEnum[VersionedReportingTaskComponentType] {
-    val values = findValues
-    case object CONNECTION extends VersionedReportingTaskComponentType
-    case object PROCESSOR extends VersionedReportingTaskComponentType
-    case object PROCESS_GROUP extends VersionedReportingTaskComponentType
-    case object REMOTE_PROCESS_GROUP extends VersionedReportingTaskComponentType
-    case object INPUT_PORT extends VersionedReportingTaskComponentType
-    case object OUTPUT_PORT extends VersionedReportingTaskComponentType
-    case object REMOTE_INPUT_PORT extends VersionedReportingTaskComponentType
-    case object REMOTE_OUTPUT_PORT extends VersionedReportingTaskComponentType
-    case object FUNNEL extends VersionedReportingTaskComponentType
-    case object LABEL extends VersionedReportingTaskComponentType
-    case object CONTROLLER_SERVICE extends VersionedReportingTaskComponentType
-    case object REPORTING_TASK extends VersionedReportingTaskComponentType
-    case object FLOW_ANALYSIS_RULE extends VersionedReportingTaskComponentType
-    case object PARAMETER_CONTEXT extends VersionedReportingTaskComponentType
-    case object PARAMETER_PROVIDER extends VersionedReportingTaskComponentType
-    case object FLOW_REGISTRY_CLIENT extends VersionedReportingTaskComponentType
-  }
-
-  sealed trait VersionedReportingTaskScheduledState extends enumeratum.EnumEntry
-  object VersionedReportingTaskScheduledState extends enumeratum.Enum[VersionedReportingTaskScheduledState] with enumeratum.CirceEnum[VersionedReportingTaskScheduledState] {
-    val values = findValues
-    case object ENABLED extends VersionedReportingTaskScheduledState
-    case object DISABLED extends VersionedReportingTaskScheduledState
-    case object RUNNING extends VersionedReportingTaskScheduledState
-  }
-  case class VersionedReportingTaskImportRequestEntity (
-    disconnectedNodeAcknowledged: Option[Boolean] = None,
-    reportingTaskSnapshot: Option[VersionedReportingTaskSnapshot] = None
-  )
-  case class VersionedReportingTaskImportResponseEntity (
-    controllerServices: Option[Set[ControllerServiceEntity]] = None,
-    reportingTasks: Option[Set[ReportingTaskEntity]] = None
-  )
-  case class VersionedReportingTaskSnapshot (
-    controllerServices: Option[Seq[VersionedControllerService]] = None,
-    reportingTasks: Option[Seq[VersionedReportingTask]] = None
-  )
-  case class VersionedResourceDefinition (
-    cardinality: Option[VersionedResourceDefinitionCardinality] = None,
-    resourceTypes: Option[Set[VersionedResourceDefinitionResourceTypesItem]] = None
-  )
-
-  sealed trait VersionedResourceDefinitionCardinality extends enumeratum.EnumEntry
-  object VersionedResourceDefinitionCardinality extends enumeratum.Enum[VersionedResourceDefinitionCardinality] with enumeratum.CirceEnum[VersionedResourceDefinitionCardinality] {
-    val values = findValues
-    case object SINGLE extends VersionedResourceDefinitionCardinality
-    case object MULTIPLE extends VersionedResourceDefinitionCardinality
-  }
-
-  sealed trait VersionedResourceDefinitionResourceTypesItem extends enumeratum.EnumEntry
-  object VersionedResourceDefinitionResourceTypesItem extends enumeratum.Enum[VersionedResourceDefinitionResourceTypesItem] with enumeratum.CirceEnum[VersionedResourceDefinitionResourceTypesItem] {
-    val values = findValues
-    case object FILE extends VersionedResourceDefinitionResourceTypesItem
-    case object DIRECTORY extends VersionedResourceDefinitionResourceTypesItem
-    case object TEXT extends VersionedResourceDefinitionResourceTypesItem
-    case object URL extends VersionedResourceDefinitionResourceTypesItem
-  }
-  case class CreateAccessTokenRequest (
-    password: Option[String] = None,
-    username: Option[String] = None
-  )
-
-  sealed trait ClearState_1BodyIn extends Product with java.io.Serializable
-  case class ClearState_1Body0In(value: Array[Byte]) extends ClearState_1BodyIn
-  case class ClearState_1BodyOption_ComponentStateEntity_In(value: Option[ComponentStateEntity]) extends ClearState_1BodyIn
-
-
-  sealed trait ClearStateBodyIn extends Product with java.io.Serializable
-  case class ClearStateBody0In(value: Array[Byte]) extends ClearStateBodyIn
-  case class ClearStateBodyOption_ComponentStateEntity_In(value: Option[ComponentStateEntity]) extends ClearStateBodyIn
-
-
-  sealed trait GetFlowMetricsProducer extends enumeratum.EnumEntry
-  object GetFlowMetricsProducer extends enumeratum.Enum[GetFlowMetricsProducer] with enumeratum.CirceEnum[GetFlowMetricsProducer] {
-    val values = findValues
-    case object PROMETHEUS extends GetFlowMetricsProducer
-    case object JSON extends GetFlowMetricsProducer
-    implicit val enumCodecSupportGetFlowMetricsProducer: ExtraParamSupport[GetFlowMetricsProducer] =
-      extraCodecSupport[GetFlowMetricsProducer]("GetFlowMetricsProducer", GetFlowMetricsProducer)
-  }
-  sealed trait DownloadFlowFileContentResponseHeader
-  case class DownloadFlowFileContentResponseHeader200(`Content-Type`: String) extends DownloadFlowFileContentResponseHeader
-  case object DownloadFlowFileContentResponseHeader206 extends DownloadFlowFileContentResponseHeader
-
-
-  sealed trait ClearState_2BodyIn extends Product with java.io.Serializable
-  case class ClearState_2Body0In(value: Array[Byte]) extends ClearState_2BodyIn
-  case class ClearState_2BodyOption_ComponentStateEntity_In(value: Option[ComponentStateEntity]) extends ClearState_2BodyIn
-
-  case class UploadProcessGroupRequest (
-    clientId: String,
-    disconnectedNodeAcknowledged: Option[Boolean] = Some(false),
-    file: Option[sttp.model.Part[java.io.File]] = None,
-    groupName: String,
-    positionX: Double,
-    positionY: Double
-  )
-
-  sealed trait GetProcessorRunStatusDetailsBodyIn extends Product with java.io.Serializable
-  case class GetProcessorRunStatusDetailsBody0In(value: Array[Byte]) extends GetProcessorRunStatusDetailsBodyIn
-  case class GetProcessorRunStatusDetailsBodyOption_RunStatusDetailsRequestEntity_In(value: Option[RunStatusDetailsRequestEntity]) extends GetProcessorRunStatusDetailsBodyIn
-
-
-  sealed trait ClearState_3BodyIn extends Product with java.io.Serializable
-  case class ClearState_3Body0In(value: Array[Byte]) extends ClearState_3BodyIn
-  case class ClearState_3BodyOption_ComponentStateEntity_In(value: Option[ComponentStateEntity]) extends ClearState_3BodyIn
-
-  sealed trait GetInputContentResponseHeader
-  case class GetInputContentResponseHeader200(`Content-Type`: String) extends GetInputContentResponseHeader
-  case object GetInputContentResponseHeader206 extends GetInputContentResponseHeader
-
-  sealed trait GetOutputContentResponseHeader
-  case class GetOutputContentResponseHeader200(`Content-Type`: String) extends GetOutputContentResponseHeader
-  case object GetOutputContentResponseHeader206 extends GetOutputContentResponseHeader
-
-
-  sealed trait ClearState_4BodyIn extends Product with java.io.Serializable
-  case class ClearState_4Body0In(value: Array[Byte]) extends ClearState_4BodyIn
-  case class ClearState_4BodyOption_ComponentStateEntity_In(value: Option[ComponentStateEntity]) extends ClearState_4BodyIn
 
 
 
@@ -7972,7 +3863,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantValueMatcher(sttp.model.StatusCode(206), emptyOutputAs(None).description("Partial Content with range of bytes requested").and(emptyOutputAs(GetOutputContentResponseHeader206))){ case (None, GetOutputContentResponseHeader206) => true},
         oneOfVariantValueMatcher(sttp.model.StatusCode(200), streamBody(sttp.capabilities.pekko.PekkoStreams)(Schema.binary[StreamingOutput], `*/*CodecFormat`()).description("").toEndpointIO.map(Some(_))(_.orNull).and(header[String]("Content-Type").validate(Validator.pattern("([^*]+|[*])/([^*]+|[*])")).map(GetOutputContentResponseHeader200(_))(_.`Content-Type`))){ case (Some(_: sttp.capabilities.pekko.PekkoStreams.BinaryStream), (_: GetOutputContentResponseHeader200)) => true }))
       .tags(List("ProvenanceEvents"))
-  
+
   type SubmitLineageRequestEndpoint = Endpoint[Unit, LineageEntity, Unit, LineageEntity, Any]
   lazy val submitLineageRequest: SubmitLineageRequestEndpoint =
     endpoint
@@ -7988,7 +3879,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[LineageEntity].description("").and(statusCode(sttp.model.StatusCode(201))))
       .tags(List("Provenance"))
-  
+
   type GetLineageEndpoint = Endpoint[Unit, (String, Option[String]), Unit, LineageEntity, Any]
   lazy val getLineage: GetLineageEndpoint =
     endpoint
@@ -8004,7 +3895,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[LineageEntity].description(""))
       .tags(List("Provenance"))
-  
+
   type DeleteLineageEndpoint = Endpoint[Unit, (String, Option[String]), Unit, LineageEntity, Any]
   lazy val deleteLineage: DeleteLineageEndpoint =
     endpoint
@@ -8020,7 +3911,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[LineageEntity].description(""))
       .tags(List("Provenance"))
-  
+
   type GetSearchOptionsEndpoint = Endpoint[Unit, Unit, Unit, ProvenanceOptionsEntity, Any]
   lazy val getSearchOptions: GetSearchOptionsEndpoint =
     endpoint
@@ -8034,7 +3925,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[ProvenanceOptionsEntity].description(""))
       .tags(List("Provenance"))
-  
+
   type GetProvenanceEndpoint = Endpoint[Unit, (String, Option[String], Option[Boolean], Option[Boolean]), Unit, ProvenanceEntity, Any]
   lazy val getProvenance: GetProvenanceEndpoint =
     endpoint
@@ -8052,7 +3943,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[ProvenanceEntity].description(""))
       .tags(List("Provenance"))
-  
+
   type DeleteProvenanceEndpoint = Endpoint[Unit, (String, Option[String]), Unit, ProvenanceEntity, Any]
   lazy val deleteProvenance: DeleteProvenanceEndpoint =
     endpoint
@@ -8068,7 +3959,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[ProvenanceEntity].description(""))
       .tags(List("Provenance"))
-  
+
   type UpdateRemoteProcessGroupRunStatusesEndpoint = Endpoint[Unit, (String, RemotePortRunStatusEntity), Unit, RemoteProcessGroupEntity, Any]
   lazy val updateRemoteProcessGroupRunStatuses: UpdateRemoteProcessGroupRunStatusesEndpoint =
     endpoint
@@ -8084,7 +3975,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[RemoteProcessGroupEntity].description(""))
       .tags(List("RemoteProcessGroups"))
-  
+
   type GetRemoteProcessGroupEndpoint = Endpoint[Unit, String, Unit, RemoteProcessGroupEntity, Any]
   lazy val getRemoteProcessGroup: GetRemoteProcessGroupEndpoint =
     endpoint
@@ -8099,7 +3990,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[RemoteProcessGroupEntity].description(""))
       .tags(List("RemoteProcessGroups"))
-  
+
   type UpdateRemoteProcessGroupEndpoint = Endpoint[Unit, (String, RemoteProcessGroupEntity), Unit, RemoteProcessGroupEntity, Any]
   lazy val updateRemoteProcessGroup: UpdateRemoteProcessGroupEndpoint =
     endpoint
@@ -8115,7 +4006,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[RemoteProcessGroupEntity].description(""))
       .tags(List("RemoteProcessGroups"))
-  
+
   type RemoveRemoteProcessGroupEndpoint = Endpoint[Unit, (String, Option[LongParameterInt], Option[ClientIdParameterStr], Option[Boolean]), Unit, RemoteProcessGroupEntity, Any]
   lazy val removeRemoteProcessGroup: RemoveRemoteProcessGroupEndpoint =
     endpoint
@@ -8133,7 +4024,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[RemoteProcessGroupEntity].description(""))
       .tags(List("RemoteProcessGroups"))
-  
+
   type UpdateRemoteProcessGroupInputPortEndpoint = Endpoint[Unit, (String, String, RemoteProcessGroupPortEntity), Unit, RemoteProcessGroupPortEntity, Any]
   lazy val updateRemoteProcessGroupInputPort: UpdateRemoteProcessGroupInputPortEndpoint =
     endpoint
@@ -8149,7 +4040,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[RemoteProcessGroupPortEntity].description(""))
       .tags(List("RemoteProcessGroups"))
-  
+
   type UpdateRemoteProcessGroupInputPortRunStatusEndpoint = Endpoint[Unit, (String, String, RemotePortRunStatusEntity), Unit, RemoteProcessGroupPortEntity, Any]
   lazy val updateRemoteProcessGroupInputPortRunStatus: UpdateRemoteProcessGroupInputPortRunStatusEndpoint =
     endpoint
@@ -8165,7 +4056,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[RemoteProcessGroupPortEntity].description(""))
       .tags(List("RemoteProcessGroups"))
-  
+
   type UpdateRemoteProcessGroupOutputPortEndpoint = Endpoint[Unit, (String, String, RemoteProcessGroupPortEntity), Unit, RemoteProcessGroupPortEntity, Any]
   lazy val updateRemoteProcessGroupOutputPort: UpdateRemoteProcessGroupOutputPortEndpoint =
     endpoint
@@ -8181,7 +4072,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[RemoteProcessGroupPortEntity].description(""))
       .tags(List("RemoteProcessGroups"))
-  
+
   type UpdateRemoteProcessGroupOutputPortRunStatusEndpoint = Endpoint[Unit, (String, String, RemotePortRunStatusEntity), Unit, RemoteProcessGroupPortEntity, Any]
   lazy val updateRemoteProcessGroupOutputPortRunStatus: UpdateRemoteProcessGroupOutputPortRunStatusEndpoint =
     endpoint
@@ -8197,7 +4088,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[RemoteProcessGroupPortEntity].description(""))
       .tags(List("RemoteProcessGroups"))
-  
+
   type UpdateRemoteProcessGroupRunStatusEndpoint = Endpoint[Unit, (String, RemotePortRunStatusEntity), Unit, RemoteProcessGroupEntity, Any]
   lazy val updateRemoteProcessGroupRunStatus: UpdateRemoteProcessGroupRunStatusEndpoint =
     endpoint
@@ -8213,7 +4104,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[RemoteProcessGroupEntity].description(""))
       .tags(List("RemoteProcessGroups"))
-  
+
   type GetState_3Endpoint = Endpoint[Unit, String, Unit, ComponentStateEntity, Any]
   lazy val getState_3: GetState_3Endpoint =
     endpoint
@@ -8228,7 +4119,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[ComponentStateEntity].description(""))
       .tags(List("RemoteProcessGroups"))
-  
+
   type GetReportingTaskEndpoint = Endpoint[Unit, String, Unit, ReportingTaskEntity, Any]
   lazy val getReportingTask: GetReportingTaskEndpoint =
     endpoint
@@ -8243,7 +4134,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[ReportingTaskEntity].description(""))
       .tags(List("ReportingTasks"))
-  
+
   type UpdateReportingTaskEndpoint = Endpoint[Unit, (String, ReportingTaskEntity), Unit, ReportingTaskEntity, Any]
   lazy val updateReportingTask: UpdateReportingTaskEndpoint =
     endpoint
@@ -8259,7 +4150,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[ReportingTaskEntity].description(""))
       .tags(List("ReportingTasks"))
-  
+
   type RemoveReportingTaskEndpoint = Endpoint[Unit, (String, Option[LongParameterInt], Option[ClientIdParameterStr], Option[Boolean]), Unit, ReportingTaskEntity, Any]
   lazy val removeReportingTask: RemoveReportingTaskEndpoint =
     endpoint
@@ -8277,7 +4168,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[ReportingTaskEntity].description(""))
       .tags(List("ReportingTasks"))
-  
+
   type AnalyzeConfiguration_3Endpoint = Endpoint[Unit, (String, ConfigurationAnalysisEntity), Unit, ConfigurationAnalysisEntity, Any]
   lazy val analyzeConfiguration_3: AnalyzeConfiguration_3Endpoint =
     endpoint
@@ -8293,7 +4184,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[ConfigurationAnalysisEntity].description(""))
       .tags(List("ReportingTasks"))
-  
+
   type SubmitConfigVerificationRequest_2Endpoint = Endpoint[Unit, (String, VerifyConfigRequestEntity), Unit, VerifyConfigRequestEntity, Any]
   lazy val submitConfigVerificationRequest_2: SubmitConfigVerificationRequest_2Endpoint =
     endpoint
@@ -8309,7 +4200,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VerifyConfigRequestEntity].description(""))
       .tags(List("ReportingTasks"))
-  
+
   type GetVerificationRequest_3Endpoint = Endpoint[Unit, (String, String), Unit, VerifyConfigRequestEntity, Any]
   lazy val getVerificationRequest_3: GetVerificationRequest_3Endpoint =
     endpoint
@@ -8324,7 +4215,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VerifyConfigRequestEntity].description(""))
       .tags(List("ReportingTasks"))
-  
+
   type DeleteVerificationRequest_3Endpoint = Endpoint[Unit, (String, String), Unit, VerifyConfigRequestEntity, Any]
   lazy val deleteVerificationRequest_3: DeleteVerificationRequest_3Endpoint =
     endpoint
@@ -8339,7 +4230,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VerifyConfigRequestEntity].description(""))
       .tags(List("ReportingTasks"))
-  
+
   type GetPropertyDescriptor_4Endpoint = Endpoint[Unit, (String, String, Option[Boolean]), Unit, PropertyDescriptorEntity, Any]
   lazy val getPropertyDescriptor_4: GetPropertyDescriptor_4Endpoint =
     endpoint
@@ -8356,7 +4247,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[PropertyDescriptorEntity].description(""))
       .tags(List("ReportingTasks"))
-  
+
   type UpdateRunStatus_5Endpoint = Endpoint[Unit, (String, ReportingTaskRunStatusEntity), Unit, ReportingTaskEntity, Any]
   lazy val updateRunStatus_5: UpdateRunStatus_5Endpoint =
     endpoint
@@ -8372,7 +4263,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[ReportingTaskEntity].description(""))
       .tags(List("ReportingTasks"))
-  
+
   type GetState_4Endpoint = Endpoint[Unit, String, Unit, ComponentStateEntity, Any]
   lazy val getState_4: GetState_4Endpoint =
     endpoint
@@ -8387,7 +4278,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[ComponentStateEntity].description(""))
       .tags(List("ReportingTasks"))
-  
+
   type ClearState_4Endpoint = Endpoint[Unit, (String, ClearState_4BodyIn), Unit, ComponentStateEntity, Any]
   lazy val clearState_4: ClearState_4Endpoint =
     endpoint
@@ -8405,7 +4296,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[ComponentStateEntity].description(""))
       .tags(List("ReportingTasks"))
-  
+
   type GetResourcesEndpoint = Endpoint[Unit, Unit, Unit, ResourcesEntity, Any]
   lazy val getResources: GetResourcesEndpoint =
     endpoint
@@ -8417,7 +4308,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(403), emptyOutput.description("Client is not authorized to make this request."))(())))
       .out(jsonBody[ResourcesEntity].description(""))
       .tags(List("Resources"))
-  
+
   type GetSiteToSiteDetailsEndpoint = Endpoint[Unit, Unit, Unit, ControllerEntity, Any]
   lazy val getSiteToSiteDetails: GetSiteToSiteDetailsEndpoint =
     endpoint
@@ -8431,7 +4322,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[ControllerEntity].description(""))
       .tags(List("SiteToSite"))
-  
+
   type GetPeersEndpoint = Endpoint[Unit, Unit, Unit, PeersEntity, Any]
   lazy val getPeers: GetPeersEndpoint =
     endpoint
@@ -8447,7 +4338,7 @@ object TapirGeneratedEndpoints {
         jsonBody[PeersEntity].description(""),
         xmlBody[PeersEntity].description("")))
       .tags(List("SiteToSite"))
-  
+
   type CreateSnippetEndpoint = Endpoint[Unit, SnippetEntity, Unit, SnippetEntity, Any]
   lazy val createSnippet: CreateSnippetEndpoint =
     endpoint
@@ -8463,7 +4354,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[SnippetEntity].description("").and(statusCode(sttp.model.StatusCode(201))))
       .tags(List("Snippets"))
-  
+
   type UpdateSnippetEndpoint = Endpoint[Unit, (String, SnippetEntity), Unit, SnippetEntity, Any]
   lazy val updateSnippet: UpdateSnippetEndpoint =
     endpoint
@@ -8479,7 +4370,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[SnippetEntity].description(""))
       .tags(List("Snippets"))
-  
+
   type DeleteSnippetEndpoint = Endpoint[Unit, (String, Option[Boolean]), Unit, SnippetEntity, Any]
   lazy val deleteSnippet: DeleteSnippetEndpoint =
     endpoint
@@ -8495,7 +4386,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[SnippetEntity].description(""))
       .tags(List("Snippets"))
-  
+
   type GetSystemDiagnosticsEndpoint = Endpoint[Unit, (Option[Boolean], Option[GetSystemDiagnosticsDiagnosticLevel], Option[String]), Unit, SystemDiagnosticsEntity, Any]
   lazy val getSystemDiagnostics: GetSystemDiagnosticsEndpoint =
     endpoint
@@ -8510,7 +4401,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(403), emptyOutput.description("Client is not authorized to make this request."))(())))
       .out(jsonBody[SystemDiagnosticsEntity].description(""))
       .tags(List("SystemDiagnostics"))
-  
+
   sealed trait GetSystemDiagnosticsDiagnosticLevel extends enumeratum.EnumEntry
   object GetSystemDiagnosticsDiagnosticLevel extends enumeratum.Enum[GetSystemDiagnosticsDiagnosticLevel] with enumeratum.CirceEnum[GetSystemDiagnosticsDiagnosticLevel] {
     val values = findValues
@@ -8519,7 +4410,7 @@ object TapirGeneratedEndpoints {
     implicit val enumCodecSupportGetSystemDiagnosticsDiagnosticLevel: ExtraParamSupport[GetSystemDiagnosticsDiagnosticLevel] =
       extraCodecSupport[GetSystemDiagnosticsDiagnosticLevel]("GetSystemDiagnosticsDiagnosticLevel", GetSystemDiagnosticsDiagnosticLevel)
   }
-  
+
   type GetJmxMetricsEndpoint = Endpoint[Unit, Option[String], Unit, JmxMetricsResultsEntity, Any]
   lazy val getJmxMetrics: GetJmxMetricsEndpoint =
     endpoint
@@ -8535,7 +4426,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[JmxMetricsResultsEntity].description(""))
       .tags(List("SystemDiagnostics"))
-  
+
   type SearchTenantsEndpoint = Endpoint[Unit, String, Unit, TenantsEntity, Any]
   lazy val searchTenants: SearchTenantsEndpoint =
     endpoint
@@ -8551,7 +4442,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[TenantsEntity].description(""))
       .tags(List("Tenants"))
-  
+
   type GetUserGroupsEndpoint = Endpoint[Unit, Unit, Unit, UserGroupsEntity, Any]
   lazy val getUserGroups: GetUserGroupsEndpoint =
     endpoint
@@ -8566,7 +4457,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[UserGroupsEntity].description(""))
       .tags(List("Tenants"))
-  
+
   type CreateUserGroupEndpoint = Endpoint[Unit, UserGroupEntity, Unit, UserGroupEntity, Any]
   lazy val createUserGroup: CreateUserGroupEndpoint =
     endpoint
@@ -8582,7 +4473,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[UserGroupEntity].description("").and(statusCode(sttp.model.StatusCode(201))))
       .tags(List("Tenants"))
-  
+
   type GetUserGroupEndpoint = Endpoint[Unit, String, Unit, UserGroupEntity, Any]
   lazy val getUserGroup: GetUserGroupEndpoint =
     endpoint
@@ -8597,7 +4488,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[UserGroupEntity].description(""))
       .tags(List("Tenants"))
-  
+
   type UpdateUserGroupEndpoint = Endpoint[Unit, (String, UserGroupEntity), Unit, UserGroupEntity, Any]
   lazy val updateUserGroup: UpdateUserGroupEndpoint =
     endpoint
@@ -8613,7 +4504,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[UserGroupEntity].description(""))
       .tags(List("Tenants"))
-  
+
   type RemoveUserGroupEndpoint = Endpoint[Unit, (String, Option[LongParameterInt], Option[ClientIdParameterStr], Option[Boolean]), Unit, UserGroupEntity, Any]
   lazy val removeUserGroup: RemoveUserGroupEndpoint =
     endpoint
@@ -8631,7 +4522,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[UserGroupEntity].description(""))
       .tags(List("Tenants"))
-  
+
   type GetUsersEndpoint = Endpoint[Unit, Unit, Unit, UsersEntity, Any]
   lazy val getUsers: GetUsersEndpoint =
     endpoint
@@ -8646,7 +4537,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[UsersEntity].description(""))
       .tags(List("Tenants"))
-  
+
   type CreateUserEndpoint = Endpoint[Unit, UserEntity, Unit, UserEntity, Any]
   lazy val createUser: CreateUserEndpoint =
     endpoint
@@ -8662,7 +4553,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[UserEntity].description("").and(statusCode(sttp.model.StatusCode(201))))
       .tags(List("Tenants"))
-  
+
   type GetUserEndpoint = Endpoint[Unit, String, Unit, UserEntity, Any]
   lazy val getUser: GetUserEndpoint =
     endpoint
@@ -8677,7 +4568,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[UserEntity].description(""))
       .tags(List("Tenants"))
-  
+
   type UpdateUserEndpoint = Endpoint[Unit, (String, UserEntity), Unit, UserEntity, Any]
   lazy val updateUser: UpdateUserEndpoint =
     endpoint
@@ -8693,7 +4584,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[UserEntity].description(""))
       .tags(List("Tenants"))
-  
+
   type RemoveUserEndpoint = Endpoint[Unit, (String, Option[LongParameterInt], Option[ClientIdParameterStr], Option[Boolean]), Unit, UserEntity, Any]
   lazy val removeUser: RemoveUserEndpoint =
     endpoint
@@ -8711,7 +4602,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[UserEntity].description(""))
       .tags(List("Tenants"))
-  
+
   type CreateVersionControlRequestEndpoint = Endpoint[Unit, CreateActiveRequestEntity, Unit, String, Any]
   lazy val createVersionControlRequest: CreateVersionControlRequestEndpoint =
     endpoint
@@ -8727,7 +4618,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(stringBody.description(""))
       .tags(List("Versions"))
-  
+
   type UpdateVersionControlRequestEndpoint = Endpoint[Unit, (String, VersionControlComponentMappingEntity), Unit, VersionControlInformationEntity, Any]
   lazy val updateVersionControlRequest: UpdateVersionControlRequestEndpoint =
     endpoint
@@ -8743,7 +4634,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VersionControlInformationEntity].description(""))
       .tags(List("Versions"))
-  
+
   type DeleteVersionControlRequestEndpoint = Endpoint[Unit, (String, Option[Boolean]), Unit, Unit, Any]
   lazy val deleteVersionControlRequest: DeleteVersionControlRequestEndpoint =
     endpoint
@@ -8758,7 +4649,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(409), emptyOutput.description("The request was valid but NiFi was not in the appropriate state to process it."))(()),
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .tags(List("Versions"))
-  
+
   type GetVersionInformationEndpoint = Endpoint[Unit, String, Unit, VersionControlInformationEntity, Any]
   lazy val getVersionInformation: GetVersionInformationEndpoint =
     endpoint
@@ -8773,7 +4664,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VersionControlInformationEntity].description(""))
       .tags(List("Versions"))
-  
+
   type UpdateFlowVersionEndpoint = Endpoint[Unit, (String, VersionedFlowSnapshotEntity), Unit, VersionControlInformationEntity, Any]
   lazy val updateFlowVersion: UpdateFlowVersionEndpoint =
     endpoint
@@ -8789,7 +4680,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VersionControlInformationEntity].description(""))
       .tags(List("Versions"))
-  
+
   type SaveToFlowRegistryEndpoint = Endpoint[Unit, (String, StartVersionControlRequestEntity), Unit, VersionControlInformationEntity, Any]
   lazy val saveToFlowRegistry: SaveToFlowRegistryEndpoint =
     endpoint
@@ -8805,7 +4696,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VersionControlInformationEntity].description(""))
       .tags(List("Versions"))
-  
+
   type StopVersionControlEndpoint = Endpoint[Unit, (String, Option[LongParameterInt], Option[ClientIdParameterStr], Option[Boolean]), Unit, VersionControlInformationEntity, Any]
   lazy val stopVersionControl: StopVersionControlEndpoint =
     endpoint
@@ -8823,7 +4714,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VersionControlInformationEntity].description(""))
       .tags(List("Versions"))
-  
+
   type ExportFlowVersionEndpoint = Endpoint[Unit, String, Unit, String, Any]
   lazy val exportFlowVersion: ExportFlowVersionEndpoint =
     endpoint
@@ -8838,7 +4729,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[String].description(""))
       .tags(List("Versions"))
-  
+
   type InitiateRevertFlowVersionEndpoint = Endpoint[Unit, (String, VersionControlInformationEntity), Unit, VersionedFlowUpdateRequestEntity, Any]
   lazy val initiateRevertFlowVersion: InitiateRevertFlowVersionEndpoint =
     endpoint
@@ -8854,7 +4745,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VersionedFlowUpdateRequestEntity].description(""))
       .tags(List("Versions"))
-  
+
   type GetRevertRequestEndpoint = Endpoint[Unit, String, Unit, VersionedFlowUpdateRequestEntity, Any]
   lazy val getRevertRequest: GetRevertRequestEndpoint =
     endpoint
@@ -8869,7 +4760,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VersionedFlowUpdateRequestEntity].description(""))
       .tags(List("Versions"))
-  
+
   type DeleteRevertRequestEndpoint = Endpoint[Unit, (String, Option[Boolean]), Unit, VersionedFlowUpdateRequestEntity, Any]
   lazy val deleteRevertRequest: DeleteRevertRequestEndpoint =
     endpoint
@@ -8885,7 +4776,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VersionedFlowUpdateRequestEntity].description(""))
       .tags(List("Versions"))
-  
+
   type InitiateVersionControlUpdateEndpoint = Endpoint[Unit, (String, VersionControlInformationEntity), Unit, VersionedFlowUpdateRequestEntity, Any]
   lazy val initiateVersionControlUpdate: InitiateVersionControlUpdateEndpoint =
     endpoint
@@ -8901,7 +4792,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VersionedFlowUpdateRequestEntity].description(""))
       .tags(List("Versions"))
-  
+
   type GetUpdateRequestEndpoint = Endpoint[Unit, String, Unit, VersionedFlowUpdateRequestEntity, Any]
   lazy val getUpdateRequest: GetUpdateRequestEndpoint =
     endpoint
@@ -8916,7 +4807,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VersionedFlowUpdateRequestEntity].description(""))
       .tags(List("Versions"))
-  
+
   type DeleteUpdateRequest_1Endpoint = Endpoint[Unit, (String, Option[Boolean]), Unit, VersionedFlowUpdateRequestEntity, Any]
   lazy val deleteUpdateRequest_1: DeleteUpdateRequest_1Endpoint =
     endpoint
@@ -8932,7 +4823,7 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(401), emptyOutput.description("Client could not be authenticated."))(())))
       .out(jsonBody[VersionedFlowUpdateRequestEntity].description(""))
       .tags(List("Versions"))
-  
+
   
   lazy val generatedEndpoints = List(logOut, logOutComplete, createAccessToken, getAuthenticationConfiguration, getConnection, updateConnection, deleteConnection, getControllerService, updateControllerService, removeControllerService, analyzeConfiguration, submitConfigVerificationRequest, getVerificationRequest, deleteVerificationRequest, getPropertyDescriptor_1, getControllerServiceReferences, updateControllerServiceReferences, updateRunStatus_1, getState, clearState_1, createBulletin, getCluster, getNode, updateNode, deleteNode, getControllerConfig, updateControllerConfig, createControllerService, getFlowAnalysisRules, createFlowAnalysisRule, getFlowAnalysisRule, updateFlowAnalysisRule, removeFlowAnalysisRule, analyzeFlowAnalysisRuleConfiguration, submitFlowAnalysisRuleConfigVerificationRequest, getFlowAnalysisRuleVerificationRequest, deleteFlowAnalysisRuleVerificationRequest, getFlowAnalysisRulePropertyDescriptor, updateRunStatus, getFlowAnalysisRuleState, clearState, deleteHistory, getNarSummaries, uploadNar, getNarSummary, deleteNar, downloadNar, getNarDetails, createParameterProvider, getFlowRegistryClients, createFlowRegistryClient, getFlowRegistryClient, updateFlowRegistryClient, deleteFlowRegistryClient, getPropertyDescriptor, getRegistryClientTypes, createReportingTask, importReportingTaskSnapshot, getNodeStatusHistory, getCounters, updateAllCounters, updateCounter, extendInputPortTransactionTTL, commitInputPortTransaction, receiveFlowFiles, extendOutputPortTransactionTTL, commitOutputPortTransaction, transferFlowFiles, createPortTransaction, getAboutInfo, getAdditionalDetails, getBanners, getBulletinBoard, generateClientId, searchCluster, getClusterSummary, getFlowConfig, getConnectionStatistics, getConnectionStatus, getConnectionStatusHistory, getContentViewers, getControllerServiceDefinition, getControllerServiceTypes, getBulletins, getControllerServicesFromController, getCurrentUser, getFlowAnalysisRuleDefinition, getFlowAnalysisRuleTypes, getAllFlowAnalysisResults, getFlowAnalysisResults, queryHistory, getComponentHistory, getAction, getInputPortStatus, getFlowMetrics, getOutputPortStatus, getParameterContexts, getParameterProviderDefinition, getParameterProviderTypes, getParameterProviders, getPrioritizers, getFlow, scheduleComponents, getBreadcrumbs, getControllerServicesFromGroup, activateControllerServices, getProcessGroupStatus, getProcessGroupStatusHistory, getProcessorDefinition, getProcessorTypes, getProcessorStatus, getProcessorStatusHistory, getRegistryClients, getBranches, getBuckets, getVersionDifferences, getFlows, getDetails, getVersions, getRemoteProcessGroupStatus, getRemoteProcessGroupStatusHistory, getReportingTaskDefinition, getReportingTaskTypes, getReportingTasks, downloadReportingTaskSnapshot, getReportingTaskSnapshot, getRuntimeManifest, searchFlow, getControllerStatus, createDropRequest, getDropRequest, removeDropRequest, getFlowFile, downloadFlowFileContent, createFlowFileListing, getListingRequest, deleteListingRequest, getFunnel, updateFunnel, removeFunnel, getInputPort, updateInputPort, removeInputPort, updateRunStatus_2, getLabel, updateLabel, removeLabel, getOutputPort, updateOutputPort, removeOutputPort, updateRunStatus_3, createParameterContext, getAssets, createAsset, getAssetContent, deleteAsset, submitParameterContextUpdate, getParameterContextUpdate, deleteUpdateRequest, submitValidationRequest, getValidationRequest, deleteValidationRequest, getParameterContext, updateParameterContext, deleteParameterContext, getParameterProvider, updateParameterProvider, removeParameterProvider, analyzeConfiguration_1, submitConfigVerificationRequest_1, getVerificationRequest_1, deleteVerificationRequest_1, getPropertyDescriptor_2, fetchParameters, getParameterProviderReferences, getState_1, clearState_2, submitApplyParameters, getParameterProviderApplyParametersRequest, deleteApplyParametersRequest, createAccessPolicy, getAccessPolicyForResource, getAccessPolicy, updateAccessPolicy, removeAccessPolicy, getReplaceProcessGroupRequest, deleteReplaceProcessGroupRequest, getProcessGroup, updateProcessGroup, removeProcessGroup, getConnections, createConnection, createControllerService_1, copy, exportProcessGroup, createEmptyAllConnectionsRequest, getDropAllFlowfilesRequest, removeDropRequest_1, replaceProcessGroup, getFunnels, createFunnel, getInputPorts, createInputPort, getLabels, createLabel, getLocalModifications, getOutputPorts, createOutputPort, paste, getProcessGroups, createProcessGroup, importProcessGroup, uploadProcessGroup, getProcessors, createProcessor, getRemoteProcessGroups, createRemoteProcessGroup, initiateReplaceProcessGroup, copySnippet, getProcessorRunStatusDetails, getProcessor, updateProcessor, deleteProcessor, analyzeConfiguration_2, submitProcessorVerificationRequest, getVerificationRequest_2, deleteVerificationRequest_2, getPropertyDescriptor_3, getProcessorDiagnostics, updateRunStatus_4, getState_2, clearState_3, terminateProcessor, submitProvenanceRequest, submitReplayLatestEvent, getLatestProvenanceEvents, submitReplay, getProvenanceEvent, getInputContent, getOutputContent, submitLineageRequest, getLineage, deleteLineage, getSearchOptions, getProvenance, deleteProvenance, updateRemoteProcessGroupRunStatuses, getRemoteProcessGroup, updateRemoteProcessGroup, removeRemoteProcessGroup, updateRemoteProcessGroupInputPort, updateRemoteProcessGroupInputPortRunStatus, updateRemoteProcessGroupOutputPort, updateRemoteProcessGroupOutputPortRunStatus, updateRemoteProcessGroupRunStatus, getState_3, getReportingTask, updateReportingTask, removeReportingTask, analyzeConfiguration_3, submitConfigVerificationRequest_2, getVerificationRequest_3, deleteVerificationRequest_3, getPropertyDescriptor_4, updateRunStatus_5, getState_4, clearState_4, getResources, getSiteToSiteDetails, getPeers, createSnippet, updateSnippet, deleteSnippet, getSystemDiagnostics, getJmxMetrics, searchTenants, getUserGroups, createUserGroup, getUserGroup, updateUserGroup, removeUserGroup, getUsers, createUser, getUser, updateUser, removeUser, createVersionControlRequest, updateVersionControlRequest, deleteVersionControlRequest, getVersionInformation, updateFlowVersion, saveToFlowRegistry, stopVersionControl, exportFlowVersion, initiateRevertFlowVersion, getRevertRequest, deleteRevertRequest, initiateVersionControlUpdate, getUpdateRequest, deleteUpdateRequest_1)
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/ExpectedJsonSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/ExpectedJsonSerdes.scala.txt
@@ -2,6 +2,7 @@ package sttp.tapir.generated
 
 object TapirGeneratedEndpointsJsonSerdes {
   import sttp.tapir.generated.TapirGeneratedEndpoints._
+  import sttp.tapir.generated.models._
   import sttp.tapir.generic.auto._
   implicit val byteStringJsonDecoder: io.circe.Decoder[ByteString] =
     io.circe.Decoder.decodeString

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/ExpectedModelPackage.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/ExpectedModelPackage.scala.txt
@@ -1,0 +1,102 @@
+
+package sttp.tapir.generated
+
+package object models {
+
+  case class CommaSeparatedValues[T](values: List[T])
+  case class ExplodedValues[T](values: List[T])
+  trait ExtraParamSupport[T] {
+    def decode(s: String): sttp.tapir.DecodeResult[T]
+    def encode(t: T): String
+  }
+
+  case class EnumExtraParamSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]) extends ExtraParamSupport[T] {
+    // Case-insensitive mapping
+    def decode(s: String): sttp.tapir.DecodeResult[T] =
+      scala.util.Try(T.upperCaseNameValuesToMap(s.toUpperCase))
+        .fold(
+          _ =>
+            sttp.tapir.DecodeResult.Error(
+              s,
+              new NoSuchElementException(
+                s"Could not find value $s for enum ${enumName}, available values: ${T.values.mkString(", ")}"
+              )
+            ),
+          sttp.tapir.DecodeResult.Value(_)
+        )
+    def encode(t: T): String = t.entryName
+  }
+  def extraCodecSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): ExtraParamSupport[T] =
+    EnumExtraParamSupport(enumName, T)
+
+  type ActionDetailsDTO = io.circe.JsonObject
+  type BulletinBoardPatternParameterStr = String
+  type ClientIdParameterStr = String
+  type ComponentDetailsDTO = io.circe.JsonObject
+  type DateTimeParameterDT = java.time.Instant
+  type IntegerParameterInt = Int
+  type LongParameterInt = Long
+  type StreamingOutput = io.circe.JsonObject
+  case class CreateAccessTokenRequest (
+    password: Option[String] = None,
+    username: Option[String] = None
+  )
+
+  sealed trait ClearState_1BodyIn extends Product with java.io.Serializable
+  case class ClearState_1Body0In(value: Array[Byte]) extends ClearState_1BodyIn
+  case class ClearState_1BodyOption_ComponentStateEntity_In(value: Option[ComponentStateEntity]) extends ClearState_1BodyIn
+
+
+  sealed trait ClearStateBodyIn extends Product with java.io.Serializable
+  case class ClearStateBody0In(value: Array[Byte]) extends ClearStateBodyIn
+  case class ClearStateBodyOption_ComponentStateEntity_In(value: Option[ComponentStateEntity]) extends ClearStateBodyIn
+
+
+  sealed trait GetFlowMetricsProducer extends enumeratum.EnumEntry
+  object GetFlowMetricsProducer extends enumeratum.Enum[GetFlowMetricsProducer] with enumeratum.CirceEnum[GetFlowMetricsProducer] {
+    val values = findValues
+    case object PROMETHEUS extends GetFlowMetricsProducer
+    case object JSON extends GetFlowMetricsProducer
+    implicit val enumCodecSupportGetFlowMetricsProducer: ExtraParamSupport[GetFlowMetricsProducer] =
+      extraCodecSupport[GetFlowMetricsProducer]("GetFlowMetricsProducer", GetFlowMetricsProducer)
+  }
+  sealed trait DownloadFlowFileContentResponseHeader
+  case class DownloadFlowFileContentResponseHeader200(`Content-Type`: String) extends DownloadFlowFileContentResponseHeader
+  case object DownloadFlowFileContentResponseHeader206 extends DownloadFlowFileContentResponseHeader
+
+
+  sealed trait ClearState_2BodyIn extends Product with java.io.Serializable
+  case class ClearState_2Body0In(value: Array[Byte]) extends ClearState_2BodyIn
+  case class ClearState_2BodyOption_ComponentStateEntity_In(value: Option[ComponentStateEntity]) extends ClearState_2BodyIn
+
+  case class UploadProcessGroupRequest (
+    clientId: String,
+    disconnectedNodeAcknowledged: Option[Boolean] = Some(false),
+    file: Option[sttp.model.Part[java.io.File]] = None,
+    groupName: String,
+    positionX: Double,
+    positionY: Double
+  )
+
+  sealed trait GetProcessorRunStatusDetailsBodyIn extends Product with java.io.Serializable
+  case class GetProcessorRunStatusDetailsBody0In(value: Array[Byte]) extends GetProcessorRunStatusDetailsBodyIn
+  case class GetProcessorRunStatusDetailsBodyOption_RunStatusDetailsRequestEntity_In(value: Option[RunStatusDetailsRequestEntity]) extends GetProcessorRunStatusDetailsBodyIn
+
+
+  sealed trait ClearState_3BodyIn extends Product with java.io.Serializable
+  case class ClearState_3Body0In(value: Array[Byte]) extends ClearState_3BodyIn
+  case class ClearState_3BodyOption_ComponentStateEntity_In(value: Option[ComponentStateEntity]) extends ClearState_3BodyIn
+
+  sealed trait GetInputContentResponseHeader
+  case class GetInputContentResponseHeader200(`Content-Type`: String) extends GetInputContentResponseHeader
+  case object GetInputContentResponseHeader206 extends GetInputContentResponseHeader
+
+  sealed trait GetOutputContentResponseHeader
+  case class GetOutputContentResponseHeader200(`Content-Type`: String) extends GetOutputContentResponseHeader
+  case object GetOutputContentResponseHeader206 extends GetOutputContentResponseHeader
+
+
+  sealed trait ClearState_4BodyIn extends Product with java.io.Serializable
+  case class ClearState_4Body0In(value: Array[Byte]) extends ClearState_4BodyIn
+  case class ClearState_4BodyOption_ComponentStateEntity_In(value: Option[ComponentStateEntity]) extends ClearState_4BodyIn
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/ExpectedProcessGroupDTO.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/ExpectedProcessGroupDTO.scala.txt
@@ -1,0 +1,70 @@
+package sttp.tapir.generated.models
+
+case class ProcessGroupDTO (
+  activeRemotePortCount: Option[Int] = None,
+  comments: Option[String] = None,
+  contents: Option[FlowSnippetDTO] = None,
+  defaultBackPressureDataSizeThreshold: Option[String] = None,
+  defaultBackPressureObjectThreshold: Option[Long] = None,
+  defaultFlowFileExpiration: Option[String] = None,
+  disabledCount: Option[Int] = None,
+  executionEngine: Option[ProcessGroupDTOExecutionEngine] = None,
+  flowfileConcurrency: Option[ProcessGroupDTOFlowfileConcurrency] = None,
+  flowfileOutboundPolicy: Option[ProcessGroupDTOFlowfileOutboundPolicy] = None,
+  id: Option[String] = None,
+  inactiveRemotePortCount: Option[Int] = None,
+  inputPortCount: Option[Int] = None,
+  invalidCount: Option[Int] = None,
+  localInputPortCount: Option[Int] = None,
+  localOutputPortCount: Option[Int] = None,
+  locallyModifiedAndStaleCount: Option[Int] = None,
+  locallyModifiedCount: Option[Int] = None,
+  logFileSuffix: Option[String] = None,
+  maxConcurrentTasks: Option[Int] = None,
+  name: Option[String] = None,
+  outputPortCount: Option[Int] = None,
+  parameterContext: Option[ParameterContextReferenceEntity] = None,
+  parentGroupId: Option[String] = None,
+  position: Option[PositionDTO] = None,
+  publicInputPortCount: Option[Int] = None,
+  publicOutputPortCount: Option[Int] = None,
+  runningCount: Option[Int] = None,
+  staleCount: Option[Int] = None,
+  statelessFlowTimeout: Option[String] = None,
+  statelessGroupScheduledState: Option[ProcessGroupDTOStatelessGroupScheduledState] = None,
+  stoppedCount: Option[Int] = None,
+  syncFailureCount: Option[Int] = None,
+  upToDateCount: Option[Int] = None,
+  versionControlInformation: Option[VersionControlInformationDTO] = None,
+  versionedComponentId: Option[String] = None
+)
+
+sealed trait ProcessGroupDTOExecutionEngine extends enumeratum.EnumEntry
+object ProcessGroupDTOExecutionEngine extends enumeratum.Enum[ProcessGroupDTOExecutionEngine] with enumeratum.CirceEnum[ProcessGroupDTOExecutionEngine] {
+  val values = findValues
+  case object STATELESS extends ProcessGroupDTOExecutionEngine
+  case object STANDARD extends ProcessGroupDTOExecutionEngine
+  case object INHERITED extends ProcessGroupDTOExecutionEngine
+}
+
+sealed trait ProcessGroupDTOFlowfileConcurrency extends enumeratum.EnumEntry
+object ProcessGroupDTOFlowfileConcurrency extends enumeratum.Enum[ProcessGroupDTOFlowfileConcurrency] with enumeratum.CirceEnum[ProcessGroupDTOFlowfileConcurrency] {
+  val values = findValues
+  case object UNBOUNDED extends ProcessGroupDTOFlowfileConcurrency
+  case object SINGLE_FLOWFILE_PER_NODE extends ProcessGroupDTOFlowfileConcurrency
+  case object SINGLE_BATCH_PER_NODE extends ProcessGroupDTOFlowfileConcurrency
+}
+
+sealed trait ProcessGroupDTOFlowfileOutboundPolicy extends enumeratum.EnumEntry
+object ProcessGroupDTOFlowfileOutboundPolicy extends enumeratum.Enum[ProcessGroupDTOFlowfileOutboundPolicy] with enumeratum.CirceEnum[ProcessGroupDTOFlowfileOutboundPolicy] {
+  val values = findValues
+  case object STREAM_WHEN_AVAILABLE extends ProcessGroupDTOFlowfileOutboundPolicy
+  case object BATCH_OUTPUT extends ProcessGroupDTOFlowfileOutboundPolicy
+}
+
+sealed trait ProcessGroupDTOStatelessGroupScheduledState extends enumeratum.EnumEntry
+object ProcessGroupDTOStatelessGroupScheduledState extends enumeratum.Enum[ProcessGroupDTOStatelessGroupScheduledState] with enumeratum.CirceEnum[ProcessGroupDTOStatelessGroupScheduledState] {
+  val values = findValues
+  case object STOPPED extends ProcessGroupDTOStatelessGroupScheduledState
+  case object RUNNING extends ProcessGroupDTOStatelessGroupScheduledState
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/ExpectedSchemas.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/ExpectedSchemas.scala.txt
@@ -1,7 +1,9 @@
 package sttp.tapir.generated
 
+
 object TapirGeneratedEndpointsSchemas1 {
   import sttp.tapir.generated.TapirGeneratedEndpoints._
+  import sttp.tapir.generated.models._
   import sttp.tapir.generic.auto._
 
   implicit lazy val byteStringSchema: sttp.tapir.Schema[ByteString] = sttp.tapir.Schema.schemaForByteArray.map(ba => Some(toByteString(ba)))(bs => bs)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/ExpectedXmlSerdes.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/ExpectedXmlSerdes.scala.txt
@@ -2,6 +2,7 @@ package sttp.tapir.generated
 
 object TapirGeneratedEndpointsXmlSerdes {
   import sttp.tapir.generated.TapirGeneratedEndpoints._
+  import sttp.tapir.generated.models._
   import sttp.tapir.generic.auto._
   import cats.data.NonEmptyList
   import cats.xml.{NodeContent, Xml, XmlData, XmlNode}
@@ -115,7 +116,7 @@ object TapirGeneratedEndpointsXmlSerdes {
     }
     case Left(t) => sttp.tapir.DecodeResult.Error(s, t)
   }
-  
+
   implicit lazy val PeerDTOXmlTypeInterpreter: XmlTypeInterpreter[PeerDTO] = XmlTypeInterpreter.auto[PeerDTO]((_, _) => false, (_, _) => false)
   implicit lazy val PeerDTOXmlDecoder: Decoder[PeerDTO] = deriveConfiguredDecoder[PeerDTO]
   implicit lazy val PeerDTOXmlEncoder: Encoder[PeerDTO] = deriveConfiguredEncoder[PeerDTO]

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/build.sbt
@@ -4,7 +4,8 @@ lazy val root = (project in file("."))
     scalaVersion := "2.13.18",
     version := "0.1",
     openapiStreamingImplementation := "pekko",
-    openapiGenerateEndpointTypes := true
+    openapiGenerateEndpointTypes := true,
+    openapiSeperateFilesForModels := true,
   )
 
 val tapirVersion = "1.13.13"
@@ -46,7 +47,9 @@ TaskKey[Unit]("check") := {
     "TapirGeneratedEndpoints.scala" -> "Expected.scala.txt",
     "TapirGeneratedEndpointsJsonSerdes.scala" -> "ExpectedJsonSerdes.scala.txt",
     "TapirGeneratedEndpointsSchemas1.scala" -> "ExpectedSchemas.scala.txt",
-    "TapirGeneratedEndpointsXmlSerdes.scala" -> "ExpectedXmlSerdes.scala.txt"
+    "TapirGeneratedEndpointsXmlSerdes.scala" -> "ExpectedXmlSerdes.scala.txt",
+    "models/ProcessGroupDTO.scala" -> "ExpectedProcessGroupDTO.scala.txt",
+    "models/package.scala" -> "ExpectedModelPackage.scala.txt",
   ).foreach { case (generated, expected) => check(generated, expected) }
   ()
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
@@ -16,6 +16,7 @@ object TapirGeneratedEndpoints {
   
   
   
+  
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
   trait ExtraParamSupport[T] {
@@ -56,9 +57,12 @@ object TapirGeneratedEndpoints {
   type ByteString <: Array[Byte]
   implicit def toByteString(ba: Array[Byte]): ByteString = ba.asInstanceOf[ByteString]
 
+  
   sealed trait ADTWithDiscriminator
   sealed trait ADTWithDiscriminatorNoMapping
   sealed trait ADTWithoutDiscriminator
+  
+  type ListType = List[String]
   
   sealed trait AnEnum extends enumeratum.EnumEntry
   object AnEnum extends enumeratum.Enum[AnEnum] {
@@ -105,7 +109,7 @@ object TapirGeneratedEndpoints {
     e: Option[AnEnum] = None,
     absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
-  type ListType = List[String]
+  
   sealed trait Aardvark
   case class AardvarkUUID(v: java.util.UUID) extends Aardvark
   case class AardvarkDate(v: java.time.LocalDate) extends Aardvark

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -33,6 +33,7 @@ object TapirGeneratedEndpoints {
       case None => (None, None)
     }
   
+
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
   trait ExtraParamSupport[T] {
@@ -97,7 +98,9 @@ object TapirGeneratedEndpoints {
   sealed trait AnyObjectWithInlineEnum
   sealed trait Error
   sealed trait ValidatedOneOf
-  
+
+  type ListType = List[String]
+
   sealed trait AnEnum extends enumeratum.EnumEntry
   object AnEnum extends enumeratum.Enum[AnEnum] with enumeratum.CirceEnum[AnEnum] {
     val values = findValues
@@ -105,22 +108,7 @@ object TapirGeneratedEndpoints {
     case object Bar extends AnEnum
     case object Baz extends AnEnum
   }
-  
-  sealed trait ObjectWithInlineEnum2InlineEnum extends enumeratum.EnumEntry
-  object ObjectWithInlineEnum2InlineEnum extends enumeratum.Enum[ObjectWithInlineEnum2InlineEnum] with enumeratum.CirceEnum[ObjectWithInlineEnum2InlineEnum] {
-    val values = findValues
-    case object bar1 extends ObjectWithInlineEnum2InlineEnum
-    case object bar2 extends ObjectWithInlineEnum2InlineEnum
-  }
-  
-  sealed trait ObjectWithInlineEnumInlineEnum extends enumeratum.EnumEntry
-  object ObjectWithInlineEnumInlineEnum extends enumeratum.Enum[ObjectWithInlineEnumInlineEnum] with enumeratum.CirceEnum[ObjectWithInlineEnumInlineEnum] {
-    val values = findValues
-    case object foo1 extends ObjectWithInlineEnumInlineEnum
-    case object foo2 extends ObjectWithInlineEnumInlineEnum
-    case object foo3 extends ObjectWithInlineEnumInlineEnum
-    case object foo4 extends ObjectWithInlineEnumInlineEnum
-  }
+
   case class Abrdvark (
     b: Boolean
   )
@@ -158,9 +146,25 @@ object TapirGeneratedEndpoints {
     id: java.util.UUID,
     inlineEnum: ObjectWithInlineEnumInlineEnum = ObjectWithInlineEnumInlineEnum.foo3
   ) extends AnyObjectWithInlineEnum
+
+  sealed trait ObjectWithInlineEnumInlineEnum extends enumeratum.EnumEntry
+  object ObjectWithInlineEnumInlineEnum extends enumeratum.Enum[ObjectWithInlineEnumInlineEnum] with enumeratum.CirceEnum[ObjectWithInlineEnumInlineEnum] {
+    val values = findValues
+    case object foo1 extends ObjectWithInlineEnumInlineEnum
+    case object foo2 extends ObjectWithInlineEnumInlineEnum
+    case object foo3 extends ObjectWithInlineEnumInlineEnum
+    case object foo4 extends ObjectWithInlineEnumInlineEnum
+  }
   case class ObjectWithInlineEnum2 (
     inlineEnum: ObjectWithInlineEnum2InlineEnum
   ) extends AnyObjectWithInlineEnum
+
+  sealed trait ObjectWithInlineEnum2InlineEnum extends enumeratum.EnumEntry
+  object ObjectWithInlineEnum2InlineEnum extends enumeratum.Enum[ObjectWithInlineEnum2InlineEnum] with enumeratum.CirceEnum[ObjectWithInlineEnum2InlineEnum] {
+    val values = findValues
+    case object bar1 extends ObjectWithInlineEnum2InlineEnum
+    case object bar2 extends ObjectWithInlineEnum2InlineEnum
+  }
   case class SimpleError (
     message: String
   ) extends Error
@@ -219,7 +223,7 @@ object TapirGeneratedEndpoints {
   case class ValidatedSubObj (
     i: String
   )
-  type ListType = List[String]
+
   sealed trait Aardvark
   case class AardvarkUUID(v: java.util.UUID) extends Aardvark
   case class AardvarkDate(v: java.time.LocalDate) extends Aardvark

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -88,6 +88,9 @@ object TapirGeneratedEndpoints {
   sealed trait ADTWithDiscriminatorNoMapping
   sealed trait ADTWithoutDiscriminator
 
+  type ListType = List[ByteString]
+  type SomeBinaryType = io.circe.JsonObject
+
   sealed trait AnEnum extends enumeratum.EnumEntry
   object AnEnum extends enumeratum.Enum[AnEnum] {
     val values = findValues
@@ -106,13 +109,6 @@ object TapirGeneratedEndpoints {
     case object sold extends PetStatus
   }
 
-  sealed trait SubtypeWithoutD3E2 extends enumeratum.EnumEntry
-  object SubtypeWithoutD3E2 extends enumeratum.Enum[SubtypeWithoutD3E2] {
-    val values = findValues
-    case object A extends SubtypeWithoutD3E2
-    case object B extends SubtypeWithoutD3E2
-    case object C extends SubtypeWithoutD3E2
-  }
   case class Abrdvark (
     b: Boolean
   )
@@ -158,6 +154,7 @@ object TapirGeneratedEndpoints {
     a: Seq[String],
     absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
+
   case class SubtypeWithoutD3 (
     s: String,
     i: Option[Int] = None,
@@ -165,6 +162,14 @@ object TapirGeneratedEndpoints {
     e2: Option[SubtypeWithoutD3E2] = None,
     absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
+  sealed trait SubtypeWithoutD3E2 extends enumeratum.EnumEntry
+  object SubtypeWithoutD3E2 extends enumeratum.Enum[SubtypeWithoutD3E2] {
+    val values = findValues
+    case object A extends SubtypeWithoutD3E2
+    case object B extends SubtypeWithoutD3E2
+    case object C extends SubtypeWithoutD3E2
+  }
+
   case class Tag (
     id: Option[Long] = None,
     name: Option[String] = None
@@ -179,8 +184,7 @@ object TapirGeneratedEndpoints {
   case class WrapB (
     w: AnEnum
   )
-  type ListType = List[ByteString]
-  type SomeBinaryType = io.circe.JsonObject
+
   sealed trait StringOrInt
   case class StringOrIntString(v: String) extends StringOrInt
   case class StringOrIntInt(v: Int) extends StringOrInt

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/project/build.properties
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.5

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/project/build.properties
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.11.5

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/project/plugins.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/project/plugins.sbt
@@ -1,5 +1,5 @@
 {
-  val pluginVersion = "1.13.23.72-LOCAL"
+  val pluginVersion = System.getProperty("plugin.version")
   if (pluginVersion == null)
     throw new RuntimeException("""|
                                   |

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -19,6 +19,7 @@ object TapirGeneratedEndpoints {
   case class BasicSecurityIn(value: UsernamePassword) extends Basic_or_Bearer_SecurityIn
   case class BearerSecurityIn(value: String) extends Basic_or_Bearer_SecurityIn
 
+
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
   trait ExtraParamSupport[T] {
@@ -87,16 +88,10 @@ object TapirGeneratedEndpoints {
   sealed trait ADTWithoutDiscriminator
   sealed trait AnyObjectWithInlineEnum
 
+  type ListType = List[String]
+
   enum AnEnum derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec {
     case Foo, Bar, Baz
-  }
-
-  enum ObjectWithInlineEnum2InlineEnum derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec {
-    case bar1, bar2
-  }
-
-  enum ObjectWithInlineEnumInlineEnum derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec {
-    case foo1, foo2, foo3, foo4
   }
   case class NotNullableThingy (
     uuid: java.util.UUID
@@ -105,9 +100,17 @@ object TapirGeneratedEndpoints {
     id: java.util.UUID,
     inlineEnum: ObjectWithInlineEnumInlineEnum
   ) extends AnyObjectWithInlineEnum
+
+  enum ObjectWithInlineEnumInlineEnum derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec {
+    case foo1, foo2, foo3, foo4
+  }
   case class ObjectWithInlineEnum2 (
     inlineEnum: ObjectWithInlineEnum2InlineEnum
   ) extends AnyObjectWithInlineEnum
+
+  enum ObjectWithInlineEnum2InlineEnum derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec {
+    case bar1, bar2
+  }
   case class SubtypeWithD1 (
     s: String,
     i: Option[Int] = None,
@@ -133,7 +136,6 @@ object TapirGeneratedEndpoints {
     e: Option[AnEnum] = None,
     absent: Option[String] = None
   ) extends ADTWithoutDiscriminator
-  type ListType = List[String]
   case class PutInlineSimpleObjectRequest (
     foo: String,
     bar: Option[java.util.UUID] = None
@@ -321,5 +323,6 @@ object TapirGeneratedEndpoints {
       Locally
     */
     val `/`: sttp.model.Uri = uri"/"
+
   }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
@@ -20,6 +20,7 @@ object TapirGeneratedEndpoints {
   case class Api_keySecurityIn(value: String) extends Bearer_or_api_key_SecurityIn
   case class BearerSecurityIn(value: String) extends Bearer_or_api_key_SecurityIn
 
+
   case class CommaSeparatedValues[T](values: List[T])
   case class ExplodedValues[T](values: List[T])
   trait ExtraParamSupport[T] {
@@ -79,21 +80,7 @@ object TapirGeneratedEndpoints {
   def extraCodecSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): ExtraParamSupport[T] =
     EnumExtraParamSupport(enumName, T)
 
-  sealed trait OrderStatus extends enumeratum.EnumEntry
-  object OrderStatus extends enumeratum.Enum[OrderStatus] with enumeratum.CirceEnum[OrderStatus] {
-    val values = findValues
-    case object placed extends OrderStatus
-    case object approved extends OrderStatus
-    case object delivered extends OrderStatus
-  }
 
-  sealed trait PetStatus extends enumeratum.EnumEntry
-  object PetStatus extends enumeratum.Enum[PetStatus] with enumeratum.CirceEnum[PetStatus] {
-    val values = findValues
-    case object available extends PetStatus
-    case object pending extends PetStatus
-    case object sold extends PetStatus
-  }
   case class ApiResponse (
     code: Option[Int] = None,
     `type`: Option[String] = None,
@@ -111,6 +98,14 @@ object TapirGeneratedEndpoints {
     status: Option[OrderStatus] = None,
     complete: Option[Boolean] = None
   )
+
+  sealed trait OrderStatus extends enumeratum.EnumEntry
+  object OrderStatus extends enumeratum.Enum[OrderStatus] with enumeratum.CirceEnum[OrderStatus] {
+    val values = findValues
+    case object placed extends OrderStatus
+    case object approved extends OrderStatus
+    case object delivered extends OrderStatus
+  }
   case class Pet (
     id: Option[Long] = None,
     name: String,
@@ -119,6 +114,14 @@ object TapirGeneratedEndpoints {
     tags: Option[Seq[Tag]] = None,
     status: Option[PetStatus] = None
   )
+
+  sealed trait PetStatus extends enumeratum.EnumEntry
+  object PetStatus extends enumeratum.Enum[PetStatus] with enumeratum.CirceEnum[PetStatus] {
+    val values = findValues
+    case object available extends PetStatus
+    case object pending extends PetStatus
+    case object sold extends PetStatus
+  }
   case class Tag (
     id: Option[Long] = None,
     name: Option[String] = None
@@ -484,11 +487,14 @@ object TapirGeneratedEndpoints {
         oneOfVariantSingletonMatcher(sttp.model.StatusCode(400), emptyOutput.description("Unexpected error"))(())))
       .tags(List("user"))
 
+
   lazy val generatedEndpoints = List(updatePet, addPet, findPetsByStatus, findPetsByTags, getPetById, updatePetWithForm, deletePet, uploadFile, getInventory, placeOrder, getOrderById, deleteOrder, createUser, createUsersWithListInput, loginUser, logoutUser, getUserByName, updateUser, deleteUser)
+
 
   object Servers {
     import sttp.model.Uri.UriContext
 
     val `https://petstore3.swagger.io/api/v3`: sttp.model.Uri = uri"https://petstore3.swagger.io/api/v3"
+
   }
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/ExpectedV1.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/ExpectedV1.scala.txt
@@ -14,14 +14,11 @@ object TapirGeneratedEndpoints {
 
 
 
-
-
-  case class CommaSeparatedValues[T](values: List[T])
-  case class ExplodedValues[T](values: List[T])
-  trait ExtraParamSupport[T] {
-    def decode(s: String): sttp.tapir.DecodeResult[T]
-    def encode(t: T): String
-  }
+  type CommaSeparatedValues[T] = sttp.tapir.generated.v2.TapirGeneratedEndpoints.CommaSeparatedValues[T]
+  def CommaSeparatedValues[T](values: List[T]) = sttp.tapir.generated.v2.TapirGeneratedEndpoints.CommaSeparatedValues[T](values)
+  type ExplodedValues[T] = sttp.tapir.generated.v2.TapirGeneratedEndpoints.ExplodedValues[T]
+  def ExplodedValues[T](values: List[T]) = sttp.tapir.generated.v2.TapirGeneratedEndpoints.ExplodedValues[T](values)
+  type ExtraParamSupport[T] = sttp.tapir.generated.v2.TapirGeneratedEndpoints.ExtraParamSupport[T]
   implicit def makePathCodecFromSupport[T](implicit support: ExtraParamSupport[T]): sttp.tapir.Codec[String, T, sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.string.mapDecode(support.decode)(support.encode)
   }
@@ -56,12 +53,12 @@ object TapirGeneratedEndpoints {
   type ByteString = sttp.tapir.generated.v2.TapirGeneratedEndpoints.ByteString
   implicit def toByteString(ba: Array[Byte]): ByteString = ba.asInstanceOf[ByteString]
 
-  
+
+  type Pet = sttp.tapir.generated.v2.TapirGeneratedEndpoints.Pet
   case class Order (
     id: Long,
     pet: Pet
   )
-  type Pet = sttp.tapir.generated.v2.TapirGeneratedEndpoints.Pet
 
 
 

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/build.sbt
@@ -15,10 +15,10 @@ import scala.util.Using
 
 TaskKey[Unit]("check") := {
   val base = sourceManaged.value / "main/sbt-openapi-codegen"
-  val main = Using(Source.fromFile(base / "TapirGeneratedEndpoints.scala"))(_.mkString).get
+  val main = Using(Source.fromFile(base / "models/package.scala"))(_.mkString).get
   val book = Using(Source.fromFile(base / "models/Book.scala"))(_.mkString).get
   if (main.contains("case class Book")) sys.error("Book model should not be in the main object")
   if (!book.contains("case class Book")) sys.error("Book model should be in models/Book.scala")
-  if (!main.contains("type Books =")) sys.error("type alias Books should remain in the main object")
+  if (!main.contains("type Books =")) sys.error("type alias Books should be defined in package object")
   ()
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/build.sbt
@@ -1,0 +1,24 @@
+lazy val root = (project in file("."))
+  .enablePlugins(OpenapiCodegenPlugin)
+  .settings(
+    scalaVersion := "2.13.18",
+    version := "0.1",
+    openapiSeperateFilesForModels := true
+  )
+
+libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % "1.10.0"
+libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.10.0"
+libraryDependencies += "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.8.0"
+
+import scala.io.Source
+import scala.util.Using
+
+TaskKey[Unit]("check") := {
+  val base = sourceManaged.value / "main/sbt-openapi-codegen"
+  val main = Using(Source.fromFile(base / "TapirGeneratedEndpoints.scala"))(_.mkString).get
+  val book = Using(Source.fromFile(base / "models/Book.scala"))(_.mkString).get
+  if (main.contains("case class Book")) sys.error("Book model should not be in the main object")
+  if (!book.contains("case class Book")) sys.error("Book model should be in models/Book.scala")
+  if (!main.contains("type Books =")) sys.error("type alias Books should remain in the main object")
+  ()
+}

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/build.sbt
@@ -3,7 +3,12 @@ lazy val root = (project in file("."))
   .settings(
     scalaVersion := "2.13.18",
     version := "0.1",
-    openapiSeperateFilesForModels := true
+    openapiSeperateFilesForModels := true,
+    openapiAdditionalPackages := List(
+      "sttp.tapir.generated" -> baseDirectory.value / "swagger.yaml",
+      "sttp.tapir.gen_dup" -> baseDirectory.value / "swagger.yaml"
+    ),
+    openapiPackageDependencies := Map("sttp.tapir.gen_dup" -> "sttp.tapir.generated")
   )
 
 libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % "1.10.0"
@@ -14,7 +19,7 @@ import scala.io.Source
 import scala.util.Using
 
 TaskKey[Unit]("check") := {
-  val base = sourceManaged.value / "main/sbt-openapi-codegen"
+  val base = sourceManaged.value / "main/sttp/tapir/generated"
   val main = Using(Source.fromFile(base / "models/package.scala"))(_.mkString).get
   val book = Using(Source.fromFile(base / "models/Book.scala"))(_.mkString).get
   if (main.contains("case class Book")) sys.error("Book model should not be in the main object")

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/project/plugins.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/project/plugins.sbt
@@ -1,5 +1,5 @@
 {
-  val pluginVersion = "1.13.23.72-LOCAL"
+  val pluginVersion = System.getProperty("plugin.version")
   if (pluginVersion == null)
     throw new RuntimeException("""|
                                   |

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/swagger.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: separate files for models test
+  version: 1.0.0
+paths:
+  /books:
+    get:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Books'
+components:
+  schemas:
+    Book:
+      type: object
+      required: [title]
+      properties:
+        title:
+          type: string
+    Books:
+      type: array
+      items:
+        $ref: '#/components/schemas/Book'

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/test
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/test
@@ -1,0 +1,4 @@
+> clean
+> generateTapirDefinitions
+> compile
+> check


### PR DESCRIPTION
Should address https://github.com/softwaremill/tapir/issues/5287 

Relevant changes are clearer after https://github.com/softwaremill/tapir/pull/5366 which commits some incidental refactoring

Adds a new `openapiSeperateFilesForModels` flag with default `false` so as not to needlessly break user code (my downstream refactor after enabling this was mostly just find+replace, but still chonky and with edge-cases)

The `nifi_test` now uses this new flag; it's a pretty large spec, so this provides good coverage, whilst also reducing the number of lines in our expectations (this is the sole reason for the diff having more deleted lines than added).

Writing the output files gets wrapped in a `Future.traverse` now because writing >1000 model files can be slower than it needs to be, otherwise.

Type aliases are now sorted alphabetically in output.

Inline enums now get written immediately after the 'container' object, rather than at the start of the file. This wasn't a particularly intentional change, but it aligns with the fact that, when 'splitting' to separate files, inline defns will live with the parent. The ordering change should have no impact on user code (although it did cause a bit of churn in test expectations...)

Incidentally fixes an issue with 'deduplicated' file structure when using zio or circe serdes and reusing a json-y Map[String T] or Array[T] type alias