### PR TITLE
codegen: refactor the code a bit

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -1,11 +1,13 @@
 package sttp.tapir.codegen
 
-import sttp.tapir.codegen.RootGenerator.{indent, mapSchemaSimpleTypeToType}
+import sttp.tapir.codegen.RootGenerator.mapSchemaSimpleTypeToType
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.json.{JsonHelpers, JsonSerdeLib, JsonSerdeGenerator, SerdeGenResponse}
 import sttp.tapir.codegen.json.JsonSerdeLib.{Circe, Jsoniter}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.{DefaultValueRenderer, OpenapiSchemaType, RenderConfig}
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
+import sttp.tapir.codegen.util.NameHelpers.indent
 import sttp.tapir.codegen.util.{DocUtils, VersionedHelpers}
 
 case class GeneratedClassDefinitions(

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -1,6 +1,7 @@
 package sttp.tapir.codegen
 import io.circe.Json
-import sttp.tapir.codegen.RootGenerator.{indent, mapSchemaSimpleTypeToType, strippedToCamelCase}
+import sttp.tapir.codegen.RootGenerator.{mapSchemaSimpleTypeToType, strippedToCamelCase}
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.json.JsonSerdeLib.JsonSerdeLib
 import sttp.tapir.codegen.XmlSerdeLib.XmlSerdeLib
 import sttp.tapir.codegen.openapi.models.OpenapiModels.{
@@ -12,31 +13,12 @@ import sttp.tapir.codegen.openapi.models.OpenapiModels.{
   OpenapiResponseContent,
   OpenapiResponseDef
 }
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  AnyType,
-  OpenapiSchemaAny,
-  OpenapiSchemaArray,
-  OpenapiSchemaBinary,
-  OpenapiSchemaEnum,
-  OpenapiSchemaMap,
-  OpenapiSchemaObject,
-  OpenapiSchemaOneOf,
-  OpenapiSchemaRef,
-  OpenapiSchemaSimpleType,
-  OpenapiSchemaString
-}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
 import sttp.tapir.codegen.openapi.models._
-import sttp.tapir.codegen.openapi.models.GenerationDirectives.{
-  forceEager,
-  forceReqEager,
-  forceReqStreaming,
-  forceRespEager,
-  forceRespStreaming,
-  forceStreaming,
-  jsonBodyAsString,
-  securityPrefixKey
-}
+import sttp.tapir.codegen.openapi.models.GenerationDirectives._
+import sttp.tapir.codegen.security.{SecurityDefn, SecurityGenerator, SecurityWrapperDefn}
 import sttp.tapir.codegen.util.ErrUtils.bail
+import sttp.tapir.codegen.util.NameHelpers.indent
 import sttp.tapir.codegen.util.{JavaEscape, Location, NameHelpers}
 
 case class EndpointTypes(security: Seq[String], in: Seq[String], err: Seq[String], out: Seq[String]) {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -1,9 +1,11 @@
 package sttp.tapir.codegen
 
+import sttp.tapir.codegen.dedup.{GenerationMeta, PackageReuseContext}
 import sttp.tapir.codegen.json.JsonSerdeLib
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{AnyType, OpenapiSchemaAny, OpenapiSchemaBinary, OpenapiSchemaBoolean, OpenapiSchemaByte, OpenapiSchemaDate, OpenapiSchemaDateTime, OpenapiSchemaDouble, OpenapiSchemaDuration, OpenapiSchemaFloat, OpenapiSchemaInt, OpenapiSchemaLong, OpenapiSchemaRef, OpenapiSchemaSimpleType, OpenapiSchemaString, OpenapiSchemaUUID}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
 import sttp.tapir.codegen.openapi.models.SpecificationExtensionRenderer
+import sttp.tapir.codegen.security.SecurityGenerator
 import sttp.tapir.codegen.util.NameHelpers
 
 object XmlSerdeLib extends Enumeration {
@@ -16,47 +18,6 @@ case class FS2(effectType: String = "cats.effect.IO") extends StreamingImplement
 object Pekko extends StreamingImplementation
 object Zio extends StreamingImplementation
 
-object GenerationMeta {
-  val default: GenerationMeta = GenerationMeta(Seq("TapirGeneratedEndpointsSchemas"), false, false, Nil, Set.empty, Nil, 0, Set.empty, Set.empty)
-}
-case class GenerationMeta(
-    schemaFiles: Seq[String],
-    hasValidators: Boolean,
-    schemasContainAny: Boolean,
-    explicitNonObjTypes: Seq[String],
-    security: Set[SecurityWrapperDefn],
-    extensions: Seq[(String, String, String)],
-    schemaObjectCount: Int,
-    allTransitiveJsonParamRefs: Set[String],
-    jsonParamRefs: Set[String],
-) {
-  def partition(securityWrappers: Set[SecurityWrapperDefn]): (Set[SecurityWrapperDefn], Set[SecurityWrapperDefn]) = {
-    val changed = scala.collection.mutable.Set.empty[SecurityWrapperDefn]
-    val m = scala.collection.mutable.Set.empty[SecurityWrapperDefn]
-    val ct = scala.collection.mutable.Set.empty[String]
-    securityWrappers.foreach(w =>
-      if (!security.contains(w)) {
-        changed += w
-        w.schemas.map(_.typeName).foreach(t => ct += t)
-      } else m += w
-    )
-    def checkChanged: Unit = {
-      var changedCount = 0
-      val mSnapshot = m.toSet
-      mSnapshot.foreach(w =>
-        if (w.schemas.map(_.typeName).exists(ct.contains)) {
-          changedCount += 1
-          w.schemas.map(_.typeName).foreach(t => ct += t)
-          changed += w
-          m.remove(w)
-        }
-      )
-      if (changedCount != 0) checkChanged
-    }
-    checkChanged
-    m.toSet -> changed.toSet
-  }
-}
 case class GenerationInfo(allFiles: Map[String, String], meta: GenerationMeta)
 
 object RootGenerator {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/SchemaGenerator.scala
@@ -1,37 +1,12 @@
 package sttp.tapir.codegen
 
-import sttp.tapir.codegen.RootGenerator.indent
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.json.JsonSerdeLib
 import sttp.tapir.codegen.json.JsonSerdeLib.JsonSerdeLib
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  AnyType,
-  Discriminator,
-  OpenapiSchemaAllOf,
-  OpenapiSchemaAny,
-  OpenapiSchemaAnyOf,
-  OpenapiSchemaArray,
-  OpenapiSchemaBinary,
-  OpenapiSchemaBoolean,
-  OpenapiSchemaByte,
-  OpenapiSchemaConstantString,
-  OpenapiSchemaDate,
-  OpenapiSchemaDateTime,
-  OpenapiSchemaDuration,
-  OpenapiSchemaEnum,
-  OpenapiSchemaField,
-  OpenapiSchemaMap,
-  OpenapiSchemaNot,
-  OpenapiSchemaNumericType,
-  OpenapiSchemaObject,
-  OpenapiSchemaOneOf,
-  OpenapiSchemaRef,
-  OpenapiSchemaSimpleType,
-  OpenapiSchemaString,
-  OpenapiSchemaStringType,
-  OpenapiSchemaUUID
-}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
+import sttp.tapir.codegen.util.NameHelpers.indent
 
 import scala.collection.mutable
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ValidationGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ValidationGenerator.scala
@@ -1,23 +1,11 @@
 package sttp.tapir.codegen
 
 import io.circe.JsonNumber
-import sttp.tapir.codegen.RootGenerator.indent
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  ArrayRestrictions,
-  ObjectRestrictions,
-  OpenapiSchemaAllOf,
-  OpenapiSchemaArray,
-  OpenapiSchemaEnum,
-  OpenapiSchemaMap,
-  OpenapiSchemaNumericType,
-  OpenapiSchemaObject,
-  OpenapiSchemaOneOf,
-  OpenapiSchemaRef,
-  OpenapiSchemaSimpleType,
-  OpenapiSchemaString
-}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
+import sttp.tapir.codegen.util.NameHelpers.indent
 import sttp.tapir.codegen.util.JavaEscape
 
 import scala.annotation.tailrec

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/XmlSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/XmlSerdeGenerator.scala
@@ -2,6 +2,7 @@ package sttp.tapir.codegen
 
 import sttp.tapir.codegen.RootGenerator.{indent, mapSchemaSimpleTypeToType}
 import sttp.tapir.codegen.XmlSerdeLib.XmlSerdeLib
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaArray,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/dedup/PackageReuseContext.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/dedup/PackageReuseContext.scala
@@ -1,6 +1,8 @@
-package sttp.tapir.codegen
+package sttp.tapir.codegen.dedup
 
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
+import sttp.tapir.codegen.dedup.PackageReuseContext
+import sttp.tapir.codegen.security.SecurityWrapperDefn
 
 /** Describes a dependency package whose models may be reused via type aliases. */
 case class PackageReuseContext(
@@ -46,4 +48,47 @@ object PackageReuseContext {
        |val $name = ${ctx.dependencyModelPath}.$name""".stripMargin
 
   def isReusedSchema(name: String, ctx: PackageReuseContext): Boolean = ctx.reusedSchemas.contains(name)
+}
+
+
+object GenerationMeta {
+  val default: GenerationMeta = GenerationMeta(Seq("TapirGeneratedEndpointsSchemas"), false, false, Nil, Set.empty, Nil, 0, Set.empty, Set.empty)
+}
+case class GenerationMeta(
+                           schemaFiles: Seq[String],
+                           hasValidators: Boolean,
+                           schemasContainAny: Boolean,
+                           explicitNonObjTypes: Seq[String],
+                           security: Set[SecurityWrapperDefn],
+                           extensions: Seq[(String, String, String)],
+                           schemaObjectCount: Int,
+                           allTransitiveJsonParamRefs: Set[String],
+                           jsonParamRefs: Set[String],
+                         ) {
+  def partition(securityWrappers: Set[SecurityWrapperDefn]): (Set[SecurityWrapperDefn], Set[SecurityWrapperDefn]) = {
+    val changed = scala.collection.mutable.Set.empty[SecurityWrapperDefn]
+    val m = scala.collection.mutable.Set.empty[SecurityWrapperDefn]
+    val ct = scala.collection.mutable.Set.empty[String]
+    securityWrappers.foreach(w =>
+      if (!security.contains(w)) {
+        changed += w
+        w.schemas.map(_.typeName).foreach(t => ct += t)
+      } else m += w
+    )
+    def checkChanged: Unit = {
+      var changedCount = 0
+      val mSnapshot = m.toSet
+      mSnapshot.foreach(w =>
+        if (w.schemas.map(_.typeName).exists(ct.contains)) {
+          changedCount += 1
+          w.schemas.map(_.typeName).foreach(t => ct += t)
+          changed += w
+          m.remove(w)
+        }
+      )
+      if (changedCount != 0) checkChanged
+    }
+    checkChanged
+    m.toSet -> changed.toSet
+  }
 }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/dedup/SchemaComparer.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/dedup/SchemaComparer.scala
@@ -1,8 +1,8 @@
-package sttp.tapir.codegen
+package sttp.tapir.codegen.dedup
 
-import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiDocument, OpenapiPath, OpenapiPathMethod, OpenapiRequestBodyDefn, OpenapiResponseDef}
+import sttp.tapir.codegen.openapi.models.OpenapiModels._
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
 import sttp.tapir.codegen.openapi.models.{OpenapiModels, OpenapiSchemaType}
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{Discriminator, OpenapiSchemaAllOf, OpenapiSchemaAny, OpenapiSchemaAnyOf, OpenapiSchemaArray, OpenapiSchemaBoolean, OpenapiSchemaByte, OpenapiSchemaConstantString, OpenapiSchemaDate, OpenapiSchemaDateTime, OpenapiSchemaDouble, OpenapiSchemaDuration, OpenapiSchemaEnum, OpenapiSchemaField, OpenapiSchemaFloat, OpenapiSchemaInt, OpenapiSchemaLong, OpenapiSchemaMap, OpenapiSchemaNot, OpenapiSchemaObject, OpenapiSchemaOneOf, OpenapiSchemaRef, OpenapiSchemaSimpleType, OpenapiSchemaString, OpenapiSchemaUUID}
 
 object SchemaComparer {
   private def resolved(doc: OpenapiDocument, ps: Map[String, OpenapiModels.OpenapiParameter])(

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/CirceSerdeImpl.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/CirceSerdeImpl.scala
@@ -1,6 +1,5 @@
 package sttp.tapir.codegen.json
 
-import sttp.tapir.codegen.PackageReuseContext
 import sttp.tapir.codegen.json.JsonHelpers.{checkForSoundness, inlineEndpointSchemas}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
@@ -23,6 +22,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaStringType,
   OpenapiSchemaUUID
 }
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.util.NameHelpers.{indent, uncapitalise}
 
 object CirceSerdeImpl {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/JsonSerdeGenerator.scala
@@ -23,7 +23,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaStringType,
   OpenapiSchemaUUID
 }
-import sttp.tapir.codegen.PackageReuseContext
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.util.NameHelpers.{addName, indent, uncapitalise}
 
 import scala.annotation.tailrec

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/JsoniterSerdeImpl.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/JsoniterSerdeImpl.scala
@@ -1,6 +1,5 @@
 package sttp.tapir.codegen.json
 
-import sttp.tapir.codegen.PackageReuseContext
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
@@ -23,6 +22,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaStringType,
   OpenapiSchemaUUID
 }
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.util.NameHelpers.{addName, indent, uncapitalise}
 
 object JsoniterSerdeImpl {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/ZioSerdeImpl.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/ZioSerdeImpl.scala
@@ -1,6 +1,5 @@
 package sttp.tapir.codegen.json
 
-import sttp.tapir.codegen.PackageReuseContext
 import sttp.tapir.codegen.json.JsonHelpers.{checkForSoundness, inlineEndpointSchemas}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
@@ -23,6 +22,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaStringType,
   OpenapiSchemaUUID
 }
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.util.NameHelpers.{indent, uncapitalise}
 
 object ZioSerdeImpl {

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/security/SecurityGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/security/SecurityGenerator.scala
@@ -1,9 +1,10 @@
-package sttp.tapir.codegen
+package sttp.tapir.codegen.security
 
-import sttp.tapir.codegen.RootGenerator.indent
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType
 import sttp.tapir.codegen.openapi.models.OpenapiSecuritySchemeType.OAuth2FlowType
 import sttp.tapir.codegen.util.ErrUtils.bail
+import sttp.tapir.codegen.util.NameHelpers.indent
 import sttp.tapir.codegen.util.Location
 
 import scala.collection.immutable

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -1,5 +1,6 @@
 package sttp.tapir.codegen
 
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.json.JsonSerdeLib
 import sttp.tapir.codegen.openapi.models.{OpenapiComponent, OpenapiSchemaType}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -1,6 +1,7 @@
 package sttp.tapir.codegen
 
 import sttp.tapir.codegen.json.JsonSerdeLib
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
 import sttp.tapir.codegen.openapi.models.OpenapiModels.{
   OpenapiDocument,

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
@@ -2,17 +2,9 @@ package sttp.tapir.codegen
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import sttp.tapir.codegen.dedup.{GenerationMeta, PackageReuseContext, SchemaComparer}
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType
-import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
-  NumericRestrictions,
-  OpenapiSchemaConstantString,
-  OpenapiSchemaEnum,
-  OpenapiSchemaField,
-  OpenapiSchemaInt,
-  OpenapiSchemaObject,
-  OpenapiSchemaRef,
-  OpenapiSchemaString
-}
+import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{NumericRestrictions, OpenapiSchemaConstantString, OpenapiSchemaEnum, OpenapiSchemaField, OpenapiSchemaInt, OpenapiSchemaObject, OpenapiSchemaRef, OpenapiSchemaString}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiInfo
@@ -79,7 +71,7 @@ class PackageReuseContextSpec extends AnyFlatSpec with Matchers {
       petDoc(),
       "sttp.tapir.generated.core",
       "TapirGeneratedEndpoints",
-      GenerationMeta.default,
+      GenerationMeta.default
     )
     ctx.reusedSchemas shouldBe Set("Pet")
     ctx.dependencyModelPath shouldBe "sttp.tapir.generated.core.TapirGeneratedEndpoints"

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -3,7 +3,8 @@ package sttp.tapir.sbt
 import sbt._
 import Keys._
 import sbt.nio.Keys.fileInputs
-import sttp.tapir.codegen.{GenerationMeta, OpenApiInputParser, PackageReuseContext}
+import sttp.tapir.codegen.OpenApiInputParser
+import sttp.tapir.codegen.dedup.{GenerationMeta, PackageReuseContext}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 
 object OpenapiCodegenPlugin extends AutoPlugin {

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -1,7 +1,8 @@
 package sttp.tapir.sbt
 
 import sbt._
-import sttp.tapir.codegen.{GenerationMeta, OpenApiInputParser, PackageReuseContext, RootGenerator}
+import sttp.tapir.codegen.{OpenApiInputParser, RootGenerator}
+import sttp.tapir.codegen.dedup.{GenerationMeta, PackageReuseContext}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 
 case class OpenapiCodegenTask(


### PR DESCRIPTION
Shuffle some files around to make structure a bit neater. There's a circular dependency between security and dedup which isn't great, but it's still cleaner than it was, and none of the sub-packages depend on the root I think.

No functional changes.

The 'put each case class (or sealed trait) in different files' pr was built after refactoring and I'd like to reduce the churn in that one a bit 😅 

Obviously we will need more refactoring. It's in the pipes but I may run out my contribution energy allotment for the foreseeable fairly soon so probably won't make this round.