### PR TITLE
codegen: various minor fixes and improvements

### DIFF
--- a/doc/generator/sbt-openapi-codegen.md
+++ b/doc/generator/sbt-openapi-codegen.md
@@ -57,6 +57,7 @@ openapiPackageDependencies            Map.empty[String, String]            Allow
                                                                            aliases to the duplicates in the 'value' package. This is still experimental - significantly, the type is likely to change
                                                                            to a Map[String, Seq[String]] in the near future to permit multiple 'inheritance', and there may be bugs in the implementation.
 openapiSeperateFilesForModels         false                                When true, models will be written to individual files under $pkg.models, with type aliases and helpers living under `package.scala` in a package object
+openapiAlwaysGenerateParamSupport     false                                When true, all enums will be generated with param & json support, even if not used in those positions. This is useful for definitions that will be reused with `openapiPackageDependencies`
 ===================================== ==================================== ==================================================================================================
 ```
 

--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -6,6 +6,7 @@ import cats.implicits._
 
 import com.monovore.decline._
 
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.{RootGenerator, YamlParser}
 
@@ -147,6 +148,7 @@ object GenScala {
                 !disableValidatorGeneration,
                 useCustomJsoniterSerdes,
                 PackageReuseContext.none,
+                false,
                 false
               )
             )

--- a/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
+++ b/openapi-codegen/cli/src/main/scala/sttp/tapir/codegen/GenScala.scala
@@ -145,7 +145,9 @@ object GenScala {
                 maxSchemasPerFile.getOrElse(400),
                 generateEndpointTypes,
                 !disableValidatorGeneration,
-                useCustomJsoniterSerdes
+                useCustomJsoniterSerdes,
+                PackageReuseContext.none,
+                false
               )
             )
             destFiles <- contents.allFiles.toVector.traverse { case (fileName, content) => writeGeneratedFile(destDir, fileName, content) }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -188,7 +188,8 @@ class ClassDefinitionGenerator {
       schemasContainAny,
       useCustomJsoniterSerdes,
       packageReuse,
-      resolvableNonClassyOneOfSchemas
+      resolvableNonClassyOneOfSchemas,
+      seperateFilesForModels
     )
     val allTransitiveXmlParamRefs = fetchTransitiveParamRefs(
       xmlParamRefs,
@@ -236,6 +237,7 @@ class ClassDefinitionGenerator {
                   targetScala3,
                   isReusedSchema,
                   packageReuse,
+                  seperateFilesForModels,
                   alwaysGenerateParamSupport
                 )
               )
@@ -321,6 +323,7 @@ class ClassDefinitionGenerator {
                 targetScala3,
                 isReused,
                 packageReuse,
+                seperateFilesForModels,
                 alwaysGenerateParamSupport
               ).mkString("\n")
             }
@@ -419,6 +422,7 @@ class ClassDefinitionGenerator {
       targetScala3: Boolean,
       isReused: Boolean,
       packageReuse: PackageReuseContext,
+      seperateFilesForModels: Boolean,
       alwaysGenerateParamSupport: Boolean
   ): Seq[String] = try {
     val isJson = jsonParamRefs contains name
@@ -477,15 +481,20 @@ class ClassDefinitionGenerator {
                   .render(allModels = allSchemas, thisType = schemaType, optional, RenderConfig(maybeEnum.map(_.enumName)))(_)
             )
           val default = maybeExplicitDefault getOrElse (if (optional) " = None" else "")
-          if (isReused) "" -> maybeEnum.map(e => s"type ${e.enumName} = ${packageReuse.dependencyModelPath}.${e.enumName}")
+          if (isReused) "" -> maybeEnum.map { e =>
+            val alias = s"${e.enumName} = ${packageReuse.modelRoot(seperateFilesForModels)}.${e.enumName}"
+            s"type $alias\nval $alias"
+          }
           else s"$fixedKey: $tpe$default" -> maybeEnum.map(_.impl)
         }
         .unzip
 
       val enumDefn = maybeEnums.flatten.toList
       val modelDefn =
-        if (isReused) s"type $className = ${packageReuse.dependencyModelPath}.$className"
-        else
+        if (isReused) {
+          val alias = s"$className = ${packageReuse.modelRoot(seperateFilesForModels)}.$className"
+          s"type $alias\nval $alias"
+        } else
           s"""|case class $className (
               |${indent(2)(properties.mkString(",\n"))}
               |)$parents$discriminatorDefBody""".stripMargin

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -136,14 +136,27 @@ class ClassDefinitionGenerator {
       jsonParamRefs.toSeq.flatMap(ref => allSchemas.get(ref.stripPrefix("#/components/schemas/")))
     )
 
+    def allChildrenDefineDiscriminator(d: String, s: OpenapiSchemaOneOf): Boolean =
+      s.types.forall {
+        case t: OpenapiSchemaRef =>
+          t.maybeResolved(doc).exists {
+            case o: OpenapiSchemaObject => o.properties.contains(d)
+            case _                      => false
+          }
+        case _ => false
+      }
+
     val adtTypes =
       adtInheritanceMap
         .flatMap(_._2)
         .toSeq
-        .map(_._1)
+        .map { s => s._1 -> s._2.discriminator.map(_.propertyName).filter(d => allChildrenDefineDiscriminator(d, s._2)) }
         .distinct
-        .filterNot(PackageReuseContext.isReusedSchema(_, packageReuse))
-        .map(name => s"sealed trait $name")
+        .filterNot(s => PackageReuseContext.isReusedSchema(s._1, packageReuse))
+        .map { case (name, maybeDiscriminator) =>
+          val maybeBody = maybeDiscriminator.map(d => s" { def ${NameHelpers.safeVariableName(d)}: String }").getOrElse("")
+          s"sealed trait $name$maybeBody"
+        }
         .sorted
         .mkString("", "\n", "\n")
     val schemasWithAny = allSchemas.filter { case (_, schema) => schemaContainsAny(schema) }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -7,7 +7,7 @@ import sttp.tapir.codegen.json.JsonSerdeLib.{Circe, Jsoniter}
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.{DefaultValueRenderer, OpenapiSchemaType, RenderConfig}
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
-import sttp.tapir.codegen.util.NameHelpers.indent
+import sttp.tapir.codegen.util.NameHelpers.{indent, safeVariableName}
 import sttp.tapir.codegen.util.{DocUtils, VersionedHelpers}
 
 case class GeneratedClassDefinitions(
@@ -154,7 +154,7 @@ class ClassDefinitionGenerator {
         .distinct
         .filterNot(s => PackageReuseContext.isReusedSchema(s._1, packageReuse))
         .map { case (name, maybeDiscriminator) =>
-          val maybeBody = maybeDiscriminator.map(d => s" { def ${NameHelpers.safeVariableName(d)}: String }").getOrElse("")
+          val maybeBody = maybeDiscriminator.map(d => s" { def ${safeVariableName(d)}: String }").getOrElse("")
           s"sealed trait $name$maybeBody"
         }
         .sorted

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -82,7 +82,8 @@ class ClassDefinitionGenerator {
       xmlParamRefs: Set[String] = Set.empty,
       useCustomJsoniterSerdes: Boolean = true,
       packageReuse: PackageReuseContext = PackageReuseContext.none,
-      seperateFilesForModels: Boolean = false
+      seperateFilesForModels: Boolean = false,
+      alwaysGenerateParamSupport: Boolean = false
   ): Option[GeneratedClassDefinitions] = {
     val allSchemas: Map[String, OpenapiSchemaType] = doc.components.toSeq.flatMap(_.schemas).toMap
     val allOneOfSchemas = allSchemas.collect { case (name, oneOf: OpenapiSchemaOneOf) => name -> oneOf }.toSeq
@@ -123,7 +124,7 @@ class ClassDefinitionGenerator {
     val generatesQueryOrPathParamEnums = enumsDefinedOnEndpointParams ||
       allSchemas
         .collect { case (name, _: OpenapiSchemaEnum) => name }
-        .exists(queryOrPathParamRefs.contains)
+        .exists(alwaysGenerateParamSupport || queryOrPathParamRefs.contains(_))
     val enumSerdeHelper = if (!generatesQueryOrPathParamEnums) "" else EnumGenerator.enumSerdeHelperDefn(targetScala3)
 
     def fetchTransitiveParamRefs(initialSet: Set[String], toCheck: Seq[OpenapiSchemaType]): Set[String] = toCheck match {
@@ -219,12 +220,44 @@ class ClassDefinitionGenerator {
         _.schemas.map {
           case (name, _: OpenapiSchemaEnum) if PackageReuseContext.isReusedSchema(name, packageReuse) =>
             (name, (0, Seq(PackageReuseContext.enumAliasType(name, packageReuse, seperateFilesForModels))))
+          case (name, obj: OpenapiSchemaObject) =>
+            val isReusedSchema = PackageReuseContext.isReusedSchema(name, packageReuse)
+            (
+              name,
+              (
+                2,
+                generateClass(
+                  allSchemas,
+                  name,
+                  obj,
+                  allTransitiveJsonParamRefs,
+                  adtInheritanceMap,
+                  jsonSerdeLib,
+                  targetScala3,
+                  isReusedSchema,
+                  packageReuse,
+                  alwaysGenerateParamSupport
+                )
+              )
+            )
           case (name, s) if PackageReuseContext.isReusedSchema(name, packageReuse) =>
             (name, (0, Seq(PackageReuseContext.aliasType(name, packageReuse, seperateFilesForModels))))
-          case (name, obj: OpenapiSchemaObject) =>
-            (name, (2, generateClass(allSchemas, name, obj, allTransitiveJsonParamRefs, adtInheritanceMap, jsonSerdeLib, targetScala3)))
           case (name, obj: OpenapiSchemaEnum) =>
-            (name, (1, EnumGenerator.generateEnum(name, obj, targetScala3, queryOrPathParamRefs, jsonSerdeLib, allTransitiveJsonParamRefs)))
+            (
+              name,
+              (
+                1,
+                EnumGenerator.generateEnum(
+                  name,
+                  obj,
+                  targetScala3,
+                  queryOrPathParamRefs,
+                  jsonSerdeLib,
+                  allTransitiveJsonParamRefs,
+                  alwaysGenerateParamSupport
+                )
+              )
+            )
           case (name, OpenapiSchemaMap(valueSchema, _, _)) =>
             (name, (0, generateMap(name, valueSchema)))
           case (name, OpenapiSchemaArray(valueSchema, _, _, rs)) =>
@@ -269,14 +302,27 @@ class ClassDefinitionGenerator {
           addModel(name, defns.mkString("\n"))
       }
 
-      adtGroups.toSeq.filterNot(p => isTypeAlias(p._1)).foreach { case (fileName, parentTraits) =>
-        val traits = parentTraits.map(p => s"sealed trait $p").mkString("\n")
+      adtGroups.toSeq.foreach { case (fileName, parentTraits) =>
+        val isReused = isTypeAlias(fileName)
+        val traits =
+          if (isReused) parentTraits.map(p => s"type $p = ${packageReuse.modelRoot(seperateFilesForModels)}.$p").mkString("\n")
+          else parentTraits.map(p => s"sealed trait $p").mkString("\n")
         val children = childToAdtFile.filter(_._2 == fileName).keys.toSeq.sorted
         val childContent = children
           .flatMap { child =>
             allSchemas.get(child).collect { case obj: OpenapiSchemaObject =>
-              generateClass(allSchemas, child, obj, allTransitiveJsonParamRefs, adtInheritanceMap, jsonSerdeLib, targetScala3)
-                .mkString("\n")
+              generateClass(
+                allSchemas,
+                child,
+                obj,
+                allTransitiveJsonParamRefs,
+                adtInheritanceMap,
+                jsonSerdeLib,
+                targetScala3,
+                isReused,
+                packageReuse,
+                alwaysGenerateParamSupport
+              ).mkString("\n")
             }
           }
           .mkString("\n")
@@ -370,7 +416,10 @@ class ClassDefinitionGenerator {
       jsonParamRefs: Set[String],
       adtInheritanceMap: Map[String, Seq[(String, OpenapiSchemaOneOf)]],
       jsonSerdeLib: JsonSerdeLib.JsonSerdeLib,
-      targetScala3: Boolean
+      targetScala3: Boolean,
+      isReused: Boolean,
+      packageReuse: PackageReuseContext,
+      alwaysGenerateParamSupport: Boolean
   ): Seq[String] = try {
     val isJson = jsonParamRefs contains name
     def rec(className: String, schemaKey: String, obj: OpenapiSchemaObject, acc: List[String]): Seq[String] = {
@@ -408,7 +457,7 @@ class ClassDefinitionGenerator {
       val discriminatorDefBody = discriminatorDefFields.filter { case (n, _) => obj.properties.map(_._1).toSet.contains(n) } match {
         case Nil    => ""
         case fields =>
-          val fs = fields.map { case (k, v) => s"""def `$k`: String = "$v"""" }.mkString("\n")
+          val fs = fields.map { case (k, v) => s"""def ${safeVariableName(k)}: String = "$v"""" }.mkString("\n")
           s""" {
              |${indent(2)(fs)}
              |}""".stripMargin
@@ -419,7 +468,7 @@ class ClassDefinitionGenerator {
         .map { case (key, OpenapiSchemaField(schemaType, maybeDefault, _)) =>
           val (tpe, maybeEnum) =
             mapSchemaTypeToType(className, key, obj.required.contains(key), schemaType, isJson, jsonSerdeLib, targetScala3)
-          val fixedKey = fixKey(key)
+          val fixedKey = safeVariableName(key)
           val optional = schemaType.nullable || !obj.required.contains(key)
           val maybeExplicitDefault =
             maybeDefault.map(
@@ -428,14 +477,19 @@ class ClassDefinitionGenerator {
                   .render(allModels = allSchemas, thisType = schemaType, optional, RenderConfig(maybeEnum.map(_.enumName)))(_)
             )
           val default = maybeExplicitDefault getOrElse (if (optional) " = None" else "")
-          s"$fixedKey: $tpe$default" -> maybeEnum.map(_.impl)
+          if (isReused) "" -> maybeEnum.map(e => s"type ${e.enumName} = ${packageReuse.dependencyModelPath}.${e.enumName}")
+          else s"$fixedKey: $tpe$default" -> maybeEnum.map(_.impl)
         }
         .unzip
 
       val enumDefn = maybeEnums.flatten.toList
-      s"""|case class $className (
-          |${indent(2)(properties.mkString(",\n"))}
-          |)$parents$discriminatorDefBody""".stripMargin :: innerClasses ::: enumDefn ::: acc
+      val modelDefn =
+        if (isReused) s"type $className = ${packageReuse.dependencyModelPath}.$className"
+        else
+          s"""|case class $className (
+              |${indent(2)(properties.mkString(",\n"))}
+              |)$parents$discriminatorDefBody""".stripMargin
+      modelDefn :: innerClasses ::: enumDefn ::: acc
     }
 
     rec(addName("", name), name, obj, Nil)
@@ -498,7 +552,8 @@ class ClassDefinitionGenerator {
             targetScala3,
             Set.empty,
             jsonSerdeLib,
-            if (isJson) Set(enumName) else Set.empty
+            if (isJson) Set(enumName) else Set.empty,
+            false
           )
           (enumName -> e.nullable, Some(InlineEnumDefn(enumName, enumDefn.mkString("\n"))))
 
@@ -512,13 +567,6 @@ class ClassDefinitionGenerator {
   private def addName(parentName: String, key: String) = RootGenerator.addName(parentName, key)
 
   private val reservedKeys = VersionedHelpers.reservedKeys
-
-  private def fixKey(key: String) = {
-    if (reservedKeys.contains(key))
-      s"`$key`"
-    else
-      key
-  }
 
   private def schemaContainsAny(schema: OpenapiSchemaType): Boolean = schema match {
     case _: OpenapiSchemaAny                => true

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -226,7 +226,7 @@ class ClassDefinitionGenerator {
             (
               name,
               (
-                2,
+                if (isReusedSchema) 0 else 2,
                 generateClass(
                   allSchemas,
                   name,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EndpointGenerator.scala
@@ -419,7 +419,7 @@ class EndpointGenerator {
       jsonSerdeLib: JsonSerdeLib,
       param: OpenapiParameter,
       e: OpenapiSchemaEnum,
-      isArray: Boolean
+      isArray: Boolean,
   ): (String, Some[Seq[String]], String, String) = {
     val enumName = endpointName.capitalize + strippedToCamelCase(param.name).capitalize
     val enumParamRefs = if (param.in == "query" || param.in == "path") Set(enumName) else Set.empty[String]
@@ -429,7 +429,8 @@ class EndpointGenerator {
       targetScala3,
       enumParamRefs,
       jsonSerdeLib,
-      Set.empty
+      Set.empty,
+      false
     )
 
     def arrayType = if (param.isExploded) "ExplodedValues" else "CommaSeparatedValues"

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EnumGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/EnumGenerator.scala
@@ -14,7 +14,8 @@ object EnumGenerator {
       targetScala3: Boolean,
       queryParamRefs: Set[String],
       jsonSerdeLib: JsonSerdeLib.JsonSerdeLib,
-      jsonParamRefs: Set[String]
+      jsonParamRefs: Set[String],
+      alwaysGenerateParamSupport: Boolean
   ): Seq[String] = {
     def maybeEscaped(s: String) = s match {
       case legalEnumName(l) => l
@@ -22,7 +23,7 @@ object EnumGenerator {
     }
     if (targetScala3) {
       val maybeCompanion =
-        if (queryParamRefs contains name) {
+        if (alwaysGenerateParamSupport || queryParamRefs.contains(name)) {
           def helperImpls =
             s"""  given enumCodecSupport${name.capitalize}: ExtraParamSupport[$name] =
                |    extraCodecSupport[$name]""".stripMargin
@@ -32,14 +33,22 @@ object EnumGenerator {
              |}""".stripMargin
         } else ""
       val maybeCodecExtensions = jsonSerdeLib match {
-        case _ if !jsonParamRefs.contains(name) && !queryParamRefs.contains(name) => ""
-        case _ if !jsonParamRefs.contains(name)                                   => " derives enumextensions.EnumMirror"
-        case JsonSerdeLib.Circe if !queryParamRefs.contains(name) => " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec"
-        case JsonSerdeLib.Circe => " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec, enumextensions.EnumMirror"
-        case JsonSerdeLib.Jsoniter if !queryParamRefs.contains(name) => ""
-        case JsonSerdeLib.Jsoniter                                   => " derives enumextensions.EnumMirror"
-        case JsonSerdeLib.Zio if !queryParamRefs.contains(name)      => " derives zio.json.JsonCodec"
-        case JsonSerdeLib.Zio                                        => " derives zio.json.JsonCodec, enumextensions.EnumMirror"
+        case _ if !alwaysGenerateParamSupport && !jsonParamRefs.contains(name) && !queryParamRefs.contains(name) =>
+          ""
+        case _ if !alwaysGenerateParamSupport && !jsonParamRefs.contains(name) =>
+          " derives enumextensions.EnumMirror"
+        case JsonSerdeLib.Circe if !alwaysGenerateParamSupport && !queryParamRefs.contains(name) =>
+          " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec"
+        case JsonSerdeLib.Circe =>
+          " derives org.latestbit.circe.adt.codec.JsonTaggedAdt.PureCodec, enumextensions.EnumMirror"
+        case JsonSerdeLib.Jsoniter if !alwaysGenerateParamSupport && !queryParamRefs.contains(name) =>
+          ""
+        case JsonSerdeLib.Jsoniter =>
+          " derives enumextensions.EnumMirror"
+        case JsonSerdeLib.Zio if !alwaysGenerateParamSupport && !queryParamRefs.contains(name) =>
+          " derives zio.json.JsonCodec"
+        case JsonSerdeLib.Zio =>
+          " derives zio.json.JsonCodec, enumextensions.EnumMirror"
       }
       s"""$maybeCompanion
          |enum $name$maybeCodecExtensions {
@@ -48,12 +57,15 @@ object EnumGenerator {
     } else {
       val members = obj.items.map { i => s"case object ${maybeEscaped(i.value)} extends $name" }
       val maybeCodecExtension = jsonSerdeLib match {
-        case _ if !jsonParamRefs.contains(name) && !queryParamRefs.contains(name) => ""
-        case JsonSerdeLib.Circe                                                   => s" with enumeratum.CirceEnum[$name]"
-        case JsonSerdeLib.Jsoniter | JsonSerdeLib.Zio                             => ""
+        case _ if !alwaysGenerateParamSupport && !jsonParamRefs.contains(name) && !queryParamRefs.contains(name) =>
+          ""
+        case JsonSerdeLib.Circe =>
+          s" with enumeratum.CirceEnum[$name]"
+        case JsonSerdeLib.Jsoniter | JsonSerdeLib.Zio =>
+          ""
       }
       val maybeQueryCodecDefn =
-        if (queryParamRefs contains name) {
+        if (alwaysGenerateParamSupport || queryParamRefs.contains(name)) {
           s"""
                |  implicit val enumCodecSupport${name.capitalize}: ExtraParamSupport[$name] =
                |    extraCodecSupport[$name]("${name}", ${name})""".stripMargin

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -302,14 +302,14 @@ object RootGenerator {
       |}
       |implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
       |  sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      |    .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+      |    .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.flatMap(support.encode).mkString(","))
       |}
       |implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
       |  sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       |    .mapDecode{
       |      case None => DecodeResult.Value(None)
       |      case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      |    }(_.map(_.values.map(support.encode).mkString(",")))
+      |    }(_.map(_.values.flatMap(support.encode).mkString(",")))
       |}
       |implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
       |  support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/RootGenerator.scala
@@ -39,8 +39,9 @@ object RootGenerator {
       generateEndpointTypes: Boolean,
       generateValidators: Boolean,
       useCustomJsoniterSerdes: Boolean,
-      packageReuse: PackageReuseContext = PackageReuseContext.none,
-      seperateFilesForModels: Boolean = false
+      packageReuse: PackageReuseContext,
+      seperateFilesForModels: Boolean,
+      alwaysGenerateParamSupport: Boolean
   ): GenerationInfo = {
     val doc = unNormalisedDoc.resolveAllOfSchemas
     val normalisedJsonLib = jsonSerdeLib.toLowerCase match {
@@ -126,7 +127,8 @@ object RootGenerator {
           xmlParamRefs = xmlParamRefs,
           useCustomJsoniterSerdes = useCustomJsoniterSerdes,
           packageReuse = packageReuse,
-          seperateFilesForModels = seperateFilesForModels
+          seperateFilesForModels = seperateFilesForModels,
+          alwaysGenerateParamSupport = alwaysGenerateParamSupport
         )
         .getOrElse(GeneratedClassDefinitions(Map.empty, None, Nil, None, false, Nil, Set.empty))
 
@@ -186,7 +188,8 @@ object RootGenerator {
          |}""".stripMargin
     }
 
-    val xmlSerdeObj = xmlSerdes.map(XmlSerdeGenerator.wrapBody(normalisedXmlLib, packagePath, objName, targetScala3, _, seperateFilesForModels))
+    val xmlSerdeObj =
+      xmlSerdes.map(XmlSerdeGenerator.wrapBody(normalisedXmlLib, packagePath, objName, targetScala3, _, seperateFilesForModels))
 
     val schemaObjs = if (schemas.size > 1) shimsAndSchemas.zipWithIndex.map { case ((shims, body), idx) =>
       val priorImports = (0 until idx).map { i => s"import $packagePath.${objName}Schemas${i + 1}._" }.mkString("\n")

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/CirceSerdeImpl.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/CirceSerdeImpl.scala
@@ -32,7 +32,8 @@ object CirceSerdeImpl {
       allSchemas: Map[String, OpenapiSchemaType],
       allTransitiveJsonParamRefs: Set[String],
       validateNonDiscriminatedOneOfs: Boolean,
-      packageReuse: PackageReuseContext
+      packageReuse: PackageReuseContext,
+      seperateFilesForModels: Boolean,
   ): SerdeGenResponse = {
     val docSchemas = doc.components.toSeq.flatMap(_.schemas).map { case (n, t) => (n, t, allTransitiveJsonParamRefs.contains(n)) }
     val pathSchemas = inlineEndpointSchemas(doc)
@@ -51,7 +52,7 @@ object CirceSerdeImpl {
       val uncapitalisedName = uncapitalise(name)
       val decoderName = s"${uncapitalisedName}JsonDecoder"
       val encoderName = s"${uncapitalisedName}JsonEncoder"
-      val companion = s"${packageReuse.dependencyModelPath}.$name"
+      val companion = s"${packageReuse.modelRoot(seperateFilesForModels)}.$name"
       s"""implicit lazy val $decoderName: io.circe.Decoder[$name] = enumeratum.Circe.decoder($companion)
          |implicit lazy val $encoderName: io.circe.Encoder[$name] = enumeratum.Circe.encoder($companion)"""
     }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/JsonSerdeGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/json/JsonSerdeGenerator.scala
@@ -50,13 +50,14 @@ object JsonSerdeGenerator {
       schemasContainAny: Boolean,
       useCustomJsoniterSerdes: Boolean,
       packageReuse: PackageReuseContext,
-      resolvableNonClassyOneOfSchemas: Seq[(String, OpenapiSchemaOneOf)]
+      resolvableNonClassyOneOfSchemas: Seq[(String, OpenapiSchemaOneOf)],
+      seperateFilesForModels: Boolean,
   ): SerdeGenResponse = {
     val allSchemas: Map[String, OpenapiSchemaType] = doc.components.toSeq.flatMap(_.schemas).toMap
 
     jsonSerdeLib match {
       case JsonSerdeLib.Circe =>
-        CirceSerdeImpl.genCirceSerdes(doc, allSchemas, allTransitiveJsonParamRefs, validateNonDiscriminatedOneOfs, packageReuse)
+        CirceSerdeImpl.genCirceSerdes(doc, allSchemas, allTransitiveJsonParamRefs, validateNonDiscriminatedOneOfs, packageReuse, seperateFilesForModels)
       case JsonSerdeLib.Jsoniter =>
         JsoniterSerdeImpl.genJsoniterSerdes(
           doc,

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/DiscriminatorCodegenSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/DiscriminatorCodegenSpec.scala
@@ -3,8 +3,9 @@ package sttp.tapir.codegen
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.tapir.codegen.json.JsonSerdeLib.Circe
+import sttp.tapir.codegen.testutils.CompileCheckTestBase
 
-class DiscriminatorCodegenSpec extends AnyFlatSpec with Matchers {
+class DiscriminatorCodegenSpec extends AnyFlatSpec with Matchers with CompileCheckTestBase {
 
   private val animalYaml =
     """openapi: 3.1.0
@@ -52,9 +53,10 @@ class DiscriminatorCodegenSpec extends AnyFlatSpec with Matchers {
     val out = gen.classDefs(doc, targetScala3 = false, jsonSerdeLib = Circe).get.classRepr
     out should include("case class Dog (")
     out should include("barks: Boolean")
-    out should not include "kind: String"
+    out should include(" { def kind: String }")
     out should include("""def `kind`: String = "dog"""")
     out should not include regex("case class Dog \\([^)]*kind".r)
+    out.shouldCompile()
   }
 
   it should "omit discriminator fields when schema key differs from generated class name" in {
@@ -88,7 +90,8 @@ class DiscriminatorCodegenSpec extends AnyFlatSpec with Matchers {
     val out = new ClassDefinitionGenerator().classDefs(doc, targetScala3 = false, jsonSerdeLib = Circe).get.classRepr
     out should include("case class Mydog (")
     out should include("barks: Boolean")
-    out should not include "kind: String"
+    out should include(" { def kind: String }")
     out should include("""def `kind`: String = "dog"""")
+    out.shouldCompile()
   }
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/DiscriminatorCodegenSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/DiscriminatorCodegenSpec.scala
@@ -54,7 +54,7 @@ class DiscriminatorCodegenSpec extends AnyFlatSpec with Matchers with CompileChe
     out should include("case class Dog (")
     out should include("barks: Boolean")
     out should include(" { def kind: String }")
-    out should include("""def `kind`: String = "dog"""")
+    out should include("""def kind: String = "dog"""")
     out should not include regex("case class Dog \\([^)]*kind".r)
     out.shouldCompile()
   }
@@ -91,7 +91,7 @@ class DiscriminatorCodegenSpec extends AnyFlatSpec with Matchers with CompileChe
     out should include("case class Mydog (")
     out should include("barks: Boolean")
     out should include(" { def kind: String }")
-    out should include("""def `kind`: String = "dog"""")
+    out should include("""def kind: String = "dog"""")
     out.shouldCompile()
   }
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -293,21 +293,26 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       ),
       Nil
     )
-    val objs: Map[String, String] = RootGenerator.generateObjects(
-      doc,
-      "sttp.tapir.generated",
-      "TapirGeneratedEndpoints",
-      targetScala3 = isScala3,
-      useHeadTagForObjectNames = false,
-      jsonSerdeLib = "circe",
-      xmlSerdeLib = "cats-xml",
-      validateNonDiscriminatedOneOfs = true,
-      maxSchemasPerFile = 400,
-      streamingImplementation = "fs2",
-      generateEndpointTypes = false,
-      generateValidators = true,
-      useCustomJsoniterSerdes = true
-    ).allFiles
+    val objs: Map[String, String] = RootGenerator
+      .generateObjects(
+        doc,
+        "sttp.tapir.generated",
+        "TapirGeneratedEndpoints",
+        targetScala3 = isScala3,
+        useHeadTagForObjectNames = false,
+        jsonSerdeLib = "circe",
+        xmlSerdeLib = "cats-xml",
+        validateNonDiscriminatedOneOfs = true,
+        maxSchemasPerFile = 400,
+        streamingImplementation = "fs2",
+        generateEndpointTypes = false,
+        generateValidators = true,
+        useCustomJsoniterSerdes = true,
+        packageReuse = PackageReuseContext.none,
+        seperateFilesForModels = false,
+        alwaysGenerateParamSupport = false
+      )
+      .allFiles
     val schemas = objs("TapirGeneratedEndpointsSchemas")
     val generatedCode = objs("TapirGeneratedEndpoints")
     generatedCode should include(
@@ -334,7 +339,10 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
       streamingImplementation = "fs2",
       generateEndpointTypes = false,
       generateValidators = true,
-      useCustomJsoniterSerdes = true
+      useCustomJsoniterSerdes = true,
+      packageReuse = PackageReuseContext.none,
+      seperateFilesForModels = false,
+      alwaysGenerateParamSupport = false,
     )
     val generatedCode = generatedObj.allFiles("TapirGeneratedEndpointsSchemas") + "\n" + generatedObj.allFiles("TapirGeneratedEndpoints")
     generatedCode.shouldCompile()

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/RootGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/RootGeneratorSpec.scala
@@ -1,5 +1,6 @@
 package sttp.tapir.codegen
 
+import sttp.tapir.codegen.dedup.PackageReuseContext
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.testutils.{CompileCheckTestBase, VersionCheck}
 
@@ -22,7 +23,10 @@ class RootGeneratorSpec extends CompileCheckTestBase {
       streamingImplementation = "fs2",
       generateEndpointTypes = false,
       generateValidators = true,
-      useCustomJsoniterSerdes = true
+      useCustomJsoniterSerdes = true,
+      packageReuse = PackageReuseContext.none,
+      seperateFilesForModels = false,
+      alwaysGenerateParamSupport = false
     ).allFiles
   }
   def gen(
@@ -145,7 +149,9 @@ class RootGeneratorSpec extends CompileCheckTestBase {
       generateEndpointTypes = false,
       generateValidators = true,
       useCustomJsoniterSerdes = true,
-      seperateFilesForModels = true
+      packageReuse = PackageReuseContext.none,
+      seperateFilesForModels = true,
+      alwaysGenerateParamSupport = false
     )
     val files = info.allFiles
     files.keys.exists(_.startsWith("models.")) shouldBe true

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenKeys.scala
@@ -18,6 +18,7 @@ case class OpenApiConfiguration(
     additionalPackages: List[(String, File)],
     packageDependencies: Map[String, String],
     seperateFilesForModels: Boolean,
+    alwaysGenerateParamSupport: Boolean,
 )
 
 trait OpenapiCodegenKeys {
@@ -43,6 +44,8 @@ trait OpenapiCodegenKeys {
     "Set to true to enable usage of custom jsoniter macros (decreases compilation flakiness, compatible with jsoniter-scala versions >= 2.36.x)"
   )
   lazy val openapiSeperateFilesForModels = settingKey[Boolean]("When true, each model will be split into a seperate file (excluding ADTS)")
+  lazy val openapiAlwaysGenerateParamSupport =
+    settingKey[Boolean]("Set to true to always generate param support for enums. Useful for openapi dedup.")
   lazy val openapiOpenApiConfiguration =
     settingKey[OpenApiConfiguration]("Aggregation of other settings. Manually set value will be disregarded.")
 

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenPlugin.scala
@@ -61,7 +61,8 @@ object OpenapiCodegenPlugin extends AutoPlugin {
       openapiUseCustomJsoniterSerdes.value,
       openapiAdditionalPackages.value,
       openapiPackageDependencies.value,
-      openapiSeperateFilesForModels.value
+      openapiSeperateFilesForModels.value,
+      openapiAlwaysGenerateParamSupport.value,
     )
   def openapiCodegenDefaultSettings: Seq[Setting[_]] = Seq(
     openapiSwaggerFile := baseDirectory.value / "swagger.yaml",
@@ -79,6 +80,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
     openapiDisableValidatorGeneration := false,
     openapiUseCustomJsoniterSerdes := false,
     openapiSeperateFilesForModels := false,
+    openapiAlwaysGenerateParamSupport := false,
     standardParamSetting
   )
 
@@ -168,6 +170,7 @@ object OpenapiCodegenPlugin extends AutoPlugin {
       directoryName,
       Some(doc),
       packageReuse,
-      c.seperateFilesForModels
+      c.seperateFilesForModels,
+      c.alwaysGenerateParamSupport,
     )
 }

--- a/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
+++ b/openapi-codegen/sbt-plugin/src/main/scala/sttp/tapir/sbt/OpenapiCodegenTask.scala
@@ -27,7 +27,8 @@ case class OpenapiCodegenTask(
     overrideDirectoryName: Option[String],
     preParsedDoc: Option[OpenapiDocument] = None,
     packageReuse: PackageReuseContext = PackageReuseContext.none,
-    seperateFilesForModels: Boolean = false
+    seperateFilesForModels: Boolean = false,
+    alwaysGenerateParamSupport: Boolean
 ) {
 
   private val directoryName: String = overrideDirectoryName.getOrElse("sbt-openapi-codegen")
@@ -55,7 +56,8 @@ case class OpenapiCodegenTask(
         !disableValidatorGeneration,
         useCustomJsoniterSerdes,
         packageReuse,
-        seperateFilesForModels
+        seperateFilesForModels,
+        alwaysGenerateParamSupport
       )
     Await.result(
       Future.traverse(generationInfo.allFiles.toSeq) { case (objectName, fileBody) =>

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/multi_file/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/multi_file/Expected.scala.txt
@@ -35,14 +35,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_.values.map(support.encode).mkString(",")))
+      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/multi_file/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/multi_file/Expected.scala.txt
@@ -35,14 +35,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.flatMap(support.encode).mkString(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
+      }(_.map(_.values.flatMap(support.encode).mkString(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/multi_file/Expected2.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/multi_file/Expected2.scala.txt
@@ -35,14 +35,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_.values.map(support.encode).mkString(",")))
+      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/multi_file/Expected2.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/multi_file/Expected2.scala.txt
@@ -35,14 +35,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.flatMap(support.encode).mkString(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
+      }(_.map(_.values.flatMap(support.encode).mkString(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/Expected.scala.txt
@@ -39,14 +39,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.flatMap(support.encode).mkString(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
+      }(_.map(_.values.flatMap(support.encode).mkString(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/nifi_test/Expected.scala.txt
@@ -39,14 +39,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_.values.map(support.encode).mkString(",")))
+      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
@@ -36,14 +36,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.flatMap(support.encode).mkString(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
+      }(_.map(_.values.flatMap(support.encode).mkString(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip-zio/Expected.scala.txt
@@ -36,14 +36,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_.values.map(support.encode).mkString(",")))
+      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -92,7 +92,7 @@ object TapirGeneratedEndpoints {
   }
   def extraCodecSupport[T <: enumeratum.EnumEntry](enumName: String, T: enumeratum.Enum[T]): ExtraParamSupport[T] =
     EnumExtraParamSupport(enumName, T)
-  sealed trait ADTWithDiscriminator
+  sealed trait ADTWithDiscriminator { def `type`: String }
   sealed trait ADTWithDiscriminatorNoMapping
   sealed trait ADTWithoutDiscriminator
   sealed trait AnyObjectWithInlineEnum

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -53,14 +53,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_.values.map(support.encode).mkString(",")))
+      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip/Expected.scala.txt
@@ -53,14 +53,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.flatMap(support.encode).mkString(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
+      }(_.map(_.values.flatMap(support.encode).mkString(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -45,14 +45,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.flatMap(support.encode).mkString(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
+      }(_.map(_.values.flatMap(support.encode).mkString(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter/Expected.scala.txt
@@ -45,14 +45,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_.values.map(support.encode).mkString(",")))
+      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
@@ -34,14 +34,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_.values.map(support.encode).mkString(",")))
+      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_jsoniter_scala3/Expected.scala.txt
@@ -34,14 +34,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.flatMap(support.encode).mkString(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
+      }(_.map(_.values.flatMap(support.encode).mkString(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -39,14 +39,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.flatMap(support.encode).mkString(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
+      }(_.map(_.values.flatMap(support.encode).mkString(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/oneOf-json-roundtrip_scala3/Expected.scala.txt
@@ -39,14 +39,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_.values.map(support.encode).mkString(",")))
+      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
@@ -40,14 +40,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_.values.map(support.encode).mkString(",")))
+      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/petstore/Expected.scala.txt
@@ -40,14 +40,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.flatMap(support.encode).mkString(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
+      }(_.map(_.values.flatMap(support.encode).mkString(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/ExpectedV1.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/ExpectedV1.scala.txt
@@ -55,6 +55,7 @@ object TapirGeneratedEndpoints {
 
 
   type Pet = sttp.tapir.generated.v2.TapirGeneratedEndpoints.Pet
+  val Pet = sttp.tapir.generated.v2.TapirGeneratedEndpoints.Pet
   case class Order (
     id: Long,
     pet: Pet

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/ExpectedV1.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/ExpectedV1.scala.txt
@@ -32,14 +32,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_.values.map(support.encode).mkString(",")))
+      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/ExpectedV1.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/ExpectedV1.scala.txt
@@ -32,14 +32,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.flatMap(support.encode).mkString(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
+      }(_.map(_.values.flatMap(support.encode).mkString(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/ExpectedV2.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/ExpectedV2.scala.txt
@@ -35,14 +35,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.map(support.encode).mkString(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_.values.map(support.encode).mkString(",")))
+      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/ExpectedV2.scala.txt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/schema_inheritance/ExpectedV2.scala.txt
@@ -35,14 +35,14 @@ object TapirGeneratedEndpoints {
   }
   implicit def makeUnexplodedQuerySeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], CommaSeparatedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHead[String, String, sttp.tapir.CodecFormat.TextPlain]
-      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_._.values.flatMap(support.encode).mkString(",")(","))
+      .mapDecode(values => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(s => CommaSeparatedValues(s.toList)))(_.values.flatMap(support.encode).mkString(","))
   }
   implicit def makeUnexplodedQueryOptSeqCodecFromListHead[T](implicit support: sttp.tapir.Codec[List[String], T, sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], Option[CommaSeparatedValues[T]], sttp.tapir.CodecFormat.TextPlain] = {
     sttp.tapir.Codec.listHeadOption[String, String, sttp.tapir.CodecFormat.TextPlain]
       .mapDecode{
         case None => DecodeResult.Value(None)
         case Some(values) => DecodeResult.sequence(values.split(',').toSeq.map(e => support.rawDecode(List(e)))).map(r => Some(CommaSeparatedValues(r.toList)))
-      }(_.map(_._.values.flatMap(support.encode).mkString(",")(",")))
+      }(_.map(_.values.flatMap(support.encode).mkString(",")))
   }
   implicit def makeExplodedQuerySeqCodecFromListSeq[T](implicit support: sttp.tapir.Codec[List[String], List[T], sttp.tapir.CodecFormat.TextPlain]): sttp.tapir.Codec[List[String], ExplodedValues[T], sttp.tapir.CodecFormat.TextPlain] = {
     support.mapDecode(l => DecodeResult.Value(ExplodedValues(l)))(_.values)


### PR DESCRIPTION
A few sundry things:
- The discriminator of each child of a oneOf is reified as `def $discriminatorName: String = "..."`, but the parent type didn't declare the abstract method, which was irritating. Parent will now declare the method.
- Fixes a reference bug when inheriting an enum using circe serdes, where parent didn't use enum in json bodies but the child does, and `seperateFilesForModels=true`
- Adds a `openapiAlwaysGenerateParamSupport` boolean flag, so that enums can be defined in an inherited openapi and used in path position, without having to redeclare them (and everything that transitively contains them)
- Fixes client encoding of non-exploded array params (was using a `.map` instead of a `.flatMap` and producing e.g. `?myParam=List(uuid1),List(uuid2)` instead of `?myParam=uuid1,uuid2` when encoding)
- Remove redundant backticks from discriminator method names when the property name is not a reserved name
- Tries harder to construct type aliases for inline definitions when 'deduplicating' between schemas. It doesn't work as it should but it's better
- Creates val aliases for 'dedupped' case class definitions