### PR TITLE
Fix flaky DatadogMetricsTest (broken wait helper, origin detection, UDP races)

### DIFF
--- a/metrics/datadog-metrics/src/test/scala/sttp/tapir/server/metrics/datadog/DatadogMetricsTest.scala
+++ b/metrics/datadog-metrics/src/test/scala/sttp/tapir/server/metrics/datadog/DatadogMetricsTest.scala
@@ -2,12 +2,14 @@ package sttp.tapir.server.metrics.datadog
 
 import com.timgroup.statsd._
 import org.scalatest.Retries.isRetryable
+import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.tagobjects.Retryable
-import org.scalatest.time.{Seconds, Span}
+import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, Canceled, Failed, Outcome}
 import sttp.shared.Identity
 import sttp.tapir.TestUtil._
@@ -25,7 +27,6 @@ import java.nio.ByteBuffer
 import java.nio.channels.DatagramChannel
 import java.nio.charset.StandardCharsets
 import java.time._
-import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Success, Try}
@@ -34,6 +35,11 @@ class DatadogMetricsTest extends AnyFlatSpec with Matchers with BeforeAndAfter w
 
   private val statsdServerPort = 17254
   private val statsdServer = new MockStatsDServer(statsdServerPort)
+
+  // increase the patience for `eventually` for slow CI tests; the statsd client aggregates metrics client-side and
+  // flushes them every 2 seconds, so datagrams arrive with a delay
+  implicit val patienceConfig: Eventually.PatienceConfig =
+    Eventually.PatienceConfig(timeout = Span(15, Seconds), interval = Span(150, Millis))
 
   override def beforeAll(): Unit = statsdServer.start()
   override def afterAll(): Unit = statsdServer.close()
@@ -65,7 +71,9 @@ class DatadogMetricsTest extends AnyFlatSpec with Matchers with BeforeAndAfter w
   }
   //
 
-  "default metrics" should "collect requests active" in {
+  // retryable, as the statsd client aggregates metrics client-side in 2-second flush windows, so counter increments
+  // can in rare cases be split or merged across windows, which no amount of waiting can heal
+  "default metrics" should "collect requests active" taggedAs Retryable in {
     // given
     val serverEp = PersonsApi { name =>
       Thread.sleep(2000)
@@ -75,6 +83,9 @@ class DatadogMetricsTest extends AnyFlatSpec with Matchers with BeforeAndAfter w
       new NonBlockingStatsDClientBuilder()
         .hostname("localhost")
         .port(statsdServerPort)
+        // origin detection appends |c:<container-id> to datagrams on machines where a container id resolves,
+        // breaking exact-match assertions
+        .originDetectionEnabled(false)
         .build()
 
     val metrics = DatadogMetrics[Identity](client).addRequestsActive()
@@ -90,26 +101,30 @@ class DatadogMetricsTest extends AnyFlatSpec with Matchers with BeforeAndAfter w
     // when
     val response = Future { interpreter.apply(PersonsApi.request("Jacob")) }
 
-    waitReceiveMessage(statsdServer)
-
     // then
-    statsdServer.getReceivedMessages should contain("""tapir.request_active.count:1|c|#method:GET""")
+    eventually {
+      statsdServer.getReceivedMessages should contain("""tapir.request_active.count:1|c|#method:GET""")
+    }
 
     statsdServer.clear()
 
     ScalaFutures.whenReady(response, Timeout(Span(3, Seconds))) { _ =>
-      waitReceiveMessage(statsdServer)
-      statsdServer.getReceivedMessages should contain("""tapir.request_active.count:-1|c|#method:GET""")
+      eventually {
+        statsdServer.getReceivedMessages should contain("""tapir.request_active.count:-1|c|#method:GET""")
+      }
     }
   }
 
-  "default metrics" should "collect requests total" in {
+  // retryable, as the statsd client aggregates metrics client-side in 2-second flush windows, so counter increments
+  // can in rare cases be split or merged across windows, which no amount of waiting can heal
+  "default metrics" should "collect requests total" taggedAs Retryable in {
     // given
     val serverEp = PersonsApi().serverEp
     val client =
       new NonBlockingStatsDClientBuilder()
         .hostname("localhost")
         .port(statsdServerPort)
+        .originDetectionEnabled(false)
         .build()
 
     val metrics = DatadogMetrics[Identity](client).addRequestsTotal()
@@ -128,11 +143,11 @@ class DatadogMetricsTest extends AnyFlatSpec with Matchers with BeforeAndAfter w
     interpreter.apply(PersonsApi.request("Mike"))
     interpreter.apply(PersonsApi.request(""))
 
-    waitReceiveMessage(statsdServer, "4xx")
-
     // then
-    statsdServer.getReceivedMessages should contain("""tapir.request_total.count:2|c|#status:2xx,path:/person,method:GET""")
-    statsdServer.getReceivedMessages should contain("""tapir.request_total.count:2|c|#status:4xx,path:/person,method:GET""")
+    eventually {
+      statsdServer.getReceivedMessages should contain("""tapir.request_total.count:2|c|#status:2xx,path:/person,method:GET""")
+      statsdServer.getReceivedMessages should contain("""tapir.request_total.count:2|c|#status:4xx,path:/person,method:GET""")
+    }
   }
 
   "default metrics" should "collect requests duration" taggedAs Retryable in {
@@ -157,6 +172,7 @@ class DatadogMetricsTest extends AnyFlatSpec with Matchers with BeforeAndAfter w
       new NonBlockingStatsDClientBuilder()
         .hostname("localhost")
         .port(statsdServerPort)
+        .originDetectionEnabled(false)
         .build()
 
     val metrics = DatadogMetrics[Identity](client).addRequestsDuration(clock = clock)
@@ -174,31 +190,32 @@ class DatadogMetricsTest extends AnyFlatSpec with Matchers with BeforeAndAfter w
     interpret(200, 2000)
     interpret(300, 3000)
 
-    waitReceiveMessage(statsdServer, "0.3")
-
     // then
     // headers
-
-    statsdServer.getReceivedMessages should contain(
-      """tapir.request_duration_seconds:0.1|h|#phase:headers,status:2xx,path:/person,method:GET"""
-    )
-    statsdServer.getReceivedMessages should contain(
-      """tapir.request_duration_seconds:0.2|h|#phase:headers,status:2xx,path:/person,method:GET"""
-    )
-    statsdServer.getReceivedMessages should contain(
-      """tapir.request_duration_seconds:0.3|h|#phase:headers,status:2xx,path:/person,method:GET"""
-    )
+    eventually {
+      statsdServer.getReceivedMessages should contain(
+        """tapir.request_duration_seconds:0.1|h|#phase:headers,status:2xx,path:/person,method:GET"""
+      )
+      statsdServer.getReceivedMessages should contain(
+        """tapir.request_duration_seconds:0.2|h|#phase:headers,status:2xx,path:/person,method:GET"""
+      )
+      statsdServer.getReceivedMessages should contain(
+        """tapir.request_duration_seconds:0.3|h|#phase:headers,status:2xx,path:/person,method:GET"""
+      )
+    }
 
     // body
-    statsdServer.getReceivedMessages should contain(
-      """tapir.request_duration_seconds:1.1|h|#phase:body,status:2xx,path:/person,method:GET"""
-    )
-    statsdServer.getReceivedMessages should contain(
-      """tapir.request_duration_seconds:2.2|h|#phase:body,status:2xx,path:/person,method:GET"""
-    )
-    statsdServer.getReceivedMessages should contain(
-      """tapir.request_duration_seconds:3.3|h|#phase:body,status:2xx,path:/person,method:GET"""
-    )
+    eventually {
+      statsdServer.getReceivedMessages should contain(
+        """tapir.request_duration_seconds:1.1|h|#phase:body,status:2xx,path:/person,method:GET"""
+      )
+      statsdServer.getReceivedMessages should contain(
+        """tapir.request_duration_seconds:2.2|h|#phase:body,status:2xx,path:/person,method:GET"""
+      )
+      statsdServer.getReceivedMessages should contain(
+        """tapir.request_duration_seconds:3.3|h|#phase:body,status:2xx,path:/person,method:GET"""
+      )
+    }
   }
 
   "default metrics" should "customize labels" taggedAs Retryable in {
@@ -209,6 +226,7 @@ class DatadogMetricsTest extends AnyFlatSpec with Matchers with BeforeAndAfter w
       new NonBlockingStatsDClientBuilder()
         .hostname("localhost")
         .port(statsdServerPort)
+        .originDetectionEnabled(false)
         .build()
 
     val metrics = DatadogMetrics[Identity](client).addRequestsTotal(labels)
@@ -224,10 +242,10 @@ class DatadogMetricsTest extends AnyFlatSpec with Matchers with BeforeAndAfter w
     // when
     interpreter.apply(PersonsApi.request("Jacob"))
 
-    waitReceiveMessage(statsdServer)
-
     // then
-    statsdServer.getReceivedMessages should contain("""tapir.request_total.count:1|c|#key:value""")
+    eventually {
+      statsdServer.getReceivedMessages should contain("""tapir.request_total.count:1|c|#key:value""")
+    }
   }
 
   "metrics" should "be collected on exception when response from exception handler" taggedAs Retryable in {
@@ -237,6 +255,7 @@ class DatadogMetricsTest extends AnyFlatSpec with Matchers with BeforeAndAfter w
       new NonBlockingStatsDClientBuilder()
         .hostname("localhost")
         .port(statsdServerPort)
+        .originDetectionEnabled(false)
         .build()
 
     val metrics = DatadogMetrics[Identity](client).addRequestsTotal()
@@ -251,30 +270,17 @@ class DatadogMetricsTest extends AnyFlatSpec with Matchers with BeforeAndAfter w
     // when
     interpreter.apply(PersonsApi.request("Jacob"))
 
-    waitReceiveMessage(statsdServer)
-
     // then
-    statsdServer.getReceivedMessages should contain("""tapir.request_total.count:1|c|#status:5xx,path:/person,method:GET""")
+    eventually {
+      statsdServer.getReceivedMessages should contain("""tapir.request_total.count:1|c|#status:5xx,path:/person,method:GET""")
+    }
   }
 }
 
 object DatadogMetricsTest {
-  val Tries = 5
-
-  @tailrec
-  private def waitReceiveMessage(statsdServer: MockStatsDServer, expected: String = "method", tries: Int = Tries): Unit = {
-    if (
-      statsdServer.getReceivedMessages
-        .count(m => !m.startsWith("datadog")) == 0 || (tries > 0 && statsdServer.getReceivedMessages
-        .count(m => m.startsWith(expected)) > 0)
-    ) {
-      Thread.sleep(100)
-      waitReceiveMessage(statsdServer, expected, tries - 1)
-    }
-  }
-
   class MockStatsDServer(port: Int) {
-    private var receivedMessages: List[String] = Nil
+    // written by the receiver thread, read by the test thread
+    @volatile private var receivedMessages: List[String] = Nil
     private val server = DatagramChannel.open()
 
     def clear(): Unit = receivedMessages = Nil


### PR DESCRIPTION
## Problem

`DatadogMetricsTest` was flaky on CI (e.g. the failure on #5369, where the 4xx counter assertion ran before the datagram arrived) and failed 5/5 when run on a dev machine. Four root causes:

1. **The `waitReceiveMessage` helper was broken.** Its `m.startsWith(expected)` check could never match — the default sentinel was `"method"` and others were `"4xx"`/`"0.3"`, while every datagram starts with `tapir.` or `datadog.`. Its polarity was also inverted (it kept looping *while* the expected message was present, rather than until it appeared), and its first clause was unbounded (a potential infinite hang if no message ever arrived). The effective behaviour degraded to "return as soon as ANY message arrives", so the assertions that followed raced in-flight UDP datagrams. The `"0.3"` sentinel in the duration test was additionally wrong — the last histogram sent is `3.3`.
2. **Origin detection breaks exact-match assertions on dev machines.** java-dogstatsd-client enables origin detection by default; on machines where a container id resolves, it appends `|c:<container-id>` to every datagram, so all exact-string assertions fail (hence 5/5 local failures). Now disabled via `.originDetectionEnabled(false)` on every client.
3. **Client-side aggregation delays and reshapes counters.** The client aggregates metrics client-side and flushes every ~2 seconds, so datagrams arrive late, and counter increments can be split or merged across flush windows.
4. **Unsynchronized cross-thread access.** `MockStatsDServer.receivedMessages` was a plain `var` written by a daemon receiver thread and read by the test thread, with no `@volatile`.

## Fix

- Replaced all `waitReceiveMessage` calls with `eventually`-wrapped assertions, using the same idiom as `ServerMetricsTest` (class-level `Eventually.PatienceConfig`, 15s timeout / 150ms interval for slow CI); deleted the broken helper.
- Added `.originDetectionEnabled(false)` to all five client builders.
- Tagged "collect requests active" and "collect requests total" as `Retryable`: aggregation can in rare cases split or merge counter increments across 2-second flush windows, which no amount of waiting can heal — the suite's existing retry mechanism handles this.
- Made `receivedMessages` `@volatile`.

## Verification

On a machine where origin detection resolves a container id:

- Baseline (before fix): `datadogMetrics/testOnly ...DatadogMetricsTest` — **0/5 passed** (all 5 fail on the appended `|c:<container-id>`).
- After fix: 3 consecutive runs — **5/5 passed, 3/3 green**.
- `datadogMetrics2_12/Test/compile` and `datadogMetrics3/Test/compile` — success.
- `datadogMetrics/Test/scalafmtCheck` — success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)