### PR TITLE
codegen: don't emit raw type aliases without object wrapper

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -469,7 +469,7 @@ class ClassDefinitionGenerator {
              |}""".stripMargin
       }
 
-      val (properties, maybeEnums) = obj.properties
+      val (properties, maybeEnums) = obj.properties.toSeq
         .filterNot(discriminatorDefFields.map(_._1) contains _._1)
         .map { case (key, OpenapiSchemaField(schemaType, maybeDefault, _)) =>
           val (tpe, maybeEnum) =

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/ClassDefinitionGenerator.scala
@@ -277,7 +277,6 @@ class ClassDefinitionGenerator {
 
     def isTypeAlias(name: String): Boolean = allSchemas.get(name) match {
       case Some(_: OpenapiSchemaMap) | Some(_: OpenapiSchemaArray) | Some(_: OpenapiSchemaSimpleType) => true
-      case Some(_: OpenapiSchemaEnum) if PackageReuseContext.isReusedSchema(name, packageReuse)       => true
       case _ if PackageReuseContext.isReusedSchema(name, packageReuse)                                => true
       case _                                                                                          => false
     }
@@ -331,7 +330,8 @@ class ClassDefinitionGenerator {
             }
           }
           .mkString("\n")
-        addModel(fileName, Seq(traits, childContent).filter(_.nonEmpty).mkString("\n"))
+        val defns = Seq(traits, childContent).filter(_.nonEmpty)
+        if (!isReused) addModel(fileName, defns.mkString("\n"))
       }
 
       resolvableNonClassyOneOfSchemas.filterNot(p => isTypeAlias(p._1)).foreach { case (name, st) =>

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/build.sbt
@@ -19,11 +19,14 @@ import scala.io.Source
 import scala.util.Using
 
 TaskKey[Unit]("check") := {
-  val base = sourceManaged.value / "main/sttp/tapir/generated"
-  val main = Using(Source.fromFile(base / "models/package.scala"))(_.mkString).get
-  val book = Using(Source.fromFile(base / "models/Book.scala"))(_.mkString).get
+  val base = sourceManaged.value / "main/sttp/tapir"
+  val main = Using(Source.fromFile(base / "generated/models/package.scala"))(_.mkString).get
+  val book = Using(Source.fromFile(base / "generated/models/Book.scala"))(_.mkString).get
+  val dup = Using(Source.fromFile(base / "gen_dup/models/package.scala"))(_.mkString).get
   if (main.contains("case class Book")) sys.error("Book model should not be in the main object")
   if (!book.contains("case class Book")) sys.error("Book model should be in models/Book.scala")
   if (!main.contains("type Books =")) sys.error("type alias Books should be defined in package object")
+  if (!dup.contains("type Books =")) sys.error("type alias Books should be defined in dependent package object")
+  if (!dup.contains("type Animal = sttp.tapir.generated.models.Animal")) sys.error("type alias Animal should be defined in package object")
   ()
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/build.sbt
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/build.sbt
@@ -10,10 +10,15 @@ lazy val root = (project in file("."))
     ),
     openapiPackageDependencies := Map("sttp.tapir.gen_dup" -> "sttp.tapir.generated")
   )
+val tapirVersion = "1.13.26"
 
-libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % "1.10.0"
-libraryDependencies += "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % "1.10.0"
-libraryDependencies += "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.8.0"
+libraryDependencies ++= Seq(
+  "com.softwaremill.sttp.tapir" %% "tapir-json-circe" % tapirVersion,
+  "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs" % tapirVersion,
+  "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % "0.11.10",
+  "com.beachape" %% "enumeratum" % "1.9.8",
+  "com.beachape" %% "enumeratum-circe" % "1.9.8"
+)
 
 import scala.io.Source
 import scala.util.Using
@@ -28,5 +33,6 @@ TaskKey[Unit]("check") := {
   if (!main.contains("type Books =")) sys.error("type alias Books should be defined in package object")
   if (!dup.contains("type Books =")) sys.error("type alias Books should be defined in dependent package object")
   if (!dup.contains("type Animal = sttp.tapir.generated.models.Animal")) sys.error("type alias Animal should be defined in package object")
+  if (!dup.contains("type BadgerTypeOfSnuffle =")) sys.error("type alias should be generated for dedupped inline enum defns")
   ()
 }

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/swagger.yaml
@@ -46,6 +46,11 @@ components:
       properties:
         snuffles:
           type: boolean
+        typeOfSnuffle:
+          type: string
+          enum:
+            - Hungry
+            - Noisy
         type:
           type: string
     Ferret:

--- a/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/swagger.yaml
+++ b/openapi-codegen/sbt-plugin/src/sbt-test/sbt-openapi-codegen/seperate_files_for_models/swagger.yaml
@@ -5,6 +5,11 @@ info:
 paths:
   /books:
     get:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Animal'
       responses:
         '200':
           content:
@@ -15,7 +20,7 @@ components:
   schemas:
     Book:
       type: object
-      required: [title]
+      required: [ title ]
       properties:
         title:
           type: string
@@ -23,3 +28,34 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Book'
+    Animal:
+      required:
+        - type
+      properties:
+        type:
+          type: string
+      oneOf:
+        - $ref: '#/components/schemas/Badger'
+        - $ref: '#/components/schemas/Ferret'
+    Badger:
+      title: Badger
+      type: object
+      required:
+        - snuffles
+        - type
+      properties:
+        snuffles:
+          type: boolean
+        type:
+          type: string
+    Ferret:
+      title: Badger
+      type: object
+      required:
+        - smells
+        - type
+      properties:
+        smells:
+          type: boolean
+        type:
+          type: string


### PR DESCRIPTION
Don't declare raw type aliases at file root level when inheriting an ADT and openapi SeperateFilesForModels := true.

They're already written to the package object in these cases


I missed this case before :(  it was writing the type aliases straight to the `models.$ADTName` file and broke compilation (at least in Scala 2)

Also ensures that type aliases get generated for inline enum defns on deduplicated classes (`.properties` is a map, so we were only generating type aliases for the last declared field)