### PR TITLE
codegen: backtick-quote reserved keywords in enum member names

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/util/StringUtils.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/util/StringUtils.scala
@@ -34,13 +34,18 @@ object NameHelpers {
       )
     else s"`$s`"
 
+  // reservedKeys only contains the keywords of the Scala version the codegen itself is built with, but the generated
+  // code may target either version — so always also quote the Scala-3-only (soft) keywords.
+  private val keywordsInAnyScalaVersion: Set[String] = reservedKeys ++ Set("enum", "given", "using")
+
   def safeVariableName(s: String): String =
-    if (!(reservedKeys ++ Set("enum", "given", "using")).contains(s) && s.matches("[A-Za-z_$][A-Za-z_$0-9]*")) s
+    if (!keywordsInAnyScalaVersion.contains(s) && s.matches("[A-Za-z_$][A-Za-z_$0-9]*")) s
     else backtickQuoteOrReject("name", s)
 
   // Enum member values become `case object`/`enum case` identifiers. Same backtick-escape gap as safeVariableName.
   def safeEnumMemberName(s: String): String =
-    if (s.matches("[a-zA-Z][a-zA-Z0-9_]*")) s else backtickQuoteOrReject("enum value", s)
+    if (!keywordsInAnyScalaVersion.contains(s) && s.matches("[a-zA-Z][a-zA-Z0-9_]*")) s
+    else backtickQuoteOrReject("enum value", s)
 
   // The generated `CodecFormat` class name for a content type. The definition site and every reference must produce
   // the same identifier, so this single derivation is the source of truth (and safely quotes/rejects the content type).

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/ClassDefinitionGeneratorSpec.scala
@@ -92,6 +92,28 @@ class ClassDefinitionGeneratorSpec extends CompileCheckTestBase {
     new ClassDefinitionGenerator().classDefs(doc, targetScala3 = isScala3).get.classRepr.shouldCompile()
   }
 
+  it should "generate enum with reserved-keyword members" in {
+    val doc = OpenapiDocument(
+      "",
+      Nil,
+      null,
+      Nil,
+      Some(
+        OpenapiComponent(
+          Map(
+            "Test" -> OpenapiSchemaEnum(
+              "string",
+              Seq("class", "object", "trait", "import", "type", "enum", "given", "using").map(OpenapiSchemaConstantString(_)),
+              false
+            )
+          )
+        )
+      ),
+      Nil
+    )
+    new ClassDefinitionGenerator().classDefs(doc, targetScala3 = isScala3).get.classRepr.shouldCompile()
+  }
+
   it should "generate simple class with reserved propName" in {
     val doc = OpenapiDocument(
       "",


### PR DESCRIPTION
Fixes #5423

Enum values coming from the OpenAPI document that happen to be Scala reserved keywords (`class`, `object`, `trait`, `import`, ...) were emitted as bare identifiers in the generated `case object`s / Scala 3 `enum` cases, producing non-compiling code — unlike case-class fields, which already went through the reserved-keyword check.

`safeEnumMemberName` now applies the same check as `safeVariableName` (shared via `keywordsInAnyScalaVersion`), which also covers the Scala-3-only keywords `enum`/`given`/`using` regardless of which Scala version the codegen itself is built with.

The wire format is unaffected: enum serialization derives names at runtime (enumeratum `entryName` / `EnumMirror`), and backtick-quoting doesn't change the runtime name — ```case object `class``` still round-trips as `"class"`.

Added a compile-check test exercising keyword enum members on both Scala 2 and Scala 3 generation paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)