### PR TITLE
Apply the mapping of oneOfBody(...).map(...) when used as an input

### DIFF
--- a/client/core/src/main/scala/sttp/tapir/client/ClientOutputParams.scala
+++ b/client/core/src/main/scala/sttp/tapir/client/ClientOutputParams.scala
@@ -14,12 +14,11 @@ abstract class ClientOutputParams {
         (s match {
           case EndpointIO.Body(_, codec, _)            => decode(codec, body)
           case EndpointIO.OneOfBody(variants, mapping) =>
-            val body2 = decode(mapping, body)
             val bodyVariant = meta.contentType
               .flatMap(MediaType.parse(_).toOption)
               .flatMap(ct => variants.find(v => ct.matches(v.range)))
               .getOrElse(variants.head)
-            body2.flatMap(decode(bodyVariant.codec, _))
+            decode(bodyVariant.codec, body).flatMap(decode(mapping, _))
           case EndpointIO.StreamBodyWrapper(StreamBodyIO(_, codec, _, _, _)) => decode(codec, body)
           case EndpointOutput.WebSocketBodyWrapper(o)                        => decodeWebSocketBody(o, body)
           case EndpointIO.Header(name, codec, _)                             => codec.decode(meta.headers(name).toList)

--- a/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
+++ b/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
@@ -100,18 +100,18 @@ private[http4s] class EndpointToHttp4sClient(clientOptions: Http4sClientOptions)
           currentUri.withQueryParam(key, values)
         }
         req.withUri(uri)
-      case EndpointIO.Empty(_, _)                                 => req
-      case EndpointIO.Body(bodyType, codec, _)                    => setBody(value, bodyType, codec, req)
-      case ob: EndpointIO.OneOfBody[_, _] if ob.variants.nonEmpty =>
+      case EndpointIO.Empty(_, _)              => req
+      case EndpointIO.Body(bodyType, codec, _) => setBody(value, bodyType, codec, req)
+      case ob: EndpointIO.OneOfBody[_, _]      =>
         ob.headVariantBodyWithAppliedMapping match {
-          case Left(body)                                                                 => setInputParams(body, params, req)
-          case Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _))) =>
+          case Some(Left(body))                                                                 => setInputParams(body, params, req)
+          case Some(Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _)))) =>
             setStreamingBody(streams)(
               codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[streams.BinaryStream],
               req
             )
+          case None => throw new RuntimeException("One of body without variants")
         }
-      case _: EndpointIO.OneOfBody[_, _]                                   => throw new RuntimeException("One of body without variants")
       case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)) =>
         setStreamingBody(streams)(value.asInstanceOf[streams.BinaryStream], req)
       case EndpointIO.Header(name, codec, _) =>

--- a/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
+++ b/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
@@ -100,15 +100,18 @@ private[http4s] class EndpointToHttp4sClient(clientOptions: Http4sClientOptions)
           currentUri.withQueryParam(key, values)
         }
         req.withUri(uri)
-      case EndpointIO.Empty(_, _)                                                   => req
-      case EndpointIO.Body(bodyType, codec, _)                                      => setBody(value, bodyType, codec, req)
-      case EndpointIO.OneOfBody(EndpointIO.OneOfBodyVariant(_, Left(body)) :: _, _) => setInputParams(body, params, req)
-      case EndpointIO.OneOfBody(
-            EndpointIO.OneOfBodyVariant(_, Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)))) :: _,
-            _
-          ) =>
-        setStreamingBody(streams)(value.asInstanceOf[streams.BinaryStream], req)
-      case EndpointIO.OneOfBody(Nil, _)                                    => throw new RuntimeException("One of body without variants")
+      case EndpointIO.Empty(_, _)                                 => req
+      case EndpointIO.Body(bodyType, codec, _)                    => setBody(value, bodyType, codec, req)
+      case ob: EndpointIO.OneOfBody[_, _] if ob.variants.nonEmpty =>
+        ob.headVariantBodyWithAppliedMapping match {
+          case Left(body)                                                                 => setInputParams(body, params, req)
+          case Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _))) =>
+            setStreamingBody(streams)(
+              codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[streams.BinaryStream],
+              req
+            )
+        }
+      case _: EndpointIO.OneOfBody[_, _]                                   => throw new RuntimeException("One of body without variants")
       case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)) =>
         setStreamingBody(streams)(value.asInstanceOf[streams.BinaryStream], req)
       case EndpointIO.Header(name, codec, _) =>

--- a/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
+++ b/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
@@ -119,13 +119,16 @@ private[play] class EndpointToPlayClient(clientOptions: PlayClientOptions, ws: S
       case EndpointIO.Body(bodyType, codec, _) =>
         val req2 = setBody(value, bodyType, codec, req)
         req2
-      case EndpointIO.OneOfBody(EndpointIO.OneOfBodyVariant(_, Left(body)) :: _, _) => setInputParams(body, params, req)
-      case EndpointIO.OneOfBody(
-            EndpointIO.OneOfBodyVariant(_, Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)))) :: _,
-            _
-          ) =>
-        setStreamingBody(streams)(value.asInstanceOf[streams.BinaryStream], req)
-      case EndpointIO.OneOfBody(Nil, _)                                    => throw new RuntimeException("One of body without variants")
+      case ob: EndpointIO.OneOfBody[_, _] if ob.variants.nonEmpty =>
+        ob.headVariantBodyWithAppliedMapping match {
+          case Left(body)                                                                 => setInputParams(body, params, req)
+          case Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _))) =>
+            setStreamingBody(streams)(
+              codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[streams.BinaryStream],
+              req
+            )
+        }
+      case _: EndpointIO.OneOfBody[_, _]                                   => throw new RuntimeException("One of body without variants")
       case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)) =>
         setStreamingBody(streams)(value.asInstanceOf[streams.BinaryStream], req)
       case EndpointIO.Header(name, codec, _) =>

--- a/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
+++ b/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
@@ -119,16 +119,16 @@ private[play] class EndpointToPlayClient(clientOptions: PlayClientOptions, ws: S
       case EndpointIO.Body(bodyType, codec, _) =>
         val req2 = setBody(value, bodyType, codec, req)
         req2
-      case ob: EndpointIO.OneOfBody[_, _] if ob.variants.nonEmpty =>
+      case ob: EndpointIO.OneOfBody[_, _] =>
         ob.headVariantBodyWithAppliedMapping match {
-          case Left(body)                                                                 => setInputParams(body, params, req)
-          case Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _))) =>
+          case Some(Left(body))                                                                 => setInputParams(body, params, req)
+          case Some(Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _)))) =>
             setStreamingBody(streams)(
               codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[streams.BinaryStream],
               req
             )
+          case None => throw new RuntimeException("One of body without variants")
         }
-      case _: EndpointIO.OneOfBody[_, _]                                   => throw new RuntimeException("One of body without variants")
       case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)) =>
         setStreamingBody(streams)(value.asInstanceOf[streams.BinaryStream], req)
       case EndpointIO.Header(name, codec, _) =>

--- a/client/play29-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
+++ b/client/play29-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
@@ -119,13 +119,16 @@ private[play] class EndpointToPlayClient(clientOptions: PlayClientOptions, ws: S
       case EndpointIO.Body(bodyType, codec, _) =>
         val req2 = setBody(value, bodyType, codec, req)
         req2
-      case EndpointIO.OneOfBody(EndpointIO.OneOfBodyVariant(_, Left(body)) :: _, _) => setInputParams(body, params, req)
-      case EndpointIO.OneOfBody(
-            EndpointIO.OneOfBodyVariant(_, Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)))) :: _,
-            _
-          ) =>
-        setStreamingBody(streams)(value.asInstanceOf[streams.BinaryStream], req)
-      case EndpointIO.OneOfBody(Nil, _)                                    => throw new RuntimeException("One of body without variants")
+      case ob: EndpointIO.OneOfBody[_, _] if ob.variants.nonEmpty =>
+        ob.headVariantBodyWithAppliedMapping match {
+          case Left(body)                                                                 => setInputParams(body, params, req)
+          case Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _))) =>
+            setStreamingBody(streams)(
+              codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[streams.BinaryStream],
+              req
+            )
+        }
+      case _: EndpointIO.OneOfBody[_, _]                                   => throw new RuntimeException("One of body without variants")
       case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)) =>
         setStreamingBody(streams)(value.asInstanceOf[streams.BinaryStream], req)
       case EndpointIO.Header(name, codec, _) =>

--- a/client/play29-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
+++ b/client/play29-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
@@ -119,16 +119,16 @@ private[play] class EndpointToPlayClient(clientOptions: PlayClientOptions, ws: S
       case EndpointIO.Body(bodyType, codec, _) =>
         val req2 = setBody(value, bodyType, codec, req)
         req2
-      case ob: EndpointIO.OneOfBody[_, _] if ob.variants.nonEmpty =>
+      case ob: EndpointIO.OneOfBody[_, _] =>
         ob.headVariantBodyWithAppliedMapping match {
-          case Left(body)                                                                 => setInputParams(body, params, req)
-          case Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _))) =>
+          case Some(Left(body))                                                                 => setInputParams(body, params, req)
+          case Some(Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _)))) =>
             setStreamingBody(streams)(
               codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[streams.BinaryStream],
               req
             )
+          case None => throw new RuntimeException("One of body without variants")
         }
-      case _: EndpointIO.OneOfBody[_, _]                                   => throw new RuntimeException("One of body without variants")
       case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)) =>
         setStreamingBody(streams)(value.asInstanceOf[streams.BinaryStream], req)
       case EndpointIO.Header(name, codec, _) =>

--- a/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
+++ b/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
@@ -95,14 +95,15 @@ private[sttp] class EndpointToSttpClient[R](clientOptions: SttpClientOptions, ws
       case EndpointIO.Body(bodyType, codec, _) =>
         val req2 = setBody(value, bodyType, codec, req)
         (uri, req2)
-      case EndpointIO.OneOfBody(EndpointIO.OneOfBodyVariant(_, Left(body)) :: _, _) => setInputParams(body, params, uri, req)
-      case EndpointIO.OneOfBody(
-            EndpointIO.OneOfBodyVariant(_, Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)))) :: _,
-            _
-          ) =>
-        val req2 = req.streamBody(streams)(value.asInstanceOf[streams.BinaryStream])
-        (uri, req2)
-      case EndpointIO.OneOfBody(Nil, _)                                    => throw new RuntimeException("One of body without variants")
+      case ob: EndpointIO.OneOfBody[_, _] if ob.variants.nonEmpty =>
+        ob.headVariantBodyWithAppliedMapping match {
+          case Left(body)                                                                 => setInputParams(body, params, uri, req)
+          case Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _))) =>
+            val req2 =
+              req.streamBody(streams)(codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[streams.BinaryStream])
+            (uri, req2)
+        }
+      case _: EndpointIO.OneOfBody[_, _]                                   => throw new RuntimeException("One of body without variants")
       case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)) =>
         val req2 = req.streamBody(streams)(value.asInstanceOf[streams.BinaryStream])
         (uri, req2)

--- a/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
+++ b/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
@@ -95,15 +95,15 @@ private[sttp] class EndpointToSttpClient[R](clientOptions: SttpClientOptions, ws
       case EndpointIO.Body(bodyType, codec, _) =>
         val req2 = setBody(value, bodyType, codec, req)
         (uri, req2)
-      case ob: EndpointIO.OneOfBody[_, _] if ob.variants.nonEmpty =>
+      case ob: EndpointIO.OneOfBody[_, _] =>
         ob.headVariantBodyWithAppliedMapping match {
-          case Left(body)                                                                 => setInputParams(body, params, uri, req)
-          case Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _))) =>
+          case Some(Left(body))                                                                 => setInputParams(body, params, uri, req)
+          case Some(Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _)))) =>
             val req2 =
               req.streamBody(streams)(codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[streams.BinaryStream])
             (uri, req2)
+          case None => throw new RuntimeException("One of body without variants")
         }
-      case _: EndpointIO.OneOfBody[_, _]                                   => throw new RuntimeException("One of body without variants")
       case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)) =>
         val req2 = req.streamBody(streams)(value.asInstanceOf[streams.BinaryStream])
         (uri, req2)

--- a/client/sttp-client4/src/main/scala/sttp/tapir/client/sttp4/EndpointToSttpClientBase.scala
+++ b/client/sttp-client4/src/main/scala/sttp/tapir/client/sttp4/EndpointToSttpClientBase.scala
@@ -112,14 +112,14 @@ private[sttp4] trait EndpointToSttpClientBase {
       case EndpointIO.Body(bodyType, codec, _) =>
         val req2 = setBody(value, bodyType, codec, req)
         (uri, req2, streamBody)
-      case ob: EndpointIO.OneOfBody[_, _] if ob.variants.nonEmpty =>
+      case ob: EndpointIO.OneOfBody[_, _] =>
         ob.headVariantBodyWithAppliedMapping match {
-          case Left(body)                                                           => setInputParams(body, params, uri, req, streamBody)
-          case Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(_, codec, _, _, _))) =>
+          case Some(Left(body)) => setInputParams(body, params, uri, req, streamBody)
+          case Some(Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(_, codec, _, _, _)))) =>
             val req2 = req.body(codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[InputStream])
             (uri, req2, streamBody)
+          case None => throw new RuntimeException("One of body without variants")
         }
-      case _: EndpointIO.OneOfBody[_, _]                                       => throw new RuntimeException("One of body without variants")
       case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _)) => (uri, req, Some((streams, codec.encode(value))))
       case EndpointIO.Header(name, codec, _)                                   =>
         val req2 = codec

--- a/client/sttp-client4/src/main/scala/sttp/tapir/client/sttp4/EndpointToSttpClientBase.scala
+++ b/client/sttp-client4/src/main/scala/sttp/tapir/client/sttp4/EndpointToSttpClientBase.scala
@@ -112,14 +112,14 @@ private[sttp4] trait EndpointToSttpClientBase {
       case EndpointIO.Body(bodyType, codec, _) =>
         val req2 = setBody(value, bodyType, codec, req)
         (uri, req2, streamBody)
-      case EndpointIO.OneOfBody(EndpointIO.OneOfBodyVariant(_, Left(body)) :: _, _) => setInputParams(body, params, uri, req, streamBody)
-      case EndpointIO.OneOfBody(
-            EndpointIO.OneOfBodyVariant(_, Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)))) :: _,
-            _
-          ) =>
-        val req2 = req.body(value.asInstanceOf[InputStream])
-        (uri, req2, streamBody)
-      case EndpointIO.OneOfBody(Nil, _)                                        => throw new RuntimeException("One of body without variants")
+      case ob: EndpointIO.OneOfBody[_, _] if ob.variants.nonEmpty =>
+        ob.headVariantBodyWithAppliedMapping match {
+          case Left(body)                                                           => setInputParams(body, params, uri, req, streamBody)
+          case Right(EndpointIO.StreamBodyWrapper(StreamBodyIO(_, codec, _, _, _))) =>
+            val req2 = req.body(codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[InputStream])
+            (uri, req2, streamBody)
+        }
+      case _: EndpointIO.OneOfBody[_, _]                                       => throw new RuntimeException("One of body without variants")
       case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _)) => (uri, req, Some((streams, codec.encode(value))))
       case EndpointIO.Header(name, codec, _)                                   =>
         val req2 = codec

--- a/client/tests/src/main/scala/sttp/tapir/client/tests/ClientBasicTests.scala
+++ b/client/tests/src/main/scala/sttp/tapir/client/tests/ClientBasicTests.scala
@@ -250,6 +250,13 @@ trait ClientBasicTests { this: ClientTests[Any] =>
     )
 
     testClient(
+      in_one_of_json_xml_text_mapped_out_string.in("api" / "echo"),
+      (),
+      FruitWrapper(Fruit("apple")),
+      Right("""{"f":"apple"}""")
+    )
+
+    testClient(
       in_string_out_one_of_json_xml_text.in(header(Header.accept(MediaType.ApplicationJson))).in("content-negotiation" / "fruit"),
       (),
       "apple",

--- a/client/tests/src/main/scala/sttp/tapir/client/tests/ClientBasicTests.scala
+++ b/client/tests/src/main/scala/sttp/tapir/client/tests/ClientBasicTests.scala
@@ -268,5 +268,12 @@ trait ClientBasicTests { this: ClientTests[Any] =>
       "apple",
       Right(Fruit("apple (xml)"))
     )
+
+    testClient(
+      in_string_out_one_of_json_xml_text_mapped.in(header(Header.accept(MediaType.ApplicationJson))).in("content-negotiation" / "fruit"),
+      (),
+      "apple",
+      Right(FruitWrapper(Fruit("apple (json)")))
+    )
   }
 }

--- a/core/src/main/scala/sttp/tapir/EndpointIO.scala
+++ b/core/src/main/scala/sttp/tapir/EndpointIO.scala
@@ -538,17 +538,23 @@ object EndpointIO {
 
     /** The body of the given variant, with this one-of-body's `mapping` composed into the variant's codec; interpreters should use the
       * returned body (not the variant's one directly), so that the mapping is applied when encoding/decoding values.
+      *
+      * For identity mappings, the variant's body is returned unchanged: this method is called per-request (server interpreters wrap every
+      * plain body input in a one-of body), so composing the mapping - which copies the body and its codec - must be skipped when it's a
+      * no-op.
       */
     private[tapir] def variantBodyWithAppliedMapping(
         variant: OneOfBodyVariant[O]
     ): Either[Body[?, T], StreamBodyWrapper[?, T]] =
-      variant.body match {
-        case Left(b)  => Left(b.map(mapping))
-        case Right(b) => Right(b.map(mapping))
-      }
+      if (mapping eq Mapping.id[Any]) variant.body.asInstanceOf[Either[Body[?, T], StreamBodyWrapper[?, T]]]
+      else
+        variant.body match {
+          case Left(b)  => Left(b.map(mapping))
+          case Right(b) => Right(b.map(mapping))
+        }
 
-    private[tapir] def headVariantBodyWithAppliedMapping: Either[Body[?, T], StreamBodyWrapper[?, T]] =
-      variantBodyWithAppliedMapping(variants.head)
+    private[tapir] def headVariantBodyWithAppliedMapping: Option[Either[Body[?, T], StreamBodyWrapper[?, T]]] =
+      variants.headOption.map(variantBodyWithAppliedMapping)
   }
 
   case class FixedHeader[T](h: sttp.model.Header, codec: Codec[Unit, T, TextPlain], info: Info[T]) extends Atom[T] {

--- a/core/src/main/scala/sttp/tapir/EndpointIO.scala
+++ b/core/src/main/scala/sttp/tapir/EndpointIO.scala
@@ -535,6 +535,20 @@ object EndpointIO {
     override def showDetail: String = show(_.showDetail)
 
     override def map[U](m: Mapping[T, U]): OneOfBody[O, U] = copy[O, U](mapping = mapping.map(m))
+
+    /** The body of the given variant, with this one-of-body's `mapping` composed into the variant's codec; interpreters should use the
+      * returned body (not the variant's one directly), so that the mapping is applied when encoding/decoding values.
+      */
+    private[tapir] def variantBodyWithAppliedMapping(
+        variant: OneOfBodyVariant[O]
+    ): Either[Body[?, T], StreamBodyWrapper[?, T]] =
+      variant.body match {
+        case Left(b)  => Left(b.map(mapping))
+        case Right(b) => Right(b.map(mapping))
+      }
+
+    private[tapir] def headVariantBodyWithAppliedMapping: Either[Body[?, T], StreamBodyWrapper[?, T]] =
+      variantBodyWithAppliedMapping(variants.head)
   }
 
   case class FixedHeader[T](h: sttp.model.Header, codec: Codec[Unit, T, TextPlain], info: Info[T]) extends Atom[T] {

--- a/core/src/main/scala/sttp/tapir/Mapping.scala
+++ b/core/src/main/scala/sttp/tapir/Mapping.scala
@@ -47,12 +47,14 @@ trait Mapping[L, H] { outer =>
 }
 
 object Mapping {
-  def id[L]: Mapping[L, L] =
-    new Mapping[L, L] {
-      override def rawDecode(l: L): DecodeResult[L] = DecodeResult.Value(l)
-      override def encode(h: L): L = h
-      override def validator: Validator[L] = Validator.pass
+  // a singleton, so that identity mappings can be detected (`eq`) and skipped by interpreters on per-request hot paths
+  private val idMapping: Mapping[Any, Any] =
+    new Mapping[Any, Any] {
+      override def rawDecode(l: Any): DecodeResult[Any] = DecodeResult.Value(l)
+      override def encode(h: Any): Any = h
+      override def validator: Validator[Any] = Validator.pass
     }
+  def id[L]: Mapping[L, L] = idMapping.asInstanceOf[Mapping[L, L]]
   def from[L, H](f: L => H)(g: H => L): Mapping[L, H] = fromDecode(f.andThen(Value(_)))(g)
   def fromDecode[L, H](f: L => DecodeResult[H])(g: H => L): Mapping[L, H] =
     new Mapping[L, H] {

--- a/core/src/main/scala/sttp/tapir/internal/package.scala
+++ b/core/src/main/scala/sttp/tapir/internal/package.scala
@@ -216,12 +216,12 @@ package object internal {
   }
 
   implicit class RichOneOfBody[O, T](body: EndpointIO.OneOfBody[O, T]) {
-    def chooseBodyToDecode(contentType: Option[MediaType]): Option[Either[EndpointIO.Body[?, O], EndpointIO.StreamBodyWrapper[?, O]]] = {
+    def chooseBodyToDecode(contentType: Option[MediaType]): Option[Either[EndpointIO.Body[?, T], EndpointIO.StreamBodyWrapper[?, T]]] = {
       contentType match {
         case Some(ct) => body.variants.find { case EndpointIO.OneOfBodyVariant(range, _) => ct.matches(range) }
         case None     => Some(body.variants.head)
       }
-    }.map(_.body)
+    }.map(body.variantBodyWithAppliedMapping)
   }
 
   private[tapir] implicit class RichStreamBody[BS, T](body: EndpointIO.StreamBodyWrapper[BS, T]) {

--- a/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/SttpStubServerTest.scala
+++ b/server/sttp-stub-server/src/test/scala/sttp/tapir/server/stub/SttpStubServerTest.scala
@@ -139,6 +139,30 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
     response2.code shouldBe StatusCode.InternalServerError
   }
 
+  it should "apply the mapping of a one-of body input when encoding the request and decoding it in the stub" in {
+    // given
+    val endpoint = sttp.tapir.endpoint.post
+      .in("api" / "mapped")
+      .in(oneOfBody(stringBody).map(Wrapped(_))(_.v))
+      .out(stringBody)
+
+    val backend: SttpBackendStub[Identity, Any] = SttpBackendStub
+      .apply(idMonad)
+      .whenInputMatches(endpoint) { body => body == Wrapped("hello") }
+      .thenSuccess("ok")
+      .whenAnyRequest
+      .thenRespondServerError()
+
+    // when: the client interpreter encodes the request (mapping is applied), the stub decodes it back
+    val response = SttpClientInterpreter()
+      .toRequestThrowDecodeFailures(endpoint, Some(uri"http://test.com"))
+      .apply(Wrapped("hello"))
+      .send(backend)
+
+    // then
+    response.body shouldBe Right("ok")
+  }
+
   it should "match with decode failure" in {
     // given
     val endpoint = sttp.tapir.endpoint
@@ -210,3 +234,5 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
 }
 
 final case class ResponseWrapper(response: Double)
+
+final case class Wrapped(v: String)

--- a/server/sttp-stub4-server/src/test/scala/sttp/tapir/server/stub4/SttpStubServerTest.scala
+++ b/server/sttp-stub4-server/src/test/scala/sttp/tapir/server/stub4/SttpStubServerTest.scala
@@ -133,6 +133,29 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
     response2.code shouldBe StatusCode.InternalServerError
   }
 
+  it should "apply the mapping of a one-of body input when encoding the request and decoding it in the stub" in {
+    // given
+    val endpoint = sttp.tapir.endpoint.post
+      .in("api" / "mapped")
+      .in(oneOfBody(stringBody).map(Wrapped(_))(_.v))
+      .out(stringBody)
+
+    val backend: SyncBackendStub = BackendStub.synchronous
+      .whenInputMatches(endpoint) { body => body == Wrapped("hello") }
+      .thenSuccess("ok")
+      .whenAnyRequest
+      .thenRespondServerError()
+
+    // when: the client interpreter encodes the request (mapping is applied), the stub decodes it back
+    val response = SttpClientInterpreter()
+      .toRequestThrowDecodeFailures(endpoint, Some(uri"http://test.com"))
+      .apply(Wrapped("hello"))
+      .send(backend)
+
+    // then
+    response.body shouldBe Right("ok")
+  }
+
   it should "match with decode failure" in {
     // given
     val endpoint = sttp.tapir.endpoint
@@ -207,3 +230,5 @@ class SttpStubServerTest extends AnyFlatSpec with Matchers {
 }
 
 final case class ResponseWrapper(response: Double)
+
+final case class Wrapped(v: String)

--- a/server/sttp-stub4-server/src/test/scala/sttp/tapir/server/stub4/TapirStubInterpreterTest.scala
+++ b/server/sttp-stub4-server/src/test/scala/sttp/tapir/server/stub4/TapirStubInterpreterTest.scala
@@ -212,6 +212,26 @@ class TapirStubInterpreterTest extends AnyFlatSpec with Matchers {
     response.code shouldBe StatusCode.InternalServerError
   }
 
+  it should "apply the mapping of a one-of body input when running server logic" in {
+    // given
+    case class Wrapped(v: String)
+    val se = endpoint.post
+      .in("test")
+      .in(oneOfBody(stringBody).map(Wrapped(_))(_.v))
+      .out(stringBody)
+      .serverLogicSuccess[Identity](w => s"ok: ${w.v}")
+    val server = TapirSyncStubInterpreter()
+      .whenServerEndpoint(se)
+      .thenRunLogic()
+      .backend()
+
+    // when
+    val response = basicRequest.post(uri"http://test.com/test").body("hello").send(server)
+
+    // then
+    response.body shouldBe Right("ok: hello")
+  }
+
   it should "handle multipart body" in {
     // given
     val e =

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerOneOfBodyTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerOneOfBodyTests.scala
@@ -9,8 +9,10 @@ import sttp.model.StatusCode
 import sttp.monad.MonadError
 import sttp.tapir.tests.OneOfBody.{
   in_one_of_json_text_range_out_string,
+  in_one_of_json_xml_text_mapped_out_string,
   in_one_of_json_xml_text_out_string,
-  in_string_out_one_of_json_xml_text
+  in_string_out_one_of_json_xml_text,
+  FruitWrapper
 }
 import sttp.tapir.tests._
 import sttp.tapir.tests.data.Fruit
@@ -29,6 +31,13 @@ class ServerOneOfBodyTests[F[_], OPTIONS, ROUTE](
         post.body("<f>orange</f>").contentType(ApplicationXml).send(backend).map(_.body shouldBe "orange") >>
         post.body("pear").contentType(TextPlain).send(backend).map(_.body shouldBe "pear") >>
         post.body("!*@#").contentType(ApplicationPdf).send(backend).map(_.code shouldBe StatusCode.UnsupportedMediaType)
+    },
+    testServer(in_one_of_json_xml_text_mapped_out_string)((fruit: FruitWrapper) => pureResult(fruit.fruit.f.asRight[Unit])) {
+      (backend, baseUri) =>
+        val post = basicRequest.post(uri"$baseUri").response(asStringAlways)
+        post.body("""{"f":"apple"}""").contentType(ApplicationJson).send(backend).map(_.body shouldBe "apple") >>
+          post.body("<f>orange</f>").contentType(ApplicationXml).send(backend).map(_.body shouldBe "orange") >>
+          post.body("pear").contentType(TextPlain).send(backend).map(_.body shouldBe "pear")
     },
     testServer(in_one_of_json_text_range_out_string)((fruit: Fruit) => pureResult(fruit.f.asRight[Unit])) { (backend, baseUri) =>
       val post = basicRequest.post(uri"$baseUri").response(asStringAlways)

--- a/server/tests/src/main/scala/sttp/tapir/server/tests/ServerOneOfBodyTests.scala
+++ b/server/tests/src/main/scala/sttp/tapir/server/tests/ServerOneOfBodyTests.scala
@@ -12,6 +12,7 @@ import sttp.tapir.tests.OneOfBody.{
   in_one_of_json_xml_text_mapped_out_string,
   in_one_of_json_xml_text_out_string,
   in_string_out_one_of_json_xml_text,
+  in_string_out_one_of_json_xml_text_mapped,
   FruitWrapper
 }
 import sttp.tapir.tests._
@@ -45,6 +46,12 @@ class ServerOneOfBodyTests[F[_], OPTIONS, ROUTE](
         post.body("<f>orange</f>").contentType(TextHtml).send(backend).map(_.body shouldBe "<f>orange</f>") >>
         post.body("pear").contentType(TextPlain).send(backend).map(_.body shouldBe "pear") >>
         post.body("!*@#").contentType(ApplicationPdf).send(backend).map(_.code shouldBe StatusCode.UnsupportedMediaType)
+    },
+    testServer(in_string_out_one_of_json_xml_text_mapped)((fruit: String) => pureResult(FruitWrapper(Fruit(fruit)).asRight[Unit])) {
+      (backend, baseUri) =>
+        val post = basicRequest.post(uri"$baseUri").response(asStringAlways)
+        post.body("apple").header(Accept, ApplicationJson.toString()).send(backend).map(_.body shouldBe """{"f":"apple"}""") >>
+          post.body("pear").header(Accept, TextPlain.toString()).send(backend).map(_.body shouldBe "pear")
     },
     testServer(in_string_out_one_of_json_xml_text)((fruit: String) => pureResult(Fruit(fruit).asRight[Unit])) { (backend, baseUri) =>
       val post = basicRequest.post(uri"$baseUri").response(asStringAlways)

--- a/tests/src/main/scala/sttp/tapir/tests/OneOfBody.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/OneOfBody.scala
@@ -66,4 +66,15 @@ object OneOfBody {
         stringBody.map(Fruit(_))(_.f)
       )
     )
+
+  val in_string_out_one_of_json_xml_text_mapped: PublicEndpoint[String, Unit, FruitWrapper, Any] = endpoint.post
+    .in(stringBody)
+    .out(
+      oneOfBody(
+        jsonBody[Fruit],
+        xmlBody[Fruit],
+        stringBody.map(Fruit(_))(_.f)
+      ).map(FruitWrapper(_))(_.fruit)
+    )
+    .name("mapped one of body output")
 }

--- a/tests/src/main/scala/sttp/tapir/tests/OneOfBody.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/OneOfBody.scala
@@ -44,6 +44,19 @@ object OneOfBody {
     )
     .out(stringBody)
 
+  case class FruitWrapper(fruit: Fruit)
+
+  val in_one_of_json_xml_text_mapped_out_string: PublicEndpoint[FruitWrapper, Unit, String, Any] = endpoint.post
+    .in(
+      oneOfBody(
+        jsonBody[Fruit],
+        xmlBody[Fruit],
+        stringBody.map(Fruit(_))(_.f)
+      ).map(FruitWrapper(_))(_.fruit)
+    )
+    .out(stringBody)
+    .name("mapped one of body")
+
   val in_string_out_one_of_json_xml_text: PublicEndpoint[String, Unit, Fruit, Any] = endpoint.post
     .in(stringBody)
     .out(


### PR DESCRIPTION
Fixes #5425.

## Problem

`EndpointIO.OneOfBody[O, T]` carries a `mapping: Mapping[O, T]` (composed via `.map` on a `oneOfBody(...)`). The mapping was only applied on the output side (server response encode in `EncodeOutputs`, client response decode in `ClientOutputParams`). On the input side it was silently dropped:

- **server request decode**: the shared `ServerInterpreter` (and both sttp stub-server decoders) decoded the request body with only the chosen variant's codec, so server logic received `O` instead of `T` — typically a `ClassCastException` → HTTP 500;
- **client request encode**: all five client interpreters delegated directly to the head variant, feeding the unmapped `T` value to the variant's codec — `ClassCastException` when building the request.

Additionally, `ClientOutputParams` decoded mapped one-of *outputs* in the wrong order (mapping before variant codec) — harmless for identity mappings, wrong for anything else.

## Fix

- `OneOfBody` gained `private[tapir] variantBodyWithAppliedMapping` / `headVariantBodyWithAppliedMapping`, returning the variant's body with the one-of mapping composed into its codec (via `Atom.map`). For identity mappings the variant's body is returned unchanged — this method sits on the per-request hot path (`DecodeBasicInputs.addBodyInput` wraps every plain body input in a synthetic `oneOfBody`), so the no-op case must not copy the body/codec, and decode failures for unmapped bodies keep reporting the original input instance.
- `Mapping.id` is now a singleton so that identity mappings are detectable (`eq`).
- `RichOneOfBody.chooseBodyToDecode` returns the mapped body — fixing `ServerInterpreter` and both stub decoders with no changes to those files.
- The five client interpreters (sttp-client, sttp-client4, http4s, play, play29) use `headVariantBodyWithAppliedMapping`; the stream-variant branches now encode through the (mapped) codec instead of casting the raw value.
- `ClientOutputParams` decodes variant codec first, then the mapping.

## Tests

- New shared endpoints in `tests/OneOfBody.scala`: a mapped one-of **input** (`in_one_of_json_xml_text_mapped_out_string`) and a mapped one-of **output** (`in_string_out_one_of_json_xml_text_mapped`), wired into `ServerOneOfBodyTests` (all server backends) and `ClientBasicTests` (all client interpreters). All new tests were verified to fail before the fix (the output-decode test was checked against the old decode order specifically).
- Stub-server regression tests in both sttp-stub modules: server-logic run through `ServerInterpreter` and a client-interpreter → stub round trip through `SttpRequestDecoder`.

Verified locally: stub suites (Scala 2.13 + 3), sttp-client3/4, http4s-client (2.13 + 3), play/play29 client suites against the test server, jdkhttp server one-of tests, cross-compilation for 2.12/2.13/3 + JS core, `core/mimaReportBinaryIssues`, scalafmt.

Note: a pre-existing inconsistency remains out of scope — the plain (non-one-of) `StreamBodyWrapper` client branches still cast the raw value without applying the codec (same family as this bug, but untouched here to keep the change focused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)