### PR TITLE
Apply the codec when encoding a stream body in a client request

### DIFF
--- a/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
+++ b/client/http4s-client/src/main/scala/sttp/tapir/client/http4s/EndpointToHttp4sClient.scala
@@ -112,8 +112,8 @@ private[http4s] class EndpointToHttp4sClient(clientOptions: Http4sClientOptions)
             )
           case None => throw new RuntimeException("One of body without variants")
         }
-      case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)) =>
-        setStreamingBody(streams)(value.asInstanceOf[streams.BinaryStream], req)
+      case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _)) =>
+        setStreamingBody(streams)(codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[streams.BinaryStream], req)
       case EndpointIO.Header(name, codec, _) =>
         val headers = codec.encode(value).map(value => Header.Raw(CIString(name), value): Header.ToRaw)
         req.putHeaders(headers: _*)

--- a/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
+++ b/client/play-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
@@ -129,8 +129,8 @@ private[play] class EndpointToPlayClient(clientOptions: PlayClientOptions, ws: S
             )
           case None => throw new RuntimeException("One of body without variants")
         }
-      case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)) =>
-        setStreamingBody(streams)(value.asInstanceOf[streams.BinaryStream], req)
+      case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _)) =>
+        setStreamingBody(streams)(codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[streams.BinaryStream], req)
       case EndpointIO.Header(name, codec, _) =>
         val req2 = codec
           .encode(value)

--- a/client/play29-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
+++ b/client/play29-client/src/main/scala/sttp/tapir/client/play/EndpointToPlayClient.scala
@@ -129,8 +129,8 @@ private[play] class EndpointToPlayClient(clientOptions: PlayClientOptions, ws: S
             )
           case None => throw new RuntimeException("One of body without variants")
         }
-      case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)) =>
-        setStreamingBody(streams)(value.asInstanceOf[streams.BinaryStream], req)
+      case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _)) =>
+        setStreamingBody(streams)(codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[streams.BinaryStream], req)
       case EndpointIO.Header(name, codec, _) =>
         val req2 = codec
           .encode(value)

--- a/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
+++ b/client/sttp-client/src/main/scala/sttp/tapir/client/sttp/EndpointToSttpClient.scala
@@ -104,8 +104,9 @@ private[sttp] class EndpointToSttpClient[R](clientOptions: SttpClientOptions, ws
             (uri, req2)
           case None => throw new RuntimeException("One of body without variants")
         }
-      case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, _, _, _, _)) =>
-        val req2 = req.streamBody(streams)(value.asInstanceOf[streams.BinaryStream])
+      case EndpointIO.StreamBodyWrapper(StreamBodyIO(streams, codec, _, _, _)) =>
+        val req2 =
+          req.streamBody(streams)(codec.asInstanceOf[Codec[Any, Any, CodecFormat]].encode(value).asInstanceOf[streams.BinaryStream])
         (uri, req2)
       case EndpointIO.Header(name, codec, _) =>
         val req2 = codec

--- a/client/tests/src/main/scala/sttp/tapir/client/tests/ClientStreamingTests.scala
+++ b/client/tests/src/main/scala/sttp/tapir/client/tests/ClientStreamingTests.scala
@@ -1,6 +1,8 @@
 package sttp.tapir.client.tests
 
 import sttp.capabilities.Streams
+import sttp.tapir.tests.Streaming.StreamWrapper
+import sttp.tapir.tests.Streaming.in_stream_mapped_out_string
 import sttp.tapir.tests.Streaming.in_stream_out_stream
 import sttp.tapir.tests.Streaming.in_stream_out_string
 import sttp.tapir.tests.Streaming.in_string_stream_out_either_stream_string
@@ -23,6 +25,12 @@ trait ClientStreamingTests[S] { this: ClientTests[S] =>
 
     test(in_stream_out_string(streams).showDetail) {
       send(in_stream_out_string(streams), port, (), mkStream("mango cranberry"))
+        .map(_.toOption.get)
+        .map(_ shouldBe "mango cranberry")
+    }
+
+    test(in_stream_mapped_out_string(streams).showDetail) {
+      send(in_stream_mapped_out_string(streams), port, (), StreamWrapper(mkStream("mango cranberry")))
         .map(_.toOption.get)
         .map(_ shouldBe "mango cranberry")
     }

--- a/tests/src/main/scala/sttp/tapir/tests/Streaming.scala
+++ b/tests/src/main/scala/sttp/tapir/tests/Streaming.scala
@@ -7,6 +7,16 @@ import sttp.tapir._
 import java.nio.charset.StandardCharsets
 
 object Streaming {
+  case class StreamWrapper[BS](stream: BS)
+
+  def in_stream_mapped_out_string[S](s: Streams[S]): PublicEndpoint[StreamWrapper[s.BinaryStream], Unit, String, S] = {
+    endpoint.post
+      .in("api" / "echo")
+      .in(streamTextBody(s)(CodecFormat.TextPlain(), Some(StandardCharsets.UTF_8)).map(StreamWrapper(_))(_.stream))
+      .out(stringBody)
+      .name("mapped stream body")
+  }
+
   def in_stream_out_stream[S](s: Streams[S]): PublicEndpoint[s.BinaryStream, Unit, s.BinaryStream, S] = {
     val sb = streamTextBody(s)(CodecFormat.TextPlain(), Some(StandardCharsets.UTF_8))
     endpoint.post.in("api" / "echo").in(sb).out(sb)


### PR DESCRIPTION
Follow-up to #5427 (same bug family, spotted during its review).

## Problem

The sttp-client3, http4s, and Play (play + play29) client interpreters cast the input value directly to the backend's stream type when setting a plain (non-`oneOfBody`) streaming request body — ignoring the stream body's codec. For stream bodies with a non-identity codec, e.g. `streamTextBody(...).map(...)`, this caused a `ClassCastException` when building the request:

```
java.lang.ClassCastException: class StreamWrapper cannot be cast to class fs2.Stream
```

The sttp-client4 interpreter already encoded through the codec, as do the server interpreters (stream input decode, stream output encode) and the client-side response decoding — client request encode was the one asymmetric leg of the round trip.

## Fix

The plain `StreamBodyWrapper` branch in the four client interpreters now encodes through the body's codec before casting to the backend stream type, using the same idiom as the adjacent `oneOfBody` stream-variant branches from #5427. For the common identity codecs (`streamTextBody` & co. without `.map`) `encode` is the identity, so existing endpoints are unaffected.

## Tests

New shared endpoint `in_stream_mapped_out_string` (a `streamTextBody(...).map(StreamWrapper(_))(_.stream)` input) in `tests/Streaming.scala`, exercised from `ClientStreamingTests` — so it runs in all seven client streaming suites (sttp3 fs2 + zio, sttp4 fs2 + zio, http4s, play, play29). Verified failing before the fix on http4s, sttp3 (both variants), and play with the exact `ClassCastException`s above, and passing on sttp-client4 (which was never affected).

Verified locally: full client suites green — sttp3 (163), sttp4 (158), http4s (69, + 69 on Scala 3), play/play29 (68 each) — plus cross-compilation on Scala 2.12/2.13/3 including the JS tests module.

## Noted for possible follow-up (pre-existing, untouched here)

- `sttp4 ws/WebSocketEndpointToSttpClient.scala` silently discards a streaming request body on WS endpoints (`val (reqWithInput, _) = ...`).
- `sttp4 EndpointToSttpClientBase` one-of stream-variant branch casts the encoded value to `InputStream` unconditionally, which would CCE for genuine fs2/pekko streams via the streaming client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)