### PR TITLE
Support nesting zio-http routes under a prefix

### DIFF
--- a/doc/server/ziohttp.md
+++ b/doc/server/ziohttp.md
@@ -64,6 +64,13 @@ overlap. The shape of the path includes exact path segments, single- and multi-w
 Such overlapping routes may cause incorrect 404 (Not Found) or 405 (Method Not Allowed) responses.
 ```
 
+```{note}
+Middleware which changes the number of path segments in a request, such as `HandlerAspect.updatePath`, should not be
+applied to Tapir-generated routes. Tapir matches the path against the endpoint definitions itself, using the path
+that ZIO Http matched when routing. If that path is changed afterwards, requests will either not match any endpoint,
+or fail with a 500 (Internal Server Error).
+```
+
 ## Server logic
 
 When defining the business logic for an endpoint, the following methods are available, which replace the

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
@@ -31,7 +31,11 @@ trait ZioHttpInterpreter[R] {
     val zioHttpResponseBody = new ZioHttpToResponseBody(zioHttpServerOptions.inputStreamChunkSize)
     val interceptors = RejectInterceptor.disableWhenSingleEndpoint(widenedServerOptions.interceptors, widenedSes)
 
-    def handleRequest(req: Request, filteredEndpoints: List[ZServerEndpoint[R & R2, ZioStreams with WebSockets]]) =
+    def handleRequest(
+        req: Request,
+        filteredEndpoints: List[ZServerEndpoint[R & R2, ZioStreams with WebSockets]],
+        contextPathSegments: Int
+    ) =
       Handler.fromZIO {
         val interpreter = new ServerInterpreter[ZioStreams with WebSockets, RIO[R & R2, *], ZioResponseBody, ZioStreams](
           _ => filteredEndpoints,
@@ -40,7 +44,9 @@ trait ZioHttpInterpreter[R] {
           interceptors,
           zioHttpServerOptions.deleteFile
         )
-        val serverRequest = ZioHttpServerRequest(req)
+        val serverRequest =
+          if (contextPathSegments > 0) ZioHttpServerRequest(req).contextPathSegments(contextPathSegments)
+          else ZioHttpServerRequest(req)
 
         interpreter
           .apply(serverRequest)
@@ -65,11 +71,21 @@ trait ZioHttpInterpreter[R] {
           )
       }
 
+    /** A zio-http route pattern, together with a description of what it consumes. `fixedSegments` is the number of path segments matched by
+      * the pattern (not counting the optional trailing wildcard). Both are needed to compute how many leading path segments come from
+      * zio-http route nesting (`Routes.nest`), which prepends segments to the pattern, but leaves the request untouched.
+      */
+    case class PatternWithShape(
+        pattern: RoutePattern[Any], // the Any here is a way to work around the type checker
+        fixedSegments: Int,
+        hasTrailing: Boolean
+    )
+
     // here we'll keep the endpoint together with the meta-data needed to create the zio-http routing information
     case class ServerEndpointWithPattern(
         index: Int,
         pathTemplate: Vector[String],
-        routePattern: RoutePattern[Any], // the Any here is a way to work around the type checker
+        routePattern: PatternWithShape,
         endpoint: ZServerEndpoint[R & R2, ZioStreams with WebSockets]
     )
 
@@ -101,25 +117,27 @@ trait ZioHttpInterpreter[R] {
         case _                                                                                                 => false
       }
 
-      val routePattern: RoutePattern[Any] = if (hasPath) {
+      val routePattern: PatternWithShape = if (hasPath) {
         val initialPattern = RoutePattern(Method.ANY, PathCodec.empty).asInstanceOf[RoutePattern[Any]]
         // The second tuple parameter specifies if PathCodec.trailing should be added to the route's pattern. It can
-        // be added either because of a PathsCapture, or because of an noTrailingSlash input.
-        val (p, addTrailing) = inputs
-          .foldLeft((initialPattern, hasNoTrailingSlash)) { case ((p, addTrailing), component) =>
+        // be added either because of a PathsCapture, or because of an noTrailingSlash input. The third one counts the
+        // segments matched by the pattern.
+        val (p, addTrailing, fixedSegments) = inputs
+          .foldLeft((initialPattern, hasNoTrailingSlash, 0)) { case ((p, addTrailing, fixedSegments), component) =>
             component match {
               case i: EndpointInput.PathCapture[_] =>
-                ((p / PathCodec.string(i.name.getOrElse("?"))).asInstanceOf[RoutePattern[Any]], addTrailing)
-              case _: EndpointInput.PathsCapture[_] => (p, true)
-              case i: EndpointInput.FixedPath[_]    => (p / PathCodec.literal(i.s), addTrailing)
-              case _                                => (p, addTrailing)
+                ((p / PathCodec.string(i.name.getOrElse("?"))).asInstanceOf[RoutePattern[Any]], addTrailing, fixedSegments + 1)
+              case _: EndpointInput.PathsCapture[_] => (p, true, fixedSegments)
+              case i: EndpointInput.FixedPath[_]    => (p / PathCodec.literal(i.s), addTrailing, fixedSegments + 1)
+              case _                                => (p, addTrailing, fixedSegments)
             }
           }
 
-        if (addTrailing) (p / PathCodec.trailing).asInstanceOf[RoutePattern[Any]] else p
+        if (addTrailing) PatternWithShape((p / PathCodec.trailing).asInstanceOf[RoutePattern[Any]], fixedSegments, hasTrailing = true)
+        else PatternWithShape(p, fixedSegments, hasTrailing = false)
       } else {
         // if there are no path inputs, we return a catch-all
-        RoutePattern(Method.ANY, PathCodec.trailing).asInstanceOf[RoutePattern[Any]]
+        PatternWithShape(RoutePattern(Method.ANY, PathCodec.trailing).asInstanceOf[RoutePattern[Any]], 0, hasTrailing = true)
       }
 
       ServerEndpointWithPattern(index, pathTemplate, routePattern, se)
@@ -144,9 +162,9 @@ trait ZioHttpInterpreter[R] {
       */
     def generaliseTemplates(endpoints: List[ServerEndpointWithPattern]): List[ServerEndpointWithPattern] = {
       // de-duplicating the path templates
-      val allTemplates: List[(Vector[String], RoutePattern[Any])] = endpoints.map(se => (se.pathTemplate, se.routePattern)).toMap.toList
+      val allTemplates: List[(Vector[String], PatternWithShape)] = endpoints.map(se => (se.pathTemplate, se.routePattern)).toMap.toList
       endpoints.map { se =>
-        val mostGeneral: (Vector[String], RoutePattern[Any]) =
+        val mostGeneral: (Vector[String], PatternWithShape) =
           allTemplates.foldLeft((se.pathTemplate, se.routePattern)) {
             case ((mostGeneralTemplate, mostGeneralPattern), (template, pattern)) =>
               if (template != mostGeneralTemplate && isAtLeastAsGeneralAs(template, mostGeneralTemplate)) {
@@ -178,13 +196,44 @@ trait ZioHttpInterpreter[R] {
         .sortBy(_.map(_.index).min)
 
     val handlers: List[Route[R & R2, Response]] = widenedSesGroupedByPathTemplate.map { sesWithPattern =>
-      val pattern = sesWithPattern.head.routePattern
-      val endpoints = sesWithPattern.sortBy(_.index).map(_.endpoint)
       // The pattern that we generate should be the same for all endpoints in a group
-      Route.handledIgnoreParams(pattern)(Handler.fromFunctionHandler { (request: Request) => handleRequest(request, endpoints) })
+      val PatternWithShape(pattern, fixedSegments, hasTrailing) = sesWithPattern.head.routePattern
+      val endpoints = sesWithPattern.sortBy(_.index).map(_.endpoint)
+
+      // The routes might be nested under a prefix by the user (`Routes.nest`, `PathCodec./`), which prepends segments
+      // to the pattern, but leaves the request as-is. Those segments are not part of the paths described by the
+      // endpoints, so they have to be skipped when matching. Their number can only be computed per-request, as the
+      // pattern that the route ends up being registered under is not known when the route is created.
+      if (hasTrailing) {
+        // The trailing wildcard consumes everything after the prefix and the fixed segments, so its length (which is
+        // available among the decoded path parameters) is needed to compute the length of the prefix.
+        Route.handled[Any, R & R2](pattern)(Handler.fromFunctionHandler { (in: (Any, Request)) =>
+          val (params, request) = in
+          val contextPathSegments = pathSegmentCount(request) - fixedSegments - trailingSegmentCount(params)
+          handleRequest(request, endpoints, contextPathSegments)
+        })
+      } else
+        Route.handledIgnoreParams(pattern)(Handler.fromFunctionHandler { (request: Request) =>
+          handleRequest(request, endpoints, pathSegmentCount(request) - fixedSegments)
+        })
     }
 
     Routes(Chunk.fromIterable(handlers))
+  }
+
+  /** The number of path segments of the request, counted the same way as zio-http's route patterns match them. */
+  private def pathSegmentCount(request: Request): Int = request.url.path.segments.count(_.nonEmpty)
+
+  /** Extracts the value captured by the `PathCodec.trailing` which ends the route's pattern. It is the last of the values decoded from the
+    * path (or the only one, if the pattern captures nothing else).
+    */
+  private def trailingSegmentCount(params: Any): Int = {
+    val trailing = params match {
+      case p: Path    => p // the trailing wildcard is the only value captured by the pattern
+      case p: Product => p.productElement(p.productArity - 1).asInstanceOf[Path]
+      case _          => Path.empty // can't happen: the pattern always captures at least the trailing wildcard
+    }
+    trailing.segments.count(_.nonEmpty)
   }
 
   private def handleWebSocketResponse(

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpInterpreter.scala
@@ -12,7 +12,7 @@ import sttp.tapir.server.interpreter.ServerInterpreter
 import sttp.tapir.server.model.ServerResponse
 import sttp.tapir.ztapir._
 import zio._
-import zio.http.codec.PathCodec
+import zio.http.codec.{PathCodec, SegmentCodec}
 import zio.http.{Header => ZioHttpHeader, Headers => ZioHttpHeaders, _}
 import scala.util.chaining._
 
@@ -44,9 +44,7 @@ trait ZioHttpInterpreter[R] {
           interceptors,
           zioHttpServerOptions.deleteFile
         )
-        val serverRequest =
-          if (contextPathSegments > 0) ZioHttpServerRequest(req).contextPathSegments(contextPathSegments)
-          else ZioHttpServerRequest(req)
+        val serverRequest = ZioHttpServerRequest(req).contextPathSegments(contextPathSegments)
 
         interpreter
           .apply(serverRequest)
@@ -71,15 +69,28 @@ trait ZioHttpInterpreter[R] {
           )
       }
 
-    /** A zio-http route pattern, together with a description of what it consumes. `fixedSegments` is the number of path segments matched by
-      * the pattern (not counting the optional trailing wildcard). Both are needed to compute how many leading path segments come from
-      * zio-http route nesting (`Routes.nest`), which prepends segments to the pattern, but leaves the request untouched.
+    /** A zio-http route pattern, together with the number of path segments it matches (`fixedSegments`, not counting the wildcard). The
+      * count is needed to compute how many leading path segments come from zio-http route nesting (`Routes.nest`), which prepends segments
+      * to the pattern, but leaves the request untouched.
       */
-    case class PatternWithShape(
-        pattern: RoutePattern[Any], // the Any here is a way to work around the type checker
-        fixedSegments: Int,
-        hasTrailing: Boolean
-    )
+    sealed trait PatternWithShape { def fixedSegments: Int }
+    object PatternWithShape {
+
+      /** A pattern which ends with a wildcard, capturing whatever follows the fixed segments. */
+      case class Wildcard(pattern: RoutePattern[Any], fixedSegments: Int) extends PatternWithShape
+
+      /** A pattern which matches exactly `fixedSegments` segments. */
+      case class Exact(pattern: RoutePattern[Any], fixedSegments: Int) extends PatternWithShape
+    }
+
+    /** The number of path segments matched by the pattern; the wildcard, which matches any number of them, is not counted. */
+    def fixedSegmentsOf(p: RoutePattern[_]): Int =
+      p.pathCodec.segments.count(s => s.nonEmpty && s != SegmentCodec.Trailing)
+
+    def endWithWildcard(p: RoutePattern[Any]): PatternWithShape.Wildcard = {
+      val withWildcard = (p / PathCodec.trailing).asInstanceOf[RoutePattern[Any]]
+      PatternWithShape.Wildcard(withWildcard, fixedSegmentsOf(withWildcard))
+    }
 
     // here we'll keep the endpoint together with the meta-data needed to create the zio-http routing information
     case class ServerEndpointWithPattern(
@@ -117,27 +128,26 @@ trait ZioHttpInterpreter[R] {
         case _                                                                                                 => false
       }
 
+      val emptyPattern = RoutePattern(Method.ANY, PathCodec.empty).asInstanceOf[RoutePattern[Any]]
+
       val routePattern: PatternWithShape = if (hasPath) {
-        val initialPattern = RoutePattern(Method.ANY, PathCodec.empty).asInstanceOf[RoutePattern[Any]]
-        // The second tuple parameter specifies if PathCodec.trailing should be added to the route's pattern. It can
-        // be added either because of a PathsCapture, or because of an noTrailingSlash input. The third one counts the
-        // segments matched by the pattern.
-        val (p, addTrailing, fixedSegments) = inputs
-          .foldLeft((initialPattern, hasNoTrailingSlash, 0)) { case ((p, addTrailing, fixedSegments), component) =>
+        // The second tuple parameter specifies if a wildcard should be added to the route's pattern. It can
+        // be added either because of a PathsCapture, or because of an noTrailingSlash input.
+        val (p, addWildcard) = inputs
+          .foldLeft((emptyPattern, hasNoTrailingSlash)) { case ((p, addWildcard), component) =>
             component match {
               case i: EndpointInput.PathCapture[_] =>
-                ((p / PathCodec.string(i.name.getOrElse("?"))).asInstanceOf[RoutePattern[Any]], addTrailing, fixedSegments + 1)
-              case _: EndpointInput.PathsCapture[_] => (p, true, fixedSegments)
-              case i: EndpointInput.FixedPath[_]    => (p / PathCodec.literal(i.s), addTrailing, fixedSegments + 1)
-              case _                                => (p, addTrailing, fixedSegments)
+                ((p / PathCodec.string(i.name.getOrElse("?"))).asInstanceOf[RoutePattern[Any]], addWildcard)
+              case _: EndpointInput.PathsCapture[_] => (p, true)
+              case i: EndpointInput.FixedPath[_]    => (p / PathCodec.literal(i.s), addWildcard)
+              case _                                => (p, addWildcard)
             }
           }
 
-        if (addTrailing) PatternWithShape((p / PathCodec.trailing).asInstanceOf[RoutePattern[Any]], fixedSegments, hasTrailing = true)
-        else PatternWithShape(p, fixedSegments, hasTrailing = false)
+        if (addWildcard) endWithWildcard(p) else PatternWithShape.Exact(p, fixedSegmentsOf(p))
       } else {
         // if there are no path inputs, we return a catch-all
-        PatternWithShape(RoutePattern(Method.ANY, PathCodec.trailing).asInstanceOf[RoutePattern[Any]], 0, hasTrailing = true)
+        endWithWildcard(emptyPattern)
       }
 
       ServerEndpointWithPattern(index, pathTemplate, routePattern, se)
@@ -196,44 +206,47 @@ trait ZioHttpInterpreter[R] {
         .sortBy(_.map(_.index).min)
 
     val handlers: List[Route[R & R2, Response]] = widenedSesGroupedByPathTemplate.map { sesWithPattern =>
-      // The pattern that we generate should be the same for all endpoints in a group
-      val PatternWithShape(pattern, fixedSegments, hasTrailing) = sesWithPattern.head.routePattern
       val endpoints = sesWithPattern.sortBy(_.index).map(_.endpoint)
 
       // The routes might be nested under a prefix by the user (`Routes.nest`, `PathCodec./`), which prepends segments
       // to the pattern, but leaves the request as-is. Those segments are not part of the paths described by the
       // endpoints, so they have to be skipped when matching. Their number can only be computed per-request, as the
       // pattern that the route ends up being registered under is not known when the route is created.
-      if (hasTrailing) {
-        // The trailing wildcard consumes everything after the prefix and the fixed segments, so its length (which is
-        // available among the decoded path parameters) is needed to compute the length of the prefix.
-        Route.handled[Any, R & R2](pattern)(Handler.fromFunctionHandler { (in: (Any, Request)) =>
-          val (params, request) = in
-          val contextPathSegments = pathSegmentCount(request) - fixedSegments - trailingSegmentCount(params)
-          handleRequest(request, endpoints, contextPathSegments)
-        })
-      } else
-        Route.handledIgnoreParams(pattern)(Handler.fromFunctionHandler { (request: Request) =>
-          handleRequest(request, endpoints, pathSegmentCount(request) - fixedSegments)
-        })
+      // The pattern that we generate should be the same for all endpoints in a group.
+      sesWithPattern.head.routePattern match {
+        case PatternWithShape.Wildcard(pattern, fixedSegments) =>
+          // the wildcard consumes everything after the prefix and the fixed segments, so its length is needed as well
+          Route.handled[Any, R & R2](pattern)(Handler.fromFunctionHandler { (in: (Any, Request)) =>
+            val (params, request) = in
+            handleRequest(request, endpoints, pathSegmentCount(request.url.path) - fixedSegments - wildcardSegmentCount(params))
+          })
+        case PatternWithShape.Exact(pattern, fixedSegments) =>
+          Route.handledIgnoreParams(pattern)(Handler.fromFunctionHandler { (request: Request) =>
+            handleRequest(request, endpoints, pathSegmentCount(request.url.path) - fixedSegments)
+          })
+      }
     }
 
     Routes(Chunk.fromIterable(handlers))
   }
 
-  /** The number of path segments of the request, counted the same way as zio-http's route patterns match them. */
-  private def pathSegmentCount(request: Request): Int = request.url.path.segments.count(_.nonEmpty)
-
-  /** Extracts the value captured by the `PathCodec.trailing` which ends the route's pattern. It is the last of the values decoded from the
-    * path (or the only one, if the pattern captures nothing else).
+  /** The number of path segments, counted the same way as zio-http's route patterns match them: leading and trailing slashes are stored as
+    * flags, and empty segments are dropped when parsing a path, so every segment counts.
     */
-  private def trailingSegmentCount(params: Any): Int = {
-    val trailing = params match {
-      case p: Path    => p // the trailing wildcard is the only value captured by the pattern
+  private def pathSegmentCount(path: Path): Int = path.segments.length
+
+  /** The number of path segments captured by the wildcard which ends the route's pattern, given the values decoded from the path. The
+    * wildcard is the last of them, or the only one, if the pattern captures nothing else. Typing the pattern as `RoutePattern[Path]`
+    * instead wouldn't work: the `Combiner` which would then discard the other captured values is chosen (and specialised) for `Unit`, while
+    * at runtime they are a tuple.
+    */
+  private def wildcardSegmentCount(params: Any): Int = {
+    val wildcard = params match {
+      case p: Path    => p // `Path` is a case class, hence this case has to come first
       case p: Product => p.productElement(p.productArity - 1).asInstanceOf[Path]
-      case _          => Path.empty // can't happen: the pattern always captures at least the trailing wildcard
+      case _          => Path.empty // can't happen: the pattern always captures at least the wildcard
     }
-    trailing.segments.count(_.nonEmpty)
+    pathSegmentCount(wildcard)
   }
 
   private def handleWebSocketResponse(

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerRequest.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerRequest.scala
@@ -39,11 +39,11 @@ case class ZioHttpServerRequest(req: Request, attributes: AttributeMap = Attribu
   override lazy val headers: Seq[SttpHeader] = req.headers.toList.map { h => SttpHeader(h.headerName, h.renderedValue) }
 
   /** Marks the first `n` path segments as belonging to the context (prefix) under which the routes are nested, and hence not described by
-    * the endpoints. Such segments are skipped in [[pathSegments]], but remain part of [[uri]]. A non-positive `n` leaves the request
-    * unchanged.
+    * the endpoints. Such segments are skipped in [[pathSegments]], but remain part of [[uri]]. A non-positive `n` clears the context.
     */
   private[ziohttp] def contextPathSegments(n: Int): ZioHttpServerRequest =
-    if (n > 0) attribute(ZioHttpServerRequest.ContextPathSegments, n) else this
+    if (n > 0) attribute(ZioHttpServerRequest.ContextPathSegments, n)
+    else copy(attributes = attributes.remove(ZioHttpServerRequest.ContextPathSegments))
 
   override def attribute[T](k: AttributeKey[T]): Option[T] = attributes.get(k)
   override def attribute[T](k: AttributeKey[T], v: T): ZioHttpServerRequest = copy(attributes = attributes.put(k, v))

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerRequest.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerRequest.scala
@@ -39,9 +39,11 @@ case class ZioHttpServerRequest(req: Request, attributes: AttributeMap = Attribu
   override lazy val headers: Seq[SttpHeader] = req.headers.toList.map { h => SttpHeader(h.headerName, h.renderedValue) }
 
   /** Marks the first `n` path segments as belonging to the context (prefix) under which the routes are nested, and hence not described by
-    * the endpoints. Such segments are skipped in [[pathSegments]], but remain part of [[uri]].
+    * the endpoints. Such segments are skipped in [[pathSegments]], but remain part of [[uri]]. A non-positive `n` leaves the request
+    * unchanged.
     */
-  def contextPathSegments(n: Int): ZioHttpServerRequest = attribute(ZioHttpServerRequest.ContextPathSegments, n)
+  private[ziohttp] def contextPathSegments(n: Int): ZioHttpServerRequest =
+    if (n > 0) attribute(ZioHttpServerRequest.ContextPathSegments, n) else this
 
   override def attribute[T](k: AttributeKey[T]): Option[T] = attributes.get(k)
   override def attribute[T](k: AttributeKey[T], v: T): ZioHttpServerRequest = copy(attributes = attributes.put(k, v))
@@ -64,5 +66,7 @@ case class ZioHttpServerRequest(req: Request, attributes: AttributeMap = Attribu
 }
 
 object ZioHttpServerRequest {
-  private val ContextPathSegments: AttributeKey[Int] = AttributeKey[Int]
+  // an explicit name is required, as attribute keys are identified by the name of the value's type alone - a derived
+  // `AttributeKey[Int]` would be shared with any other `Int`-valued attribute
+  private val ContextPathSegments: AttributeKey[Int] = new AttributeKey[Int]("sttp.tapir.server.ziohttp.ContextPathSegments")
 }

--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerRequest.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpServerRequest.scala
@@ -23,7 +23,9 @@ case class ZioHttpServerRequest(req: Request, attributes: AttributeMap = Attribu
   // zio-http already decodes percent-encoded path segments while preserving segment boundaries (an encoded
   // slash stays within a single segment), so use them directly rather than re-joining and re-parsing, which
   // would turn an encoded slash into a segment separator.
-  override lazy val pathSegments: List[String] = req.url.path.segments.toList.filter(_.nonEmpty)
+  // Can differ from `uri.path`, if the routes are nested under a prefix (see `contextPathSegments`).
+  override lazy val pathSegments: List[String] =
+    req.url.path.segments.toList.filter(_.nonEmpty).drop(attributes.get(ZioHttpServerRequest.ContextPathSegments).getOrElse(0))
   override lazy val queryParameters: QueryParams = QueryParams.fromMultiMap(req.url.queryParams.map)
   override lazy val method: SttpMethod = SttpMethod(req.method.name.toUpperCase)
   override lazy val showShort: String = s"$method ${encodeQueryParams(req.url.path.encode, req.url.queryParams.normalize, Charsets.Http)}"
@@ -35,6 +37,12 @@ case class ZioHttpServerRequest(req: Request, attributes: AttributeMap = Attribu
     )
   }
   override lazy val headers: Seq[SttpHeader] = req.headers.toList.map { h => SttpHeader(h.headerName, h.renderedValue) }
+
+  /** Marks the first `n` path segments as belonging to the context (prefix) under which the routes are nested, and hence not described by
+    * the endpoints. Such segments are skipped in [[pathSegments]], but remain part of [[uri]].
+    */
+  def contextPathSegments(n: Int): ZioHttpServerRequest = attribute(ZioHttpServerRequest.ContextPathSegments, n)
+
   override def attribute[T](k: AttributeKey[T]): Option[T] = attributes.get(k)
   override def attribute[T](k: AttributeKey[T], v: T): ZioHttpServerRequest = copy(attributes = attributes.put(k, v))
   override def withUnderlying(underlying: Any): ServerRequest = ZioHttpServerRequest(req = underlying.asInstanceOf[Request], attributes)
@@ -53,4 +61,8 @@ case class ZioHttpServerRequest(req: Request, attributes: AttributeMap = Attribu
 
     encoder.toString
   }
+}
+
+object ZioHttpServerRequest {
+  private val ContextPathSegments: AttributeKey[Int] = AttributeKey[Int]
 }

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
@@ -45,7 +45,8 @@ class ZioHttpCompositionTest(
               endpoint.get.in("p1").zServerLogic[Any](_ => ZIO.unit),
               withPathCapture.put.zServerLogic[Any](_ => ZIO.unit),
               withPathCapture.delete.zServerLogic[Any](_ => ZIO.unit),
-              endpoint.get.in("wild").in(paths).zServerLogic[Any](ps => ZIO.succeed(ps).unit),
+              // the query input verifies that only path inputs are counted when computing the length of the prefix
+              endpoint.get.in("wild").in(paths).in(query[String]("q")).zServerLogic[Any](_ => ZIO.unit),
               endpoint.get.zServerLogic[Any](_ => ZIO.unit)
             )
           )
@@ -55,9 +56,8 @@ class ZioHttpCompositionTest(
       basicRequest.get(uri"$baseUri/api/p1").send(backend).map(_.code shouldBe StatusCode.Ok) >>
         basicRequest.put(uri"$baseUri/api/x").send(backend).map(_.code shouldBe StatusCode.Ok) >>
         basicRequest.delete(uri"$baseUri/api/x").send(backend).map(_.code shouldBe StatusCode.Ok) >>
-        basicRequest.get(uri"$baseUri/api/wild/a/b").send(backend).map(_.code shouldBe StatusCode.Ok) >>
-        basicRequest.get(uri"$baseUri/api").send(backend).map(_.code shouldBe StatusCode.Ok) >>
-        basicRequest.get(uri"$baseUri/p1").send(backend).map(_.code shouldBe StatusCode.NotFound)
+        basicRequest.get(uri"$baseUri/api/wild/a/b?q=v").send(backend).map(_.code shouldBe StatusCode.Ok) >>
+        basicRequest.get(uri"$baseUri/api").send(backend).map(_.code shouldBe StatusCode.Ok)
     }
   )
 }

--- a/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
+++ b/server/zio-http-server/src/test/scala/sttp/tapir/server/ziohttp/ZioHttpCompositionTest.scala
@@ -35,6 +35,29 @@ class ZioHttpCompositionTest(
       basicRequest.get(uri"$baseUri/p1").send(backend).map(_.code shouldBe StatusCode.Ok) >>
         basicRequest.get(uri"$baseUri/p2").send(backend).map(_.code shouldBe StatusCode.Ok) >>
         basicRequest.get(uri"$baseUri/p3").send(backend).map(_.code shouldBe StatusCode.BadRequest)
+    },
+    testServer(
+      "zio http apps nested under a prefix", {
+        val withPathCapture = endpoint.in(path[String]("id"))
+        ZioHttpInterpreter()
+          .toHttp[Any](
+            List(
+              endpoint.get.in("p1").zServerLogic[Any](_ => ZIO.unit),
+              withPathCapture.put.zServerLogic[Any](_ => ZIO.unit),
+              withPathCapture.delete.zServerLogic[Any](_ => ZIO.unit),
+              endpoint.get.in("wild").in(paths).zServerLogic[Any](ps => ZIO.succeed(ps).unit),
+              endpoint.get.zServerLogic[Any](_ => ZIO.unit)
+            )
+          )
+          .nest("api")
+      }
+    ) { (backend, baseUri) =>
+      basicRequest.get(uri"$baseUri/api/p1").send(backend).map(_.code shouldBe StatusCode.Ok) >>
+        basicRequest.put(uri"$baseUri/api/x").send(backend).map(_.code shouldBe StatusCode.Ok) >>
+        basicRequest.delete(uri"$baseUri/api/x").send(backend).map(_.code shouldBe StatusCode.Ok) >>
+        basicRequest.get(uri"$baseUri/api/wild/a/b").send(backend).map(_.code shouldBe StatusCode.Ok) >>
+        basicRequest.get(uri"$baseUri/api").send(backend).map(_.code shouldBe StatusCode.Ok) >>
+        basicRequest.get(uri"$baseUri/p1").send(backend).map(_.code shouldBe StatusCode.NotFound)
     }
   )
 }


### PR DESCRIPTION
Fixes #5435.

### Problem

zio-http's `Routes.nest(prefix)` (and `PathCodec./`) only rewrites the *route pattern* — `RoutePattern.nest` is `copy(pathCodec = prefix ++ pathCodec)`. The `Request` passed to the handler keeps its full path.

The tapir interpreter uses zio-http routing only to dispatch (`Route.handledIgnoreParams`) and then re-matches the whole path itself, from `req.url.path.segments`. So after `.nest("api")`, an endpoint declared as `path[UUID]` (one segment) is matched against `/api/<uuid>` (two segments), and nothing matches.

The reported symptom is `405 Method Not Allowed` rather than `404`: with two or more endpoints the reject interceptor is active, and the first failure of the non-matching-method endpoint is on its `FixedMethod` input, so `DefaultRejectHandler` reports a method mismatch. With a single endpoint (reject interceptor disabled) the same setup returns `404`. Nesting was broken in general, not just for this combination.

### Fix

The interpreter now computes, per request, how many leading path segments come from the nesting prefix, and skips them when matching. This can only be done per-request, as the pattern under which a route ends up being registered is not known when the route is created.

* `ZioHttpInterpreter`: the generated route pattern now carries its shape (number of matched segments, and whether it ends with a trailing wildcard).
  * without a trailing wildcard: `context = requestSegments - patternSegments`
  * with one (`paths`, `noTrailingSlash`, or endpoints with no path inputs): the wildcard absorbs the rest of the path, so its length is needed as well — such routes are created using `Route.handled`, whose decoded parameters include the trailing `Path`; then `context = requestSegments - patternSegments - trailingSegments`

  Both are exact, for a prefix of any length.
* `ZioHttpServerRequest`: gains `contextPathSegments(n)`, stored as an attribute, which `pathSegments` skips. `uri` remains the full request URI — the same split that the http4s interpreter already uses for routes mounted in a context.

### Tests

`ZioHttpCompositionTest` covers a path capture with two methods, a fixed path, a `paths` wildcard and an endpoint without path inputs, all under `.nest("api")`, plus a check that un-prefixed paths still yield a 404. The test fails on master with `405 was not equal to 200`.
