### PR TITLE
openapi-codegen: support components.headers

### DIFF
--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/OpenApiMerger.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/OpenApiMerger.scala
@@ -50,7 +50,8 @@ object OpenApiMerger {
     val mergedRequestBodies = left.requestBodies ++ right.requestBodies.filterNot { case (k, _) =>
       left.requestBodies.contains(k)
     }
+    val mergedHeaders = left.headers ++ right.headers.filterNot { case (k, _) => left.headers.contains(k) }
 
-    OpenapiComponent(mergedSchemas, mergedSecuritySchemes, mergedParameters, mergedResponses, mergedRequestBodies)
+    OpenapiComponent(mergedSchemas, mergedSecuritySchemes, mergedParameters, mergedResponses, mergedRequestBodies, mergedHeaders)
   }
 }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/OpenApiMerger.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/OpenApiMerger.scala
@@ -51,6 +51,15 @@ object OpenApiMerger {
       left.requestBodies.contains(k)
     }
     val mergedHeaders = left.headers ++ right.headers.filterNot { case (k, _) => left.headers.contains(k) }
+    // as for schemas, and unlike the other component maps: a header definition determines the generated endpoint's type, so silently
+    // keeping the left one would generate the wrong type for the right document's endpoints
+    val conflictingHeaders = left.headers.keySet.intersect(right.headers.keySet).filter { k =>
+      left.headers(k) != right.headers(k)
+    }
+    if (conflictingHeaders.nonEmpty)
+      throw new IllegalArgumentException(
+        s"Conflicting header definitions when merging OpenAPI documents: ${conflictingHeaders.mkString(", ")}"
+      )
 
     OpenapiComponent(mergedSchemas, mergedSecuritySchemes, mergedParameters, mergedResponses, mergedRequestBodies, mergedHeaders)
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/dedup/SchemaComparer.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/dedup/SchemaComparer.scala
@@ -4,6 +4,8 @@ import sttp.tapir.codegen.openapi.models.OpenapiModels._
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType._
 import sttp.tapir.codegen.openapi.models.{OpenapiModels, OpenapiSchemaType}
 
+import scala.util.{Success, Try}
+
 object SchemaComparer {
   private def resolved(doc: OpenapiDocument, ps: Map[String, OpenapiModels.OpenapiParameter])(
       p: OpenapiPath
@@ -35,6 +37,19 @@ object SchemaComparer {
     val resolvedCurr = current.paths.flatMap(resolved(current, currPs)).groupBy(_._1).map { case (k, v) => k -> v.head._2 }
     val mayMatch = resolvedCurr.filter { case (name, m) => resolvedDeps.get(name).contains(m) }
 
+    // response headers are compared by their definitions, not by the refs: the same ref may resolve differently in each document. A header
+    // that cannot be resolved in both is treated as not matching, so the endpoint is regenerated rather than reused with a stale header.
+    def headersMatch(name: String, m: OpenapiPathMethod): Boolean =
+      m.responses.forall { r =>
+        r.asInstanceOf[OpenapiResponseDef].getHeaders.forall { case (headerName, h) =>
+          (Try(h.resolved(headerName, current)), Try(h.resolved(headerName, dependency))) match {
+            case (Success(c), Success(d)) =>
+              c == d && schemasEqual(name, c.param.schema, currentSchemas, name, d.param.schema, dependencySchemas, Set.empty)
+            case _ => false
+          }
+        }
+      }
+
     mayMatch.filter { case (name, m) =>
       m.requestBody.toSeq
         .flatMap(_.asInstanceOf[OpenapiRequestBodyDefn].content.map(_.schema))
@@ -45,6 +60,7 @@ object SchemaComparer {
       m.parameters
         .map(_.resolve(currPs).schema)
         .forall(t => schemasEqual(name, t, currentSchemas, name, t, dependencySchemas, Set.empty)) &&
+      headersMatch(name, m) &&
       securityMatches(current, dependency)(m.security.get)
     }.keySet
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
@@ -35,7 +35,6 @@ object OpenapiComponent {
         parameters.map { case (k, v) => s"#/components/parameters/$k" -> v },
         responses,
         requestBodies,
-        // re-keyed by full ref, exactly like `parameters` above, so that OpenapiHeaderRef.resolved can look up by `$ref.name`
         headers.map { case (k, v) => s"#/components/headers/$k" -> v }
       )
     }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
@@ -29,6 +29,8 @@ object OpenapiComponent {
       requestBodies <- c.getOrElse[Map[String, OpenapiRequestBody]]("requestBodies")(Map.empty)
       headers <- c.getOrElse[Map[String, OpenapiHeader]]("headers")(Map.empty)
     } yield {
+      // parameters and headers are keyed by full ref, so that a $ref is looked up as-is; responses and requestBodies keep bare keys and
+      // strip the prefix at the lookup site instead
       OpenapiComponent(
         schemas,
         securitySchemes,

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiComponent.scala
@@ -1,13 +1,14 @@
 package sttp.tapir.codegen.openapi.models
 
-import OpenapiModels.OpenapiParameter
+import OpenapiModels.{OpenapiHeader, OpenapiParameter}
 
 case class OpenapiComponent(
     schemas: Map[String, OpenapiSchemaType],
     securitySchemes: Map[String, OpenapiSecuritySchemeType] = Map.empty,
     parameters: Map[String, OpenapiParameter] = Map.empty,
     responses: Map[String, OpenapiResponseDefn] = Map.empty,
-    requestBodies: Map[String, OpenapiRequestBody] = Map.empty
+    requestBodies: Map[String, OpenapiRequestBody] = Map.empty,
+    headers: Map[String, OpenapiHeader] = Map.empty
 )
 
 object OpenapiComponent {
@@ -26,13 +27,16 @@ object OpenapiComponent {
       parameters <- c.getOrElse[Map[String, OpenapiParameter]]("parameters")(Map.empty)
       responses <- c.getOrElse[Map[String, OpenapiResponseDefn]]("responses")(Map.empty)
       requestBodies <- c.getOrElse[Map[String, OpenapiRequestBody]]("requestBodies")(Map.empty)
+      headers <- c.getOrElse[Map[String, OpenapiHeader]]("headers")(Map.empty)
     } yield {
       OpenapiComponent(
         schemas,
         securitySchemes,
         parameters.map { case (k, v) => s"#/components/parameters/$k" -> v },
         responses,
-        requestBodies
+        requestBodies,
+        // re-keyed by full ref, exactly like `parameters` above, so that OpenapiHeaderRef.resolved can look up by `$ref.name`
+        headers.map { case (k, v) => s"#/components/headers/$k" -> v }
       )
     }
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -192,7 +192,7 @@ object OpenapiModels {
       // components.headers holds Header Objects; its keys are re-written to full refs at decode time
       def fromHeaders: Option[OpenapiHeaderDef] = doc.components.flatMap(_.headers.get($ref.name)).map {
         case OpenapiHeaderDef(param) => OpenapiHeaderDef(param.copy(name = name))
-        case _: OpenapiHeaderRef =>
+        case _: OpenapiHeaderRef     =>
           throw new IllegalStateException(
             s"Header component ${$ref.name} is itself a reference; chained header references are not supported"
           )

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -189,7 +189,6 @@ object OpenapiModels {
   }
   case class OpenapiHeaderRef($ref: OpenapiSchemaRef) extends OpenapiHeader {
     def resolved(name: String, doc: OpenapiDocument): OpenapiHeaderDef = {
-      // components.headers holds Header Objects; its keys are re-written to full refs at decode time
       def fromHeaders: Option[OpenapiHeaderDef] = doc.components.flatMap(_.headers.get($ref.name)).map {
         case OpenapiHeaderDef(param) => OpenapiHeaderDef(param.copy(name = name))
         case _: OpenapiHeaderRef     =>
@@ -197,7 +196,6 @@ object OpenapiModels {
             s"Header component ${$ref.name} is itself a reference; chained header references are not supported"
           )
       }
-      // a request-header Parameter may also be referenced from a response header
       def fromParameters: Option[OpenapiHeaderDef] = doc.components
         .flatMap(_.parameters.get($ref.name))
         .map(b => if (b.in != "header") throw new IllegalStateException(s"Referenced parameter ${$ref.name} is not header") else b)

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -174,24 +174,40 @@ object OpenapiModels {
   }
   object OpenapiHeader {
     import io.circe._
-    implicit val OpenapiHeaderDecoder: Decoder[OpenapiHeader] =
-      OpenapiSchemaRefDecoder
-        .map(OpenapiHeaderRef(_))
-        .or((c: HCursor) => {
-          OpenapiParameterDecoder
-            .tryDecode(c.withFocus(_.mapObject(("name" -> Json.fromString("inline")) +: ("in" -> Json.fromString("header")) +: _)))
-            .map(OpenapiHeaderDef(_))
-        })
+    // a header we cannot model is kept, rather than failing the whole document: it only matters if something references it
+    implicit val OpenapiHeaderDecoder: Decoder[OpenapiHeader] = (c: HCursor) => {
+      val asRef = OpenapiSchemaRefDecoder.tryDecode(c).map(OpenapiHeaderRef(_): OpenapiHeader)
+      lazy val asDef = OpenapiParameterDecoder
+        .tryDecode(c.withFocus(_.mapObject(("name" -> Json.fromString("inline")) +: ("in" -> Json.fromString("header")) +: _)))
+        .map(OpenapiHeaderDef(_): OpenapiHeader)
+      asRef match {
+        case r: Right[?, ?] => r
+        case _              =>
+          asDef match {
+            case r: Right[?, ?] => r
+            case Left(failure)  => Right(OpenapiHeaderUnsupported(unsupportedCause(c, failure)))
+          }
+      }
+    }
+
+    private def unsupportedCause(c: HCursor, failure: DecodingFailure): String =
+      if (c.downField("content").succeeded) "headers described with 'content' instead of 'schema' are not supported"
+      else failure.getMessage
   }
   case class OpenapiHeaderDef(param: OpenapiParameter) extends OpenapiHeader {
     def resolved(name: String, doc: OpenapiDocument): OpenapiHeaderDef =
       if (name == param.name) this else OpenapiHeaderDef(param.copy(name = name))
   }
+  case class OpenapiHeaderUnsupported(cause: String) extends OpenapiHeader {
+    def resolved(name: String, doc: OpenapiDocument): OpenapiHeaderDef =
+      throw new IllegalStateException(s"Header $name cannot be generated: $cause")
+  }
   case class OpenapiHeaderRef($ref: OpenapiSchemaRef) extends OpenapiHeader {
     def resolved(name: String, doc: OpenapiDocument): OpenapiHeaderDef = {
       def fromHeaders: Option[OpenapiHeaderDef] = doc.components.flatMap(_.headers.get($ref.name)).map {
-        case OpenapiHeaderDef(param) => OpenapiHeaderDef(param.copy(name = name))
-        case _: OpenapiHeaderRef     =>
+        case d: OpenapiHeaderDef         => d.resolved(name, doc)
+        case u: OpenapiHeaderUnsupported => u.resolved(name, doc)
+        case _: OpenapiHeaderRef         =>
           throw new IllegalStateException(
             s"Header component ${$ref.name} is itself a reference; chained header references are not supported"
           )
@@ -204,7 +220,9 @@ object OpenapiModels {
       fromHeaders
         .orElse(fromParameters)
         .getOrElse(
-          throw new IllegalStateException(s"Header component ${$ref.name} is referenced but not found in components.headers or components.parameters")
+          throw new IllegalStateException(
+            s"Header component ${$ref.name} is referenced but not found in components.headers or components.parameters"
+          )
         )
     }
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -189,10 +189,22 @@ object OpenapiModels {
   }
   case class OpenapiHeaderRef($ref: OpenapiSchemaRef) extends OpenapiHeader {
     def resolved(name: String, doc: OpenapiDocument): OpenapiHeaderDef = {
-      doc.components
+      // components.headers holds Header Objects; its keys are re-written to full refs at decode time
+      def fromHeaders: Option[OpenapiHeaderDef] = doc.components.flatMap(_.headers.get($ref.name)).map {
+        case OpenapiHeaderDef(param) => OpenapiHeaderDef(param.copy(name = name))
+        case _: OpenapiHeaderRef =>
+          throw new IllegalStateException(
+            s"Header component ${$ref.name} is itself a reference; chained header references are not supported"
+          )
+      }
+      // a request-header Parameter may also be referenced from a response header
+      def fromParameters: Option[OpenapiHeaderDef] = doc.components
         .flatMap(_.parameters.get($ref.name))
         .map(b => if (b.in != "header") throw new IllegalStateException(s"Referenced parameter ${$ref.name} is not header") else b)
         .map(b => OpenapiHeaderDef(b.copy(name = name)))
+
+      fromHeaders
+        .orElse(fromParameters)
         .getOrElse(throw new IllegalStateException(s"Response component ${$ref.name} is referenced but not found"))
     }
   }

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -203,7 +203,9 @@ object OpenapiModels {
 
       fromHeaders
         .orElse(fromParameters)
-        .getOrElse(throw new IllegalStateException(s"Response component ${$ref.name} is referenced but not found"))
+        .getOrElse(
+          throw new IllegalStateException(s"Header component ${$ref.name} is referenced but not found in components.headers or components.parameters")
+        )
     }
   }
 

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiModels.scala
@@ -203,14 +203,16 @@ object OpenapiModels {
       throw new IllegalStateException(s"Header $name cannot be generated: $cause")
   }
   case class OpenapiHeaderRef($ref: OpenapiSchemaRef) extends OpenapiHeader {
-    def resolved(name: String, doc: OpenapiDocument): OpenapiHeaderDef = {
+    def resolved(name: String, doc: OpenapiDocument): OpenapiHeaderDef = resolvedFollowing(name, doc, Seq.empty)
+
+    // a header component may itself be a reference, so follow the chain, keeping the visited refs to report a cycle rather than hang
+    private def resolvedFollowing(name: String, doc: OpenapiDocument, visited: Seq[String]): OpenapiHeaderDef = {
+      if (visited.contains($ref.name))
+        throw new IllegalStateException(s"Circular header reference: ${(visited :+ $ref.name).mkString(" -> ")}")
+
       def fromHeaders: Option[OpenapiHeaderDef] = doc.components.flatMap(_.headers.get($ref.name)).map {
-        case d: OpenapiHeaderDef         => d.resolved(name, doc)
-        case u: OpenapiHeaderUnsupported => u.resolved(name, doc)
-        case _: OpenapiHeaderRef         =>
-          throw new IllegalStateException(
-            s"Header component ${$ref.name} is itself a reference; chained header references are not supported"
-          )
+        case r: OpenapiHeaderRef => r.resolvedFollowing(name, doc, visited :+ $ref.name)
+        case h                   => h.resolved(name, doc)
       }
       def fromParameters: Option[OpenapiHeaderDef] = doc.components
         .flatMap(_.parameters.get($ref.name))

--- a/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
+++ b/openapi-codegen/core/src/main/scala/sttp/tapir/codegen/openapi/models/OpenapiSchemaType.scala
@@ -7,9 +7,10 @@ import scala.collection.mutable
 
 object NameValidation {
   val validName = """[a-zA-Z_$][a-zA-Z0-9_$]*"""
-  val validOrHyphen = """[a-zA-Z_$][a-zA-Z0-9_$-]*"""
-  // Schema refs have stricter validation, since used directly as types; parameters etc can also contain hyphens
-  val validRef = s"""#/components/(schemas/$validName|(?!schemas)[a-zA-Z]+/$validOrHyphen)"""
+  // the keys openapi allows in the components section - cf https://swagger.io/specification/#components-object
+  val validComponentKey = """[a-zA-Z0-9._-]+"""
+  // Schema refs have stricter validation, since used directly as types; parameters, headers etc are only ever looked up by key
+  val validRef = s"""#/components/(schemas/$validName|(?!schemas)[a-zA-Z]+/$validComponentKey)"""
 }
 import NameValidation._
 

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -6,6 +6,8 @@ import sttp.tapir.codegen.endpoints.{EndpointGenerator, FS2}
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
 import sttp.tapir.codegen.openapi.models.OpenapiModels.{
   OpenapiDocument,
+  OpenapiHeaderDef,
+  OpenapiHeaderRef,
   OpenapiParameter,
   OpenapiPath,
   OpenapiPathMethod,
@@ -452,6 +454,63 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
     )
     generatedCode should include("case object StatusCodeDisambig401\n  extends DeleteDeleteOneResponseErrCode")
     generatedCode should not include "case object DeleteDeleteOneResponseCode200"
+    generatedCode.shouldCompile()
+  }
+
+  it should "generate a response header from a components.headers ref" in {
+    val doc = OpenapiDocument(
+      "3.1.0",
+      Nil,
+      null,
+      Seq(
+        OpenapiPath(
+          "ping",
+          Seq(
+            OpenapiPathMethod(
+              methodType = "get",
+              parameters = Nil,
+              responses = Seq(
+                OpenapiResponseDef(
+                  "200",
+                  "",
+                  Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false))),
+                  Map("X-Rate-Limit" -> OpenapiHeaderRef(OpenapiSchemaRef("#/components/headers/RateLimit")))
+                )
+              ),
+              requestBody = None
+            )
+          )
+        )
+      ),
+      Some(
+        OpenapiComponent(
+          schemas = Map.empty,
+          headers = Map(
+            "#/components/headers/RateLimit" ->
+              OpenapiHeaderDef(OpenapiParameter("inline", "header", Some(true), None, OpenapiSchemaString(false)))
+          )
+        )
+      ),
+      Nil
+    )
+    val generatedCode = RootGenerator.imports(JsonSerdeLib.Circe) +
+      new EndpointGenerator()
+        .endpointDefs(
+          doc,
+          useHeadTagForObjectNames = false,
+          targetScala3 = isScala3,
+          jsonSerdeLib = JsonSerdeLib.Circe,
+          xmlSerdeLib = XmlSerdeLib.CatsXml,
+          streamingImplementation = FS2(),
+          generateEndpointTypes = false,
+          validators = ValidationDefns.empty,
+          generateValidators = true,
+          packageReuse = PackageReuseContext.none,
+          seperateFilesForModels = false,
+          addDisambiguationCodes = true
+        )
+        .endpointDecls(None)
+    generatedCode should include("""header[String]("X-Rate-Limit")""")
     generatedCode.shouldCompile()
   }
 

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -488,7 +488,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
           schemas = Map.empty,
           headers = Map(
             "#/components/headers/RateLimit" ->
-              OpenapiHeaderDef(OpenapiParameter("inline", "header", Some(true), None, OpenapiSchemaString(false)))
+              TestHelpers.inlineHeaderDef()
           )
         )
       ),

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/EndpointGeneratorSpec.scala
@@ -8,6 +8,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiModels.{
   OpenapiDocument,
   OpenapiHeaderDef,
   OpenapiHeaderRef,
+  OpenapiInfo,
   OpenapiParameter,
   OpenapiPath,
   OpenapiPathMethod,
@@ -461,7 +462,7 @@ class EndpointGeneratorSpec extends CompileCheckTestBase {
     val doc = OpenapiDocument(
       "3.1.0",
       Nil,
-      null,
+      OpenapiInfo("test", "1.0"),
       Seq(
         OpenapiPath(
           "ping",

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
@@ -233,12 +233,12 @@ class OpenApiMergerSpec extends AnyFlatSpec with Matchers {
     intercept[IllegalArgumentException](OpenApiMerger.merge(Seq(a, b)))
   }
 
-  it should "merge components.headers from both documents, left winning on collisions" in {
+  it should "merge components.headers from both documents" in {
     val left = docWith(
       OpenapiComponent(
         schemas = Map.empty,
         headers = Map(
-          "#/components/headers/RateLimit" -> headerDef("left rate limit"),
+          "#/components/headers/RateLimit" -> headerDef("rate limit"),
           "#/components/headers/OnlyLeft" -> headerDef("only left")
         )
       )
@@ -247,7 +247,7 @@ class OpenApiMergerSpec extends AnyFlatSpec with Matchers {
       OpenapiComponent(
         schemas = Map.empty,
         headers = Map(
-          "#/components/headers/RateLimit" -> headerDef("right rate limit"),
+          "#/components/headers/RateLimit" -> headerDef("rate limit"),
           "#/components/headers/OnlyRight" -> headerDef("only right")
         )
       )
@@ -257,10 +257,19 @@ class OpenApiMergerSpec extends AnyFlatSpec with Matchers {
 
     merged.components.map(_.headers) shouldBe Some(
       Map(
-        "#/components/headers/RateLimit" -> headerDef("left rate limit"),
+        "#/components/headers/RateLimit" -> headerDef("rate limit"),
         "#/components/headers/OnlyLeft" -> headerDef("only left"),
         "#/components/headers/OnlyRight" -> headerDef("only right")
       )
     )
+  }
+
+  it should "fail when the same header is defined differently in both documents" in {
+    val left = docWith(OpenapiComponent(schemas = Map.empty, headers = Map("#/components/headers/RateLimit" -> headerDef("left"))))
+    val right = docWith(OpenapiComponent(schemas = Map.empty, headers = Map("#/components/headers/RateLimit" -> headerDef("right"))))
+
+    val thrown = intercept[IllegalArgumentException](OpenApiMerger.merge(Seq(left, right)))
+    thrown.getMessage should include("Conflicting header definitions")
+    thrown.getMessage should include("RateLimit")
   }
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
@@ -16,11 +16,60 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
 }
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
-import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiHeaderDef, OpenapiInfo, OpenapiParameter}
+import sttp.tapir.codegen.openapi.models.OpenapiModels.{
+  OpenapiHeaderDef,
+  OpenapiHeaderRef,
+  OpenapiInfo,
+  OpenapiParameter,
+  OpenapiPath,
+  OpenapiPathMethod,
+  OpenapiResponseContent,
+  OpenapiResponseDef
+}
 
 import scala.collection.mutable
 
 class SchemaComparerSpec extends AnyFlatSpec with Matchers {
+
+  private def docWithSharedHeader(headerDescription: String) = {
+    def doc(headerDescription: String) = OpenapiDocument(
+      "3.1.0",
+      Nil,
+      OpenapiInfo("t", "1"),
+      Seq(
+        OpenapiPath(
+          "/ping",
+          Seq(
+            OpenapiPathMethod(
+              methodType = "get",
+              parameters = Nil,
+              responses = Seq(
+                OpenapiResponseDef(
+                  "200",
+                  "",
+                  Seq(OpenapiResponseContent("text/plain", OpenapiSchemaString(false))),
+                  Map("X-Rate-Limit" -> OpenapiHeaderRef(OpenapiSchemaRef("#/components/headers/RateLimit")))
+                )
+              ),
+              requestBody = None
+            )
+          )
+        )
+      ),
+      Some(
+        OpenapiComponent(
+          schemas = Map.empty,
+          headers = Map(
+            "#/components/headers/RateLimit" ->
+              OpenapiHeaderDef(OpenapiParameter("inline", "header", Some(true), Some(headerDescription), OpenapiSchemaString(false)))
+          )
+        )
+      ),
+      Nil
+    )
+
+    doc(headerDescription)
+  }
 
   "SchemaComparer" should "find identical schemas by name and structure" in {
     val pet = OpenapiSchemaObject(
@@ -53,6 +102,13 @@ class SchemaComparerSpec extends AnyFlatSpec with Matchers {
     val e1 = OpenapiSchemaEnum("string", Seq(OpenapiSchemaConstantString("A")), false)
     val e2 = OpenapiSchemaEnum("string", Seq(OpenapiSchemaConstantString("B")), false)
     SchemaComparer.findIdenticalSchemaNames(Map("S" -> e1), Map("S" -> e2)) shouldBe Set.empty
+  }
+
+  it should "not reuse an endpoint whose shared response header is defined differently" in {
+    val current = docWithSharedHeader("Requests left")
+
+    SchemaComparer.findReusedEndpointNames(current, docWithSharedHeader("Requests left"), Map.empty, Map.empty) should have size 1
+    SchemaComparer.findReusedEndpointNames(current, docWithSharedHeader("Something else"), Map.empty, Map.empty) shouldBe empty
   }
 }
 

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
@@ -16,7 +16,7 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
 }
 import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiDocument
 import sttp.tapir.codegen.openapi.models.OpenapiComponent
-import sttp.tapir.codegen.openapi.models.OpenapiModels.OpenapiInfo
+import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiHeaderDef, OpenapiInfo, OpenapiParameter}
 
 import scala.collection.mutable
 
@@ -151,6 +151,12 @@ class OpenApiMergerSpec extends AnyFlatSpec with Matchers {
   private def minimalDoc(title: String, schemas: Map[String, OpenapiSchemaString]) =
     OpenapiDocument("3.0.0", Nil, OpenapiInfo(title, "1"), Nil, Some(OpenapiComponent(schemas)), Nil)
 
+  private def headerDef(description: String): OpenapiHeaderDef =
+    OpenapiHeaderDef(OpenapiParameter("inline", "header", Some(true), Some(description), OpenapiSchemaString(false)))
+
+  private def docWith(components: OpenapiComponent) =
+    OpenapiDocument("3.0.0", Nil, OpenapiInfo("test", "1"), Nil, Some(components), Nil)
+
   "OpenApiMerger" should "merge schemas from multiple documents" in {
     val a = minimalDoc("a", Map("A" -> OpenapiSchemaString(false)))
     val b = minimalDoc("b", Map("B" -> OpenapiSchemaString(false)))
@@ -169,5 +175,36 @@ class OpenApiMergerSpec extends AnyFlatSpec with Matchers {
       Nil
     )
     intercept[IllegalArgumentException](OpenApiMerger.merge(Seq(a, b)))
+  }
+
+  it should "merge components.headers from both documents, left winning on collisions" in {
+    val left = docWith(
+      OpenapiComponent(
+        schemas = Map.empty,
+        headers = Map(
+          "#/components/headers/RateLimit" -> headerDef("left rate limit"),
+          "#/components/headers/OnlyLeft" -> headerDef("only left")
+        )
+      )
+    )
+    val right = docWith(
+      OpenapiComponent(
+        schemas = Map.empty,
+        headers = Map(
+          "#/components/headers/RateLimit" -> headerDef("right rate limit"),
+          "#/components/headers/OnlyRight" -> headerDef("only right")
+        )
+      )
+    )
+
+    val merged = OpenApiMerger.merge(Seq(left, right))
+
+    merged.components.map(_.headers) shouldBe Some(
+      Map(
+        "#/components/headers/RateLimit" -> headerDef("left rate limit"),
+        "#/components/headers/OnlyLeft" -> headerDef("only left"),
+        "#/components/headers/OnlyRight" -> headerDef("only right")
+      )
+    )
   }
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/PackageReuseSpec.scala
@@ -31,8 +31,8 @@ import scala.collection.mutable
 
 class SchemaComparerSpec extends AnyFlatSpec with Matchers {
 
-  private def docWithSharedHeader(headerDescription: String) = {
-    def doc(headerDescription: String) = OpenapiDocument(
+  private def docWithSharedHeader(headerDescription: String) =
+    OpenapiDocument(
       "3.1.0",
       Nil,
       OpenapiInfo("t", "1"),
@@ -61,15 +61,12 @@ class SchemaComparerSpec extends AnyFlatSpec with Matchers {
           schemas = Map.empty,
           headers = Map(
             "#/components/headers/RateLimit" ->
-              OpenapiHeaderDef(OpenapiParameter("inline", "header", Some(true), Some(headerDescription), OpenapiSchemaString(false)))
+              TestHelpers.inlineHeaderDef(Some(headerDescription))
           )
         )
       ),
       Nil
     )
-
-    doc(headerDescription)
-  }
 
   "SchemaComparer" should "find identical schemas by name and structure" in {
     val pet = OpenapiSchemaObject(
@@ -204,14 +201,12 @@ class PackageReuseContextSpec extends AnyFlatSpec with Matchers {
 
 class OpenApiMergerSpec extends AnyFlatSpec with Matchers {
 
-  private def minimalDoc(title: String, schemas: Map[String, OpenapiSchemaString]) =
-    OpenapiDocument("3.0.0", Nil, OpenapiInfo(title, "1"), Nil, Some(OpenapiComponent(schemas)), Nil)
+  private def docWith(components: OpenapiComponent, title: String = "test") =
+    OpenapiDocument("3.0.0", Nil, OpenapiInfo(title, "1"), Nil, Some(components), Nil)
 
-  private def headerDef(description: String): OpenapiHeaderDef =
-    OpenapiHeaderDef(OpenapiParameter("inline", "header", Some(true), Some(description), OpenapiSchemaString(false)))
+  private def minimalDoc(title: String, schemas: Map[String, OpenapiSchemaString]) = docWith(OpenapiComponent(schemas), title)
 
-  private def docWith(components: OpenapiComponent) =
-    OpenapiDocument("3.0.0", Nil, OpenapiInfo("test", "1"), Nil, Some(components), Nil)
+  private def headerDef(description: String): OpenapiHeaderDef = TestHelpers.inlineHeaderDef(Some(description))
 
   "OpenApiMerger" should "merge schemas from multiple documents" in {
     val a = minimalDoc("a", Map("A" -> OpenapiSchemaString(false)))

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/TestHelpers.scala
@@ -25,6 +25,10 @@ import scala.collection.mutable
 
 object TestHelpers {
 
+  // the shape the header decoder produces for an inline definition
+  def inlineHeaderDef(description: Option[String] = None): OpenapiHeaderDef =
+    OpenapiHeaderDef(OpenapiParameter("inline", "header", Some(true), description, OpenapiSchemaString(false)))
+
   val myBookshopYaml =
     """
       |openapi: 3.1.0

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
@@ -19,11 +19,12 @@ import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaString,
   OpenapiSchemaUUID
 }
+import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
 
-class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers {
+class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers with EitherValues {
   import io.circe.yaml.parser
   import cats.implicits._
   import io.circe._
@@ -276,8 +277,7 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers {
       .parse(yaml)
       .leftMap(err => err: Error)
       .flatMap(_.as[OpenapiDocument])
-      .toOption
-      .get
+      .value
 
     val response = doc.paths.head.methods.head.responses.head.asInstanceOf[OpenapiResponseDef]
     val (headerName, header) = response.getHeaders.head

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
@@ -336,6 +336,44 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers with Eithe
     )
   }
 
+  it should "resolve a header ref whose key contains characters that are not legal in a scala name" in {
+    val yaml = """
+                 |openapi: 3.1.0
+                 |info:
+                 |  title: Rate limited
+                 |  version: '1.0'
+                 |paths:
+                 |  /ping:
+                 |    get:
+                 |      operationId: getPing
+                 |      responses:
+                 |        '200':
+                 |          description: ''
+                 |          headers:
+                 |            Retry-After:
+                 |              $ref: '#/components/headers/Retry.After'
+                 |components:
+                 |  schemas: {}
+                 |  headers:
+                 |    Retry.After:
+                 |      required: true
+                 |      schema:
+                 |        type: string""".stripMargin
+
+    val doc = parser
+      .parse(yaml)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[OpenapiDocument])
+      .value
+
+    val response = doc.paths.head.methods.head.responses.head.asInstanceOf[OpenapiResponseDef]
+    val (headerName, header) = response.getHeaders.head
+
+    header.resolved(headerName, doc) shouldBe OpenapiHeaderDef(
+      OpenapiParameter("Retry-After", "header", Some(true), None, OpenapiSchemaString(false))
+    )
+  }
+
   it should "resolve a header component which is itself a reference" in {
     val doc = OpenapiDocument(
       "3.1.0",

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
@@ -336,6 +336,58 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers with Eithe
     )
   }
 
+  it should "resolve a header component which is itself a reference" in {
+    val doc = OpenapiDocument(
+      "3.1.0",
+      Nil,
+      OpenapiInfo("Rate limited", "1.0"),
+      Nil,
+      Some(
+        OpenapiComponent(
+          schemas = Map.empty,
+          parameters = Map(
+            "#/components/parameters/RateLimit" ->
+              OpenapiParameter("RateLimit", "header", Some(true), Some("Requests left"), OpenapiSchemaString(false))
+          ),
+          headers = Map(
+            "#/components/headers/Alias" -> OpenapiHeaderRef(OpenapiSchemaRef("#/components/parameters/RateLimit"))
+          )
+        )
+      ),
+      Nil
+    )
+
+    val ref = OpenapiHeaderRef(OpenapiSchemaRef("#/components/headers/Alias"))
+
+    ref.resolved("X-Rate-Limit", doc) shouldBe OpenapiHeaderDef(
+      OpenapiParameter("X-Rate-Limit", "header", Some(true), Some("Requests left"), OpenapiSchemaString(false))
+    )
+  }
+
+  it should "fail with a clear message when header references form a cycle" in {
+    val doc = OpenapiDocument(
+      "3.1.0",
+      Nil,
+      OpenapiInfo("Rate limited", "1.0"),
+      Nil,
+      Some(
+        OpenapiComponent(
+          schemas = Map.empty,
+          headers = Map(
+            "#/components/headers/A" -> OpenapiHeaderRef(OpenapiSchemaRef("#/components/headers/B")),
+            "#/components/headers/B" -> OpenapiHeaderRef(OpenapiSchemaRef("#/components/headers/A"))
+          )
+        )
+      ),
+      Nil
+    )
+
+    val ref = OpenapiHeaderRef(OpenapiSchemaRef("#/components/headers/A"))
+
+    val thrown = intercept[IllegalStateException](ref.resolved("X-Rate-Limit", doc))
+    thrown.getMessage should include("Circular header reference")
+  }
+
   it should "fail with a clear message when a response header ref matches nothing" in {
     val doc = OpenapiDocument("3.1.0", Nil, OpenapiInfo("Rate limited", "1.0"), Nil, Some(OpenapiComponent(Map.empty)), Nil)
 

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
@@ -1,7 +1,14 @@
 package sttp.tapir.codegen.openapi.models
 
 import sttp.tapir.codegen.TestHelpers
-import sttp.tapir.codegen.openapi.models.OpenapiModels.{OpenapiDocument, OpenapiResponse, OpenapiResponseContent, OpenapiResponseDef}
+import sttp.tapir.codegen.openapi.models.OpenapiModels.{
+  OpenapiDocument,
+  OpenapiHeaderDef,
+  OpenapiParameter,
+  OpenapiResponse,
+  OpenapiResponseContent,
+  OpenapiResponseDef
+}
 import sttp.tapir.codegen.openapi.models.OpenapiSchemaType.{
   OpenapiSchemaArray,
   OpenapiSchemaConstantString,
@@ -204,6 +211,33 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers {
 
     res shouldBe Right(
       TestHelpers.oneOfDocsWithMapping
+    )
+  }
+
+  it should "parse a components headers section, re-keyed by full ref" in {
+    val yaml = """
+                 |schemas: {}
+                 |headers:
+                 |  X-Rate-Limit:
+                 |    description: Requests left in the current window
+                 |    required: true
+                 |    schema:
+                 |      type: string""".stripMargin
+
+    val res = parser
+      .parse(yaml)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[OpenapiComponent])
+
+    res shouldBe Right(
+      OpenapiComponent(
+        schemas = Map.empty,
+        headers = Map(
+          "#/components/headers/X-Rate-Limit" -> OpenapiHeaderDef(
+            OpenapiParameter("inline", "header", Some(true), Some("Requests left in the current window"), OpenapiSchemaString(false))
+          )
+        )
+      )
     )
   }
 }

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
@@ -217,6 +217,30 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers with Eithe
     )
   }
 
+  it should "parse a components header described with content, without failing the document" in {
+    val yaml = """
+                 |schemas: {}
+                 |headers:
+                 |  X-Rate-Limit:
+                 |    description: Requests left in the current window
+                 |    content:
+                 |      text/plain:
+                 |        schema:
+                 |          type: string""".stripMargin
+
+    val res = parser
+      .parse(yaml)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[OpenapiComponent])
+
+    res.value.headers.keys.toList shouldBe List("#/components/headers/X-Rate-Limit")
+
+    val thrown = intercept[IllegalStateException] {
+      res.value.headers("#/components/headers/X-Rate-Limit").resolved("X-Rate-Limit", null)
+    }
+    thrown.getMessage should include("'content' instead of 'schema'")
+  }
+
   it should "parse a components headers section, re-keyed by full ref" in {
     val yaml = """
                  |schemas: {}

--- a/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
+++ b/openapi-codegen/core/src/test/scala/sttp/tapir/codegen/models/ModelParserSpec.scala
@@ -4,6 +4,8 @@ import sttp.tapir.codegen.TestHelpers
 import sttp.tapir.codegen.openapi.models.OpenapiModels.{
   OpenapiDocument,
   OpenapiHeaderDef,
+  OpenapiHeaderRef,
+  OpenapiInfo,
   OpenapiParameter,
   OpenapiResponse,
   OpenapiResponseContent,
@@ -239,5 +241,83 @@ class ModelParserSpec extends AnyFlatSpec with Matchers with Checkers {
         )
       )
     )
+  }
+
+  it should "resolve a response header ref against components.headers" in {
+    val yaml = """
+                 |openapi: 3.1.0
+                 |info:
+                 |  title: Rate limited
+                 |  version: '1.0'
+                 |paths:
+                 |  /ping:
+                 |    get:
+                 |      operationId: getPing
+                 |      responses:
+                 |        '200':
+                 |          description: ''
+                 |          headers:
+                 |            X-Rate-Limit:
+                 |              $ref: '#/components/headers/RateLimit'
+                 |          content:
+                 |            text/plain:
+                 |              schema:
+                 |                type: string
+                 |components:
+                 |  schemas: {}
+                 |  headers:
+                 |    RateLimit:
+                 |      description: Requests left in the current window
+                 |      required: true
+                 |      schema:
+                 |        type: string""".stripMargin
+
+    val doc = parser
+      .parse(yaml)
+      .leftMap(err => err: Error)
+      .flatMap(_.as[OpenapiDocument])
+      .toOption
+      .get
+
+    val response = doc.paths.head.methods.head.responses.head.asInstanceOf[OpenapiResponseDef]
+    val (headerName, header) = response.getHeaders.head
+
+    header.resolved(headerName, doc) shouldBe OpenapiHeaderDef(
+      OpenapiParameter("X-Rate-Limit", "header", Some(true), Some("Requests left in the current window"), OpenapiSchemaString(false))
+    )
+  }
+
+  it should "still resolve a response header ref against components.parameters" in {
+    val doc = OpenapiDocument(
+      "3.1.0",
+      Nil,
+      OpenapiInfo("Rate limited", "1.0"),
+      Nil,
+      Some(
+        OpenapiComponent(
+          schemas = Map.empty,
+          parameters = Map(
+            "#/components/parameters/RateLimit" ->
+              OpenapiParameter("RateLimit", "header", Some(true), Some("Requests left"), OpenapiSchemaString(false))
+          )
+        )
+      ),
+      Nil
+    )
+
+    val ref = OpenapiHeaderRef(OpenapiSchemaRef("#/components/parameters/RateLimit"))
+
+    ref.resolved("X-Rate-Limit", doc) shouldBe OpenapiHeaderDef(
+      OpenapiParameter("X-Rate-Limit", "header", Some(true), Some("Requests left"), OpenapiSchemaString(false))
+    )
+  }
+
+  it should "fail with a clear message when a response header ref matches nothing" in {
+    val doc = OpenapiDocument("3.1.0", Nil, OpenapiInfo("Rate limited", "1.0"), Nil, Some(OpenapiComponent(Map.empty)), Nil)
+
+    val ref = OpenapiHeaderRef(OpenapiSchemaRef("#/components/headers/Missing"))
+
+    val thrown = intercept[IllegalStateException](ref.resolved("X-Rate-Limit", doc))
+    thrown.getMessage should include("is referenced but not found")
   }
 }


### PR DESCRIPTION
Add support for `$ref` pointing to `components.headers` (previously it supported only parameters).

A response header written as `$ref: '#/components/headers/Foo'` passed ref validation and then failed at generation with `IllegalStateException: Response component #/components/headers/Foo is referenced but not found`.

Fixing this now, as it will happen more often when we add support for reusable headers (https://github.com/softwaremill/tapir/issues/1411, https://github.com/softwaremill/tapir/pull/5478).

Documents that do not use `components.headers` are unaffected.


