### PR TITLE
Fix enumeration does not handle customise annotation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1296,7 +1296,7 @@ lazy val openapiVerifier: ProjectMatrix = (projectMatrix in file("docs/openapi-v
   )
   .dependsOn(core, openapiDocs, tests % Test)
 
-lazy val openapiDocs3 = openapiDocs.jvm(scala3).dependsOn(enumeratum.jvm(scala3))
+lazy val openapiDocs3 = openapiDocs.jvm(scala3).dependsOn(enumeratum.jvm(scala3) % Test)
 lazy val openapiDocs2_13 = openapiDocs.jvm(scala2_13).dependsOn(enumeratum.jvm(scala2_13))
 lazy val openapiDocs2_12 = openapiDocs.jvm(scala2_12).dependsOn(enumeratum.jvm(scala2_12))
 

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ def versionedScalaSourceDirectories(sourceDir: File, scalaVersion: String): List
 
 def versionedScalaJvmSourceDirectories(sourceDir: File, scalaVersion: String): List[File] =
   CrossVersion.partialVersion(scalaVersion) match {
-    case Some((3, _))            => List(sourceDir / "scalajvm-3")
+    case Some((3, _))            => List(sourceDir / "scalajvm-3", sourceDir / "scalajvm-3-2.13+")
     case Some((2, n)) if n >= 13 => List(sourceDir / "scalajvm-2", sourceDir / "scalajvm-3-2.13+")
     case _                       => List(sourceDir / "scalajvm-2")
   }
@@ -1257,7 +1257,13 @@ lazy val openapiDocs: ProjectMatrix = (projectMatrix in file("docs/openapi-docs"
       "com.softwaremill.quicklens" %%% "quicklens" % Versions.quicklens,
       "com.softwaremill.sttp.apispec" %%% "openapi-model" % Versions.sttpApispec,
       "com.softwaremill.sttp.apispec" %% "openapi-circe-yaml" % Versions.sttpApispec % Test
-    )
+    ),
+    Test / scalacOptions ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((3, _)) => Seq("-Yretain-trees")
+        case _            => Seq()
+      }
+    }
   )
   .jvmPlatform(
     scalaVersions = scala2And3Versions,
@@ -1290,7 +1296,7 @@ lazy val openapiVerifier: ProjectMatrix = (projectMatrix in file("docs/openapi-v
   )
   .dependsOn(core, openapiDocs, tests % Test)
 
-lazy val openapiDocs3 = openapiDocs.jvm(scala3).dependsOn()
+lazy val openapiDocs3 = openapiDocs.jvm(scala3).dependsOn(enumeratum.jvm(scala3))
 lazy val openapiDocs2_13 = openapiDocs.jvm(scala2_13).dependsOn(enumeratum.jvm(scala2_13))
 lazy val openapiDocs2_12 = openapiDocs.jvm(scala2_12).dependsOn(enumeratum.jvm(scala2_12))
 

--- a/core/src/main/scala-2/sttp/tapir/generic/auto/SchemaMagnoliaDerivation.scala
+++ b/core/src/main/scala-2/sttp/tapir/generic/auto/SchemaMagnoliaDerivation.scala
@@ -70,7 +70,7 @@ trait SchemaMagnoliaDerivation {
       case (schema, ann: Schema.annotations.format)    => schema.format(ann.format)
       case (schema, ann: Schema.annotations.title)     => schema.title(ann.name)
       case (schema, _: Schema.annotations.deprecated)  => schema.deprecated(true)
-      case (schema, ann: Schema.annotations.customise) => ann.f(schema).asInstanceOf[Schema[X]]
+      case (schema, ann: Schema.annotations.customise) => ann.f(schema.asInstanceOf[Schema[Any]]).asInstanceOf[Schema[X]]
       case (schema, _)                                 => schema
     }
   }

--- a/core/src/main/scala-2/sttp/tapir/internal/SchemaAnnotationsMacro.scala
+++ b/core/src/main/scala-2/sttp/tapir/internal/SchemaAnnotationsMacro.scala
@@ -18,6 +18,7 @@ private[tapir] object SchemaAnnotationsMacro {
     val EncodedNameAnn = typeOf[sttp.tapir.Schema.annotations.encodedName]
     val ValidateAnn = typeOf[sttp.tapir.Schema.annotations.validate[_]]
     val ValidateEachAnn = typeOf[sttp.tapir.Schema.annotations.validateEach[_]]
+    val CustomiseAnn = typeOf[sttp.tapir.Schema.annotations.customise]
 
     val weakType = weakTypeOf[T]
 
@@ -41,9 +42,10 @@ private[tapir] object SchemaAnnotationsMacro {
     val encodedName = annotations.collectFirst { case ann if ann.tree.tpe <:< EncodedNameAnn => firstArg(ann) }
     val validate = annotations.collect { case ann if ann.tree.tpe <:< ValidateAnn => firstArg(ann) }
     val validateEach = annotations.collect { case ann if ann.tree.tpe <:< ValidateEachAnn => firstArg(ann) }
+    val customise = annotations.collectFirst { case ann if ann.tree.tpe <:< CustomiseAnn => firstArg(ann) }
 
     c.Expr[SchemaAnnotations[T]](
-      q"""_root_.sttp.tapir.SchemaAnnotations.apply($description, $encodedExample, $default, $format, $deprecated, $hidden, $encodedName, _root_.scala.List(..$validate), _root_.scala.List(..$validateEach))"""
+      q"""_root_.sttp.tapir.SchemaAnnotations.apply($description, $encodedExample, $default, $format, $deprecated, $hidden, $encodedName, _root_.scala.List(..$validate), _root_.scala.List(..$validateEach), $customise)"""
     )
   }
 }

--- a/core/src/main/scala-2/sttp/tapir/internal/SchemaAnnotationsMacro.scala
+++ b/core/src/main/scala-2/sttp/tapir/internal/SchemaAnnotationsMacro.scala
@@ -44,8 +44,10 @@ private[tapir] object SchemaAnnotationsMacro {
     val validateEach = annotations.collect { case ann if ann.tree.tpe <:< ValidateEachAnn => firstArg(ann) }
     val customise = annotations.collectFirst { case ann if ann.tree.tpe <:< CustomiseAnn => firstArg(ann) }
 
+    val base = q"""_root_.sttp.tapir.SchemaAnnotations.apply($description, $encodedExample, $default, $format, $deprecated, $hidden, $encodedName, _root_.scala.List(..$validate), _root_.scala.List(..$validateEach))"""
+
     c.Expr[SchemaAnnotations[T]](
-      q"""_root_.sttp.tapir.SchemaAnnotations.apply($description, $encodedExample, $default, $format, $deprecated, $hidden, $encodedName, _root_.scala.List(..$validate), _root_.scala.List(..$validateEach), $customise)"""
+      customise.fold(base)(f => q"$base.withCustomise($f)")
     )
   }
 }

--- a/core/src/main/scala-2/sttp/tapir/internal/SchemaAnnotationsMacro.scala
+++ b/core/src/main/scala-2/sttp/tapir/internal/SchemaAnnotationsMacro.scala
@@ -42,12 +42,13 @@ private[tapir] object SchemaAnnotationsMacro {
     val encodedName = annotations.collectFirst { case ann if ann.tree.tpe <:< EncodedNameAnn => firstArg(ann) }
     val validate = annotations.collect { case ann if ann.tree.tpe <:< ValidateAnn => firstArg(ann) }
     val validateEach = annotations.collect { case ann if ann.tree.tpe <:< ValidateEachAnn => firstArg(ann) }
-    val customise = annotations.collectFirst { case ann if ann.tree.tpe <:< CustomiseAnn => firstArg(ann) }
+    val customise = annotations.collect { case ann if ann.tree.tpe <:< CustomiseAnn => firstArg(ann) }
 
-    val base = q"""_root_.sttp.tapir.SchemaAnnotations.apply($description, $encodedExample, $default, $format, $deprecated, $hidden, $encodedName, _root_.scala.List(..$validate), _root_.scala.List(..$validateEach))"""
+    val base =
+      q"""_root_.sttp.tapir.SchemaAnnotations.apply($description, $encodedExample, $default, $format, $deprecated, $hidden, $encodedName, _root_.scala.List(..$validate), _root_.scala.List(..$validateEach))"""
 
     c.Expr[SchemaAnnotations[T]](
-      customise.fold(base)(f => q"$base.withCustomise($f)")
+      customise.foldLeft(base)((acc, f) => q"$acc.withCustomise($f)")
     )
   }
 }

--- a/core/src/main/scala-3/sttp/tapir/generic/auto/SchemaMagnoliaDerivation.scala
+++ b/core/src/main/scala-3/sttp/tapir/generic/auto/SchemaMagnoliaDerivation.scala
@@ -73,7 +73,7 @@ trait SchemaMagnoliaDerivation {
           case (schema, ann: Schema.annotations.format)    => schema.format(ann.format)
           case (schema, ann: Schema.annotations.title)     => schema.title(ann.name)
           case (schema, _: Schema.annotations.deprecated)  => schema.deprecated(true)
-          case (schema, ann: Schema.annotations.customise) => ann.f(schema).asInstanceOf[Schema[X]]
+          case (schema, ann: Schema.annotations.customise) => ann.f(schema.asInstanceOf[Schema[Any]]).asInstanceOf[Schema[X]]
           case (schema, _)                                 => schema
         }
       }

--- a/core/src/main/scala-3/sttp/tapir/internal/SchemaAnnotationsMacro.scala
+++ b/core/src/main/scala-3/sttp/tapir/internal/SchemaAnnotationsMacro.scala
@@ -74,7 +74,7 @@ private[tapir] object SchemaAnnotationsMacro {
         sa => firstAnnArg(EncodedNameAnn).map(arg => '{ ${ sa }.copy(encodedName = Some(${ arg.asExprOf[String] })) }).getOrElse(sa),
         sa => '{ ${ sa }.copy(validate = ${ Expr.ofList(allAnnArg(ValidateAnn).map(_.asExprOf[sttp.tapir.Validator[T]])) }) },
         sa => '{ ${ sa }.copy(validateEach = ${ Expr.ofList(allAnnArg(ValidateEachAnn).map(_.asExprOf[sttp.tapir.Validator[Any]])) }) },
-        sa => firstAnnArg(CustomiseAnn).map(arg => '{ ${ sa }.copy(customise = Some( ${ arg.asExprOf[Schema[Any] => Schema[Any]] } ))  }).getOrElse(sa)
+        sa => firstAnnArg(CustomiseAnn).map(arg => '{ ${ sa }.withCustomise(${ arg.asExprOf[Schema[Any] => Schema[Any]] } ) }).getOrElse(sa)
       )
 
     transformations.foldLeft('{ SchemaAnnotations.empty[T] })((sa, t) => t(sa))

--- a/core/src/main/scala-3/sttp/tapir/internal/SchemaAnnotationsMacro.scala
+++ b/core/src/main/scala-3/sttp/tapir/internal/SchemaAnnotationsMacro.scala
@@ -1,7 +1,7 @@
 package sttp.tapir.internal
 
 import sttp.tapir.Schema.annotations.format
-import sttp.tapir.SchemaAnnotations
+import sttp.tapir.{Schema, SchemaAnnotations}
 
 import scala.quoted.*
 
@@ -19,6 +19,8 @@ private[tapir] object SchemaAnnotationsMacro {
     val EncodedNameAnn = TypeTree.of[sttp.tapir.Schema.annotations.encodedName].tpe
     val ValidateAnn = TypeTree.of[sttp.tapir.Schema.annotations.validate[_]].tpe
     val ValidateEachAnn = TypeTree.of[sttp.tapir.Schema.annotations.validateEach[_]].tpe
+    val CustomiseAnn = TypeTree.of[sttp.tapir.Schema.annotations.customise].tpe
+    
 
     val tpe = TypeRepr.of[T]
 
@@ -71,7 +73,8 @@ private[tapir] object SchemaAnnotationsMacro {
         sa => annotations.find { _.tpe <:< HiddenAnn }.map(_ => '{ ${ sa }.copy(hidden = Some(true)) }).getOrElse(sa),
         sa => firstAnnArg(EncodedNameAnn).map(arg => '{ ${ sa }.copy(encodedName = Some(${ arg.asExprOf[String] })) }).getOrElse(sa),
         sa => '{ ${ sa }.copy(validate = ${ Expr.ofList(allAnnArg(ValidateAnn).map(_.asExprOf[sttp.tapir.Validator[T]])) }) },
-        sa => '{ ${ sa }.copy(validateEach = ${ Expr.ofList(allAnnArg(ValidateEachAnn).map(_.asExprOf[sttp.tapir.Validator[Any]])) }) }
+        sa => '{ ${ sa }.copy(validateEach = ${ Expr.ofList(allAnnArg(ValidateEachAnn).map(_.asExprOf[sttp.tapir.Validator[Any]])) }) },
+        sa => firstAnnArg(CustomiseAnn).map(arg => '{ ${ sa }.copy(customise = Some( ${ arg.asExprOf[Schema[?] => Schema[?]] } ))  }).getOrElse(sa)
       )
 
     transformations.foldLeft('{ SchemaAnnotations.empty[T] })((sa, t) => t(sa))

--- a/core/src/main/scala-3/sttp/tapir/internal/SchemaAnnotationsMacro.scala
+++ b/core/src/main/scala-3/sttp/tapir/internal/SchemaAnnotationsMacro.scala
@@ -20,7 +20,6 @@ private[tapir] object SchemaAnnotationsMacro {
     val ValidateAnn = TypeTree.of[sttp.tapir.Schema.annotations.validate[_]].tpe
     val ValidateEachAnn = TypeTree.of[sttp.tapir.Schema.annotations.validateEach[_]].tpe
     val CustomiseAnn = TypeTree.of[sttp.tapir.Schema.annotations.customise].tpe
-    
 
     val tpe = TypeRepr.of[T]
 
@@ -74,7 +73,7 @@ private[tapir] object SchemaAnnotationsMacro {
         sa => firstAnnArg(EncodedNameAnn).map(arg => '{ ${ sa }.copy(encodedName = Some(${ arg.asExprOf[String] })) }).getOrElse(sa),
         sa => '{ ${ sa }.copy(validate = ${ Expr.ofList(allAnnArg(ValidateAnn).map(_.asExprOf[sttp.tapir.Validator[T]])) }) },
         sa => '{ ${ sa }.copy(validateEach = ${ Expr.ofList(allAnnArg(ValidateEachAnn).map(_.asExprOf[sttp.tapir.Validator[Any]])) }) },
-        sa => firstAnnArg(CustomiseAnn).map(arg => '{ ${ sa }.withCustomise(${ arg.asExprOf[Schema[Any] => Schema[Any]] } ) }).getOrElse(sa)
+        sa => allAnnArg(CustomiseAnn).foldLeft(sa)((acc, arg) => '{ ${ acc }.withCustomise(${ arg.asExprOf[Schema[Any] => Schema[Any]] }) })
       )
 
     transformations.foldLeft('{ SchemaAnnotations.empty[T] })((sa, t) => t(sa))

--- a/core/src/main/scala-3/sttp/tapir/internal/SchemaAnnotationsMacro.scala
+++ b/core/src/main/scala-3/sttp/tapir/internal/SchemaAnnotationsMacro.scala
@@ -74,7 +74,7 @@ private[tapir] object SchemaAnnotationsMacro {
         sa => firstAnnArg(EncodedNameAnn).map(arg => '{ ${ sa }.copy(encodedName = Some(${ arg.asExprOf[String] })) }).getOrElse(sa),
         sa => '{ ${ sa }.copy(validate = ${ Expr.ofList(allAnnArg(ValidateAnn).map(_.asExprOf[sttp.tapir.Validator[T]])) }) },
         sa => '{ ${ sa }.copy(validateEach = ${ Expr.ofList(allAnnArg(ValidateEachAnn).map(_.asExprOf[sttp.tapir.Validator[Any]])) }) },
-        sa => firstAnnArg(CustomiseAnn).map(arg => '{ ${ sa }.copy(customise = Some( ${ arg.asExprOf[Schema[?] => Schema[?]] } ))  }).getOrElse(sa)
+        sa => firstAnnArg(CustomiseAnn).map(arg => '{ ${ sa }.copy(customise = Some( ${ arg.asExprOf[Schema[Any] => Schema[Any]] } ))  }).getOrElse(sa)
       )
 
     transformations.foldLeft('{ SchemaAnnotations.empty[T] })((sa, t) => t(sa))

--- a/core/src/main/scala/sttp/tapir/Schema.scala
+++ b/core/src/main/scala/sttp/tapir/Schema.scala
@@ -503,6 +503,7 @@ object Schema extends LowPrioritySchema with SchemaCompanionMacros {
       * [[Schema.annotations]] can't express, e.g. setting an attribute rendered by a documentation interpreter:
       *
       * {{{
+      * // with sttp.tapir.docs.apispec.DocsExtensionAttribute._ in scope
       * @customise(_.docsExtension("x-enum-varnames", List("UnPaid", "Paid")))
       * sealed trait OrderStatus
       * }}}

--- a/core/src/main/scala/sttp/tapir/Schema.scala
+++ b/core/src/main/scala/sttp/tapir/Schema.scala
@@ -498,6 +498,20 @@ object Schema extends LowPrioritySchema with SchemaCompanionMacros {
       * }}}
       */
     class validateEach[T](val v: Validator[T]) extends StaticAnnotation with Serializable
+
+    /** Applies an arbitrary transformation `f` to the derived schema of the annotated class, field or enumeration. An escape hatch for
+      * customisations that the other annotations in [[Schema.annotations]] can't express - most often setting a schema attribute, which
+      * documentation interpreters then render (e.g. an OpenAPI extension):
+      * {{{
+      *
+      * @customise(_.attribute(AttributeKey[List[String]], List("UnPaid", "Paid")))
+      * sealed trait OrderStatus
+      * }}}
+      *
+      * `f` is applied after the metadata annotations ([[description]], [[encodedExample]], [[default]], [[format]], [[deprecated]],
+      * [[hidden]], [[encodedName]]), so it can override what they set. When deriving a schema for an enumeration, it is applied before
+      * [[validate]] and [[validateEach]] - a validator set inside `f` is therefore added to, not replaced by, those annotations.
+      */
     class customise(val f: Schema[Any] => Schema[Any]) extends StaticAnnotation with Serializable
   }
 

--- a/core/src/main/scala/sttp/tapir/Schema.scala
+++ b/core/src/main/scala/sttp/tapir/Schema.scala
@@ -499,18 +499,20 @@ object Schema extends LowPrioritySchema with SchemaCompanionMacros {
       */
     class validateEach[T](val v: Validator[T]) extends StaticAnnotation with Serializable
 
-    /** Applies an arbitrary transformation `f` to the derived schema of the annotated class, field or enumeration. An escape hatch for
-      * customisations that the other annotations in [[Schema.annotations]] can't express - most often setting a schema attribute, which
-      * documentation interpreters then render (e.g. an OpenAPI extension):
-      * {{{
+    /** Applies `f` to the schema derived for the annotated class, field or enumeration - an escape hatch for what the other
+      * [[Schema.annotations]] can't express, e.g. setting an attribute rendered by a documentation interpreter:
       *
-      * @customise(_.attribute(AttributeKey[List[String]], List("UnPaid", "Paid")))
+      * {{{
+      * @customise(_.docsExtension("x-enum-varnames", List("UnPaid", "Paid")))
       * sealed trait OrderStatus
       * }}}
       *
-      * `f` is applied after the metadata annotations ([[description]], [[encodedExample]], [[default]], [[format]], [[deprecated]],
-      * [[hidden]], [[encodedName]]), so it can override what they set. When deriving a schema for an enumeration, it is applied before
-      * [[validate]] and [[validateEach]] - a validator set inside `f` is therefore added to, not replaced by, those annotations.
+      * All `@customise` annotations are applied, in declaration order. `Schema.derived` and auto derivation apply annotations in
+      * declaration order; `Schema.derivedEnumeration` and the enumeration / enumeratum codecs apply `f` after the metadata annotations and
+      * before [[validate]] / [[validateEach]].
+      *
+      * `f` is `Schema[Any] => Schema[Any]`, not `Schema[?] => Schema[?]`: the Scala 2 macro splices its tree, and an existential parameter
+      * type carries a skolem that can't be lifted.
       */
     class customise(val f: Schema[Any] => Schema[Any]) extends StaticAnnotation with Serializable
   }

--- a/core/src/main/scala/sttp/tapir/Schema.scala
+++ b/core/src/main/scala/sttp/tapir/Schema.scala
@@ -498,7 +498,7 @@ object Schema extends LowPrioritySchema with SchemaCompanionMacros {
       * }}}
       */
     class validateEach[T](val v: Validator[T]) extends StaticAnnotation with Serializable
-    class customise(val f: Schema[?] => Schema[?]) extends StaticAnnotation with Serializable
+    class customise(val f: Schema[Any] => Schema[Any]) extends StaticAnnotation with Serializable
   }
 
   /** Wraps the given schema with a single-field product, where `fieldName` maps to `schema`.

--- a/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
@@ -15,8 +15,22 @@ final case class SchemaAnnotations[T](
     encodedName: Option[String],
     validate: List[Validator[T]],
     validateEach: List[Validator[Any]],
-    customise: Option[Schema[Any] => Schema[Any]] = None
+    customise: Option[Schema[Any] => Schema[Any]]
 ) {
+
+  /** Retained for binary compatibility with 1.13.x */
+  def this(
+      description: Option[String],
+      encodedExample: Option[Any],
+      default: Option[(T, Option[Any])],
+      format: Option[String],
+      deprecated: Option[Boolean],
+      hidden: Option[Boolean],
+      encodedName: Option[String],
+      validate: List[Validator[T]],
+      validateEach: List[Validator[Any]]
+  ) = this(description, encodedExample, default, format, deprecated, hidden, encodedName, validate, validateEach, None)
+
   private case class SchemaEnrich(current: Schema[T]) {
     def optionally(f: Schema[T] => Option[Schema[T]]): SchemaEnrich = f(current).map(SchemaEnrich.apply).getOrElse(this)
   }

--- a/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
@@ -15,7 +15,7 @@ final case class SchemaAnnotations[T](
     encodedName: Option[String],
     validate: List[Validator[T]],
     validateEach: List[Validator[Any]],
-    customise: Option[Schema[?] => Schema[?]]
+    customise: Option[Schema[Any] => Schema[Any]]
 ) {
   private case class SchemaEnrich(current: Schema[T]) {
     def optionally(f: Schema[T] => Option[Schema[T]]): SchemaEnrich = f(current).map(SchemaEnrich.apply).getOrElse(this)
@@ -30,7 +30,7 @@ final case class SchemaAnnotations[T](
       .optionally(s => deprecated.map(s.deprecated(_)))
       .optionally(s => hidden.map(s.hidden(_)))
       .optionally(s => encodedName.map(en => s.name(SName(en))))
-      .optionally(s => customise.map(c => c(s).asInstanceOf[Schema[T]]))
+      .optionally(s => customise.map(c => c(s.asInstanceOf[Schema[Any]]).asInstanceOf[Schema[T]]))
       .current
 
     val s3 = validate.foldLeft(s2)((current, v) => current.validate(v))

--- a/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
@@ -30,56 +30,48 @@ final case class SchemaAnnotations[T](
       .optionally(s => deprecated.map(s.deprecated(_)))
       .optionally(s => hidden.map(s.hidden(_)))
       .optionally(s => encodedName.map(en => s.name(SName(en))))
-      .optionally(s => _customise.map(c => c(s.asInstanceOf[Schema[Any]]).asInstanceOf[Schema[T]]))
       .current
 
-    val s3 = validate.foldLeft(s2)((current, v) => current.validate(v))
+    // after the metadata annotations above, before the validators below
+    val s2c = _customise(s2.asInstanceOf[Schema[Any]]).asInstanceOf[Schema[T]]
+
+    val s3 = validate.foldLeft(s2c)((current, v) => current.validate(v))
 
     validateEach.foldLeft(s3)((current, v) => current.modifyUnsafe(Schema.ModifyCollectionElements)((_: Schema[Any]).validate(v)))
   }
 
-  /** Customise transformation function taken from @cusomise annotation Extraction was accidentally omitted when the annotation was
-    * introduced
+  /** Transformation from the `@customise` annotations, composed in declaration order.
     *
-    * Stored as a private var only to keep backward compatibility. Moving this to the parameter list would break copy() and apply()
-    * signatures for a generated jvm class.
-    *
-    * When breaking binary compatibility would be an option, consider moving this into a regular parameter list with adjusting
-    * SchemaAnnotationsMacro(both scala 3 and 2) accordingly
+    * Not a constructor parameter, to keep the generated `apply`, `unapply` and constructor signatures binary compatible (MiMa, 2.12/2.13).
+    * Consequence: invisible to the generated `equals`, `hashCode`, `toString`, `unapply` and `productIterator`.
     */
-  private var _customise: Option[Schema[Any] => Schema[Any]] = None
+  private var _customise: Schema[Any] => Schema[Any] = identity
 
+  /** Composes `c` after the current transformation. */
   def withCustomise(c: Schema[Any] => Schema[Any]): SchemaAnnotations[T] = {
     val copy = this.copy[T]()
-    copy._customise = Some(c)
+    copy._customise = _customise.andThen(c)
     copy
   }
 
-  /** Replaces the `copy` that would otherwise be generated for this case class, so that the `_customise` field - which is not a constructor
-    * parameter - is carried over to the copy.
+  /** Replaces the generated `copy`, so that `_customise` is carried over.
     *
-    * The signature must stay exactly as the generated one would be. Scala 3 skips generating `copy` only when a user-defined `copy` matches
-    * that signature; a differently shaped one becomes an overload instead, making every defaulted call ambiguous. Keeping the type
-    * parameter named `T` also keeps the erased and generic signatures identical to the generated ones, which is what makes this binary
-    * compatible. The casts below are needed because this `T` shadows the class's one - the generated `copy` is special-cased by the
-    * compiler and needs no casts.
-    *
-    * Remove this method once `_customise` moves to a regular parameter list: the generated `copy` takes over again, and the explicit
-    * `copy[T]()` in `withCustomise` can go back to `copy()`.
+    * The signature must match the generated one exactly, type parameter included - otherwise Scala 3 generates its own `copy` as well, and
+    * the two overloads make every defaulted call unresolvable. Hence the casts below, and hence `R` is not taken from the receiver: without
+    * an expected type it is inferred as `Nothing`, so callers apply it explicitly (`copy[String](...)`).
     */
-
-  def copy[T](
+  def copy[R](
       description: Option[String] = this.description,
       encodedExample: Option[Any] = this.encodedExample,
-      default: Option[(T, Option[Any])] = this.default.asInstanceOf[Option[(T, Option[Any])]],
+      default: Option[(R, Option[Any])] = this.default.asInstanceOf[Option[(R, Option[Any])]],
       format: Option[String] = this.format,
       deprecated: Option[Boolean] = this.deprecated,
       hidden: Option[Boolean] = this.hidden,
       encodedName: Option[String] = this.encodedName,
-      validate: List[Validator[T]] = this.validate.asInstanceOf[List[Validator[T]]],
+      validate: List[Validator[R]] = this.validate.asInstanceOf[List[Validator[R]]],
       validateEach: List[Validator[Any]] = this.validateEach
-  ): SchemaAnnotations[T] = {
-    val c = new SchemaAnnotations[T](
+  ): SchemaAnnotations[R] = {
+    val c = new SchemaAnnotations[R](
       description,
       encodedExample,
       default,

--- a/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
@@ -14,23 +14,10 @@ final case class SchemaAnnotations[T](
     hidden: Option[Boolean],
     encodedName: Option[String],
     validate: List[Validator[T]],
-    validateEach: List[Validator[Any]],
-    customise: Option[Schema[Any] => Schema[Any]]
+    validateEach: List[Validator[Any]]
 ) {
 
-  /** Retained for binary compatibility with 1.13.x. No default arguments: only one `copy` overload may have them. */
-  def copy(
-      description: Option[String],
-      encodedExample: Option[Any],
-      default: Option[(T, Option[Any])],
-      format: Option[String],
-      deprecated: Option[Boolean],
-      hidden: Option[Boolean],
-      encodedName: Option[String],
-      validate: List[Validator[T]],
-      validateEach: List[Validator[Any]]
-  ): SchemaAnnotations[T] =
-    new SchemaAnnotations(description, encodedExample, default, format, deprecated, hidden, encodedName, validate, validateEach, this.customise)
+  private var _customise: Option[Schema[Any] => Schema[Any]] = None
 
   private case class SchemaEnrich(current: Schema[T]) {
     def optionally(f: Schema[T] => Option[Schema[T]]): SchemaEnrich = f(current).map(SchemaEnrich.apply).getOrElse(this)
@@ -45,15 +32,21 @@ final case class SchemaAnnotations[T](
       .optionally(s => deprecated.map(s.deprecated(_)))
       .optionally(s => hidden.map(s.hidden(_)))
       .optionally(s => encodedName.map(en => s.name(SName(en))))
-      .optionally(s => customise.map(c => c(s.asInstanceOf[Schema[Any]]).asInstanceOf[Schema[T]]))
+      .optionally(s => _customise.map(c => c(s.asInstanceOf[Schema[Any]]).asInstanceOf[Schema[T]]))
       .current
 
     val s3 = validate.foldLeft(s2)((current, v) => current.validate(v))
 
     validateEach.foldLeft(s3)((current, v) => current.modifyUnsafe(Schema.ModifyCollectionElements)((_: Schema[Any]).validate(v)))
   }
+  
+  def withCustomise(c: Schema[Any] => Schema[Any]): SchemaAnnotations[T] = {
+    val copy = this.copy()
+    copy._customise = Some(c)
+    copy
+  }
 }
 
 object SchemaAnnotations extends SchemaAnnotationsMacros {
-  def empty[T]: SchemaAnnotations[T] = SchemaAnnotations(None, None, None, None, None, None, None, Nil, Nil, None)
+  def empty[T]: SchemaAnnotations[T] = SchemaAnnotations(None, None, None, None, None, None, None, Nil, Nil)
 }

--- a/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
@@ -15,7 +15,7 @@ final case class SchemaAnnotations[T](
     encodedName: Option[String],
     validate: List[Validator[T]],
     validateEach: List[Validator[Any]],
-    customise: Option[Schema[Any] => Schema[Any]]
+    customise: Option[Schema[Any] => Schema[Any]] = None
 ) {
   private case class SchemaEnrich(current: Schema[T]) {
     def optionally(f: Schema[T] => Option[Schema[T]]): SchemaEnrich = f(current).map(SchemaEnrich.apply).getOrElse(this)

--- a/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
@@ -38,16 +38,17 @@ final case class SchemaAnnotations[T](
     validateEach.foldLeft(s3)((current, v) => current.modifyUnsafe(Schema.ModifyCollectionElements)((_: Schema[Any]).validate(v)))
   }
 
-  /**
-   * Customise transformation function taken from @cusomise annotation
-   * Extraction was accidentally omitted when the annotation was introduced
-   *
-   * Stored as a private var only to keep backward compatibility.
-   * Moving this to the parameter list would break copy() and apply() signatures for a generated jvm class.
-   *
-   * When breaking binary compatibility would be an option, consider moving this into a regular parameter list
-   * with adjusting SchemaAnnotationsMacro(both scala 3 and 2) accordingly
-   */
+  /** Customise transformation function taken from @cusomise annotation Extraction was accidentally omitted when the annotation was
+    * introduced
+    *
+    * Stored as a private var only to keep backward compatibility. Moving this to the parameter list would break copy() and apply()
+    * signatures for a generated jvm class.
+    *
+    * When breaking binary compatibility would be an option, consider moving this into a regular parameter list with adjusting
+    * SchemaAnnotationsMacro(both scala 3 and 2) accordingly
+    *
+    * This has to be called last within macro transformations otherwise it would be lost as it is not a part of the auto generated copy
+    */
   private var _customise: Option[Schema[Any] => Schema[Any]] = None
 
   def withCustomise(c: Schema[Any] => Schema[Any]): SchemaAnnotations[T] = {

--- a/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
@@ -18,8 +18,8 @@ final case class SchemaAnnotations[T](
     customise: Option[Schema[Any] => Schema[Any]]
 ) {
 
-  /** Retained for binary compatibility with 1.13.x */
-  def this(
+  /** Retained for binary compatibility with 1.13.x. No default arguments: only one `copy` overload may have them. */
+  def copy(
       description: Option[String],
       encodedExample: Option[Any],
       default: Option[(T, Option[Any])],
@@ -29,7 +29,8 @@ final case class SchemaAnnotations[T](
       encodedName: Option[String],
       validate: List[Validator[T]],
       validateEach: List[Validator[Any]]
-  ) = this(description, encodedExample, default, format, deprecated, hidden, encodedName, validate, validateEach, None)
+  ): SchemaAnnotations[T] =
+    new SchemaAnnotations(description, encodedExample, default, format, deprecated, hidden, encodedName, validate, validateEach, this.customise)
 
   private case class SchemaEnrich(current: Schema[T]) {
     def optionally(f: Schema[T] => Option[Schema[T]]): SchemaEnrich = f(current).map(SchemaEnrich.apply).getOrElse(this)
@@ -54,19 +55,5 @@ final case class SchemaAnnotations[T](
 }
 
 object SchemaAnnotations extends SchemaAnnotationsMacros {
-
-  def apply[T](
-      description: Option[String],
-      encodedExample: Option[Any],
-      default: Option[(T, Option[Any])],
-      format: Option[String],
-      deprecated: Option[Boolean],
-      hidden: Option[Boolean],
-      encodedName: Option[String],
-      validate: List[Validator[T]],
-      validateEach: List[Validator[Any]]
-  ): SchemaAnnotations[T] =
-    SchemaAnnotations(description, encodedExample, default, format, deprecated, hidden, encodedName, validate, validateEach, None)
-
   def empty[T]: SchemaAnnotations[T] = SchemaAnnotations(None, None, None, None, None, None, None, Nil, Nil, None)
 }

--- a/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
@@ -17,8 +17,6 @@ final case class SchemaAnnotations[T](
     validateEach: List[Validator[Any]]
 ) {
 
-  private var _customise: Option[Schema[Any] => Schema[Any]] = None
-
   private case class SchemaEnrich(current: Schema[T]) {
     def optionally(f: Schema[T] => Option[Schema[T]]): SchemaEnrich = f(current).map(SchemaEnrich.apply).getOrElse(this)
   }
@@ -39,7 +37,19 @@ final case class SchemaAnnotations[T](
 
     validateEach.foldLeft(s3)((current, v) => current.modifyUnsafe(Schema.ModifyCollectionElements)((_: Schema[Any]).validate(v)))
   }
-  
+
+  /**
+   * Customise transformation function taken from @cusomise annotation
+   * Extraction was accidentally omitted when the annotation was introduced
+   *
+   * Stored as a private var only to keep backward compatibility.
+   * Moving this to the parameter list would break copy() and apply() signatures for a generated jvm class.
+   *
+   * When breaking binary compatibility would be an option, consider moving this into a regular parameter list
+   * with adjusting SchemaAnnotationsMacro(both scala 3 and 2) accordingly
+   */
+  private var _customise: Option[Schema[Any] => Schema[Any]] = None
+
   def withCustomise(c: Schema[Any] => Schema[Any]): SchemaAnnotations[T] = {
     val copy = this.copy()
     copy._customise = Some(c)

--- a/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
@@ -40,5 +40,19 @@ final case class SchemaAnnotations[T](
 }
 
 object SchemaAnnotations extends SchemaAnnotationsMacros {
+
+  def apply[T](
+      description: Option[String],
+      encodedExample: Option[Any],
+      default: Option[(T, Option[Any])],
+      format: Option[String],
+      deprecated: Option[Boolean],
+      hidden: Option[Boolean],
+      encodedName: Option[String],
+      validate: List[Validator[T]],
+      validateEach: List[Validator[Any]]
+  ): SchemaAnnotations[T] =
+    SchemaAnnotations(description, encodedExample, default, format, deprecated, hidden, encodedName, validate, validateEach, None)
+
   def empty[T]: SchemaAnnotations[T] = SchemaAnnotations(None, None, None, None, None, None, None, Nil, Nil, None)
 }

--- a/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
@@ -46,15 +46,52 @@ final case class SchemaAnnotations[T](
     *
     * When breaking binary compatibility would be an option, consider moving this into a regular parameter list with adjusting
     * SchemaAnnotationsMacro(both scala 3 and 2) accordingly
-    *
-    * This has to be called last within macro transformations otherwise it would be lost as it is not a part of the auto generated copy
     */
   private var _customise: Option[Schema[Any] => Schema[Any]] = None
 
   def withCustomise(c: Schema[Any] => Schema[Any]): SchemaAnnotations[T] = {
-    val copy = this.copy()
+    val copy = this.copy[T]()
     copy._customise = Some(c)
     copy
+  }
+
+  /** Replaces the `copy` that would otherwise be generated for this case class, so that the `_customise` field - which is not a constructor
+    * parameter - is carried over to the copy.
+    *
+    * The signature must stay exactly as the generated one would be. Scala 3 skips generating `copy` only when a user-defined `copy` matches
+    * that signature; a differently shaped one becomes an overload instead, making every defaulted call ambiguous. Keeping the type
+    * parameter named `T` also keeps the erased and generic signatures identical to the generated ones, which is what makes this binary
+    * compatible. The casts below are needed because this `T` shadows the class's one - the generated `copy` is special-cased by the
+    * compiler and needs no casts.
+    *
+    * Remove this method once `_customise` moves to a regular parameter list: the generated `copy` takes over again, and the explicit
+    * `copy[T]()` in `withCustomise` can go back to `copy()`.
+    */
+
+  def copy[T](
+      description: Option[String] = this.description,
+      encodedExample: Option[Any] = this.encodedExample,
+      default: Option[(T, Option[Any])] = this.default.asInstanceOf[Option[(T, Option[Any])]],
+      format: Option[String] = this.format,
+      deprecated: Option[Boolean] = this.deprecated,
+      hidden: Option[Boolean] = this.hidden,
+      encodedName: Option[String] = this.encodedName,
+      validate: List[Validator[T]] = this.validate.asInstanceOf[List[Validator[T]]],
+      validateEach: List[Validator[Any]] = this.validateEach
+  ): SchemaAnnotations[T] = {
+    val c = new SchemaAnnotations[T](
+      description,
+      encodedExample,
+      default,
+      format,
+      deprecated,
+      hidden,
+      encodedName,
+      validate,
+      validateEach
+    )
+    c._customise = this._customise
+    c
   }
 }
 

--- a/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
+++ b/core/src/main/scala/sttp/tapir/SchemaAnnotations.scala
@@ -14,7 +14,8 @@ final case class SchemaAnnotations[T](
     hidden: Option[Boolean],
     encodedName: Option[String],
     validate: List[Validator[T]],
-    validateEach: List[Validator[Any]]
+    validateEach: List[Validator[Any]],
+    customise: Option[Schema[?] => Schema[?]]
 ) {
   private case class SchemaEnrich(current: Schema[T]) {
     def optionally(f: Schema[T] => Option[Schema[T]]): SchemaEnrich = f(current).map(SchemaEnrich.apply).getOrElse(this)
@@ -29,6 +30,7 @@ final case class SchemaAnnotations[T](
       .optionally(s => deprecated.map(s.deprecated(_)))
       .optionally(s => hidden.map(s.hidden(_)))
       .optionally(s => encodedName.map(en => s.name(SName(en))))
+      .optionally(s => customise.map(c => c(s).asInstanceOf[Schema[T]]))
       .current
 
     val s3 = validate.foldLeft(s2)((current, v) => current.validate(v))
@@ -38,5 +40,5 @@ final case class SchemaAnnotations[T](
 }
 
 object SchemaAnnotations extends SchemaAnnotationsMacros {
-  def empty[T]: SchemaAnnotations[T] = SchemaAnnotations(None, None, None, None, None, None, None, Nil, Nil)
+  def empty[T]: SchemaAnnotations[T] = SchemaAnnotations(None, None, None, None, None, None, None, Nil, Nil, None)
 }

--- a/core/src/test/scala/sttp/tapir/SchemaAnnotationsTest.scala
+++ b/core/src/test/scala/sttp/tapir/SchemaAnnotationsTest.scala
@@ -24,4 +24,17 @@ class SchemaAnnotationsTest extends AnyFlatSpec with Matchers {
       .name(SName("encoded-name"))
       .validate(Validator.pass[MyString])
   }
+
+  behavior of "SchemaAnnotations copy"
+
+  // `copy` is hand-written, hence the explicit type argument
+  it should "carry over the customise functions" in {
+    val baseSchema: Schema[MyString] = Schema.string[MyString]
+    val annotations = SchemaAnnotations.empty[MyString].withCustomise(_.format("f"))
+
+    val enriched = annotations.copy[MyString](description = Some("d")).enrich(baseSchema)
+
+    enriched.description shouldBe Some("d")
+    enriched.format shouldBe Some("f")
+  }
 }

--- a/doc/endpoint/schemas.md
+++ b/doc/endpoint/schemas.md
@@ -305,6 +305,9 @@ field of a case class. One way the automatic & semi-automatic derivation can be 
 * `@validate` will add the given validator to a case class field
 * `@validateEach` will add the given validator to the elements of a case class field. Useful for validating the
   value contained in an `Option` (when it's defined), and collection elements
+* `@customise` applies an arbitrary `Schema[Any] => Schema[Any]` function to the schema derived for the annotated
+  class, field or enumeration; an escape hatch for what the annotations above can't express. All `@customise`
+  annotations are applied, in declaration order
 
 These annotations will adjust schemas, after they are looked up using the normal implicit mechanisms.
 

--- a/doc/server/netty.md
+++ b/doc/server/netty.md
@@ -88,7 +88,7 @@ NettySyncServer(NettyConfig.default.socketBacklog(256))
 ```
 
 ```{note}
-Unlike other server interpreters, the Netty-based servers are by default
+Unlike other server interpreters, the Netty-based servers are bydefault
 configured to return a 404, in case none of the given endpoints match a request.
 This can be changed by using a different `RejectHandler`.
 

--- a/doc/server/netty.md
+++ b/doc/server/netty.md
@@ -88,7 +88,7 @@ NettySyncServer(NettyConfig.default.socketBacklog(256))
 ```
 
 ```{note}
-Unlike other server interpreters, the Netty-based servers are bydefault
+Unlike other server interpreters, the Netty-based servers are by default
 configured to return a 404, in case none of the given endpoints match a request.
 This can be changed by using a different `RejectHandler`.
 

--- a/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_short_enum_with_docs_extension.yml
+++ b/docs/openapi-docs/src/test/resources/enum/expected_enumeratum_short_enum_with_docs_extension.yml
@@ -1,0 +1,38 @@
+openapi: 3.1.0
+info:
+  title: Orders
+  version: '1.0'
+paths:
+  /order:
+    get:
+      operationId: getOrder
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderStatusResponse'
+components:
+  schemas:
+    OrderStatus:
+      title: OrderStatus
+      type: integer
+      enum:
+        - 0
+        - 1
+        - 2
+        - 3
+      x-enum-varnames:
+        - UnPaid
+        - Paid
+        - Finish
+        - Cancel
+    OrderStatusResponse:
+      title: OrderStatusResponse
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/OrderStatus'

--- a/docs/openapi-docs/src/test/scalajvm-2/sttp/tapir/docs/openapi/VerifyYamlEnumeratumTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm-2/sttp/tapir/docs/openapi/VerifyYamlEnumeratumTest.scala
@@ -6,16 +6,19 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import sttp.apispec.openapi.Info
 import sttp.apispec.openapi.circe.yaml._
-import sttp.tapir.Schema.annotations.{default, description}
+import sttp.tapir.Schema.annotations.{default, description, customise}
 import sttp.tapir._
 import sttp.tapir.docs.openapi.VerifyYamlEnumeratumTest._
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe.jsonBody
-
+import sttp.tapir.json.circe._
+import sttp.tapir.docs.apispec.DocsExtensionAttribute._
+import enumeratum.{Enum, EnumEntry}
+import enumeratum.values.{IntEnum, IntEnumEntry, ShortEnum, ShortEnumEntry}
 import scala.collection.immutable
+import sttp.tapir.codec.enumeratum._
 
 class VerifyYamlEnumeratumTest extends AnyFunSuite with Matchers {
-  import sttp.tapir.codec.enumeratum._
 
   test("should use enumeratum validator for array elements") {
     val expectedYaml = load("validator/expected_valid_enumeratum.yml")
@@ -148,11 +151,19 @@ class VerifyYamlEnumeratumTest extends AnyFunSuite with Matchers {
 
     noIndentation(actualYaml) shouldBe expectedYaml
   }
+
+  test("should add docs extension from @customise annotation on a ShortEnum") {
+    val actualYaml = OpenAPIDocsInterpreter()
+      .toOpenAPI(endpoint.in("order").out(jsonBody[OrderStatusResponse]), "Orders", "1.0")
+      .toYaml
+
+    val expectedYaml = load("enum/expected_enumeratum_short_enum_with_docs_extension.yml")
+
+    noIndentation(actualYaml) shouldBe expectedYaml
+  }
 }
 
 object VerifyYamlEnumeratumTest {
-  import enumeratum.{Enum, EnumEntry}
-  import enumeratum.values.{IntEnum, IntEnumEntry}
 
   case class FruitWithEnum(fruit: String, amount: Int, fruitType: List[FruitType])
 
@@ -206,4 +217,17 @@ object VerifyYamlEnumeratumTest {
 
     override def values: immutable.IndexedSeq[ErrorCode] = findValues
   }
+
+  @customise(_.docsExtension("x-enum-varnames", List("UnPaid", "Paid", "Finish", "Cancel")))
+  sealed abstract class OrderStatus(val value: Short) extends ShortEnumEntry
+
+  object OrderStatus extends ShortEnum[OrderStatus] {
+    case object UnPaid extends OrderStatus(0)
+    case object Paid extends OrderStatus(1)
+    case object Finish extends OrderStatus(2)
+    case object Cancel extends OrderStatus(3)
+    override def values: immutable.IndexedSeq[OrderStatus] = findValues
+  }
+
+  case class OrderStatusResponse(status: OrderStatus)
 }

--- a/docs/openapi-docs/src/test/scalajvm-2/sttp/tapir/docs/openapi/VerifyYamlEnumeratumTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm-2/sttp/tapir/docs/openapi/VerifyYamlEnumeratumTest.scala
@@ -6,19 +6,17 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import sttp.apispec.openapi.Info
 import sttp.apispec.openapi.circe.yaml._
-import sttp.tapir.Schema.annotations.{default, description, customise}
+import sttp.tapir.Schema.annotations.{customise, default, description}
 import sttp.tapir._
+import sttp.tapir.docs.apispec.DocsExtensionAttribute._
 import sttp.tapir.docs.openapi.VerifyYamlEnumeratumTest._
 import sttp.tapir.generic.auto._
-import sttp.tapir.json.circe.jsonBody
 import sttp.tapir.json.circe._
-import sttp.tapir.docs.apispec.DocsExtensionAttribute._
-import enumeratum.{Enum, EnumEntry}
-import enumeratum.values.{IntEnum, IntEnumEntry, ShortEnum, ShortEnumEntry}
+
 import scala.collection.immutable
-import sttp.tapir.codec.enumeratum._
 
 class VerifyYamlEnumeratumTest extends AnyFunSuite with Matchers {
+  import sttp.tapir.codec.enumeratum._
 
   test("should use enumeratum validator for array elements") {
     val expectedYaml = load("validator/expected_valid_enumeratum.yml")
@@ -164,6 +162,8 @@ class VerifyYamlEnumeratumTest extends AnyFunSuite with Matchers {
 }
 
 object VerifyYamlEnumeratumTest {
+  import enumeratum.{Enum, EnumEntry}
+  import enumeratum.values.{IntEnum, IntEnumEntry, ShortEnum, ShortEnumEntry}
 
   case class FruitWithEnum(fruit: String, amount: Int, fruitType: List[FruitType])
 

--- a/docs/openapi-docs/src/test/scalajvm-3-2.13+/sttp/tapir/docs/openapi/VerifyYamlEnumerationTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm-3-2.13+/sttp/tapir/docs/openapi/VerifyYamlEnumerationTest.scala
@@ -58,9 +58,22 @@ class VerifyYamlEnumerationTest extends AnyFunSuite with Matchers {
 
     noIndentation(actualYaml) shouldBe expectedYaml
   }
+
+  test("should add docs extension from @customise annotation on a ShortEnum") {
+    import sttp.tapir.codec.enumeratum._
+
+    val actualYaml = OpenAPIDocsInterpreter()
+      .toOpenAPI(endpoint.in("order").out(jsonBody[OrderStatusResponse]), "Orders", "1.0")
+      .toYaml
+
+    val expectedYaml = load("enum/expected_enumeratum_short_enum_with_docs_extension.yml")
+
+    noIndentation(actualYaml) shouldBe expectedYaml
+  }
 }
 
 object VerifyYamlEnumerationTest {
+
   sealed trait Game
   case object Strategy extends Game
   case object Action extends Game
@@ -93,4 +106,23 @@ object VerifyYamlEnumerationTest {
   }
 
   case class Square(cornerStyle: Option[CornerStyle.Value], tags: Seq[Tag.Value])
+
+  import sttp.tapir.Schema.annotations.customise
+  import sttp.tapir.json.circe._
+  import sttp.tapir.docs.apispec.DocsExtensionAttribute._
+  import enumeratum.values.{ShortEnum, ShortEnumEntry}
+  import scala.collection.immutable
+
+  @customise(_.docsExtension("x-enum-varnames", List("UnPaid", "Paid", "Finish", "Cancel")))
+  sealed abstract class OrderStatus(val value: Short) extends ShortEnumEntry
+  object OrderStatus extends ShortEnum[OrderStatus] {
+    case object UnPaid extends OrderStatus(0)
+    case object Paid extends OrderStatus(1)
+    case object Finish extends OrderStatus(2)
+    case object Cancel extends OrderStatus(3)
+
+    override def values: immutable.IndexedSeq[OrderStatus] = findValues
+  }
+
+  case class OrderStatusResponse(status: OrderStatus)
 }

--- a/docs/openapi-docs/src/test/scalajvm-3-2.13+/sttp/tapir/docs/openapi/VerifyYamlEnumerationTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm-3-2.13+/sttp/tapir/docs/openapi/VerifyYamlEnumerationTest.scala
@@ -1,20 +1,21 @@
 package sttp.tapir.docs.openapi
 
+import enumeratum.values.{ShortEnum, ShortEnumEntry}
 import io.circe.generic.auto._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import sttp.apispec.openapi.circe.yaml._
 import sttp.tapir.Schema.SName
+import sttp.tapir.Schema.annotations.customise
+import sttp.tapir.codec.enumeratum._
+import sttp.tapir.docs.apispec.DocsExtensionAttribute._
 import sttp.tapir.docs.openapi.VerifyYamlEnumerationTest._
 import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import sttp.tapir.model.{CommaSeparated, Delimited}
 import sttp.tapir.{Schema, Validator, _}
-import sttp.tapir.docs.apispec.DocsExtensionAttribute._
-import enumeratum.values.{ShortEnum, ShortEnumEntry}
-import Schema.annotations.customise
+
 import scala.collection.immutable
-import sttp.tapir.codec.enumeratum._
 
 class VerifyYamlEnumerationTest extends AnyFunSuite with Matchers {
 
@@ -76,7 +77,6 @@ class VerifyYamlEnumerationTest extends AnyFunSuite with Matchers {
 }
 
 object VerifyYamlEnumerationTest {
-
   sealed trait Game
   case object Strategy extends Game
   case object Action extends Game
@@ -112,12 +112,12 @@ object VerifyYamlEnumerationTest {
 
   @customise(_.docsExtension("x-enum-varnames", List("UnPaid", "Paid", "Finish", "Cancel")))
   sealed abstract class OrderStatus(val value: Short) extends ShortEnumEntry
+
   object OrderStatus extends ShortEnum[OrderStatus] {
     case object UnPaid extends OrderStatus(0)
     case object Paid extends OrderStatus(1)
     case object Finish extends OrderStatus(2)
     case object Cancel extends OrderStatus(3)
-
     override def values: immutable.IndexedSeq[OrderStatus] = findValues
   }
 

--- a/docs/openapi-docs/src/test/scalajvm-3-2.13+/sttp/tapir/docs/openapi/VerifyYamlEnumerationTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm-3-2.13+/sttp/tapir/docs/openapi/VerifyYamlEnumerationTest.scala
@@ -113,7 +113,8 @@ object VerifyYamlEnumerationTest {
   import enumeratum.values.{ShortEnum, ShortEnumEntry}
   import scala.collection.immutable
 
-  @customise(_.docsExtension("x-enum-varnames", List("UnPaid", "Paid", "Finish", "Cancel")))
+
+  @customise(new RichSchema(_).docsExtension("x-enum-varnames", List("UnPaid", "Paid", "Finish", "Cancel")))
   sealed abstract class OrderStatus(val value: Short) extends ShortEnumEntry
   object OrderStatus extends ShortEnum[OrderStatus] {
     case object UnPaid extends OrderStatus(0)

--- a/docs/openapi-docs/src/test/scalajvm-3-2.13+/sttp/tapir/docs/openapi/VerifyYamlEnumerationTest.scala
+++ b/docs/openapi-docs/src/test/scalajvm-3-2.13+/sttp/tapir/docs/openapi/VerifyYamlEnumerationTest.scala
@@ -10,6 +10,11 @@ import sttp.tapir.generic.auto._
 import sttp.tapir.json.circe._
 import sttp.tapir.model.{CommaSeparated, Delimited}
 import sttp.tapir.{Schema, Validator, _}
+import sttp.tapir.docs.apispec.DocsExtensionAttribute._
+import enumeratum.values.{ShortEnum, ShortEnumEntry}
+import Schema.annotations.customise
+import scala.collection.immutable
+import sttp.tapir.codec.enumeratum._
 
 class VerifyYamlEnumerationTest extends AnyFunSuite with Matchers {
 
@@ -60,8 +65,6 @@ class VerifyYamlEnumerationTest extends AnyFunSuite with Matchers {
   }
 
   test("should add docs extension from @customise annotation on a ShortEnum") {
-    import sttp.tapir.codec.enumeratum._
-
     val actualYaml = OpenAPIDocsInterpreter()
       .toOpenAPI(endpoint.in("order").out(jsonBody[OrderStatusResponse]), "Orders", "1.0")
       .toYaml
@@ -107,14 +110,7 @@ object VerifyYamlEnumerationTest {
 
   case class Square(cornerStyle: Option[CornerStyle.Value], tags: Seq[Tag.Value])
 
-  import sttp.tapir.Schema.annotations.customise
-  import sttp.tapir.json.circe._
-  import sttp.tapir.docs.apispec.DocsExtensionAttribute._
-  import enumeratum.values.{ShortEnum, ShortEnumEntry}
-  import scala.collection.immutable
-
-
-  @customise(new RichSchema(_).docsExtension("x-enum-varnames", List("UnPaid", "Paid", "Finish", "Cancel")))
+  @customise(_.docsExtension("x-enum-varnames", List("UnPaid", "Paid", "Finish", "Cancel")))
   sealed abstract class OrderStatus(val value: Short) extends ShortEnumEntry
   object OrderStatus extends ShortEnum[OrderStatus] {
     case object UnPaid extends OrderStatus(0)

--- a/json/pickler/src/main/scala/sttp/tapir/json/pickler/SchemaDerivation.scala
+++ b/json/pickler/src/main/scala/sttp/tapir/json/pickler/SchemaDerivation.scala
@@ -117,7 +117,7 @@ private class SchemaDerivation(genericDerivationConfig: Expr[Configuration])(usi
           '{ $schema.modifyUnsafe[X](Schema.ModifyCollectionElements)((_: Schema[X]).validate($ann.v.asInstanceOf[Validator[X]])) }
         case '{ $ann: Schema.annotations.format }     => '{ $schema.format($ann.format) }
         case '{ $ann: Schema.annotations.deprecated } => '{ $schema.deprecated(true) }
-        case '{ $ann: Schema.annotations.customise }  => '{ $ann.f($schema).asInstanceOf[Schema[X]] }
+        case '{ $ann: Schema.annotations.customise }  => '{ $ann.f($schema.asInstanceOf[Schema[Any]]).asInstanceOf[Schema[X]] }
         case _                                        => schema
     }
 


### PR DESCRIPTION
Why I did it?
In order to test and fix a bug [#4292](https://github.com/softwaremill/tapir/issues/4292)

How I did it:
I prepared a new test case in VerifyYamlEnumerationTest with a user provided code

After that. I've extended SchemaAnnotations to handle customise annotation and related macros accordingly.
I've changed customise annotation param itself from Schema[?] => Schema[Any] in order to properly derive types 
to avoid call site changes and keep api stable.